### PR TITLE
fix: a shared schema file must not kill a round, and an arm belongs in the branch name

### DIFF
--- a/src_bench/CoaiBench.Tests/ParallelRepeatsAreSeparateSessionsTests.cs
+++ b/src_bench/CoaiBench.Tests/ParallelRepeatsAreSeparateSessionsTests.cs
@@ -30,7 +30,21 @@ public sealed class ParallelRepeatsAreSeparateSessionsTests
     public void ARunOfAReviewedCase_HasItsOwnBranch_NamedForTheRun()
     {
         Bench.BranchFor(new Cell(Reviewed, "codex,gemini,local", Repeat: 2))
-            .Should().Be("bench/split-once-r2");
+            .Should().Be("bench/codex-gemini-local/split-once-r2");
+    }
+
+    [Fact]
+    public void TwoARMS_OfOneCaseAndRepeat_AreTwoBranches()
+    {
+        // Found by the seven-arm matrix of 2026-09-05 in its first minute: the branch was named for
+        // the case and the repeat alone, so all seven arms of one cell shared one ref and one
+        // worktree — `git worktree add: Preparing worktree (detached HEAD 267e07a)` from whichever
+        // server lost. An arm is what makes a run different from its neighbours; it belongs in the name.
+        var one = Bench.BranchFor(new Cell(Reviewed, "codex", 1));
+        var two = Bench.BranchFor(new Cell(Reviewed, "codex,gemini", 1));
+
+        one.Should().NotBe(two);
+        two.Should().Be("bench/codex-gemini/split-once-r1", "a comma is not a ref character");
     }
 
     [Fact]

--- a/src_bench/CoaiBench/Running/Bench.cs
+++ b/src_bench/CoaiBench/Running/Bench.cs
@@ -99,7 +99,12 @@ public sealed class Bench(
     /// all along.
     /// </remarks>
     internal static string BranchFor(Cell cell) =>
-        cell.Case.Commit.Length > 0 ? $"bench/{cell.Case.Name}-r{cell.Repeat}" : "HEAD";
+        cell.Case.Commit.Length > 0
+            ? $"bench/{Ref(cell.Arm)}/{cell.Case.Name}-r{cell.Repeat}"
+            : "HEAD";
+
+    /// <summary>An arm as a git ref component: commas separate vendors, and a ref cannot hold one.</summary>
+    private static string Ref(string arm) => arm.Replace(',', '-').Replace(' ', '-');
 
     /// <summary>What the run's ref points at — the reviewed commit and nothing newer.</summary>
     internal static string RefTarget(Case work) => work.Commit;

--- a/src_mcp/src/Server/PanelService.cs
+++ b/src_mcp/src/Server/PanelService.cs
@@ -791,9 +791,7 @@ public sealed class PanelService
         IReadOnlyList<string>? planPrompts = null,
         bool deal = false)
     {
-        var schemaFile = Path.Combine(_settings.DataDir, "finding-schema.json");
-        Directory.CreateDirectory(_settings.DataDir);
-        File.WriteAllText(schemaFile, FindingSchema.Json);
+        var schemaFile = SchemaFile.Ensure(_settings.DataDir);
         var outputDir = Directory.CreateTempSubdirectory("coai-answers-").FullName;
         PruneOldAnswerDirs();
 

--- a/src_mcp/src/Server/SchemaFile.cs
+++ b/src_mcp/src/Server/SchemaFile.cs
@@ -1,0 +1,61 @@
+using CoaiMcp.Core.Findings;
+
+namespace CoaiMcp.Server;
+
+/// <summary>
+/// The finding schema on disk — one file, shared by every server on this machine.
+/// </summary>
+/// <remarks>
+/// <para>Every round hands its reviewers a path to this file, and every round used to rewrite it
+/// first. The data directory belongs to every window, so with several servers running that is
+/// several processes writing one file at the same instant — and on Windows the losers get an
+/// exception rather than a queue. The seven-lane matrix of 2026-09-05 killed a whole round on it:
+/// <c>the round failed: The process cannot access the file 'finding-schema.json' because it is being
+/// used by another process</c>, for a file whose content is a compile-time constant and was already
+/// correct on disk.</para>
+/// <para>So the write happens only when the file is missing or different, and losing the race is not
+/// an error: the neighbour is writing the same bytes. It fails OPEN — the caller always gets the
+/// path — because a reviewer that cannot read the schema answers unshaped JSON, which a round
+/// already handles, while a round that never launches over a locked constant is strictly worse.</para>
+/// </remarks>
+public static class SchemaFile
+{
+    public const string Name = "finding-schema.json";
+
+    /// <summary>The schema's path in <paramref name="dataDir"/>, written there if it is not already right.</summary>
+    public static string Ensure(string dataDir)
+    {
+        var file = Path.Combine(dataDir, Name);
+        try
+        {
+            Directory.CreateDirectory(dataDir);
+            if (!File.Exists(file) || !SameAsSchema(file))
+            {
+                File.WriteAllText(file, FindingSchema.Json);
+            }
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Somebody else is writing it, with the same content. Nothing to do and nothing to say.
+        }
+
+        return file;
+    }
+
+    /// <summary>Whether the file already holds the schema — a read that a concurrent write may refuse.</summary>
+    private static bool SameAsSchema(string file)
+    {
+        try
+        {
+            using var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream);
+
+            return reader.ReadToEnd() == FindingSchema.Json;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Unreadable right now: assume a neighbour is mid-write with the same bytes and leave it.
+            return true;
+        }
+    }
+}

--- a/src_mcp/tests/SchemaFileSurvivesNeighboursTests.cs
+++ b/src_mcp/tests/SchemaFileSurvivesNeighboursTests.cs
@@ -1,0 +1,92 @@
+using Xunit;
+using FluentAssertions;
+using CoaiMcp.Core.Findings;
+using CoaiMcp.Server;
+
+namespace CoaiMcp.Tests;
+
+/// <summary>
+/// The schema file is shared by every server on this machine, and writing it must not kill a round.
+/// </summary>
+/// <remarks>
+/// <para>Found by the seven-lane matrix of 2026-09-05, on the first run: <c>the round failed: The
+/// process cannot access the file 'finding-schema.json' because it is being used by another
+/// process</c>. Every round rewrites that file before it launches its reviewers, the data directory
+/// is shared by every window, and on Windows two writers is an exception rather than a queue. A whole
+/// round died for a file whose content is a compile-time constant and was already correct on disk.</para>
+/// <para>So: written only when it is missing or different, and a lost race is not an error — the
+/// neighbour is writing the same bytes. The one thing that must never happen is a round dying for it.</para>
+/// </remarks>
+public sealed class SchemaFileSurvivesNeighboursTests : IDisposable
+{
+    private readonly string _dir = Directory.CreateTempSubdirectory("coai-schema-").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private string Path_ => System.IO.Path.Combine(_dir, "finding-schema.json");
+
+    [Fact]
+    public void ItWritesTheSchemaWhenThereIsNone()
+    {
+        SchemaFile.Ensure(_dir).Should().Be(Path_);
+
+        File.ReadAllText(Path_).Should().Be(FindingSchema.Json);
+    }
+
+    [Fact]
+    public void ANeighbourHoldingTheFileOpenDoesNotKillTheRound()
+    {
+        // The exact shape of the failure: the file is already there and correct, and somebody else
+        // has it open for writing. On Windows that is an IOException to anyone who tries; the round
+        // must not care, because the bytes it wanted are already on disk.
+        File.WriteAllText(Path_, FindingSchema.Json);
+        using var held = new FileStream(Path_, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        var act = () => SchemaFile.Ensure(_dir);
+
+        act.Should().NotThrow();
+        SchemaFile.Ensure(_dir).Should().Be(Path_);
+    }
+
+    [Fact]
+    public void ItDoesNotRewriteAFileThatAlreadyMatches()
+    {
+        SchemaFile.Ensure(_dir);
+        var written = File.GetLastWriteTimeUtc(Path_);
+
+        SchemaFile.Ensure(_dir);
+
+        File.GetLastWriteTimeUtc(Path_).Should().Be(written, "the content is a constant; rewriting it is a race for nothing");
+    }
+
+    [Fact]
+    public void AStaleOrTruncatedFileIsReplaced()
+    {
+        File.WriteAllText(Path_, "{ this is not the schema");
+
+        SchemaFile.Ensure(_dir);
+
+        File.ReadAllText(Path_).Should().Be(FindingSchema.Json);
+    }
+
+    [Fact]
+    public void AndWhenItCannotBeWrittenAtAll_TheRoundStillGetsAPath()
+    {
+        // Failing OPEN, like the caller memory does: a reviewer that cannot read the schema file is a
+        // reviewer that answers unshaped JSON, which the round already handles. A round that never
+        // launches because of a locked constant is strictly worse.
+        File.WriteAllText(Path_, "stale");
+        using var held = new FileStream(Path_, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        SchemaFile.Ensure(_dir).Should().Be(Path_);
+    }
+}


### PR DESCRIPTION
Both found by the seven-arm matrix of 2026-09-05, in its first minute — which is what the matrix is
for.

**The product.** `the round failed: The process cannot access the file 'finding-schema.json'
because it is being used by another process.` Every round rewrote that file before launching its
reviewers; the data directory belongs to every window on the machine; on Windows two writers is an
exception rather than a queue. A whole round died for a file whose content is a compile-time
constant and was already correct on disk. `SchemaFile.Ensure` writes it only when it is missing or
different, and fails OPEN — a reviewer that cannot read the schema answers unshaped JSON, which a
round already handles, while a round that never launches over a locked constant is strictly worse.

**The bench.** `git worktree add: Preparing worktree (detached HEAD 267e07a)`. The branch was named
for the case and the repeat alone, so all seven arms of one cell shared one ref and one worktree —
the other half of the mistake the five-window run found last week. The arm is what makes a run
different from its neighbours, so it is in the name; a comma is not a ref character and becomes a
dash.

Red first for both. Server 615, bench 91.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)