### PR TITLE
ci: the title check takes a proper noun in the subject

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,5 +1,10 @@
 name: pr · title
 
+# The subject is free text on purpose: proper nouns start with capitals — SonarCloud, CodeRabbit,
+# Dependabot — and a pattern forbidding a capital first letter rejected six real pull requests in a
+# row, including every one Dependabot opens. The TYPE prefix is the rule; the sentence after it is
+# somebody's writing.
+#
 # The pull request title becomes the line in main's history (rebase keeps commits, squash uses the
 # title), so it has to say what changed in the family's own shape: `type: what changed`.
 on:
@@ -32,6 +37,3 @@ jobs:
             ci
             build
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
-          subjectPatternError: |
-            The subject "{subject}" starts with a capital letter; the family writes `type: lower-case what changed`.


### PR DESCRIPTION
The pattern forbidding a capital first letter is still on main — an earlier removal was overwritten
by a later push to the same branch, and nobody noticed because the check only speaks up on a title
that has one. It has since rejected six pull requests in a row: every Dependabot title ("Bump
typescript…") and every one of mine naming SonarCloud or CodeRabbit.

The type prefix is the rule and stays enforced. What follows it is a sentence somebody wrote, and
proper nouns are capitalised in sentences.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)