### PR TITLE
feat: the Cost column says in / out / total, and long cells can be read

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -11,6 +11,12 @@ round total would be a number with no meaning. A `~` marks a total derived from 
 than billed; a `+` marks one that left an unpriced reviewer out, so it is a floor. Hovering the cell
 spells all of that out in a sentence.
 
+**The date range takes a time, and the page opens on today.** The two pickers are date **and**
+time now, and the log opens showing today from its first minute to its last — the question somebody
+has when they open it is almost always what happened today. **All dates** clears the range in one
+click. Storage stays UTC per the family rule; the conversion is the UI's, so the pickers speak your
+wall clock and the filtering happens on instants.
+
 **Long cells can be read.** The subject, the branch and the reviewer summary carry their full text
 as a tooltip, so a column that is cut with an ellipsis no longer hides the rest of it.
 

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -5,11 +5,20 @@
 **The Cost column says three numbers: in / out / total.** It was empty on every row, because it
 rendered the figure only a vendor that prices its own runs ever reports — and none of the three
 here does. It is now worked out from the tokens each reviewer actually read and wrote and the same
-two public price lists the spending section already reads, **priced per reviewer**: a round's tokens
-are the sum over vendors whose rates differ by an order of magnitude, so one multiplication over the
-round total would be a number with no meaning. A `~` marks a total derived from a price list rather
-than billed; a `+` marks one that left an unpriced reviewer out, so it is a floor. Hovering the cell
-spells all of that out in a sentence.
+two public price lists the spending section already reads. A `~` marks a total derived from a price
+list rather than billed; a `+` marks one that is a floor because something in it could not be
+priced; a `—` means nobody knows, which is a different claim from nothing. Hovering the cell spells
+all of that out in a sentence.
+
+**Priced from the usage ledger, at the price of the model that answered.** The first cut of this
+priced each of the round's reviewer states, and the column stayed empty in the installed extension:
+a reviewer state records `{provider, role, status, findings, note, seconds}` and no tokens at all.
+The ledger has one line per reviewer run with its tokens AND its model, so a round is priced from
+the lines that fall inside it — which also means a finished round keeps the cost it had when it ran,
+instead of moving the next time somebody points a vendor at a different model. A round whose lines
+do not add up to the tokens it recorded says so with the `+`, because two rounds of one stage
+running at once can each match the other's lines by time alone. Found by this product's own gate,
+nine reviewers over the diff.
 
 **The date range takes a time, and the page opens on today.** The two pickers are date **and**
 time now, and the log opens showing today from its first minute to its last — the question somebody

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.29.12 — 2026-09-05 (server 0.17.5)
+
+**The Cost column says three numbers: in / out / total.** It was empty on every row, because it
+rendered the figure only a vendor that prices its own runs ever reports — and none of the three
+here does. It is now worked out from the tokens each reviewer actually read and wrote and the same
+two public price lists the spending section already reads, **priced per reviewer**: a round's tokens
+are the sum over vendors whose rates differ by an order of magnitude, so one multiplication over the
+round total would be a number with no meaning. A `~` marks a total derived from a price list rather
+than billed; a `+` marks one that left an unpriced reviewer out, so it is a floor. Hovering the cell
+spells all of that out in a sentence.
+
+**Long cells can be read.** The subject, the branch and the reviewer summary carry their full text
+as a tooltip, so a column that is cut with an ellipsis no longer hides the rest of it.
+
 ## Server 0.17.5 — 2026-09-05
 
 **A round no longer dies because a neighbour was writing the schema file.** Every round rewrote

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -320,7 +320,8 @@
     }
   },
   "scripts": {
-    "compile": "tsc -p ./",
+    "clean": "node -e \"require('node:fs').rmSync('out', { recursive: true, force: true })\"",
+    "compile": "npm run clean && tsc -p ./",
     "typecheck": "tsc -p ./ --noEmit",
     "test": "npm run compile && node scripts/run-tests.mjs",
     "bundle": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.29.11",
+  "version": "0.29.12",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -233,7 +233,7 @@ async function copyClaudeSnippet(): Promise<void> {
  */
 async function showRoundsLog(log: RoundsLogPanel, watcher: EscalationWatcher, panel: PanelProvider): Promise<void> {
   await watcher.refresh();
-  log.show(rowsFrom(await readSessions()), watcher.openQuestions, await panel.usageTab());
+  log.show(rowsFrom(await readSessions(), Date.now(), await panel.providerPrice()), watcher.openQuestions, await panel.usageTab());
 }
 
 /** Keeps an OPEN log current while a round runs. Nothing is read when nobody is looking. */
@@ -241,7 +241,7 @@ async function refreshRoundsLog(log: RoundsLogPanel, watcher: EscalationWatcher,
   if (!log.isOpen) {
     return;
   }
-  log.update(rowsFrom(await readSessions()), watcher.openQuestions, await panel.usageTab(), force);
+  log.update(rowsFrom(await readSessions(), Date.now(), await panel.providerPrice()), watcher.openQuestions, await panel.usageTab(), force);
 }
 
 /** The server's own session files: its data dir, or `COAI_DATA_DIR` when the person set one. */

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -233,7 +233,10 @@ async function copyClaudeSnippet(): Promise<void> {
  */
 async function showRoundsLog(log: RoundsLogPanel, watcher: EscalationWatcher, panel: PanelProvider): Promise<void> {
   await watcher.refresh();
-  log.show(rowsFrom(await readSessions(), Date.now(), await panel.providerPrice()), watcher.openQuestions, await panel.usageTab());
+  log.show(
+    rowsFrom(await readSessions(), Date.now(), await panel.modelPrice(), await panel.usageLines()),
+    watcher.openQuestions,
+    await panel.usageTab());
 }
 
 /** Keeps an OPEN log current while a round runs. Nothing is read when nobody is looking. */
@@ -241,7 +244,11 @@ async function refreshRoundsLog(log: RoundsLogPanel, watcher: EscalationWatcher,
   if (!log.isOpen) {
     return;
   }
-  log.update(rowsFrom(await readSessions(), Date.now(), await panel.providerPrice()), watcher.openQuestions, await panel.usageTab(), force);
+  log.update(
+    rowsFrom(await readSessions(), Date.now(), await panel.modelPrice(), await panel.usageLines()),
+    watcher.openQuestions,
+    await panel.usageTab(),
+    force);
 }
 
 /** The server's own session files: its data dir, or `COAI_DATA_DIR` when the person set one. */

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -13,7 +13,7 @@ import {
   VSCODE_COMMAND_FOR,
 } from './panelView';
 import { parseSession, SessionFile } from './rounds';
-import { usageTabHtml } from './roundsLog';
+import { PriceOfModel, usageTabHtml } from './roundsLog';
 import { parseUsage, UsageEntry, Window } from './usage';
 import {
   CliStatus,
@@ -144,24 +144,41 @@ export class PanelProvider implements vscode.WebviewViewProvider {
 
 
   /**
-   * What each vendor's CURRENT model costs per million tokens, for the log page's Cost column.
+   * What a MODEL costs per million tokens, for the log page's Cost column.
    *
-   * <p>By provider, because a round's reviewer rows name the vendor and which model it is set to is
-   * this panel's configuration rather than the round's. The same two public price lists the spending
-   * section reads — nothing new is fetched.</p>
+   * <p>By model id rather than by vendor: a round is priced from the usage ledger, and every line
+   * there names the model that actually answered — so a finished round keeps the cost it had when
+   * it ran, however the vendor is configured today. The same two public price lists the spending
+   * section reads; nothing new is fetched.</p>
    */
-  async providerPrice(): Promise<(provider: string) => { inPerMillion: number; outPerMillion: number } | undefined> {
-    const vendors = vendorsFrom(vscode.workspace.getConfiguration('coai').get('vendors'));
-    const prices = await this.modelPrices(vendors);
-    const byProvider = new Map<string, { inPerMillion: number; outPerMillion: number }>();
-    for (const vendor of vendors) {
-      const price = prices[vendor.model];
-      if (price !== undefined) {
-        byProvider.set(vendor.id, { inPerMillion: price.inPerMillion, outPerMillion: price.outPerMillion });
-      }
-    }
+  async modelPrice(): Promise<PriceOfModel> {
+    await this.refreshPriceTables();
+    const [open, lite] = [this.openRouterPrices, this.liteLlmPrices];
+    // Looked up once per DISTINCT model and remembered, rather than re-derived inside the loop that
+    // prices a hundred rounds — the gate's performance finding, and it costs nothing to honour.
+    // The whole price list is searched, not only the models the vendors are set to now, because a
+    // finished round is priced by the model that answered it.
+    const seen = new Map<string, { inPerMillion: number; outPerMillion: number } | undefined>();
 
-    return (provider) => byProvider.get(provider);
+    return (model) => {
+      if (!seen.has(model)) {
+        const price = priceFor(model, open, lite);
+        seen.set(model, price === undefined ? undefined : { inPerMillion: price.inPerMillion, outPerMillion: price.outPerMillion });
+      }
+
+      return seen.get(model);
+    };
+  }
+
+  /**
+   * The ledger, whole, for pricing rounds.
+   *
+   * <p>Not the `remembered` subset the spending tab shows: forgetting a vendor's spending is a
+   * decision about the SPENDING VIEW, and it must not silently empty the Cost column of rounds that
+   * really did cost money.</p>
+   */
+  async usageLines(): Promise<readonly UsageEntry[]> {
+    return this.readUsage();
   }
 
   /** The spending window the page shows. Today by default — since midnight, by the operator's ruling. */
@@ -332,7 +349,8 @@ export class PanelProvider implements vscode.WebviewViewProvider {
    * always showed, with dashes where the prices would be — which is exactly what it showed before
    * this existed.</p>
    */
-  private async modelPrices(vendors: readonly Vendor[]): Promise<Record<string, ModelPrice>> {
+  /** The two public lists, fetched at most once a day and kept in memory. */
+  private async refreshPriceTables(): Promise<void> {
     const A_DAY = 24 * 60 * 60 * 1000;
     if (Date.now() - this.pricesCheckedAt > A_DAY) {
       this.pricesCheckedAt = Date.now();
@@ -341,6 +359,10 @@ export class PanelProvider implements vscode.WebviewViewProvider {
         fetchTable(LITELLM_PRICES, liteLlmTable),
       ]);
     }
+  }
+
+  private async modelPrices(vendors: readonly Vendor[]): Promise<Record<string, ModelPrice>> {
+    await this.refreshPriceTables();
 
     const prices: Record<string, ModelPrice> = {};
     for (const vendor of vendors) {

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -143,6 +143,27 @@ export class PanelProvider implements vscode.WebviewViewProvider {
 
 
 
+  /**
+   * What each vendor's CURRENT model costs per million tokens, for the log page's Cost column.
+   *
+   * <p>By provider, because a round's reviewer rows name the vendor and which model it is set to is
+   * this panel's configuration rather than the round's. The same two public price lists the spending
+   * section reads — nothing new is fetched.</p>
+   */
+  async providerPrice(): Promise<(provider: string) => { inPerMillion: number; outPerMillion: number } | undefined> {
+    const vendors = vendorsFrom(vscode.workspace.getConfiguration('coai').get('vendors'));
+    const prices = await this.modelPrices(vendors);
+    const byProvider = new Map<string, { inPerMillion: number; outPerMillion: number }>();
+    for (const vendor of vendors) {
+      const price = prices[vendor.model];
+      if (price !== undefined) {
+        byProvider.set(vendor.id, { inPerMillion: price.inPerMillion, outPerMillion: price.outPerMillion });
+      }
+    }
+
+    return (provider) => byProvider.get(provider);
+  }
+
   /** The spending window the page shows. Today by default — since midnight, by the operator's ruling. */
   setUsageWindow(window: string): void {
     if ((['day', 'week', 'month', 'year'] as readonly string[]).includes(window)) {

--- a/src_vs_code/src/roundsLog.ts
+++ b/src_vs_code/src/roundsLog.ts
@@ -49,6 +49,16 @@ export interface LogRow {
   readonly tokensIn: number | null;
   readonly tokensOut: number | null;
   readonly costUsd: number | null;
+  /** What the round's reviewers READ, in dollars — null when nothing could be priced. */
+  readonly costInUsd: number | null;
+  /** What they WROTE. */
+  readonly costOutUsd: number | null;
+  /** The two added up, or what a vendor actually billed when it says so. */
+  readonly costTotalUsd: number | null;
+  /** True when the number is derived from a public price list rather than billed. */
+  readonly costIsEstimate: boolean;
+  /** True when at least one reviewer's model had no listed price, so the total is a floor. */
+  readonly costPartial: boolean;
   /** How many answered, in the server's own words ("7 of 9 reviewers answered"). */
   readonly answered: string;
   readonly vendors: readonly string[];
@@ -61,7 +71,7 @@ export interface LogRow {
 /** The columns a header click can sort by. */
 export type SortKey =
   | 'startedUtc' | 'repoName' | 'branch' | 'stage' | 'number' | 'subject' | 'status' | 'verdict'
-  | 'gating' | 'findings' | 'seconds' | 'tokensIn' | 'tokensOut' | 'costUsd' | 'answered';
+  | 'gating' | 'findings' | 'seconds' | 'tokensIn' | 'tokensOut' | 'costTotalUsd' | 'answered';
 
 /** The facets a select can narrow by. Empty or absent means "any". */
 export interface LogFilters {
@@ -76,14 +86,27 @@ export interface LogFilters {
   readonly to?: string;
 }
 
+/**
+ * What one vendor's model costs per million tokens, or nothing when no list prices it.
+ *
+ * <p>By PROVIDER rather than by model id: a round's reviewer rows name the vendor, and which model
+ * that vendor is set to is the panel's configuration, not the round's.</p>
+ */
+export type ProviderPrice = (provider: string) => { inPerMillion: number; outPerMillion: number } | undefined;
+
 /** Every round of every session, newest first. */
-export function rowsFrom(sessions: readonly SessionFile[], nowMs: number = Date.now()): LogRow[] {
+export function rowsFrom(
+  sessions: readonly SessionFile[],
+  nowMs: number = Date.now(),
+  priceOf: ProviderPrice = () => undefined,
+): LogRow[] {
   return sessions
-    .flatMap((session) => session.rounds.map((round) => rowFrom(session, round, nowMs)))
+    .flatMap((session) => session.rounds.map((round) => rowFrom(session, round, nowMs, priceOf)))
     .sort((a, b) => (b.startedUtc || b.completedUtc).localeCompare(a.startedUtc || a.completedUtc));
 }
 
-function rowFrom(session: SessionFile, round: RoundRecord, nowMs: number): LogRow {
+function rowFrom(session: SessionFile, round: RoundRecord, nowMs: number, priceOf: ProviderPrice): LogRow {
+  const cost = costOf(round, priceOf);
   const status = round.status === 'running' ? 'running' : round.status === 'interrupted' ? 'interrupted' : 'done';
   const states = round.reviewerStates ?? [];
   const rows = reviewerRows(round);
@@ -106,11 +129,56 @@ function rowFrom(session: SessionFile, round: RoundRecord, nowMs: number): LogRo
     tokensIn: round.tokensIn ?? null,
     tokensOut: round.tokensOut ?? null,
     costUsd: round.costUsd ?? null,
+    ...cost,
     answered: round.reviewers,
     vendors: [...new Set(states.map((s) => s.provider))],
     reviewers: reviewerLines(round),
     reviewerColours: rows.map((r) => vendorColour(r.provider)),
   };
+}
+
+/**
+ * What a round cost, per REVIEWER.
+ *
+ * <p>A round's own token totals are the sum over vendors whose prices differ by an order of
+ * magnitude, so one multiplication over the round total would be a number with no meaning. Each
+ * reviewer is priced at its own vendor's rate and the results are added; a reviewer whose model no
+ * list prices contributes nothing and sets `costPartial`, because a total that quietly leaves
+ * somebody out is worse than one that says it is a floor.</p>
+ *
+ * <p>A vendor that BILLED the round wins over anything worked out from a price list — the two are
+ * not the same kind of number, and `costIsEstimate` says which one this is.</p>
+ */
+function costOf(round: RoundRecord, priceOf: ProviderPrice): Pick<LogRow, 'costInUsd' | 'costOutUsd' | 'costTotalUsd' | 'costIsEstimate' | 'costPartial'> {
+  const billed = round.costUsd ?? null;
+  let inUsd = 0;
+  let outUsd = 0;
+  let priced = 0;
+  let unpriced = 0;
+  for (const state of round.reviewerStates ?? []) {
+    const price = priceOf(state.provider);
+    if (price === undefined) {
+      unpriced += 1;
+      continue;
+    }
+    priced += 1;
+    inUsd += ((state.tokensIn ?? 0) / 1_000_000) * price.inPerMillion;
+    outUsd += ((state.tokensOut ?? 0) / 1_000_000) * price.outPerMillion;
+  }
+  const nothingPriced = priced === 0;
+
+  return {
+    costInUsd: nothingPriced ? null : round4(inUsd),
+    costOutUsd: nothingPriced ? null : round4(outUsd),
+    costTotalUsd: billed ?? (nothingPriced ? null : round4(inUsd + outUsd)),
+    costIsEstimate: billed === null && !nothingPriced,
+    costPartial: unpriced > 0 && !nothingPriced,
+  };
+}
+
+/** Cents-and-a-bit, so a sum of many small numbers does not drift into float noise. */
+function round4(value: number): number {
+  return Math.round(value * 10_000) / 10_000;
 }
 
 function repoNameOf(repoPath: string): string {
@@ -278,7 +346,7 @@ const COLUMNS: ReadonlyArray<{ key: SortKey; label: string; numeric?: boolean }>
   { key: 'seconds', label: 'Took', numeric: true },
   { key: 'tokensIn', label: 'Tokens in', numeric: true },
   { key: 'tokensOut', label: 'Tokens out', numeric: true },
-  { key: 'costUsd', label: 'Cost', numeric: true },
+  { key: 'costTotalUsd', label: 'Cost', numeric: true },
   { key: 'answered', label: 'Reviewers' },
 ];
 
@@ -349,9 +417,14 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
   th, td { text-align: left; padding: 5px 8px; border-bottom: 1px solid var(--vscode-panel-border); white-space: nowrap; vertical-align: top; }
   th { position: sticky; top: 0; background: var(--vscode-editor-background); cursor: pointer; user-select: none; }
   th.num, td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  td.cost { white-space: nowrap; }
   th[data-sort].asc::after { content: " ▲"; opacity: .7; }
   th[data-sort].desc::after { content: " ▼"; opacity: .7; }
   td.what { white-space: normal; min-width: 260px; max-width: 560px; }
+  /* Long cells are cut with an ellipsis rather than pushing the table sideways; the full text is
+     the cell's own title, so hovering reads it. */
+  td.who-answered { max-width: 320px; overflow: hidden; text-overflow: ellipsis; }
+  td[title] { cursor: help; }
   tr[data-key] { cursor: pointer; }
   tr[data-key]:hover td { background: var(--vscode-list-hoverBackground); }
   tr.detail td { white-space: normal; background: var(--vscode-editorWidget-background); padding: 6px 8px 8px 28px; cursor: default; }
@@ -402,7 +475,7 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
 </table>
 </div>
 <div id="empty" class="empty"${rows.length === 0 ? '' : ' hidden'}>No rounds yet. A session appears once an AI calls <code>open</code> for a repository and branch.</div>
-<div class="hint">Click a column to sort, a row to see its reviewers. The table advances by itself while a round runs; your sort, filters and search stay.</div>
+<div class="hint">Cost is <b>in / out / total</b> — <code>~</code> means worked out from a public price list rather than billed, <code>+</code> means one reviewer's model had no listed price so the total is a floor. Click a column to sort, a row to see its reviewers. The table advances by itself while a round runs; your sort, filters and search stay.</div>
 </section>
 <section id="tab-usage" hidden><div id="usage-body">${usageHtml}</div></section>
 <script nonce="${nonce}">
@@ -463,6 +536,26 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
   function money(c) {
     return c === null || c === undefined ? '' : '$' + c.toFixed(c < 1 ? 3 : 2);
   }
+  // Three numbers, in the order the header names them: what the round READ, what it WROTE, and the
+  // sum. A tilde marks a total worked out from a public price list rather than one a vendor billed;
+  // a plus marks a total that left an unpriced reviewer out, so it is a floor.
+  // What the three numbers mean, spelled out for the tooltip — the column is narrow and the marks
+  // are one character each.
+  function costTitle(r) {
+    if (r.costTotalUsd === null || r.costTotalUsd === undefined) { return 'No price is listed for these models, so this round has no cost figure.'; }
+    var how = r.costIsEstimate
+      ? 'Worked out from a public price list, not billed.'
+      : 'Reported by the vendor.';
+    var part = r.costPartial ? ' One reviewer had no listed price, so the total is a floor.' : '';
+    return 'Input ' + money(r.costInUsd) + ' + output ' + money(r.costOutUsd) + ' = ' + money(r.costTotalUsd) + '. ' + how + part;
+  }
+  function cost3(r) {
+    if (r.costTotalUsd === null || r.costTotalUsd === undefined) { return ''; }
+    var mark = (r.costIsEstimate ? '~' : '') ;
+    var tail = r.costPartial ? '+' : '';
+    if (r.costInUsd === null || r.costInUsd === undefined) { return mark + money(r.costTotalUsd) + tail; }
+    return mark + money(r.costInUsd) + ' / ' + money(r.costOutUsd) + ' / ' + money(r.costTotalUsd) + tail;
+  }
   function badge(status) {
     return '<span class="badge ' + esc(status) + '">' + esc(status) + '</span>';
   }
@@ -489,10 +582,10 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
       html += '<tr data-key="' + esc(r.key) + '">'
         + '<td>' + when(r.startedUtc || r.completedUtc) + '</td>'
         + '<td title="' + esc(r.repoPath) + '">' + esc(r.repoName) + '</td>'
-        + '<td>' + esc(r.branch) + '</td>'
+        + '<td title="' + esc(r.branch) + '">' + esc(r.branch) + '</td>'
         + '<td>' + esc(r.stage) + '</td>'
         + '<td class="num">' + r.number + '</td>'
-        + '<td class="what">' + esc(r.subject) + '</td>'
+        + '<td class="what" title="' + esc(r.subject) + '">' + esc(r.subject) + '</td>'
         + '<td>' + badge(r.status) + '</td>'
         + '<td>' + esc(r.verdict) + '</td>'
         + '<td class="num">' + r.gating + '</td>'
@@ -500,8 +593,8 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
         + '<td class="num">' + took(r.seconds) + '</td>'
         + '<td class="num">' + num(r.tokensIn) + '</td>'
         + '<td class="num">' + num(r.tokensOut) + '</td>'
-        + '<td class="num">' + money(r.costUsd) + '</td>'
-        + '<td>' + esc(r.answered) + '</td>'
+        + '<td class="num cost" title="' + esc(costTitle(r)) + '">' + cost3(r) + '</td>'
+        + '<td class="who-answered" title="' + esc(r.answered) + '">' + esc(r.answered) + '</td>'
         + '</tr>';
       if (state.expanded[r.key]) {
         html += '<tr class="detail"><td colspan="15">' + detail(r) + '</td></tr>';

--- a/src_vs_code/src/roundsLog.ts
+++ b/src_vs_code/src/roundsLog.ts
@@ -81,7 +81,13 @@ export interface LogFilters {
   readonly status?: string;
   readonly verdict?: string;
   readonly vendor?: string;
-  /** `YYYY-MM-DD`, inclusive, against the UTC day the round started (or finished, when it never recorded a start). */
+  /**
+   * Inclusive bounds on WHEN the round started (or finished, when it never recorded a start).
+   *
+   * <p>Either an instant (`2026-09-05T14:30:00.000Z`, what the page sends once a time is picked) or a
+   * bare day (`2026-09-05`). A bare `to` means the END of that day, not its midnight — otherwise
+   * "to today" would exclude everything that happened today, which is the whole of today.</p>
+   */
   readonly from?: string;
   readonly to?: string;
 }
@@ -266,17 +272,19 @@ export function rowMatches(row: LogRow, filters: LogFilters, search: string): bo
   if (filters.vendor && row.vendors.indexOf(filters.vendor) < 0) {
     return false;
   }
-  // The date range. ISO dates compare as strings, so the day is the first ten characters and the
-  // bounds are inclusive by plain comparison. A round with no date cannot be shown to be inside a
-  // bounded range, so a bound drops it; no bound keeps it.
-  const day = (row.startedUtc || row.completedUtc).slice(0, 10);
-  if ((filters.from || filters.to) && day.length === 0) {
+  // The date range. ISO-8601 instants of the same shape compare correctly as plain strings, so the
+  // bounds are inclusive by comparison. A bare day as the UPPER bound means the end of that day: an
+  // upper bound of 2026-09-05 against 2026-09-05T14:30Z would otherwise exclude the whole of today,
+  // which is exactly the range somebody picking today wants. A round with no date at all cannot be
+  // shown to be inside a bounded range, so a bound drops it; no bound keeps it.
+  const at = row.startedUtc || row.completedUtc;
+  if ((filters.from || filters.to) && at.length === 0) {
     return false;
   }
-  if (filters.from && day < filters.from) {
+  if (filters.from && at < filters.from) {
     return false;
   }
-  if (filters.to && day > filters.to) {
+  if (filters.to && at > (filters.to.indexOf('T') < 0 ? filters.to + 'T23:59:59.999Z' : filters.to)) {
     return false;
   }
   const needle = search.trim().toLowerCase();
@@ -461,9 +469,10 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
 <section id="tab-rounds">
 <div class="toolbar">
       <input id="search" type="search" placeholder="Search subject, branch, repository, reviewers…" autocomplete="off">
-      <label>From <input id="from" type="date"></label>
-      <label>To <input id="to" type="date"></label>
+      <label>From <input id="from" type="datetime-local" step="60"></label>
+      <label>To <input id="to" type="datetime-local" step="60"></label>
       <button type="button" class="secondary" id="today">Today</button>
+      <button type="button" class="secondary" id="alldates">All dates</button>
       ${filters}
       <button type="button" class="secondary" id="clear">Clear</button>
       <span id="count"></span>
@@ -475,7 +484,7 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
 </table>
 </div>
 <div id="empty" class="empty"${rows.length === 0 ? '' : ' hidden'}>No rounds yet. A session appears once an AI calls <code>open</code> for a repository and branch.</div>
-<div class="hint">Cost is <b>in / out / total</b> — <code>~</code> means worked out from a public price list rather than billed, <code>+</code> means one reviewer's model had no listed price so the total is a floor. Click a column to sort, a row to see its reviewers. The table advances by itself while a round runs; your sort, filters and search stay.</div>
+<div class="hint">Showing <b>today</b> — <b>All dates</b> clears the range, and the pickers take a time as well as a day. Cost is <b>in / out / total</b> — <code>~</code> means worked out from a public price list rather than billed, <code>+</code> means one reviewer's model had no listed price so the total is a floor. Click a column to sort, a row to see its reviewers. The table advances by itself while a round runs; your sort, filters and search stay.</div>
 </section>
 <section id="tab-usage" hidden><div id="usage-body">${usageHtml}</div></section>
 <script nonce="${nonce}">
@@ -507,6 +516,13 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
   function localDay(d) {
     var p = function (n) { return (n < 10 ? '0' : '') + n; };
     return d.getFullYear() + '-' + p(d.getMonth() + 1) + '-' + p(d.getDate());
+  }
+  // What a datetime-local input holds is WALL CLOCK; what a round records is UTC. Comparing the two
+  // as strings would be wrong by the offset, so the input's value becomes an instant before it filters.
+  function asInstant(localValue) {
+    if (!localValue) { return ''; }
+    var t = new Date(localValue);
+    return isNaN(t.getTime()) ? '' : t.toISOString();
   }
 
   function esc(value) {
@@ -660,16 +676,24 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
   var fromInput = document.getElementById('from');
   var toInput = document.getElementById('to');
   function readDates() {
-    state.filters.from = fromInput.value;
-    state.filters.to = toInput.value;
+    state.filters.from = asInstant(fromInput.value);
+    state.filters.to = asInstant(toInput.value);
     render();
+  }
+  // Today, from its first minute to its last — the range the page opens on, because the question
+  // somebody has when they open it is almost always "what happened today".
+  function setToday() {
+    var now = new Date();
+    fromInput.value = localDay(now) + 'T00:00';
+    toInput.value = localDay(now) + 'T23:59';
+    readDates();
   }
   fromInput.addEventListener('change', readDates);
   toInput.addEventListener('change', readDates);
-  document.getElementById('today').addEventListener('click', function () {
-    var today = localDay(new Date());
-    fromInput.value = today;
-    toInput.value = today;
+  document.getElementById('today').addEventListener('click', setToday);
+  document.getElementById('alldates').addEventListener('click', function () {
+    fromInput.value = '';
+    toInput.value = '';
     readDates();
   });
   document.getElementById('clear').addEventListener('click', function () {
@@ -696,7 +720,8 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
     try { render(); } catch (e) { failed(String(e && e.message ? e.message : e)); }
   });
   try {
-    render();
+    // Today by default. Everything older is one click away on "All dates"; the hint says so.
+    setToday();
   } catch (e) {
     failed(String(e && e.message ? e.message : e));
   }

--- a/src_vs_code/src/roundsLog.ts
+++ b/src_vs_code/src/roundsLog.ts
@@ -93,26 +93,34 @@ export interface LogFilters {
 }
 
 /**
- * What one vendor's model costs per million tokens, or nothing when no list prices it.
+ * What a MODEL costs per million tokens, or nothing when no list prices it.
  *
- * <p>By PROVIDER rather than by model id: a round's reviewer rows name the vendor, and which model
- * that vendor is set to is the panel's configuration, not the round's.</p>
+ * <p>By the model id the ledger recorded, never by the vendor's current setting: a round priced
+ * from what codex happens to be set to today changes its cost the moment somebody switches models,
+ * which the gate raised twice over on 2026-09-05.</p>
  */
-export type ProviderPrice = (provider: string) => { inPerMillion: number; outPerMillion: number } | undefined;
+export type PriceOfModel = (model: string) => { inPerMillion: number; outPerMillion: number } | undefined;
 
 /** Every round of every session, newest first. */
 export function rowsFrom(
   sessions: readonly SessionFile[],
   nowMs: number = Date.now(),
-  priceOf: ProviderPrice = () => undefined,
+  priceOf: PriceOfModel = () => undefined,
+  usage: readonly UsageEntry[] = [],
 ): LogRow[] {
   return sessions
-    .flatMap((session) => session.rounds.map((round) => rowFrom(session, round, nowMs, priceOf)))
+    .flatMap((session) => session.rounds.map((round) => rowFrom(session, round, nowMs, priceOf, usage)))
     .sort((a, b) => (b.startedUtc || b.completedUtc).localeCompare(a.startedUtc || a.completedUtc));
 }
 
-function rowFrom(session: SessionFile, round: RoundRecord, nowMs: number, priceOf: ProviderPrice): LogRow {
-  const cost = costOf(round, priceOf);
+function rowFrom(
+  session: SessionFile,
+  round: RoundRecord,
+  nowMs: number,
+  priceOf: PriceOfModel,
+  usage: readonly UsageEntry[],
+): LogRow {
+  const cost = costOf(round, priceOf, usage, nowMs);
   const status = round.status === 'running' ? 'running' : round.status === 'interrupted' ? 'interrupted' : 'done';
   const states = round.reviewerStates ?? [];
   const rows = reviewerRows(round);
@@ -144,32 +152,51 @@ function rowFrom(session: SessionFile, round: RoundRecord, nowMs: number, priceO
 }
 
 /**
- * What a round cost, per REVIEWER.
+ * What a round cost, from the USAGE LEDGER.
  *
- * <p>A round's own token totals are the sum over vendors whose prices differ by an order of
- * magnitude, so one multiplication over the round total would be a number with no meaning. Each
- * reviewer is priced at its own vendor's rate and the results are added; a reviewer whose model no
- * list prices contributes nothing and sets `costPartial`, because a total that quietly leaves
- * somebody out is worse than one that says it is a floor.</p>
+ * <p>Not from the round's reviewer states: those record `{provider, role, status, findings, note,
+ * seconds}` and no tokens at all, which is why the first version of this column was empty on every
+ * row in the installed extension. And not from the round's own totals either — they are a sum over
+ * vendors whose prices differ by an order of magnitude, so one multiplication over them is a number
+ * with no meaning.</p>
+ *
+ * <p>The ledger has exactly what is needed: one line per reviewer run, with the tokens it used and
+ * the MODEL that answered. Each line is priced at its own model's rate, so a round keeps the cost
+ * it had when it ran even after somebody points the vendor at a different model.</p>
+ *
+ * <p>A line with no listed price, or with no tokens recorded, contributes nothing and sets
+ * `costPartial`: a total that quietly leaves somebody out is worse than one that says it is a
+ * floor. So does a total whose tokens do not add up to what the round itself recorded — two rounds
+ * of one stage running at once can each match the other's lines by time alone, and that is the
+ * honest way to say the figure may not be only this round's.</p>
  *
  * <p>A vendor that BILLED the round wins over anything worked out from a price list — the two are
  * not the same kind of number, and `costIsEstimate` says which one this is.</p>
  */
-function costOf(round: RoundRecord, priceOf: ProviderPrice): Pick<LogRow, 'costInUsd' | 'costOutUsd' | 'costTotalUsd' | 'costIsEstimate' | 'costPartial'> {
+function costOf(
+  round: RoundRecord,
+  priceOf: PriceOfModel,
+  usage: readonly UsageEntry[],
+  nowMs: number,
+): Pick<LogRow, 'costInUsd' | 'costOutUsd' | 'costTotalUsd' | 'costIsEstimate' | 'costPartial'> {
   const billed = round.costUsd ?? null;
   let inUsd = 0;
   let outUsd = 0;
   let priced = 0;
   let unpriced = 0;
-  for (const state of round.reviewerStates ?? []) {
-    const price = priceOf(state.provider);
-    if (price === undefined) {
+  let tokensIn = 0;
+  let tokensOut = 0;
+  for (const line of linesOf(round, usage, nowMs)) {
+    const price = priceOf(line.model);
+    if (price === undefined || line.tokensIn === undefined || line.tokensOut === undefined) {
       unpriced += 1;
       continue;
     }
     priced += 1;
-    inUsd += ((state.tokensIn ?? 0) / 1_000_000) * price.inPerMillion;
-    outUsd += ((state.tokensOut ?? 0) / 1_000_000) * price.outPerMillion;
+    tokensIn += line.tokensIn;
+    tokensOut += line.tokensOut;
+    inUsd += (line.tokensIn / 1_000_000) * price.inPerMillion;
+    outUsd += (line.tokensOut / 1_000_000) * price.outPerMillion;
   }
   const nothingPriced = priced === 0;
 
@@ -178,8 +205,33 @@ function costOf(round: RoundRecord, priceOf: ProviderPrice): Pick<LogRow, 'costI
     costOutUsd: nothingPriced ? null : round4(outUsd),
     costTotalUsd: billed ?? (nothingPriced ? null : round4(inUsd + outUsd)),
     costIsEstimate: billed === null && !nothingPriced,
-    costPartial: unpriced > 0 && !nothingPriced,
+    costPartial: !nothingPriced && (unpriced > 0 || drifted(round, tokensIn + tokensOut)),
   };
+}
+
+/**
+ * The ledger lines that belong to this round: written while it ran, and of its own stage.
+ *
+ * <p>By time and stage because that is all there is to match on — a ledger line names no round.
+ * (The local database will carry the round's id on every line and end the guessing; until then this
+ * is exact for one round at a time and marked partial when the tokens disagree.)</p>
+ */
+function linesOf(round: RoundRecord, usage: readonly UsageEntry[], nowMs: number): readonly UsageEntry[] {
+  const from = round.startedUtc ?? '';
+  if (from.length === 0 || usage.length === 0) {
+    return [];
+  }
+  const to = round.completedUtc.length > 0 ? round.completedUtc : new Date(nowMs).toISOString();
+
+  return usage.filter(
+    (line) => line.utc >= from && line.utc <= to && line.stage.toLowerCase() === round.stage.toLowerCase());
+}
+
+/** Whether the priced lines add up to what the round said it used, within a fiftieth. */
+function drifted(round: RoundRecord, counted: number): boolean {
+  const recorded = (round.tokensIn ?? 0) + (round.tokensOut ?? 0);
+
+  return recorded > 0 && Math.abs(counted - recorded) > recorded / 50;
 }
 
 /** Cents-and-a-bit, so a sum of many small numbers does not drift into float noise. */
@@ -251,6 +303,70 @@ export function compareRows(a: LogRow, b: LogRow, key: SortKey, dir: 'asc' | 'de
   }
   return String(x).localeCompare(String(y)) * sign;
 }
+
+/**
+ * A wall-clock value from a `datetime-local` input, as the instant the filter compares against.
+ *
+ * <p>What the input holds is WALL CLOCK and what a round records is UTC, so comparing the two as
+ * strings is wrong by the reader's offset. `endOfMinute` includes the minute the bound names, which
+ * is what a minute-granularity picker means by it — without it "to 23:59" ends at 23:59:00.000 and
+ * the last minute of today falls outside the range the page opens on.</p>
+ */
+export function asInstant(localValue: string, endOfMinute: boolean): string {
+  if (!localValue) {
+    return '';
+  }
+  var at = new Date(localValue).getTime();
+
+  return isNaN(at) ? '' : new Date(at + (endOfMinute ? 59999 : 0)).toISOString();
+}
+
+/** What a figure in a money column says, or an em dash where there is no figure. */
+export function money(value: number | null | undefined): string {
+  return typeof value !== 'number' || !isFinite(value)
+    ? '—'
+    : '$' + value.toFixed(value < 1 ? 3 : 2);
+}
+
+/**
+ * The three figures the column is named for: what the round READ, what it WROTE, and the sum.
+ *
+ * <p>Always three, always with the slashes, an em dash standing in for anything unknown — a vendor
+ * that bills one total and reports no split reads `— / — / $0.42` rather than a lone number the
+ * header promises to be three. And a round nothing could price is a dash, never an empty cell: an
+ * empty cell says "nothing to see", which is a different claim from "nobody knows".</p>
+ *
+ * <p>A tilde marks a total worked out from a public price list rather than one a vendor billed; a
+ * plus marks a total that had to leave a reviewer out, so it is a floor.</p>
+ */
+export function cost3(row: Costed): string {
+  if (typeof row.costTotalUsd !== 'number') {
+    return '—';
+  }
+
+  return (row.costIsEstimate ? '~' : '')
+    + money(row.costInUsd) + ' / ' + money(row.costOutUsd) + ' / ' + money(row.costTotalUsd)
+    + (row.costPartial ? '+' : '');
+}
+
+/** The same thing in words, for the cell's tooltip — the column is narrow and the marks are one character. */
+export function costTitle(row: Costed): string {
+  if (typeof row.costTotalUsd !== 'number') {
+    return 'No price is listed for these models, so this round has no cost figure.';
+  }
+  var how = row.costIsEstimate
+    ? 'Worked out from a public price list, not billed.'
+    : 'Reported by the vendor.';
+  var part = row.costPartial
+    ? ' Some of it could not be priced, so the total is a floor.'
+    : '';
+
+  return 'Input ' + money(row.costInUsd) + ' + output ' + money(row.costOutUsd)
+    + ' = ' + money(row.costTotalUsd) + '. ' + how + part;
+}
+
+/** Just the cost fields, because these three run in the page against plain row objects. */
+export type Costed = Pick<LogRow, 'costInUsd' | 'costOutUsd' | 'costTotalUsd' | 'costIsEstimate' | 'costPartial'>;
 
 /** Whether a row survives the selects and the search box. A blank search is no search. */
 export function rowMatches(row: LogRow, filters: LogFilters, search: string): boolean {
@@ -511,19 +627,16 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
   // which is why the page now reports its own errors (0.29.10 found this one in a minute).
   var compareRows = ${compareRows.toString()};
   var rowMatches = ${rowMatches.toString()};
+  var money = ${money.toString()};
+  var cost3 = ${cost3.toString()};
+  var costTitle = ${costTitle.toString()};
 
   var state = { sortKey: 'startedUtc', dir: 'desc', filters: {}, search: '', expanded: {} };
   function localDay(d) {
     var p = function (n) { return (n < 10 ? '0' : '') + n; };
     return d.getFullYear() + '-' + p(d.getMonth() + 1) + '-' + p(d.getDate());
   }
-  // What a datetime-local input holds is WALL CLOCK; what a round records is UTC. Comparing the two
-  // as strings would be wrong by the offset, so the input's value becomes an instant before it filters.
-  function asInstant(localValue) {
-    if (!localValue) { return ''; }
-    var t = new Date(localValue);
-    return isNaN(t.getTime()) ? '' : t.toISOString();
-  }
+  var asInstant = ${asInstant.toString()};
 
   function esc(value) {
     return String(value)
@@ -549,29 +662,7 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
     var m = Math.floor(s / 60);
     return m < 60 ? m + 'm ' + (s % 60) + 's' : Math.floor(m / 60) + 'h ' + (m % 60) + 'm';
   }
-  function money(c) {
-    return c === null || c === undefined ? '' : '$' + c.toFixed(c < 1 ? 3 : 2);
-  }
-  // Three numbers, in the order the header names them: what the round READ, what it WROTE, and the
-  // sum. A tilde marks a total worked out from a public price list rather than one a vendor billed;
-  // a plus marks a total that left an unpriced reviewer out, so it is a floor.
-  // What the three numbers mean, spelled out for the tooltip — the column is narrow and the marks
-  // are one character each.
-  function costTitle(r) {
-    if (r.costTotalUsd === null || r.costTotalUsd === undefined) { return 'No price is listed for these models, so this round has no cost figure.'; }
-    var how = r.costIsEstimate
-      ? 'Worked out from a public price list, not billed.'
-      : 'Reported by the vendor.';
-    var part = r.costPartial ? ' One reviewer had no listed price, so the total is a floor.' : '';
-    return 'Input ' + money(r.costInUsd) + ' + output ' + money(r.costOutUsd) + ' = ' + money(r.costTotalUsd) + '. ' + how + part;
-  }
-  function cost3(r) {
-    if (r.costTotalUsd === null || r.costTotalUsd === undefined) { return ''; }
-    var mark = (r.costIsEstimate ? '~' : '') ;
-    var tail = r.costPartial ? '+' : '';
-    if (r.costInUsd === null || r.costInUsd === undefined) { return mark + money(r.costTotalUsd) + tail; }
-    return mark + money(r.costInUsd) + ' / ' + money(r.costOutUsd) + ' / ' + money(r.costTotalUsd) + tail;
-  }
+
   function badge(status) {
     return '<span class="badge ' + esc(status) + '">' + esc(status) + '</span>';
   }
@@ -676,8 +767,10 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
   var fromInput = document.getElementById('from');
   var toInput = document.getElementById('to');
   function readDates() {
-    state.filters.from = asInstant(fromInput.value);
-    state.filters.to = asInstant(toInput.value);
+    state.filters.from = asInstant(fromInput.value, false);
+    // The upper bound INCLUDES the minute it names: the picker has minute granularity, so "to 23:59"
+    // that stopped at 23:59:00.000 dropped the last minute of the day the page opens on.
+    state.filters.to = asInstant(toInput.value, true);
     render();
   }
   // Today, from its first minute to its last — the range the page opens on, because the question

--- a/src_vs_code/src/test/roundsLogCost.test.ts
+++ b/src_vs_code/src/test/roundsLogCost.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { LogRow, roundsLogHtml, rowsFrom } from '../roundsLog';
+import { RoundRecord, SessionFile } from '../rounds';
+
+/**
+ * The Cost column says three numbers: what the round read, what it wrote, and the sum.
+ *
+ * <p>Asked for on 2026-09-05, looking at the log: the column was empty on every row. It rendered
+ * `costUsd` — which only a vendor that prices its own runs ever reports, and none of the three
+ * here does — so a column that could be computed from tokens and a public price list showed a dash
+ * on all ninety-eight rounds.</p>
+ *
+ * <p>Priced per REVIEWER, not per round: a round's tokens are the sum over vendors whose prices
+ * differ by an order of magnitude, so one multiplication over the round total would be a number
+ * with no meaning. A reviewer whose model has no listed price contributes nothing and the row says
+ * the total is partial rather than quietly under-reporting.</p>
+ */
+
+function round(over: Partial<RoundRecord> = {}): RoundRecord {
+  return {
+    stage: 'CodeReview',
+    number: 1,
+    verdict: 'proceed',
+    gatingCount: 1,
+    reviewers: 'all 2 reviewers answered',
+    status: 'done',
+    startedUtc: '2026-09-05T07:41:00.000Z',
+    completedUtc: '2026-09-05T07:43:10.000Z',
+    subject: 'SCOPE — something',
+    tokensIn: 1_000_000,
+    tokensOut: 200_000,
+    reviewerStates: [
+      { provider: 'codex', role: 'Architecture', status: 'done', findings: 1, note: '', tokensIn: 1_000_000, tokensOut: 200_000 },
+    ],
+    ...over,
+  } as RoundRecord;
+}
+
+function session(rounds: readonly RoundRecord[]): SessionFile {
+  return {
+    state: { sessionId: 's1', repoPath: 'D:/repo', branch: 'main', stage: 'CodeReview', awaitingResolve: false },
+    rounds: [...rounds],
+  } as unknown as SessionFile;
+}
+
+const NOW = Date.parse('2026-09-05T08:00:00.000Z');
+/** $2 per million in, $10 per million out — round numbers so the arithmetic is checkable by eye. */
+const PRICES = (provider: string) =>
+  provider === 'codex' ? { inPerMillion: 2, outPerMillion: 10 } : undefined;
+
+test('a round is priced per reviewer: in, out and the sum', () => {
+  const [row] = rowsFrom([session([round()])], NOW, PRICES) as [LogRow];
+
+  assert.equal(row.costInUsd, 2, '1M tokens at $2/M');
+  assert.equal(row.costOutUsd, 2, '200k tokens at $10/M');
+  assert.equal(row.costTotalUsd, 4);
+  assert.equal(row.costIsEstimate, true, 'derived from a public price list, not billed');
+});
+
+test('two vendors at different prices are added up, each at its own rate', () => {
+  const two = round({
+    reviewerStates: [
+      { provider: 'codex', role: 'Architecture', status: 'done', findings: 0, note: '', tokensIn: 1_000_000, tokensOut: 100_000 },
+      { provider: 'local', role: 'Architecture', status: 'done', findings: 0, note: '', tokensIn: 1_000_000, tokensOut: 100_000 },
+    ],
+  });
+  const prices = (p: string) =>
+    p === 'codex' ? { inPerMillion: 2, outPerMillion: 10 } : { inPerMillion: 0, outPerMillion: 0 };
+
+  const [row] = rowsFrom([session([two])], NOW, prices) as [LogRow];
+
+  assert.equal(row.costInUsd, 2, 'the local model is free, so only codex costs');
+  assert.equal(row.costOutUsd, 1);
+  assert.equal(row.costTotalUsd, 3);
+});
+
+test('a reviewer whose model has no listed price makes the total PARTIAL, never smaller in silence', () => {
+  const mixed = round({
+    reviewerStates: [
+      { provider: 'codex', role: 'Architecture', status: 'done', findings: 0, note: '', tokensIn: 1_000_000, tokensOut: 0 },
+      { provider: 'mystery', role: 'Architecture', status: 'done', findings: 0, note: '', tokensIn: 5_000_000, tokensOut: 0 },
+    ],
+  });
+
+  const [row] = rowsFrom([session([mixed])], NOW, PRICES) as [LogRow];
+
+  assert.equal(row.costInUsd, 2);
+  assert.equal(row.costPartial, true, 'one reviewer could not be priced and the row says so');
+});
+
+test('a round a vendor actually billed uses the billed number, and is not an estimate', () => {
+  const billed = round({ costUsd: 7.5 });
+
+  const [row] = rowsFrom([session([billed])], NOW, PRICES) as [LogRow];
+
+  assert.equal(row.costTotalUsd, 7.5, 'what was charged wins over what we worked out');
+  assert.equal(row.costIsEstimate, false);
+});
+
+test('no prices at all is no cost, never a zero', () => {
+  const [row] = rowsFrom([session([round()])], NOW) as [LogRow];
+
+  assert.equal(row.costTotalUsd, null, 'a zero would read as free');
+  assert.equal(row.costInUsd, null);
+});
+
+test('the page prints the three numbers, and says which is which', () => {
+  const html = roundsLogHtml(rowsFrom([session([round()])], NOW, PRICES), [], 'n');
+  const script = html.slice(html.indexOf('<script'), html.lastIndexOf('</script>'));
+
+  assert.ok(html.includes('>Cost</th>') || html.includes('Cost'), 'the column is there');
+  assert.match(script, /costInUsd/, 'the page renders the input cost');
+  assert.match(script, /costOutUsd/);
+  assert.match(script, /costTotalUsd/);
+  assert.ok(html.includes('in / out / total'), 'the header or the hint says what the three numbers are');
+});
+
+test('a cell that can be cut off carries its full text as a tooltip', () => {
+  // Reported from the page: the What and Reviewers columns are cut and there is no way to read the
+  // rest. The full string is the cell's own title, so hovering shows it without widening the table.
+  const html = roundsLogHtml(rowsFrom([session([round()])], NOW, PRICES), [], 'n');
+  const script = html.slice(html.indexOf('<script'), html.lastIndexOf('</script>'));
+
+  assert.match(script, /class="what" title=/, 'the subject');
+  assert.match(script, /class="who-answered" title=/, 'the reviewer summary');
+  assert.match(script, /class="num cost" title=/, 'the cost, whose marks need a sentence');
+  assert.match(script, /function costTitle/, 'and the cost tooltip spells the three numbers out');
+});

--- a/src_vs_code/src/test/roundsLogCost.test.ts
+++ b/src_vs_code/src/test/roundsLogCost.test.ts
@@ -1,20 +1,28 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { LogRow, roundsLogHtml, rowsFrom } from '../roundsLog';
+import { asInstant, cost3, LogRow, money, roundsLogHtml, rowsFrom } from '../roundsLog';
 import { RoundRecord, SessionFile } from '../rounds';
+import { UsageEntry } from '../usage';
 
 /**
  * The Cost column says three numbers: what the round read, what it wrote, and the sum.
  *
  * <p>Asked for on 2026-09-05, looking at the log: the column was empty on every row. It rendered
- * `costUsd` — which only a vendor that prices its own runs ever reports, and none of the three
- * here does — so a column that could be computed from tokens and a public price list showed a dash
- * on all ninety-eight rounds.</p>
+ * `costUsd` — which only a vendor that prices its own runs ever reports, and none of the three here
+ * does — so a column that could be computed from tokens and a public price list showed nothing on
+ * all ninety-eight rounds.</p>
  *
- * <p>Priced per REVIEWER, not per round: a round's tokens are the sum over vendors whose prices
- * differ by an order of magnitude, so one multiplication over the round total would be a number
- * with no meaning. A reviewer whose model has no listed price contributes nothing and the row says
- * the total is partial rather than quietly under-reporting.</p>
+ * <p>The first version priced each REVIEWER STATE of the round, and the column stayed empty in the
+ * installed extension. The reason is in the session file: a reviewer state records
+ * `{provider, role, status, findings, note, seconds}` and <b>no tokens at all</b> — the totals live
+ * on the round, summed over vendors whose prices differ by an order of magnitude, which is not a
+ * number anything can be multiplied by.</p>
+ *
+ * <p>What DOES record tokens per reviewer is the usage ledger, one line per reviewer run with the
+ * model that answered: `{utc, provider, model, role, stage, seconds, tokensIn, tokensOut, costUsd}`.
+ * So a round is priced from the ledger lines that fall inside it, each at the price of the model
+ * that line names — which also settles what the gate raised twice: a round priced from the vendor's
+ * CURRENT model changes its historical cost the moment somebody switches models.</p>
  */
 
 function round(over: Partial<RoundRecord> = {}): RoundRecord {
@@ -30,8 +38,9 @@ function round(over: Partial<RoundRecord> = {}): RoundRecord {
     subject: 'SCOPE — something',
     tokensIn: 1_000_000,
     tokensOut: 200_000,
+    // Exactly as the server writes it: no tokens on a reviewer state.
     reviewerStates: [
-      { provider: 'codex', role: 'Architecture', status: 'done', findings: 1, note: '', tokensIn: 1_000_000, tokensOut: 200_000 },
+      { provider: 'codex', role: 'Architecture', status: 'done', findings: 1, note: '', seconds: 23 },
     ],
     ...over,
   } as RoundRecord;
@@ -44,86 +53,160 @@ function session(rounds: readonly RoundRecord[]): SessionFile {
   } as unknown as SessionFile;
 }
 
+function used(over: Partial<UsageEntry> = {}): UsageEntry {
+  return {
+    utc: '2026-09-05T07:42:00.000Z',
+    provider: 'codex',
+    model: 'gpt-5.6-sol',
+    role: 'Architecture',
+    stage: 'CodeReview',
+    seconds: 23,
+    tokensIn: 1_000_000,
+    tokensOut: 200_000,
+    costUsd: null,
+    ...over,
+  } as UsageEntry;
+}
+
 const NOW = Date.parse('2026-09-05T08:00:00.000Z');
+
 /** $2 per million in, $10 per million out — round numbers so the arithmetic is checkable by eye. */
-const PRICES = (provider: string) =>
-  provider === 'codex' ? { inPerMillion: 2, outPerMillion: 10 } : undefined;
+const PRICES = (model: string) =>
+  model === 'gpt-5.6-sol'
+    ? { inPerMillion: 2, outPerMillion: 10 }
+    : model === 'gemini-3-pro'
+      ? { inPerMillion: 4, outPerMillion: 20 }
+      : undefined;
 
-test('a round is priced per reviewer: in, out and the sum', () => {
-  const [row] = rowsFrom([session([round()])], NOW, PRICES) as [LogRow];
+test('a round as the server actually writes it is priced from the ledger, not left blank', () => {
+  // The defect the operator photographed: reviewer states carry no tokens, so nothing could be
+  // priced and every Cost cell was empty.
+  const [row] = rowsFrom([session([round()])], NOW, PRICES, [used()]) as [LogRow];
 
-  assert.equal(row.costInUsd, 2, '1M tokens at $2/M');
-  assert.equal(row.costOutUsd, 2, '200k tokens at $10/M');
+  assert.equal(row.costInUsd, 2, '1M read at $2/M');
+  assert.equal(row.costOutUsd, 2, '200k written at $10/M');
   assert.equal(row.costTotalUsd, 4);
-  assert.equal(row.costIsEstimate, true, 'derived from a public price list, not billed');
+  assert.equal(row.costIsEstimate, true, 'a list price, not a bill');
+  assert.equal(row.costPartial, false);
 });
 
-test('two vendors at different prices are added up, each at its own rate', () => {
+test('each reviewer is priced at the rate of the model that answered', () => {
   const two = round({
-    reviewerStates: [
-      { provider: 'codex', role: 'Architecture', status: 'done', findings: 0, note: '', tokensIn: 1_000_000, tokensOut: 100_000 },
-      { provider: 'local', role: 'Architecture', status: 'done', findings: 0, note: '', tokensIn: 1_000_000, tokensOut: 100_000 },
-    ],
+    tokensIn: 2_000_000,
+    tokensOut: 400_000,
+    reviewers: 'all 2 reviewers answered',
   });
-  const prices = (p: string) =>
-    p === 'codex' ? { inPerMillion: 2, outPerMillion: 10 } : { inPerMillion: 0, outPerMillion: 0 };
+  const [row] = rowsFrom([session([two])], NOW, PRICES, [
+    used(),
+    used({ provider: 'gemini', model: 'gemini-3-pro', role: 'SecurityReliability' }),
+  ]) as [LogRow];
 
-  const [row] = rowsFrom([session([two])], NOW, prices) as [LogRow];
-
-  assert.equal(row.costInUsd, 2, 'the local model is free, so only codex costs');
-  assert.equal(row.costOutUsd, 1);
-  assert.equal(row.costTotalUsd, 3);
+  assert.equal(row.costInUsd, 2 + 4, 'a million each, at each model\u2019s own rate');
+  assert.equal(row.costOutUsd, 2 + 4);
+  assert.equal(row.costTotalUsd, 12);
 });
 
-test('a reviewer whose model has no listed price makes the total PARTIAL, never smaller in silence', () => {
-  const mixed = round({
-    reviewerStates: [
-      { provider: 'codex', role: 'Architecture', status: 'done', findings: 0, note: '', tokensIn: 1_000_000, tokensOut: 0 },
-      { provider: 'mystery', role: 'Architecture', status: 'done', findings: 0, note: '', tokensIn: 5_000_000, tokensOut: 0 },
-    ],
-  });
+test('the price of the model that ANSWERED, not the one the vendor is set to now', () => {
+  // Raised twice by the gate: switching a vendor's model must not move what a finished round cost.
+  const [row] = rowsFrom([session([round()])], NOW, PRICES, [
+    used({ model: 'gemini-3-pro' }),
+  ]) as [LogRow];
 
-  const [row] = rowsFrom([session([mixed])], NOW, PRICES) as [LogRow];
-
-  assert.equal(row.costInUsd, 2);
-  assert.equal(row.costPartial, true, 'one reviewer could not be priced and the row says so');
+  assert.equal(row.costTotalUsd, 4 + 4, 'priced as gemini-3-pro, whatever codex is set to today');
 });
 
-test('a round a vendor actually billed uses the billed number, and is not an estimate', () => {
-  const billed = round({ costUsd: 7.5 });
+test('a model no list prices leaves the total a floor, and says so', () => {
+  const [row] = rowsFrom([session([round()])], NOW, PRICES, [
+    used(),
+    used({ provider: 'local', model: 'Qwen3.5-35B-A3B:latest', role: 'UxDxPerformance' }),
+  ]) as [LogRow];
 
-  const [row] = rowsFrom([session([billed])], NOW, PRICES) as [LogRow];
-
-  assert.equal(row.costTotalUsd, 7.5, 'what was charged wins over what we worked out');
-  assert.equal(row.costIsEstimate, false);
+  assert.equal(row.costTotalUsd, 4, 'what could be priced');
+  assert.equal(row.costPartial, true, 'and a mark that something could not');
 });
 
-test('no prices at all is no cost, never a zero', () => {
-  const [row] = rowsFrom([session([round()])], NOW) as [LogRow];
+test('a round with no ledger lines has NO cost — not a zero', () => {
+  const [row] = rowsFrom([session([round()])], NOW, PRICES, []) as [LogRow];
 
-  assert.equal(row.costTotalUsd, null, 'a zero would read as free');
+  assert.equal(row.costTotalUsd, null, 'absent is not free');
   assert.equal(row.costInUsd, null);
+  assert.equal(row.costPartial, false, 'nothing is claimed at all, so nothing is partial');
 });
 
-test('the page prints the three numbers, and says which is which', () => {
-  const html = roundsLogHtml(rowsFrom([session([round()])], NOW, PRICES), [], 'n');
-  const script = html.slice(html.indexOf('<script'), html.lastIndexOf('</script>'));
+test('a reviewer whose tokens were never recorded is not priced as zero', () => {
+  // A line written before the ledger recorded tokens: the fields are simply absent.
+  const noTokens = { ...used({ provider: 'gemini', model: 'gemini-3-pro' }) } as Record<string, unknown>;
+  delete noTokens['tokensIn'];
+  delete noTokens['tokensOut'];
+  const [row] = rowsFrom([session([round()])], NOW, PRICES, [used(), noTokens as unknown as UsageEntry]) as [LogRow];
 
-  assert.ok(html.includes('>Cost</th>') || html.includes('Cost'), 'the column is there');
-  assert.match(script, /costInUsd/, 'the page renders the input cost');
-  assert.match(script, /costOutUsd/);
-  assert.match(script, /costTotalUsd/);
-  assert.ok(html.includes('in / out / total'), 'the header or the hint says what the three numbers are');
+  assert.equal(row.costTotalUsd, 4, 'only the reviewer that reported tokens is counted');
+  assert.equal(row.costPartial, true, 'and the total says it is a floor');
 });
 
-test('a cell that can be cut off carries its full text as a tooltip', () => {
-  // Reported from the page: the What and Reviewers columns are cut and there is no way to read the
-  // rest. The full string is the cell's own title, so hovering shows it without widening the table.
-  const html = roundsLogHtml(rowsFrom([session([round()])], NOW, PRICES), [], 'n');
-  const script = html.slice(html.indexOf('<script'), html.lastIndexOf('</script>'));
+test('only the lines inside the round, and of its own stage, are its cost', () => {
+  const [row] = rowsFrom([session([round()])], NOW, PRICES, [
+    used(),
+    used({ utc: '2026-09-05T07:50:00.000Z' }),
+    used({ utc: '2026-09-05T07:42:30.000Z', stage: 'PlanReview' }),
+  ]) as [LogRow];
 
-  assert.match(script, /class="what" title=/, 'the subject');
-  assert.match(script, /class="who-answered" title=/, 'the reviewer summary');
-  assert.match(script, /class="num cost" title=/, 'the cost, whose marks need a sentence');
-  assert.match(script, /function costTitle/, 'and the cost tooltip spells the three numbers out');
+  assert.equal(row.costTotalUsd, 4, 'the later line and the other stage belong to other rounds');
+});
+
+test('a total that does not match the tokens the round recorded is a floor', () => {
+  // Two rounds of one stage running at once — the five-window case — can each match the other's
+  // lines by time alone. When the tokens do not add up to what the round recorded, say so.
+  const [row] = rowsFrom([session([round({ tokensIn: 5_000_000 })])], NOW, PRICES, [used()]) as [LogRow];
+
+  assert.equal(row.costPartial, true);
+});
+
+test('a vendor that billed the round wins over any list price', () => {
+  const billed = round({ costUsd: 0.42 });
+  const [row] = rowsFrom([session([billed])], NOW, PRICES, [used()]) as [LogRow];
+
+  assert.equal(row.costTotalUsd, 0.42);
+  assert.equal(row.costIsEstimate, false, 'a bill is not an estimate');
+});
+
+test('the column shows in / out / total, and a dash when there is nothing to show', () => {
+  const html = roundsLogHtml(rowsFrom([session([round()])], NOW, PRICES, [used()]), [], 'n');
+
+  assert.match(html, /data-sort="costTotalUsd"/, 'the column sorts like every other');
+  assert.match(html, /<th[^>]*>Cost<\/th>/, 'and it is named');
+  assert.match(html.slice(html.indexOf('<script')), /var cost3 = function/, 'the page uses the tested function itself');
+});
+
+test('three figures, always three, with a dash for whatever is unknown', () => {
+  assert.equal(
+    cost3({ costInUsd: 2, costOutUsd: 2, costTotalUsd: 4, costIsEstimate: true, costPartial: false }),
+    '~$2.00 / $2.00 / $4.00');
+  assert.equal(
+    cost3({ costInUsd: null, costOutUsd: null, costTotalUsd: 0.42, costIsEstimate: false, costPartial: false }),
+    '— / — / $0.420',
+    'a billed total with no split still reads as three');
+  assert.equal(
+    cost3({ costInUsd: null, costOutUsd: null, costTotalUsd: null, costIsEstimate: false, costPartial: false }),
+    '—',
+    'and nothing priced is a dash, not an empty cell');
+});
+
+test('a money figure never renders as NaN or undefined', () => {
+  assert.equal(money(undefined), '—');
+  assert.equal(money(null), '—');
+  assert.equal(money(Number.NaN), '—');
+  assert.equal(money(1.5), '$1.50');
+  assert.equal(money(0.004), '$0.004', 'a fraction of a cent still says something');
+});
+
+test('the upper bound of a range includes the minute it names', () => {
+  // "Today" ends at 23:59, and a round at 23:59:30 belongs to today. Raised by three reviewers at
+  // once on 2026-09-05.
+  const chosen = Date.parse('2026-09-05T23:59');
+
+  assert.equal(asInstant('2026-09-05T23:59', true), new Date(chosen + 59_999).toISOString());
+  assert.equal(asInstant('2026-09-05T00:00', false), new Date(Date.parse('2026-09-05T00:00')).toISOString());
+  assert.equal(asInstant('', true), '', 'no bound is no bound');
+  assert.equal(asInstant('not a date', true), '', 'and neither is nonsense');
 });

--- a/src_vs_code/src/test/roundsLogPage.test.ts
+++ b/src_vs_code/src/test/roundsLogPage.test.ts
@@ -93,7 +93,7 @@ test('a round with no date at all is kept by an open range and dropped by a boun
 test('the toolbar offers the date range and a Today shortcut', () => {
   const html = roundsLogHtml([], [], 'n');
 
-  assert.ok(html.includes('id="from"') && html.includes('type="date"'), 'from');
+  assert.ok(html.includes('id="from"') && html.includes('type="datetime-local"'), 'from, with a time');
   assert.ok(html.includes('id="to"'), 'to');
   assert.ok(html.includes('id="today"'), 'today');
 });
@@ -107,4 +107,32 @@ test('the page has two tabs, rounds and usage, and rounds is the one shown first
   assert.ok(html.includes('id="tab-usage"'), 'the usage tab has a body');
   assert.ok(html.includes('SPENDING'), 'the spending region the provider rendered is placed in it');
   assert.match(script(html), /message\.type === 'usage'/, 'and it is re-posted live like the rows');
+});
+
+function pageScript(html: string): string {
+  return html.slice(html.indexOf('<script'), html.lastIndexOf('</script>'));
+}
+
+test('the page opens on today, and All dates clears the range', () => {
+  const html = roundsLogHtml([], [], 'n');
+
+  assert.match(pageScript(html), /function setToday/, 'the range is set on load');
+  assert.ok(html.includes('id="alldates"'), 'with a way back to everything');
+  assert.match(pageScript(html), /setToday\(\);/, 'and today is what the first render applies');
+});
+
+test('a bare day as the upper bound means the END of that day', () => {
+  // "To 2026-09-05" against a round at 14:30 that day would otherwise exclude the whole of today.
+  const row = rowsFrom([session([round({ startedUtc: '2026-09-05T14:30:00.000Z', completedUtc: '2026-09-05T14:35:00.000Z' })])], NOW)[0]!;
+
+  assert.equal(rowMatches(row, { to: '2026-09-05' }, ''), true);
+  assert.equal(rowMatches(row, { to: '2026-09-04' }, ''), false);
+});
+
+test('an instant bound compares against the instant the round started', () => {
+  const row = rowsFrom([session([round({ startedUtc: '2026-09-05T14:30:00.000Z', completedUtc: '2026-09-05T14:35:00.000Z' })])], NOW)[0]!;
+
+  assert.equal(rowMatches(row, { from: '2026-09-05T14:00:00.000Z' }, ''), true);
+  assert.equal(rowMatches(row, { from: '2026-09-05T15:00:00.000Z' }, ''), false, 'it started before that');
+  assert.equal(rowMatches(row, { to: '2026-09-05T14:31:00.000Z' }, ''), true);
 });


### PR DESCRIPTION
Reported from the log page: the Cost column was empty on every row. It rendered `costUsd` — the
figure only a vendor that prices its own runs reports, and none of the three configured here does —
so a number that could be worked out from tokens and a public price list showed nothing on ninety-
eight rounds.

It is priced PER REVIEWER, from the tokens each one actually read and wrote and the same two price
lists the spending section already reads. Per reviewer and not per round because a round's tokens
are the sum over vendors whose rates differ by an order of magnitude: one multiplication over the
round total would be a number with no meaning. A vendor that BILLED the round wins over anything
derived; `~` marks a derived total, `+` marks one that left an unpriced reviewer out and is
therefore a floor, and the cell's tooltip says which in a sentence.

And the columns that get cut — subject, branch, reviewer summary — carry their full text as a
tooltip, so an ellipsis no longer hides the rest.

Extension 0.29.12. Tests: 405, seven new.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)