### PR TITLE
ci: dependabot version updates, a pull request template, and semantic titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# Dependabot version updates — grouped, weekly, on Monday morning Kyiv time, one pull request per
+# ecosystem so a week of bumps is one review rather than fifteen.
+#
+# Security updates are separate and immediate (enabled in the repository settings, 2026-09-05).
+#
+# Family exceptions: FluentAssertions stays on 7.x — 8.x changed its licence; the pin is deliberate
+# and is the one major bump Dependabot must not propose.
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Kyiv"
+    groups:
+      nuget-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "FluentAssertions"
+        update-types: ["version-update:semver-major"]
+    labels: ["dependencies", "nuget"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "npm"
+    directory: "/src_vs_code"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Kyiv"
+    groups:
+      npm-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels: ["dependencies", "npm"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Kyiv"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels: ["dependencies", "ci"]
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!-- The title is the changelog line: `type: what changed` — feat, fix, docs, test, chore, refactor, perf, ci, build. -->
+
+## What changed, and why
+
+<!-- The symptom or the ask first, then what shipped. A reader who sees only this text should know both. -->
+
+## Evidence
+
+- [ ] **Red-green:** every bug or problem spot here has a test that failed before the fix and passes after — name it.
+- [ ] **All the tests ran** (not only the ones near the change), and this is what they printed:
+
+```
+<paste the test runner's summary lines>
+```
+
+## Documentation
+
+- [ ] The docs that describe what changed are updated in this PR — `research/module_*.md`, README, CHANGELOG, the manifest (`package.json` / `.csproj`) where a version or a contribution changed.
+- [ ] If this finishes a plan in `todo/`, it is promoted to `research/` here, with what shipped differently.
+
+## The reviewer
+
+<!-- Filled in about five minutes after opening: what CodeRabbit said, what was fixed, and what was NOT acted on — with the reason, citing the code or the rule. -->
+
+## Release
+
+- [ ] No release needed / a release tag will be cut on `main` after the merge: `<tag>`.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,10 @@ jobs:
     name: pr · semantic title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      # Pinned to a commit, not a tag: a tag can be moved under you, and this action reads the
+      # pull request with a token. SonarCloud githubactions:S7637, 2026-09-05. Dependabot keeps the
+      # comment's version current — it rewrites both the SHA and the trailing tag.
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,34 @@
+name: pr · title
+
+# The pull request title becomes the line in main's history (rebase keeps commits, squash uses the
+# title), so it has to say what changed in the family's own shape: `type: what changed`.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic:
+    name: pr · semantic title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            test
+            chore
+            refactor
+            perf
+            ci
+            build
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" starts with a capital letter; the family writes `type: lower-case what changed`.


### PR DESCRIPTION
Three of the items from the operator's hardening list of 2026-09-05
(todo/PLAN_family_ci_hardening.md, epic 3), for this repository first:

* .github/dependabot.yml — grouped weekly version updates: NuGet minor+patch in one PR, npm (the
  extension) in one, GitHub Actions in one; Monday 07:00 Kyiv; FluentAssertions pinned below 8.x
  (its licence changed), which is the one major bump Dependabot must not propose. Security updates
  are immediate and separate — enabled in the settings the same day.
* .github/pull_request_template.md — the checklist the rules already demand, in the order a
  reviewer reads it: what and why, the red-green test, what ALL the tests printed, the docs touched,
  what the automated reviewer said and what was not acted on, the release tag.
* .github/workflows/pr-title.yml — amannn/action-semantic-pull-request: the title is the line in
  main's history, so it is `type: what changed` with the family's types. To be made a required
  check once it has reported on one pull request.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)