### PR TITLE
ci: SonarCloud analysis of the .NET halves, with coverage

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,65 @@
+name: sonarcloud
+
+# SonarCloud analysis of the .NET halves (src_mcp, src_bench) with test coverage, on every push to
+# main and every pull request. The scanner for .NET needs the build to happen between `begin` and
+# `end`, a JDK, and — in this family — the tests run as the runner executables xUnit v3 / MTP
+# builds, under dotnet-coverage: `dotnet test` has no VSTest host here and would abort, which is
+# not a coverage report. The TypeScript extension is not in this analysis (the .NET scanner sees
+# the files of the projects it builds); it is a follow-up with a scanner of its own.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: sonarcloud-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sonar:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # blame and new-code detection need the whole history
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: Install the scanner and the coverage tool
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
+          dotnet tool install --global dotnet-coverage
+      - name: Begin
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet-sonarscanner begin \
+            /k:"remsoftdev_dew_flow_connect_other_ais" \
+            /o:"remsoftdev" \
+            /d:sonar.token="$SONAR_TOKEN" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.cs.vscoveragexml.reportsPaths="coverage/*.xml" \
+            /d:sonar.exclusions="**/bin/**,**/obj/**,artifacts/**,**/node_modules/**,src_mcp/tests_fakecli/**" \
+            /d:sonar.coverage.exclusions="**/tests/**,**/*.Tests/**,src_mcp/tests_fakecli/**"
+      - name: Build
+        run: dotnet build dew_flow_connect_other_ais.slnx -c Release --no-incremental
+      - name: Test with coverage
+        run: |
+          mkdir -p coverage
+          dotnet-coverage collect -f xml -o coverage/server.xml -- ./src_mcp/tests/bin/Release/net10.0/CoaiMcp.Tests
+          dotnet-coverage collect -f xml -o coverage/bench.xml -- ./src_bench/CoaiBench.Tests/bin/Release/net10.0/CoaiBench.Tests
+      - name: End
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"


### PR DESCRIPTION
Project remsoftdev_dew_flow_connect_other_ais in the remsoftdev organisation, created 2026-09-05;
the token is the SONAR_TOKEN repository secret. The operator's template, corrected for this family:
.NET 10 from global.json rather than 9; JDK 21; the tests are the runner executables xUnit v3 / MTP
builds and run under dotnet-coverage (dotnet test has no VSTest host here — it aborts, which is not
a coverage report); one coverage file per runner, both handed to the scanner; build output, the
fake CLI and the test projects excluded from coverage. The TypeScript extension is a follow-up with
a scanner of its own — the .NET scanner sees only the files of the projects it builds.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)