### PR TITLE
feat(extension): the panel can see the gate rule where it now lives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Pin check
         run: node .claude/rules/shared/tools/pin-check.mjs
 
+      # This product's own gate rule is the shared one now, and this repository is where the text
+      # comes from — so a copy here would be the source disagreeing with itself.
+      - name: Gate snippet
+        run: node .claude/rules/shared/tools/gate-snippet-check.mjs
+
       # A workflow file that does not PARSE fails at startup, in zero seconds, with no job, no log
       # and no annotation — and the run that discovers it is the release you just tagged. Measured
       # 2026-09-03: a single stray carriage return inside a quoted `tr -d '\r'` reads as a line

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The snippet the ⋯ menu hands out and the shared rule six repositories load must be the same
+      # text, and the only test that can compare them reads the rule out of this submodule. Without
+      # this step that test has nothing to read — and it FAILS here rather than skipping, because a
+      # skip in CI is how a changed snippet merges behind a green tick. One submodule, depth 1: the
+      # job needs a markdown file, not a history.
+      - name: Conventions submodule
+        run: git submodule update --init --depth 1 .claude/rules/shared
+
       - uses: actions/setup-node@v7
         with:
           node-version: 22

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -28,6 +28,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # blame and new-code detection need the whole history
+      # This job runs the extension's tests for their coverage, and one of them compares the shared
+      # rule with the snippet the menu hands out — so it needs the rule on disk for the same reason
+      # the CI job does. It fails rather than skips without it, deliberately.
+      - name: Conventions submodule
+        run: git submodule update --init --depth 1 .claude/rules/shared
       - uses: actions/setup-java@v6
         with:
           distribution: zulu

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -289,6 +289,20 @@ back out of the workspace's `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` or `.github/co
 of this product should disagree about which files an AI reads. The first file carrying the block
 wins; a repository with it in two places has a problem this panel cannot fix.
 
+**And since 2026-09-04 the block is not a paste at all where a family shares rules.** It is
+`common/coai-review-gate.md` in `dew_flow_conventions`, mounted at `.claude/rules/shared` in six
+repositories, so `SNIPPET_LOCATIONS` continues past the four instruction files to
+`.claude/rules/shared/common/coai-review-gate.md` and its unmounted twin. Named paths, not a walk —
+this runs on every repaint. The instruction files stay FIRST on that list deliberately: a paste in
+`CLAUDE.md` is what the AI in that repository actually reads, so a stale one must be the sentence
+the panel says, and answering with the mounted rule's version instead would be a green light over
+text still being obeyed. The duplicate itself is a red build rather than a panel line —
+`gate-snippet-check.mjs` in the conventions repository fails when a consumer carries its own copy,
+which is the half a panel can never do, because a panel only sees a repository somebody opened.
+`snippetVersion.test.ts` asserts the mounted file is byte-identical to `claudeSnippet()`, skipping
+locally when the submodule is not checked out and FAILING under `CI`, where the workflow initialises
+it and an unchecked drift would merge behind a green tick.
+
 **A number, not a hash — and both.** A hash cannot be forgotten but only answers "different", while
 the useful sentence is "OLDER than the current one": a stale paste and a locally edited one want
 opposite advice, and only an ordered number tells them apart. So the number is ordered and

--- a/src_vs_code/src/claudeSnippet.ts
+++ b/src_vs_code/src/claudeSnippet.ts
@@ -37,6 +37,32 @@ export const SNIPPET_VERSION = 5;
 /** The snippet body's hash, so the version above cannot silently stop meaning anything. */
 export const SNIPPET_BODY_SHA = '4e951347aa178972';
 
+/**
+ * Where a repository is allowed to keep the block, in the order a reader should believe them.
+ *
+ * <p><b>The instruction files come first, and that ordering is the whole point.</b> A block pasted
+ * into `CLAUDE.md` is what the AI in that repository actually reads, so if it is three revisions
+ * old that is the sentence the panel must say — reporting the mounted rule's version instead would
+ * be a green light over the stale text still being obeyed.</p>
+ *
+ * <p>The last two are the shared rule this family now keeps in `dew_flow_conventions`, mounted at
+ * `.claude/rules/shared`, plus the same file kept locally by a repository that has no submodule.
+ * Named paths rather than a walk: this runs on every panel repaint, and the file NAME is the
+ * convention. A repository that files it somewhere else reports `absent`, which is honest — the
+ * panel cannot claim to know about a copy it was never told to look for.</p>
+ */
+export const SNIPPET_LOCATIONS: readonly string[] = [
+  'CLAUDE.md',
+  'AGENTS.md',
+  'GEMINI.md',
+  '.github/copilot-instructions.md',
+  '.claude/rules/shared/common/coai-review-gate.md',
+  '.claude/rules/common/coai-review-gate.md',
+];
+
+/** The sentence a copy is recognised by, wherever it sits. */
+export const SNIPPET_MARKER = 'Multi-model review gate (ConnectOtherAIs)';
+
 /** What a workspace's pasted copy is, relative to what this build hands out. */
 export type SnippetStatus =
   | { readonly kind: 'current'; readonly current: number }
@@ -65,7 +91,7 @@ export function snippetVersionIn(text: string): number | undefined {
  */
 export function snippetStatus(pasted: string | undefined): SnippetStatus {
   const current = SNIPPET_VERSION;
-  if (pasted === undefined || !pasted.includes('Multi-model review gate (ConnectOtherAIs)')) {
+  if (pasted === undefined || !pasted.includes(SNIPPET_MARKER)) {
     return { kind: 'absent', current };
   }
   const found = snippetVersionIn(pasted);

--- a/src_vs_code/src/snippetInWorkspace.ts
+++ b/src_vs_code/src/snippetInWorkspace.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { SnippetStatus, snippetStatus } from './claudeSnippet';
+import { SNIPPET_LOCATIONS, SNIPPET_MARKER, SnippetStatus, snippetStatus } from './claudeSnippet';
 
 /**
  * Which generation of the snippet this workspace is carrying, if any.
@@ -8,6 +8,11 @@ import { SnippetStatus, snippetStatus } from './claudeSnippet';
  * because the COPY command needs the same answer — a person clicking "Copy the CLAUDE.md snippet"
  * is entitled to be told that the copy already in this repository is older than the one they just
  * took — and two readers of the same four files would drift the moment somebody added a fifth.</p>
+ *
+ * <p><b>Since the block became a shared rule</b> (`dew_flow_conventions/common/coai-review-gate.md`,
+ * mounted at `.claude/rules/shared`), a repository in that family keeps NO copy of its own and the
+ * four instruction files are empty of it — so the mounted rule is read too, and such a repository
+ * reports `current` instead of the `absent` it would have reported before.</p>
  */
 export async function pastedSnippetStatus(): Promise<SnippetStatus> {
   const root = vscode.workspace.workspaceFolders?.[0]?.uri;
@@ -15,11 +20,14 @@ export async function pastedSnippetStatus(): Promise<SnippetStatus> {
     return snippetStatus(undefined);
   }
 
-  for (const name of ['CLAUDE.md', 'AGENTS.md', 'GEMINI.md', '.github/copilot-instructions.md']) {
+  for (const name of SNIPPET_LOCATIONS) {
     const text = await readIfPresent(vscode.Uri.joinPath(root, name));
-    // The FIRST file that carries it wins. A repository with the block in two files has a problem
-    // this panel cannot fix, and reporting the older of the two would be arbitrary.
-    if (text.includes('Multi-model review gate (ConnectOtherAIs)')) {
+    // The FIRST location that carries it wins, and the instruction files are first on that list on
+    // purpose: a paste in CLAUDE.md is what the AI here actually READS, so a stale one has to be
+    // the sentence this reports. Answering with the mounted rule's version instead would put a
+    // green light over text three revisions old that is still being obeyed. The duplicate itself
+    // is somebody else's job — `gate-snippet-check.mjs` fails the build over it.
+    if (text.includes(SNIPPET_MARKER)) {
       return snippetStatus(text);
     }
   }

--- a/src_vs_code/src/test/snippetVersion.test.ts
+++ b/src_vs_code/src/test/snippetVersion.test.ts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { test } from 'node:test';
 import {
   claudeSnippet,
   SNIPPET_BODY_SHA,
+  SNIPPET_LOCATIONS,
   SNIPPET_VERSION,
   snippetNote,
   snippetStatus,
@@ -81,6 +84,67 @@ test('the snippet text and its version number move together', () => {
       + `SNIPPET_BODY_SHA to '${sha}'. Both, together — a version that does not move with the text `
       + 'tells every pasted copy it is current forever, which is the defect this exists to catch.',
   );
+});
+
+/**
+ * The block is now a SHARED RULE, and a rule file is a second copy of this text.
+ *
+ * <p>`dew_flow_conventions/common/coai-review-gate.md` is what six repositories actually load, via
+ * the submodule they already mount — so if it and this function ever disagree, the family is
+ * obeying one text while the ⋯ menu hands out another. That is the same defect the version number
+ * exists to catch, one level out, and it gets the same treatment: a test that fails until both move
+ * together.</p>
+ *
+ * <p>This repository mounts that submodule too, which is the only reason the comparison can be made
+ * here at all. Absent submodule: a SKIP locally (a fresh clone without `--recurse-submodules` is a
+ * setup state, not a defect) and a FAILURE under CI, where the workflow initialises it and an
+ * unchecked drift would merge behind a green tick.</p>
+ */
+test('the mounted shared rule is byte-identical to what the menu hands out', (t) => {
+  const mounted = mountedRuleFile();
+  if (mounted === '') {
+    const message = 'the conventions submodule is not checked out — run '
+      + 'git submodule update --init .claude/rules/shared';
+    if (process.env.CI !== undefined) {
+      assert.fail(`${message} (CI must not skip this: it is the only check that the rule matches the snippet)`);
+    }
+    t.skip(message);
+
+    return;
+  }
+
+  assert.equal(
+    fs.readFileSync(mounted, 'utf8').replace(/\r\n/g, '\n'),
+    claudeSnippet(),
+    `${mounted} has drifted from claudeSnippet(). Regenerate it from the snippet — six repositories `
+      + 'load that file, and the one they load is the one being obeyed.',
+  );
+});
+
+/** The rules mount, found by walking up from this file rather than by trusting a cwd. */
+function mountedRuleFile(): string {
+  const relative = path.join('.claude', 'rules', 'shared', 'common', 'coai-review-gate.md');
+  for (let dir = __dirname, seen = ''; dir !== seen; seen = dir, dir = path.dirname(dir)) {
+    const candidate = path.join(dir, relative);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return '';
+}
+
+test('the instruction files are searched BEFORE the mounted rule', () => {
+  // A stale paste in CLAUDE.md is what the AI here reads. Reporting the mounted rule's version
+  // instead would be a green light over the text actually being obeyed.
+  assert.deepEqual(SNIPPET_LOCATIONS.slice(0, 4), [
+    'CLAUDE.md',
+    'AGENTS.md',
+    'GEMINI.md',
+    '.github/copilot-instructions.md',
+  ]);
+  assert.ok(SNIPPET_LOCATIONS.includes('.claude/rules/shared/common/coai-review-gate.md'));
+  assert.ok(SNIPPET_LOCATIONS.includes('.claude/rules/common/coai-review-gate.md'));
 });
 
 test('the panel says nothing when the paste is current or absent', () => {


### PR DESCRIPTION
## What was wrong

The block that teaches a repository's main AI to call this gate used to be **pasted** into each
repository's `CLAUDE.md`, and pasted text does not move when its source does. Measured 2026-09-04:
`dew_flow_creds_for_devs` carried **v2** while the extension handed out **v5** — three revisions
behind, missing the whole COMMANDS block, the "reject in round 1" rule and the enforced stop after
`call_human`. It was found by hand, because `pastedSnippetStatus` only looks at a repository somebody
has opened in VS Code, and only at its four root instruction files.

The rule itself already moved: `dew_flow_conventions/common/coai-review-gate.md` is on that
repository's `main` and pinned in all six consumers, so every session loads it today. This is the
half that was left: the panel could not see it, and nothing failed a build over a repository that
kept its own copy.

## What shipped

- **`SNIPPET_LOCATIONS`** carries the search order and the reason for it. The four instruction files
  stay **first**: a paste in `CLAUDE.md` is what the AI in that repository actually reads, so a stale
  one has to be the sentence the panel says — answering with the mounted rule's version instead would
  be a green light over text still being obeyed. Then the mounted rule and its unmounted twin. Named
  paths, not a walk, because this runs on every panel repaint.
- **A repository whose only copy is the mount now reports `current`** instead of the `absent` it
  would have reported before.
- **A drift guard**: `snippetVersion.test.ts` asserts the mounted file is byte-identical to
  `claudeSnippet()`. It **skips locally** when the submodule is not checked out and **fails under
  `CI`**, where the workflow initialises it — a skip there would let a changed snippet merge behind a
  green tick.
- **The CI step** for `gate-snippet-check.mjs`, at full strength: a copy of the block anywhere
  outside the mounted rule fails the build. This repository is where the text comes from, so a copy
  here would be the source disagreeing with itself.

## What the tests showed

```
npm test (src_vs_code) — tests 419, pass 419, fail 0, skipped 0
gate-snippet-check: OK — the gate rule is only at .claude/rules/shared/common/coai-review-gate.md (v5)
plan-lifecycle: clean.   pin-check: OK — 1 pin(s) at their remote tips.
```

The drift guard was tested in anger rather than trusted: appending one line to the mounted rule
turned it red with its real message — *"has drifted from claudeSnippet()"* — and restoring the file
turned it green.

## Review gate

Plan round: all 3 reviewers answered, verdict `good_enough`, 14 findings — 5 accepted, 9 rejected
with reasons. Two of the rejections were findings that were simply inaccurate about the code (the
checker does read the four root instruction files; `[core]` already closes a submodule section), and
one asked for a runtime drift check that belongs in CI, which is where it is.

The code round for this branch could not run: the gate's own session files were held open, which is
the defect `main` has since fixed with `SessionTurn`. The plan round's findings are all resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)