### PR TITLE
fix: a local review cannot list findings until the token ceiling cuts it off

### DIFF
--- a/src_mcp/runners/Reviewers/LocalAsk.cs
+++ b/src_mcp/runners/Reviewers/LocalAsk.cs
@@ -225,6 +225,9 @@ public static class LocalAsk
     /// reject <c>maxLength</c> as an unsupported keyword with a 400 — so the bound is added to the copy
     /// this route sends, never to <c>FindingSchema.Json</c>.</para>
     /// </remarks>
+    /// <summary>How many findings one local reviewer may return. See <see cref="Bounded"/>.</summary>
+    private const int MaxFindings = 10;
+
     private static readonly (string Field, int MaxLength)[] FreeTextBounds =
     [
         ("title", 200),
@@ -243,10 +246,19 @@ public static class LocalAsk
     internal static JsonNode Bounded(string schemaJson)
     {
         var root = JsonNode.Parse(schemaJson) ?? throw new JsonException("the schema parsed to nothing");
-        if (root["properties"]?["findings"]?["items"]?["properties"] is not JsonObject fields)
+        if (root["properties"]?["findings"] is not JsonObject findings
+            || findings["items"]?["properties"] is not JsonObject fields)
         {
             return root;
         }
+
+        // The third way the local model fails, found once the strings were bounded: forty-three
+        // findings in 385 lines, and the token ceiling inside the forty-third's `why`. Every string
+        // was finite; the array was not. Ten is the number at which a full-length review — every
+        // string at its bound, ~2,400 characters a finding — still fits the 8,192-token ceiling, so a
+        // schema-valid answer can always finish; it is also more than any local reviewer here has
+        // returned and been worth resolving. A review with forty findings is a review nobody reads.
+        findings["maxItems"] = MaxFindings;
 
         foreach (var (field, maxLength) in FreeTextBounds)
         {

--- a/src_mcp/tests/LocalReviewIsBoundedInCountTests.cs
+++ b/src_mcp/tests/LocalReviewIsBoundedInCountTests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using Xunit;
+using FluentAssertions;
+using CoaiMcp.Core.Findings;
+using CoaiMcp.Runners.Reviewers;
+
+namespace CoaiMcp.Tests;
+
+/// <summary>
+/// A local review cannot list findings until the token ceiling cuts it off mid-string.
+/// </summary>
+/// <remarks>
+/// <para>The third way the local model fails, found by the five-window campaign of 2026-09-05 after
+/// the first two were fixed: with every string bounded (0.17.2), a reviewer produced <b>forty-three</b>
+/// findings in 385 lines and hit <c>max_tokens</c> inside the forty-third's <c>why</c> — an
+/// unterminated string at character 32,066 of 32,112, one repair launch, the same again. Every
+/// string was finite; the ARRAY was not.</para>
+/// <para>The grammar bounds arrays too. And the bound is not only a guard: a review with forty
+/// findings is a review nobody reads. Ten is the count at which a review with every string at its
+/// bound still fits the token ceiling — the point being that a schema-valid answer can always
+/// finish — and more than any local reviewer here has returned and been worth resolving.</para>
+/// </remarks>
+public sealed class LocalReviewIsBoundedInCountTests
+{
+    private static JsonElement SchemaSent() =>
+        JsonDocument.Parse(LocalAsk.RequestBody("qwen", "review this", FindingSchema.Json, 42, "none", 8192))
+            .RootElement.GetProperty("response_format").GetProperty("json_schema").GetProperty("schema");
+
+    [Fact]
+    public void TheFindingsArray_IsBounded_InTheSchemaTheLocalEngineReceives()
+    {
+        var findings = SchemaSent().GetProperty("properties").GetProperty("findings");
+
+        findings.TryGetProperty("maxItems", out var max).Should().BeTrue(
+            "an unbounded array is where a model lists findings until the token ceiling");
+        max.GetInt32().Should().BeLessThanOrEqualTo(25).And.BeGreaterThanOrEqualTo(10);
+    }
+
+    [Fact]
+    public void TheBoundFitsTheTokenCeiling()
+    {
+        // Every finding at its string bounds (200 + 1000 + 1000 characters plus the fixed fields) must
+        // fit under the 8192-token ceiling the request carries — the point is that a schema-valid
+        // answer can always finish, even the longest one the grammar allows.
+        var schema = SchemaSent();
+        var items = schema.GetProperty("properties").GetProperty("findings").GetProperty("maxItems").GetInt32();
+        var perFinding = 200 + 1000 + 1000 + 200; // title, why, fix, and the enum/path/line fields
+        var roughTokens = items * perFinding / 3;   // ~3 characters per token for English prose
+
+        roughTokens.Should().BeLessThan(8192, "otherwise the bound does not bound anything");
+    }
+
+    [Fact]
+    public void TheSharedSchema_StaysUnbounded_BecauseOpenAIStrictModeRejectsMaxItems() =>
+        FindingSchema.Json.Should().NotContain("maxItems");
+}

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Server 0.17.4 — 2026-09-05
+
+**A local review cannot list findings until the token ceiling cuts it off.** The third way the local
+model fails, found by the five-window campaign once the strings were bounded: forty-three findings in
+385 lines, and `max_tokens` inside the forty-third's `why`. Every string was finite; the array was
+not. The schema the local route sends now bounds `findings` at ten — the count at which a review with
+every string at its bound still fits the ceiling, so a schema-valid answer can always finish. Ten is
+also more than any local reviewer here has returned and been worth resolving; a review with forty
+findings is a review nobody reads.
+
 ## 0.29.11 — 2026-09-05 (server 0.17.3)
 
 **The Review rounds page draws its rows in the installed extension, not only on a developer's


### PR DESCRIPTION
The third way the local model fails, found by the five-window campaign of 2026-09-05 once the
strings were bounded (0.17.2): forty-three findings in 385 lines, and max_tokens inside the
forty-third's `why` — an unterminated string at character 32,066 of 32,112, one repair launch, the
same again. Every string was finite; the array was not.

The schema the local route sends now bounds `findings` at ten: the count at which a review with
every string at its bound (~2,400 characters a finding) still fits the 8,192-token ceiling, so a
schema-valid answer can always finish — and more than any local reviewer here has returned and been
worth resolving. The shared schema stays unbounded (OpenAI strict mode). Red first; server tests 610.
Server 0.17.4.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)