### PR TITLE
test: the page is checked as it ships — bundled and minified

### DIFF
--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+/**
+ * The page is checked as it SHIPS — bundled and minified — not as it compiles.
+ *
+ * <p>0.29.10 shipped a Review rounds page that came up as a header row over nothing. The same HTML
+ * rendered all ninety-eight rows in node and in headless Chromium; only the installed extension
+ * failed, with `rowMatches is not defined`. The page embeds its sort and filter functions by their
+ * SOURCE TEXT so the tested function is the one that runs — and esbuild, minifying, renames a
+ * function that is not a top-level export. The page received `function m(a, b, c, d)` and called
+ * `rowMatches()`.</p>
+ *
+ * <p>Every test in this suite ran against `out/`, which is compiled and not bundled, so none of them
+ * could see it. This one bundles the module the way `npm run bundle` does and asserts on what the
+ * page then produces. It is slow by the standards of this suite (a second or so) and it is the only
+ * test that can catch this class of defect at all.</p>
+ */
+
+/** The repository's `src_vs_code`. The suite runs from its root, which is what `npm test` does. */
+const ROOT = process.cwd();
+
+function bundledPage(): { html: string; script: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coai-bundle-'));
+  const entry = path.join(dir, 'entry.mjs');
+  const out = path.join(dir, 'bundle.cjs');
+  // A tiny entry so the bundle exports exactly what the assertion needs; `--minify` is what the
+  // shipped bundle uses, and the renaming it does is the whole point of this test.
+  fs.writeFileSync(entry, `export { roundsLogHtml, rowsFrom } from ${JSON.stringify(path.join(ROOT, 'src', 'roundsLog.ts'))};\n`);
+  execFileSync(
+    process.execPath,
+    [path.join(ROOT, 'node_modules', 'esbuild', 'bin', 'esbuild'), entry,
+      '--bundle', `--outfile=${out}`, '--format=cjs', '--platform=node', '--minify'],
+    { stdio: 'pipe' },
+  );
+  const bundle = fs.readFileSync(out, 'utf8');
+  // CJS, because minification renames the exported bindings too: the export CLAUSE is what maps them
+  // back to their public names, and `module.exports` keeps that map where an ESM bundle loses it to
+  // any attempt to evaluate the text directly.
+  const shim = { exports: {} as Record<string, unknown> };
+  new Function('module', 'exports', bundle)(shim, shim.exports);
+  const module_ = shim.exports as unknown as {
+    roundsLogHtml: (rows: unknown[], questions: unknown[], nonce: string, usage?: string) => string;
+  };
+  const html = module_.roundsLogHtml([], [], 'n0nce');
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  return { html, script: html.slice(html.indexOf('<script'), html.lastIndexOf('</script>')) };
+}
+
+test('the minified bundle still defines the functions the page calls', () => {
+  const { script } = bundledPage();
+
+  for (const name of ['compareRows', 'rowMatches']) {
+    assert.ok(
+      new RegExp(`var ${name}\\s*=\\s*function`).test(script),
+      `${name} is not defined in the page the bundle produces — this is the 0.29.10 defect`,
+    );
+  }
+});
+
+test('the page script the bundle produces parses and runs', () => {
+  const { script } = bundledPage();
+  const body = script.replace(/^<script[^>]*>/, '');
+
+  // Parses at all — the cheapest half of what the webview does with it.
+  assert.doesNotThrow(() => new Function(body), 'the page script is not valid JavaScript');
+
+  // And runs: a stub DOM and the VS Code API bridge, exactly as the webview provides them.
+  const seen: Record<string, { innerHTML: string; textContent: string; hidden: boolean }> = {};
+  const element = () => ({
+    innerHTML: '', textContent: '', hidden: false, value: '', className: '',
+    addEventListener() {}, getAttribute: () => null, setAttribute() {}, querySelectorAll: () => [],
+  });
+  const document_ = {
+    getElementById: (id: string) => (seen[id] ??= element() as never),
+    querySelectorAll: () => [],
+    addEventListener() {},
+  };
+  assert.doesNotThrow(
+    () => new Function('document', 'window', 'acquireVsCodeApi', body)(
+      document_, { addEventListener() {} }, () => ({ postMessage() {} })),
+    'the page script threw on its first render',
+  );
+  assert.equal(seen['failed']?.textContent ?? '', '', 'the page reported an error to itself on first render');
+});

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -3,7 +3,6 @@ import { test } from 'node:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { execFileSync } from 'node:child_process';
 
 /**
  * The page is checked as it SHIPS — bundled and minified — not as it compiles.
@@ -31,12 +30,14 @@ function bundledPage(): { html: string; script: string } {
   // A tiny entry so the bundle exports exactly what the assertion needs; `--minify` is what the
   // shipped bundle uses, and the renaming it does is the whole point of this test.
   fs.writeFileSync(entry, `export { roundsLogHtml, rowsFrom } from ${JSON.stringify(path.join(ROOT, 'src', 'roundsLog.ts'))};\n`);
-  execFileSync(
-    process.execPath,
-    [path.join(ROOT, 'node_modules', 'esbuild', 'bin', 'esbuild'), entry,
-      '--bundle', `--outfile=${out}`, '--format=cjs', '--platform=node', '--minify'],
-    { stdio: 'pipe' },
-  );
+  // esbuild's JS API, not its binary: on Linux `node_modules/esbuild/bin/esbuild` is a shell shim,
+  // and running it through node is a SyntaxError — which is exactly how this test passed on Windows
+  // and failed on the CI runner the day it was written.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const esbuild = require('esbuild') as { buildSync: (options: Record<string, unknown>) => void };
+  esbuild.buildSync({
+    entryPoints: [entry], outfile: out, bundle: true, format: 'cjs', platform: 'node', minify: true,
+  });
   const bundle = fs.readFileSync(out, 'utf8');
   // CJS, because minification renames the exported bindings too: the export CLAUSE is what maps them
   // back to their public names, and `module.exports` keeps that map where an ESM bundle loses it to

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -66,7 +66,10 @@ test('the minified bundle still defines the functions the page calls', () => {
 
 test('the page script the bundle produces parses and runs', () => {
   const { script } = bundledPage();
-  const body = script.replace(/^<script[^>]*>/, '');
+  // Cut after the opening tag rather than matching it: a regexp shaped like an HTML tag filter is
+  // one CodeQL flags on sight (js/bad-tag-filter), and it is right that the shape is fragile — the
+  // nonce cannot contain a '>' but a reader has to know that to believe the pattern.
+  const body = script.slice(script.indexOf('>') + 1);
 
   // Parses at all — the cheapest half of what the webview does with it.
   assert.doesNotThrow(() => new Function(body), 'the page script is not valid JavaScript');


### PR DESCRIPTION
0.29.10 shipped a Review rounds page that came up as a header row over nothing: `rowMatches is not
defined`. The page embeds its sort and filter functions by their SOURCE TEXT so the tested function
is the one that runs, and esbuild — minifying — renames a function that is not a top-level export.
The page received `function m(a, b, c, d)` and called `rowMatches()`. Every test in this suite ran
against out/, which is compiled and not bundled, so none of them could see it; node and headless
Chromium both rendered all ninety-eight rows from the same HTML.

This test bundles the module exactly as `npm run bundle` does — cjs, minified — and asserts on the
page that comes out: both functions defined, the script parsing, and the script RUNNING against a
stub DOM without reporting an error to itself. It is the only test that can catch this class at all.

Proved to have teeth: with the assignment form reverted it fails with "compareRows is not defined in
the page the bundle produces"; restored, 400 of 400 pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)