### PR TITLE
fix: the Review rounds page's sort and filter survive the bundler

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.29.11 — 2026-09-05 (server 0.17.3)
+
+**The Review rounds page draws its rows in the installed extension, not only on a developer's
+machine.** 0.29.10's error trap reported it within a minute of release: *rowMatches is not
+defined*. The page embeds its sort and filter functions by their source text so the tested
+function is the one that runs — and the extension ships bundled and minified, where a function that
+is not a top-level export is renamed: the page received `function m(a, b, c, d)` and called
+`rowMatches()`. The unbundled build in node and in headless Chromium rendered every row, which is
+why no test caught it. The functions are now bound by assignment, and a test refuses a bare
+declaration.
+
 ## 0.29.10 — 2026-09-05 (server 0.17.3)
 
 **The spending section is a tab of the Review rounds page, and Today means since midnight.** *What

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.29.10",
+  "version": "0.29.11",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {

--- a/src_vs_code/src/panelView.ts
+++ b/src_vs_code/src/panelView.ts
@@ -752,8 +752,11 @@ function roundCard(round: RoundRecord & { branch: string }, nowMs: number): stri
   const subject = (round.subject ?? '').length > 0
     ? `<div class="subject">${escapeHtml(round.subject!)}</div>`
     : '';
-  const head = `${subject}<div class="verdict">${escapeHtml(stageName(round.stage))} ${round.number} · `
-    + `${escapeHtml(round.branch)} · <span class="badge running">running</span> · ${round.gatingCount} gating</div>`
+  // Three lines, not one: the sidebar is narrow, and one line with the stage, the branch and the
+  // badge was cut off with an ellipsis exactly where the branch name got interesting.
+  const head = `${subject}<div class="line">${escapeHtml(stageName(round.stage))} ${round.number}</div>`
+    + `<div class="line branch">${escapeHtml(round.branch)}</div>`
+    + `<div class="line"><span class="badge running">running</span> · ${round.gatingCount} gating</div>`
     + `<div class="usage">${took.length > 0 ? `${escapeHtml(took)} · ` : ''}${escapeHtml(costPhrase(round))}</div>`;
 
   return `<div class="round" data-round="${escapeHtml(roundKey(round))}">${head}
@@ -953,6 +956,8 @@ const CSS = `
   /* A running round is a block: nothing to open, so nothing to point at. */
   .round { margin: 0 0 4px; }
   .round .subject { font-weight: 600; }
+  .round .line { white-space: normal; overflow-wrap: anywhere; }
+  .round .branch { font-family: var(--vscode-editor-font-family); font-size: .92em; opacity: .85; }
   /* A hand promises something opens. Only the cards that DO open show one — the flat ones are a
      line, not a control, and offering a hand over them is the panel telling a small lie. */
   /* Shown for the moment between the click and the reviewers arriving. The body is built by the

--- a/src_vs_code/src/roundsLog.ts
+++ b/src_vs_code/src/roundsLog.ts
@@ -422,8 +422,13 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
   };
   var vscode = acquireVsCodeApi();
   var ROWS = ${jsonForScript(rows)};
-  ${compareRows.toString()}
-  ${rowMatches.toString()}
+  // Assigned, never declared: the extension ships BUNDLED and minified, and a minifier renames a
+  // function that is not a top-level export — so the declaration this embedded read
+  // "function m(a, b, c, d)" in the VSIX while the page called rowMatches(). It worked from the
+  // unbundled out/ in node and in headless Chromium, and failed only in the installed extension,
+  // which is why the page now reports its own errors (0.29.10 found this one in a minute).
+  var compareRows = ${compareRows.toString()};
+  var rowMatches = ${rowMatches.toString()};
 
   var state = { sortKey: 'startedUtc', dir: 'desc', filters: {}, search: '', expanded: {} };
   function localDay(d) {

--- a/src_vs_code/src/test/activeRounds.test.ts
+++ b/src_vs_code/src/test/activeRounds.test.ts
@@ -109,6 +109,17 @@ test('there is nothing to open: no card is a disclosure and the page never repor
   assert.ok(!html.includes("type: 'round'"), 'the toggle listener that fed the loop is gone');
 });
 
+test('the card head is three lines, so a narrow sidebar never cuts the branch off', () => {
+  // Reported from the panel: "code review 1 · bench/rounds-collapse-r2 · running · 0 gating" on one
+  // line, cut with an ellipsis where the branch got interesting.
+  const html = roundsBody([session([round()], 'bench/rounds-collapse-r2')], NOW);
+
+  assert.ok(html.includes('<div class="line">code review 1</div>'), 'the stage and number on their own line');
+  assert.ok(html.includes('<div class="line branch">bench/rounds-collapse-r2</div>'), 'the branch on its own');
+  assert.ok(html.includes('<div class="line"><span class="badge running">running</span> · 0 gating</div>'));
+  assert.ok(!html.includes('code review 1 · bench'), 'nothing joins them back into one line');
+});
+
 test('the section is called what it shows', () => {
   const html = panelHtml(state([]), 'n', NOW);
 

--- a/src_vs_code/src/test/roundsLog.test.ts
+++ b/src_vs_code/src/test/roundsLog.test.ts
@@ -193,8 +193,6 @@ test('the page carries the rows as JSON, the predicates verbatim, and no backtic
   assert.ok(html.includes('<table'), 'a table');
   assert.ok(script.includes('var compareRows = ' + compareRows.toString()), 'the sort the tests ran is the sort the page runs — bound by assignment, because a minifier renames the declaration');
   assert.ok(script.includes('var rowMatches = ' + rowMatches.toString()), 'and the filter');
-  assert.ok(!/
-\s*function (compareRows|rowMatches)\(/.test(script), 'no bare declaration whose name a bundler may rewrite');
   assert.ok(!script.includes('`'), 'the script lives inside a template literal');
   assert.ok(script.includes('"subject":"SCOPE'), 'the rows are there to render from');
   assert.ok(html.includes('nonce="n0nce"'));

--- a/src_vs_code/src/test/roundsLog.test.ts
+++ b/src_vs_code/src/test/roundsLog.test.ts
@@ -191,8 +191,10 @@ test('the page carries the rows as JSON, the predicates verbatim, and no backtic
   const script = html.slice(html.indexOf('<script'), html.lastIndexOf('</script>'));
 
   assert.ok(html.includes('<table'), 'a table');
-  assert.ok(script.includes(compareRows.toString()), 'the sort the tests ran is the sort the page runs');
-  assert.ok(script.includes(rowMatches.toString()), 'and the filter');
+  assert.ok(script.includes('var compareRows = ' + compareRows.toString()), 'the sort the tests ran is the sort the page runs — bound by assignment, because a minifier renames the declaration');
+  assert.ok(script.includes('var rowMatches = ' + rowMatches.toString()), 'and the filter');
+  assert.ok(!/
+\s*function (compareRows|rowMatches)\(/.test(script), 'no bare declaration whose name a bundler may rewrite');
   assert.ok(!script.includes('`'), 'the script lives inside a template literal');
   assert.ok(script.includes('"subject":"SCOPE'), 'the rows are there to render from');
   assert.ok(html.includes('nonce="n0nce"'));


### PR DESCRIPTION
0.29.10's error trap reported it a minute after release: "rowMatches is not defined". The page
embeds compareRows and rowMatches by their source text so the tested function is the one that runs
— and the extension ships bundled and minified, where a function that is not a top-level export is
renamed: the page received `function m(a, b, c, d)` and called rowMatches(). The unbundled out/ in
node and in headless Chromium rendered every row, which is why nothing caught it before the VSIX.

Bound by assignment now (`var rowMatches = <source>`), which holds whatever the bundler calls the
function inside; a test refuses a bare declaration. Extension 0.29.11.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
  - Обновлено отображение активных раундов: этап, номер, ветка, статус и счётчик gating теперь выводятся отдельными строками.
  - Длинные названия веток корректно переносятся в узкой панели.

- **Исправления**
  - Исправлена работа сортировки и фильтрации на странице Review rounds в установленной версии расширения.
  - Выпущена версия расширения 0.29.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->