### PR TITLE
ci: SonarCloud sees the extension's coverage too

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -48,7 +48,7 @@ jobs:
             /o:"remsoftdev" \
             /d:sonar.token="$SONAR_TOKEN" \
             /d:sonar.host.url="https://sonarcloud.io" \
-            /d:sonar.cs.vscoveragexml.reportsPaths="coverage/*.xml" \
+            /d:sonar.cs.vscoveragexml.reportsPaths="coverage/*.xml"             /d:sonar.javascript.lcov.reportPaths="coverage/extension.lcov"             /d:sonar.typescript.lcov.reportPaths="coverage/extension.lcov" \
             /d:sonar.exclusions="**/bin/**,**/obj/**,artifacts/**,**/node_modules/**,src_mcp/tests_fakecli/**" \
             /d:sonar.coverage.exclusions="**/tests/**,**/*.Tests/**,src_mcp/tests_fakecli/**"
       - name: Build
@@ -58,6 +58,16 @@ jobs:
           mkdir -p coverage
           dotnet-coverage collect -f xml -o coverage/server.xml -- ./src_mcp/tests/bin/Release/net10.0/CoaiMcp.Tests
           dotnet-coverage collect -f xml -o coverage/bench.xml -- ./src_bench/CoaiBench.Tests/bin/Release/net10.0/CoaiBench.Tests
+      # The extension is TypeScript and the .NET scanner does not run its tests, so every change to
+      # src_vs_code arrived at the gate as 0 % coverage of new code — a number about the analysis
+      # rather than about the change. Node's own runner writes lcov.
+      - name: The extension's coverage
+        working-directory: src_vs_code
+        run: |
+          npm ci
+          npm run compile
+          mkdir -p ../coverage
+          node --test --experimental-test-coverage --test-reporter=lcov                --test-reporter-destination=../coverage/extension.lcov "out/test/"*.test.js
       - name: End
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -64,7 +64,10 @@ jobs:
       - name: The extension's coverage
         working-directory: src_vs_code
         run: |
-          npm ci
+          # --ignore-scripts: SonarCloud githubactions:S6505 — a lifecycle script runs as CI with the
+          # token in the environment. esbuild ships its binary as an optional platform dependency
+          # rather than a postinstall download, so the bundler the tests use still works without them.
+          npm ci --ignore-scripts
           npm run compile
           mkdir -p ../coverage
           node --test --experimental-test-coverage --test-reporter=lcov                --test-reporter-destination=../coverage/extension.lcov "out/test/"*.test.js


### PR DESCRIPTION
Every change to src_vs_code reached the quality gate as 0 % coverage of new code, because the .NET
scanner does not run the extension's tests — a number about the analysis rather than about the
change, and the gate was right to refuse it either way. The workflow now runs the extension's own
suite under node's coverage reporter and hands the lcov to the scanner beside the .NET reports.

The honest fix rather than a lowered threshold (common/automated-checks.md).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)