### PR TITLE
fix: an escalation answer is refused while the server polls for it

### DIFF
--- a/src_mcp/src/Server/Escalations.cs
+++ b/src_mcp/src/Server/Escalations.cs
@@ -197,6 +197,8 @@ public sealed class Escalations(string dataDir, TimeSpan? pollInterval = null)
     {
         try
         {
+            using var turn = SessionTurn.Take(path);
+
             return JsonSerializer.Deserialize(SharedRead.Text(path), EscalationJsonContext.Default.EscalationQuestion);
         }
         catch (JsonException)
@@ -220,6 +222,7 @@ public sealed class Escalations(string dataDir, TimeSpan? pollInterval = null)
 
         try
         {
+            using var turn = SessionTurn.Take(path);
             var answer = JsonSerializer.Deserialize(SharedRead.Text(path), EscalationJsonContext.Default.EscalationAnswer);
             return answer is { Answer.Length: > 0 } ? answer : null;
         }
@@ -233,8 +236,22 @@ public sealed class Escalations(string dataDir, TimeSpan? pollInterval = null)
         }
     }
 
+    /// <summary>
+    /// Written whole or not at all — and under the same TURN every reader of this file takes.
+    /// </summary>
+    /// <remarks>
+    /// Sharing flags alone are not enough here, and this repository has already measured why: with a
+    /// reader opening the file <c>ReadWrite | Delete</c> and the rename retried ten times over half a
+    /// second, hot readers still starved the writer in two runs of three (see <see cref="SessionTurn"/>).
+    /// The escalation answer is the file a PERSON is writing while the server polls for it a second
+    /// at a time, so it gets the mechanism rather than the hope. Measured on 2026-09-05: 382 of 400
+    /// plain writes and 174 of 200 atomic replacements were refused before this. What carries the
+    /// measurement is the READER taking the turn — this side is symmetry, and it is what protects
+    /// the file from a reader that is not this code.
+    /// </remarks>
     private static void WriteAtomic(string path, string content)
     {
+        using var turn = SessionTurn.Take(path);
         var temp = path + ".tmp";
         File.WriteAllText(temp, content);
         File.Move(temp, path, overwrite: true);

--- a/src_mcp/src/Server/Escalations.cs
+++ b/src_mcp/src/Server/Escalations.cs
@@ -197,7 +197,7 @@ public sealed class Escalations(string dataDir, TimeSpan? pollInterval = null)
     {
         try
         {
-            return JsonSerializer.Deserialize(File.ReadAllText(path), EscalationJsonContext.Default.EscalationQuestion);
+            return JsonSerializer.Deserialize(SharedRead.Text(path), EscalationJsonContext.Default.EscalationQuestion);
         }
         catch (JsonException)
         {
@@ -220,7 +220,7 @@ public sealed class Escalations(string dataDir, TimeSpan? pollInterval = null)
 
         try
         {
-            var answer = JsonSerializer.Deserialize(File.ReadAllText(path), EscalationJsonContext.Default.EscalationAnswer);
+            var answer = JsonSerializer.Deserialize(SharedRead.Text(path), EscalationJsonContext.Default.EscalationAnswer);
             return answer is { Answer.Length: > 0 } ? answer : null;
         }
         catch (JsonException)

--- a/src_mcp/src/Server/Escalations.cs
+++ b/src_mcp/src/Server/Escalations.cs
@@ -205,8 +205,10 @@ public sealed class Escalations(string dataDir, TimeSpan? pollInterval = null)
         {
             return null;
         }
-        catch (IOException)
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
+            // BOTH: a file being replaced right now answers with the second, and this repository has
+            // already lost six rounds to a catch that named only the first.
             return null;
         }
     }
@@ -230,9 +232,9 @@ public sealed class Escalations(string dataDir, TimeSpan? pollInterval = null)
         {
             return null;
         }
-        catch (IOException)
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
-            return null; // being written right now; the next poll will find it whole
+            return null; // being written or replaced right now; the next poll will find it whole
         }
     }
 

--- a/src_mcp/src/Server/SessionStore.cs
+++ b/src_mcp/src/Server/SessionStore.cs
@@ -209,12 +209,10 @@ public sealed class SessionStore(string dataDir)
     private static string ReadShared(string file)
     {
         using var turn = SessionTurn.Take(file);
-        using var stream = new FileStream(
-            file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-        using var reader = new StreamReader(stream);
 
-        return reader.ReadToEnd();
+        return SharedRead.Text(file);
     }
+
 
     public void Save(PersistedSession session)
     {

--- a/src_mcp/src/Server/SharedRead.cs
+++ b/src_mcp/src/Server/SharedRead.cs
@@ -1,0 +1,29 @@
+namespace CoaiMcp.Server;
+
+/// <summary>
+/// Reading a file WITHOUT forbidding anyone else to write it.
+/// </summary>
+/// <remarks>
+/// <para>The cause nobody looks for, and this family has now paid for it four times:
+/// <c>File.ReadAllText</c> opens with <see cref="FileShare.Read"/>, so a READER forbids writing. In a
+/// data directory that five servers and a panel all touch, that turns an ordinary poll into a lock
+/// somebody else's write fails on — and the failure surfaces at the writer, wearing the words
+/// "Access to the path is denied", nowhere near the read that caused it.</para>
+/// <para><see cref="FileShare.Delete"/> belongs in the set as well as <c>ReadWrite</c>: on Windows a
+/// rename over an open file is a delete of that file, so a reader that permits writing but not
+/// deleting still blocks the atomic save every writer here performs.</para>
+/// <para><see cref="SessionStore"/> keeps its own copy of this because its read also takes the
+/// session's turn; everything else in this directory should come through here.</para>
+/// </remarks>
+internal static class SharedRead
+{
+    /// <summary>The file's text, or empty when it cannot be read right now.</summary>
+    public static string Text(string path)
+    {
+        using var stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/src_mcp/src/Server/SharedRead.cs
+++ b/src_mcp/src/Server/SharedRead.cs
@@ -12,12 +12,23 @@ namespace CoaiMcp.Server;
 /// <para><see cref="FileShare.Delete"/> belongs in the set as well as <c>ReadWrite</c>: on Windows a
 /// rename over an open file is a delete of that file, so a reader that permits writing but not
 /// deleting still blocks the atomic save every writer here performs.</para>
-/// <para><see cref="SessionStore"/> keeps its own copy of this because its read also takes the
-/// session's turn; everything else in this directory should come through here.</para>
+/// <para><b>Sharing is half of it.</b> Measured in this repository twice over: with the reader
+/// sharing delete and the rename retried ten times over half a second, hot readers still starved
+/// the writer. So a POLLING reader in this directory pairs this with <see cref="SessionTurn"/>,
+/// which <see cref="SessionStore"/> and <c>Escalations</c> both do — this alone shortens the window
+/// and does not close it.</para>
 /// </remarks>
 internal static class SharedRead
 {
-    /// <summary>The file's text, or empty when it cannot be read right now.</summary>
+    /// <summary>
+    /// The file's text.
+    /// </summary>
+    /// <remarks>
+    /// It THROWS — <see cref="IOException"/> when the file is busy, <see cref="UnauthorizedAccessException"/>
+    /// when it is being replaced underneath — and every caller here treats both as "nothing yet, the
+    /// next poll will find it whole". Said plainly because the first version of this summary claimed
+    /// an empty string, and a future reader would have written no catch at all.
+    /// </remarks>
     public static string Text(string path)
     {
         using var stream = new FileStream(

--- a/src_mcp/tests/EscalationsTests.cs
+++ b/src_mcp/tests/EscalationsTests.cs
@@ -236,4 +236,77 @@ public sealed class EscalationsTests : IDisposable
         await polling;
         failures.Should().Be(0, "a person's answer must not be refused because the server was looking at the file");
     }
+
+    [Fact]
+    public async Task TheServersOwnAtomicWrite_IsNotRefusedByAServerReadingIt()
+    {
+        // The half the first test missed, and the gate caught: the server saves a question by
+        // writing a scratch file and MOVING it over the real one, and on Windows that move is a
+        // DELETE of the open file. Sharing flags alone were measured to be not enough here — with
+        // the reader sharing delete and the rename retried ten times, hot readers still starved the
+        // writer — so both sides take the same TURN, which is the mechanism this repository already
+        // arrived at for session files. 174 of 200 replacements were refused before that.
+        using var stop = new CancellationTokenSource();
+        var polling = Task.Run(() =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                _escalations.DecisionFor("s-1");
+            }
+        });
+
+        var failures = 0;
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            try
+            {
+                _escalations.Notify(Question("q1") with { Question = "attempt " + attempt });
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            {
+                // BOTH, because File.Move answers with UnauthorizedAccessException and this
+                // repository has already lost six rounds to a catch that named only IOException.
+                failures++;
+            }
+        }
+
+        await stop.CancelAsync();
+        await polling;
+        failures.Should().Be(0, "the server's own atomic save must survive another server reading the file");
+    }
+
+    [Fact]
+    public async Task TheSameHoldsForTheQUESTIONFile_NotOnlyTheAnswer()
+    {
+        // Both reads were on the plain File.ReadAllText, and a fix that took only the one this test
+        // suite happened to exercise would leave the other blocking the panel's own writes.
+        var path = _escalations.QuestionPath("q1");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "{}");
+        using var stop = new CancellationTokenSource();
+        var polling = Task.Run(() =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                _escalations.DecisionFor("s-1");
+            }
+        });
+
+        var failures = 0;
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            try
+            {
+                File.WriteAllText(path, "{\"id\":\"q1\",\"text\":\"attempt " + attempt + "\"}");
+            }
+            catch (IOException)
+            {
+                failures++;
+            }
+        }
+
+        await stop.CancelAsync();
+        await polling;
+        failures.Should().Be(0, "the question file is written by the panel while the server reads it");
+    }
 }

--- a/src_mcp/tests/EscalationsTests.cs
+++ b/src_mcp/tests/EscalationsTests.cs
@@ -199,4 +199,41 @@ public sealed class EscalationsTests : IDisposable
         File.Exists(escalations.QuestionPath("qFirst")).Should().BeTrue(
             "a notice nobody can see is the defect, not the cure");
     }
+
+    [Fact]
+    public async Task ReadingAnAnswer_DoesNotForbidWritingIt()
+    {
+        // The defect this family has already paid for three times, in a fourth place: File.ReadAllText
+        // opens with FileShare.Read, so a READER forbids writing. Here the reader is the server
+        // polling for an answer and the writer is the person answering — and their answer fails with
+        // "used by another process" and is lost. Found on 2026-09-05 by a flaky test of this class.
+        var path = _escalations.AnswerPath("q1");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "{}");
+        using var stop = new CancellationTokenSource();
+        var polling = Task.Run(() =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                _escalations.ReadAnswer("q1");
+            }
+        });
+
+        var failures = 0;
+        for (var attempt = 0; attempt < 400; attempt++)
+        {
+            try
+            {
+                File.WriteAllText(path, "{\"answer\":\"attempt " + attempt + "\"}");
+            }
+            catch (IOException)
+            {
+                failures++;
+            }
+        }
+
+        await stop.CancelAsync();
+        await polling;
+        failures.Should().Be(0, "a person's answer must not be refused because the server was looking at the file");
+    }
 }

--- a/src_mcp/tests/EscalationsTests.cs
+++ b/src_mcp/tests/EscalationsTests.cs
@@ -309,4 +309,29 @@ public sealed class EscalationsTests : IDisposable
         await polling;
         failures.Should().Be(0, "the question file is written by the panel while the server reads it");
     }
+
+    [Fact]
+    public void AFileNobodyCanReadRightNow_IsNothingYet_NotAThrow()
+    {
+        // The other half of the sharing contract, and the one that keeps a poll alive: when the file
+        // genuinely cannot be opened — somebody holding it exclusively, a half-finished replacement —
+        // the read answers "nothing yet" and the next poll finds it whole. A throw here would take
+        // down the round that is waiting for the person.
+        var path = _escalations.AnswerPath("q1");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "{\"answer\":\"there\"}");
+        using var held = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        _escalations.ReadAnswer("q1").Should().BeNull("a file nobody can open is not an answer");
+    }
+
+    [Fact]
+    public void AQuestionFileNobodyCanReadRightNow_IsSkipped_NotAThrow()
+    {
+        _escalations.Notify(Question("q1"));
+        using var held = new FileStream(
+            _escalations.QuestionPath("q1"), FileMode.Open, FileAccess.Read, FileShare.None);
+
+        _escalations.DecisionFor("s-1").ToString().Should().Be("None", "and the walk over questions continues");
+    }
 }


### PR DESCRIPTION
**Measured before the fix: 382 of 400 plain writes and 174 of 200 atomic replacements of an escalation answer file were REFUSED while the server polled for it.** The person answering an escalation gets "used by another process", and their answer is lost.

Found by a flaky test of this class — it failed intermittently on its own cleanup, and the reason turned out to be the product, not the test.

## Two causes, both of which this repository had already found in another file

1. **`File.ReadAllText` opens with `FileShare.Read`, so a READER forbids writing.** `Escalations` polls every second for exactly the file a person is writing. `SharedRead.Text` is the shared version, with `FileShare.Delete` in the set as well — on Windows a rename over an open file is a delete of that file, so a reader that permits writing but not deleting still blocks the atomic save every writer here performs. `SessionStore` now composes it instead of keeping a second copy of the flags.
2. **Sharing alone is not enough**, and `SessionTurn`'s own remark records the measurement that says so: *"with the reader opening the file `ReadWrite | Delete` and the rename retried ten times over half a second, four readers in a hot loop still starved the writer in two runs of three. Retrying harder is not a mechanism — it is a hope with a bigger budget. A turn is a mechanism."* So both reads and `WriteAtomic` take the turn. The reader's turn is what carries the measurement; the writer's is symmetry, and it protects the file from a reader that is not this code.

Both reads now catch `UnauthorizedAccessException` as well as `IOException` — a file being replaced underneath answers with the first, and this repository has already lost six rounds to a catch that named only the second.

## Red first, three ways

- a plain write past a polling reader: **382 of 400 refused** before, none after;
- an **atomic replacement** through the product's own `WriteAtomic`, not a hand-rolled move: **174 of 200 refused** before, none after — this test exists because the gate pointed out that the first one passes with `FileShare.ReadWrite` alone while the real save still fails;
- the **question** file as well as the answer — both reads were on the plain reader, and a fix that took only the path this suite happened to exercise would have left the other blocking.

**618 tests pass.**

## The review gate

Both stages, before this pull request. **Plan round:** 11 findings, 4 accepted — the atomic-replacement test, the question-file test, `SessionStore` composing the shared reader, and testing the real writer rather than a simulated one. **Code round 1:** 22 findings, of which 16 were an artefact of a branch cut from a stale local main; 1 accepted (the widened catches). **Code round 2:** `proceed`, 4 findings, 2 accepted — both about this file's own remarks contradicting it. Every finding has a recorded decision and every rejection a reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)