### PR TITLE
fix(runners): a rate-limited reviewer climbs a ladder instead of retrying once

### DIFF
--- a/research/module_runners.md
+++ b/research/module_runners.md
@@ -80,6 +80,12 @@ sequenceDiagram
   reported through `PanelSettings.Unrecognised` rather than half-applied.
   The round's summary carries the attempts it actually took (`RateLimited.Attempts`), because
   "after one retry" was a true sentence with one step and a confident wrong number with four.
+  **A retry gets what is LEFT of the deadline**, never the whole of it again: a first launch that
+  spends nine minutes of a ten-minute budget and comes back rate limited would otherwise be followed
+  by a second carrying ten more, and a reviewer would run for nineteen minutes against a deadline of
+  ten. And the wait is **said out loud** — the ladder can hold a reviewer for over three minutes,
+  where "running" reads exactly like a model that is thinking, so each wait reports the attempt and
+  how long it will be. Both found by codex reviewing this very change.
 - **Antigravity (`agy`) is the closest fit to this product's contract**: `--json-schema` puts the
   finding schema straight into `result.response`, the same envelope carries `usage`, and the model
   ids carry their own reasoning effort. Its prompt rides `--input-format stream-json` on stdin as

--- a/research/module_runners.md
+++ b/research/module_runners.md
@@ -43,7 +43,8 @@ sequenceDiagram
 | `ReviewerRuntimeSelector` | same | unknown provider refuses naming the catalog |
 | `ReviewerOutcome` (closed), `ReviewerExecutor`, `RateLimit` | `Reviewers/ReviewerExecutor.cs` | one launch + one repair; SIX named outcomes incl. NotStarted; `Ok` carries the run's `Usage`, both launches counted when repaired |
 | `Usage`, `UsageParser` | `core/Findings/UsageParser.cs` | schema-less scan over any vendor envelope; MAX per key name then sum per category, so a streamed cumulative total is never summed with itself; money only when the vendor priced the run |
-| `BoundedScheduler`, `ReviewerWork`, `ReviewerSummaryFactory` | `Reviewers/BoundedScheduler.cs` | global + per-provider semaphores; one rate-limit retry after backoff |
+| `BoundedScheduler`, `ReviewerWork`, `ReviewerSummaryFactory` | `Reviewers/BoundedScheduler.cs` | global + per-provider semaphores; a rate limit climbs the ladder below |
+| `RetryLadder` | `Reviewers/RetryLadder.cs` | the waits and when to stop: four steps, jittered, bounded by the reviewer's own deadline; pure, so the jitter is a table rather than a stopwatch |
 
 ## The decisions a reader needs
 
@@ -62,6 +63,23 @@ sequenceDiagram
   ground, with the visibility half accepted.
 - **Provider cap beside the global cap** — a rate limit is per vendor; a global cap alone puts all
   its slots on one provider.
+- **A rate limit gets a LADDER, not one retry** — 5 s, 30 s, 60 s, 120 s (`COAI_RETRY_BACKOFF`),
+  each spread by up to a fifth either way. One interval was the wrong single number for the two
+  things it had to serve: a plain `429`/`503 high demand` clears in seconds, while a usage window
+  does not clear inside a round at all. The jitter is not decoration — a code round launches nine
+  reviewers at once, so nine meet the limit in the same instant and a fixed interval would send them
+  all back into it in the same instant too.
+  Three things end the climb: the ladder is spent, the limit is **hopeless** (a daily allowance —
+  still not retried at all, ladder or no ladder), or the next wait would outrun the reviewer's own
+  deadline. That last budget counts WALL CLOCK from the first launch, not the sum of the waits: the
+  failed launches are most of the time spent, and 5 s + 30 s of waiting fits a 60-second deadline
+  that the two attempts producing them have already blown.
+  **`COAI_RATE_LIMIT_BACKOFF_SECONDS` still means what it meant** — set alone, it is a one-step
+  ladder at that number. A deployment that deliberately chose 45 seconds must not silently become
+  four retries, and nothing would have said so; an unreadable `COAI_RETRY_BACKOFF` falls back and is
+  reported through `PanelSettings.Unrecognised` rather than half-applied.
+  The round's summary carries the attempts it actually took (`RateLimited.Attempts`), because
+  "after one retry" was a true sentence with one step and a confident wrong number with four.
 - **Antigravity (`agy`) is the closest fit to this product's contract**: `--json-schema` puts the
   finding schema straight into `result.response`, the same envelope carries `usage`, and the model
   ids carry their own reasoning effort. Its prompt rides `--input-format stream-json` on stdin as

--- a/src_mcp/runners/Reviewers/BoundedScheduler.cs
+++ b/src_mcp/runners/Reviewers/BoundedScheduler.cs
@@ -43,15 +43,37 @@ public sealed record ReviewerProgress(
 /// <remarks>
 /// A global cap bounds the machine; a per-provider cap bounds each vendor, because a rate limit
 /// is per vendor and a global cap alone would happily put all of its slots on one provider. A
-/// rate-limited reviewer is retried exactly once after a backoff, and only then reported.
+/// rate-limited reviewer climbs a ladder of waits — 5 s, 30 s, 60 s, 120 s by default, each jittered
+/// — and is reported only when the ladder is spent, the limit is hopeless, or the next wait would
+/// outrun the reviewer's own deadline.
 /// </remarks>
 public sealed class BoundedScheduler(
     int globalCap = 3,
     int perProviderCap = 2,
     TimeSpan? rateLimitBackoff = null,
-    int sharedResourceCap = 1)
+    int sharedResourceCap = 1,
+    IReadOnlyList<TimeSpan>? retryLadder = null,
+    Func<double>? jitterRoll = null)
 {
-    private readonly TimeSpan _backoff = rateLimitBackoff ?? TimeSpan.FromSeconds(15);
+    /// <summary>
+    /// The waits a rate-limited reviewer climbs, widest source first.
+    /// </summary>
+    /// <remarks>
+    /// A ladder if one was given; otherwise the single backoff if THAT was given, because passing
+    /// it is how a caller says "one retry, at this interval" and a deployment that set
+    /// <c>COAI_RATE_LIMIT_BACKOFF_SECONDS</c> must keep meaning what it meant; otherwise the
+    /// shipped ladder. The distinction is possible only because the parameter is nullable — a
+    /// defaulted fifteen seconds and a configured fifteen seconds would be the same value.
+    /// </remarks>
+    private readonly IReadOnlyList<TimeSpan> _ladder =
+        retryLadder is { Count: > 0 } ladder ? ladder
+        : rateLimitBackoff is { } backoff ? [backoff]
+        : RetryLadder.Default;
+
+    /// <summary>
+    /// Where the jitter comes from — injected, so a test can pin a wait instead of sleeping.
+    /// </summary>
+    private readonly Func<double> _roll = jitterRoll ?? Random.Shared.NextDouble;
 
     private int _running;
 
@@ -215,7 +237,7 @@ public sealed class BoundedScheduler(
                             var watch = System.Diagnostics.Stopwatch.StartNew();
                             try
                             {
-                                var outcome = await RunWithOneRetryAsync(w, executor, ct);
+                                var outcome = await RunWithLadderAsync(w, executor, ct);
                                 Report(onProgress, w.Invocation, outcome is ReviewerOutcome.Ok ? "done" : "failed", outcome, watch.Elapsed);
                                 return (w.Invocation, outcome);
                             }
@@ -361,23 +383,41 @@ public sealed class BoundedScheduler(
         }
     }
 
-    private async Task<ReviewerOutcome> RunWithOneRetryAsync(ReviewerWork w, ReviewerExecutor executor, CancellationToken ct)
+    /// <summary>
+    /// Launch, and while the answer is a rate limit worth waiting out, climb the ladder.
+    /// </summary>
+    /// <remarks>
+    /// <para>The budget is the reviewer's OWN deadline and the clock starts at the first launch, so
+    /// what is measured is wall time — the failed launches as well as the waits. A reviewer that has
+    /// already spent its deadline being refused does not then wait two more minutes to be refused
+    /// once more.</para>
+    /// <para>A daily allowance is still not retried at all, ladder or no ladder: it clears at
+    /// midnight in somebody else's timezone, and the one measured case cost a round 157 seconds
+    /// instead of 19 for a second doomed launch.</para>
+    /// </remarks>
+    private async Task<ReviewerOutcome> RunWithLadderAsync(ReviewerWork w, ReviewerExecutor executor, CancellationToken ct)
     {
+        var budget = w.Invocation.Request.Timeout;
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        var attempts = 1;
         var outcome = await executor.RunAsync(w.Invocation, w.Repair, ct);
-        if (outcome is not ReviewerOutcome.RateLimited limited)
+
+        while (outcome is ReviewerOutcome.RateLimited limited && !RateLimit.Hopeless(limited.Reason))
         {
-            return outcome;
+            var wait = RetryLadder.NextWait(attempts - 1, _ladder, _roll(), watch.Elapsed, budget);
+            if (wait is null)
+            {
+                return limited with { Attempts = attempts };
+            }
+
+            await Task.Delay(wait.Value, ct);
+            attempts += 1;
+            outcome = await executor.RunAsync(w.Invocation, w.Repair, ct);
         }
 
-        // A retry is for a limit that clears while you wait. A daily allowance does not, and
-        // spending the backoff plus a second doomed launch on one only makes the round slower.
-        if (RateLimit.Hopeless(limited.Reason))
-        {
-            return limited;
-        }
-
-        await Task.Delay(_backoff, ct);
-        return await executor.RunAsync(w.Invocation, w.Repair, ct);
+        return outcome is ReviewerOutcome.RateLimited hopeless
+            ? hopeless with { Attempts = attempts }
+            : outcome;
     }
 }
 
@@ -395,7 +435,10 @@ public static class ReviewerSummaryFactory
     public static string Describe(ReviewerOutcome outcome) => outcome switch
     {
         ReviewerOutcome.TimedOut => "timeout",
-        ReviewerOutcome.RateLimited r => $"rate limited (after one retry){Because(r.Reason)}",
+        // The real number, because after the ladder it is not always one — and a round that says
+        // "one retry" over four launches is a sentence a person would plan around.
+        ReviewerOutcome.RateLimited r =>
+            $"rate limited (after {r.Attempts} attempt{(r.Attempts == 1 ? "" : "s")}){Because(r.Reason)}",
         // The stderr tail travels WITH the exit code. "exit 1" alone was what made the same codex
         // failure undiagnosable twice at a real gate: the executor had captured the reason and
         // this sentence — the only place a person reads — threw it away.

--- a/src_mcp/runners/Reviewers/BoundedScheduler.cs
+++ b/src_mcp/runners/Reviewers/BoundedScheduler.cs
@@ -237,7 +237,7 @@ public sealed class BoundedScheduler(
                             var watch = System.Diagnostics.Stopwatch.StartNew();
                             try
                             {
-                                var outcome = await RunWithLadderAsync(w, executor, ct);
+                                var outcome = await RunWithLadderAsync(w, executor, onProgress, ct);
                                 Report(onProgress, w.Invocation, outcome is ReviewerOutcome.Ok ? "done" : "failed", outcome, watch.Elapsed);
                                 return (w.Invocation, outcome);
                             }
@@ -395,7 +395,11 @@ public sealed class BoundedScheduler(
     /// midnight in somebody else's timezone, and the one measured case cost a round 157 seconds
     /// instead of 19 for a second doomed launch.</para>
     /// </remarks>
-    private async Task<ReviewerOutcome> RunWithLadderAsync(ReviewerWork w, ReviewerExecutor executor, CancellationToken ct)
+    private async Task<ReviewerOutcome> RunWithLadderAsync(
+        ReviewerWork w,
+        ReviewerExecutor executor,
+        Action<ReviewerProgress>? onProgress,
+        CancellationToken ct)
     {
         var budget = w.Invocation.Request.Timeout;
         var watch = System.Diagnostics.Stopwatch.StartNew();
@@ -410,15 +414,30 @@ public sealed class BoundedScheduler(
                 return limited with { Attempts = attempts };
             }
 
+            // Said out loud, because the ladder can hold a reviewer for minutes and "running" reads
+            // exactly like a model that is thinking.
+            Report(onProgress, w.Invocation, "running", elapsed: watch.Elapsed,
+                note: $"rate limited on attempt {attempts} — waiting {wait.Value.TotalSeconds:F0}s before the next");
             await Task.Delay(wait.Value, ct);
             attempts += 1;
-            outcome = await executor.RunAsync(w.Invocation, w.Repair, ct);
+            // What is LEFT of the deadline, never the whole of it again.
+            outcome = await executor.RunAsync(
+                WithinRemaining(w.Invocation, watch.Elapsed, budget),
+                w.Repair is null ? null : WithinRemaining(w.Repair, watch.Elapsed, budget),
+                ct);
         }
 
         return outcome is ReviewerOutcome.RateLimited hopeless
             ? hopeless with { Attempts = attempts }
             : outcome;
     }
+
+    /// <summary>The same launch, allowed only the time this reviewer has left.</summary>
+    private static ReviewerInvocation WithinRemaining(ReviewerInvocation invocation, TimeSpan elapsed, TimeSpan budget) =>
+        invocation with
+        {
+            Request = invocation.Request with { Timeout = RetryLadder.Remaining(elapsed, budget) },
+        };
 }
 
 /// <summary>Folds a fan-out's outcomes into the core's honest per-round summary.</summary>

--- a/src_mcp/runners/Reviewers/RetryLadder.cs
+++ b/src_mcp/runners/Reviewers/RetryLadder.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+
+namespace CoaiMcp.Runners.Reviewers;
+
+/// <summary>
+/// How long a rate-limited reviewer waits before trying again, and when it stops trying.
+/// </summary>
+/// <remarks>
+/// <para>It replaces a single retry at a single interval. Fifteen seconds was the wrong one number
+/// for what vendors actually do: codex and claude meter a five-hour rolling window plus a weekly
+/// cap and say so in words ("You've hit your usage limit", "resets 3:45pm"), antigravity meters a
+/// per-plan quota, and a plain <c>429 Too Many Requests</c> or <c>503 ... high demand</c> clears in
+/// seconds to a couple of minutes. One interval either gives up on the transient case too early or,
+/// raised to cover it, makes every rate-limited reviewer of a round wait that long for nothing.</para>
+///
+/// <para><b>The jitter is not decoration.</b> A code round launches nine reviewers at once, so nine
+/// reviewers meet the same limit in the same instant — and with a fixed interval they would all
+/// retry in the same instant too, which is a synchronised second wave into the limit they just hit.
+/// A fifth either way spreads them.</para>
+///
+/// <para>Everything here is pure, and the jitter's roll is a PARAMETER rather than an internal
+/// <see cref="Random"/>: a wait cannot be asserted by sleeping through it without the assertion
+/// becoming a stopwatch on a loaded runner.</para>
+/// </remarks>
+public static class RetryLadder
+{
+    /// <summary>Five seconds, then thirty, then a minute, then two.</summary>
+    public static readonly IReadOnlyList<TimeSpan> Default =
+    [
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(30),
+        TimeSpan.FromSeconds(60),
+        TimeSpan.FromSeconds(120),
+    ];
+
+    /// <summary>How far either way a step is spread — a fifth.</summary>
+    public const double JitterFraction = 0.2;
+
+    /// <summary>
+    /// The wait before attempt <paramref name="attempt"/> + 2, or null when there is not going to
+    /// be one — the ladder is spent, or the deadline would be.
+    /// </summary>
+    /// <param name="attempt">Zero for the wait after the first failure.</param>
+    /// <param name="roll">A sample in [0,1]: 0 is the bottom of the jitter band, 1 the top.</param>
+    /// <param name="elapsed">
+    /// WALL CLOCK since the first launch — the launches, not only the earlier waits.
+    /// </param>
+    /// <param name="budget">
+    /// What this reviewer has to spend, which is its own process timeout.
+    /// </param>
+    /// <remarks>
+    /// The budget counts elapsed time rather than the sum of the waits, and that distinction is the
+    /// finding three reviewers raised independently on this change's plan: five plus thirty seconds
+    /// of waiting fits a sixty-second deadline, and the two failed launches that produced them have
+    /// already taken ninety.
+    /// </remarks>
+    public static TimeSpan? NextWait(
+        int attempt,
+        IReadOnlyList<TimeSpan> steps,
+        double roll,
+        TimeSpan elapsed,
+        TimeSpan budget)
+    {
+        if (attempt < 0 || attempt >= steps.Count)
+        {
+            return null;
+        }
+
+        var wait = Jittered(steps[attempt], roll);
+
+        return elapsed + wait < budget ? wait : null;
+    }
+
+    /// <summary>One step, spread by up to a fifth either way.</summary>
+    private static TimeSpan Jittered(TimeSpan step, double roll) =>
+        step * (1 + ((Math.Clamp(roll, 0, 1) * 2) - 1) * JitterFraction);
+
+    /// <summary>
+    /// <c>"5,30,60,120"</c> — the steps in seconds — or nothing at all when any part of it cannot
+    /// be read.
+    /// </summary>
+    /// <remarks>
+    /// All or nothing, deliberately. A half-parsed ladder is a policy nobody wrote: it would run a
+    /// different wait from the one in the config file and say nothing about it. Empty is the
+    /// caller's signal to fall back AND to report, which is what <c>PanelSettings.Unrecognised</c>
+    /// already exists for.
+    /// </remarks>
+    public static IReadOnlyList<TimeSpan> Parse(string? csv)
+    {
+        var parts = (csv ?? string.Empty)
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            return [];
+        }
+
+        var steps = new List<TimeSpan>(parts.Length);
+        foreach (var part in parts)
+        {
+            if (!double.TryParse(part, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds)
+                || seconds <= 0)
+            {
+                return [];
+            }
+
+            steps.Add(TimeSpan.FromSeconds(seconds));
+        }
+
+        return steps;
+    }
+}

--- a/src_mcp/runners/Reviewers/RetryLadder.cs
+++ b/src_mcp/runners/Reviewers/RetryLadder.cs
@@ -87,25 +87,68 @@ public static class RetryLadder
     /// </remarks>
     public static IReadOnlyList<TimeSpan> Parse(string? csv)
     {
-        var parts = (csv ?? string.Empty)
-            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length == 0)
+        var text = (csv ?? string.Empty).Trim();
+        if (text.Length == 0)
         {
             return [];
         }
 
+        // Empty entries are KEPT and then refused. Dropping them silently is how `5,,60` would
+        // become `5,60` — a ladder nobody wrote, applied without a word. (codex, code round.)
+        var parts = text.Split(',', StringSplitOptions.TrimEntries);
+
         var steps = new List<TimeSpan>(parts.Length);
         foreach (var part in parts)
         {
-            if (!double.TryParse(part, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds)
-                || seconds <= 0)
+            if (!Step(part, out var step))
             {
                 return [];
             }
 
-            steps.Add(TimeSpan.FromSeconds(seconds));
+            steps.Add(step);
         }
 
         return steps;
     }
+
+    /// <summary>
+    /// One entry as a wait, or false — including for the values that PARSE and cannot be a wait.
+    /// </summary>
+    /// <remarks>
+    /// <c>Infinity</c>, <c>NaN</c> and <c>1e20</c> all satisfy <see cref="double.TryParse(string,
+    /// NumberStyles, IFormatProvider, out double)"/> and then throw out of
+    /// <see cref="TimeSpan.FromSeconds(double)"/> — and this runs while a server is reading its
+    /// settings, so the throw would take the whole configuration down instead of falling back to
+    /// the shipped ladder and reporting the value. A day is the ceiling because anything longer is
+    /// not a retry ladder, it is a typo, and a typo deserves the fallback and the sentence.
+    /// </remarks>
+    private static bool Step(string part, out TimeSpan step)
+    {
+        step = TimeSpan.Zero;
+        if (!double.TryParse(part, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds)
+            || !double.IsFinite(seconds)
+            || seconds <= 0
+            || seconds > MaxStepSeconds)
+        {
+            return false;
+        }
+
+        step = TimeSpan.FromSeconds(seconds);
+
+        return true;
+    }
+
+    private static readonly double MaxStepSeconds = TimeSpan.FromDays(1).TotalSeconds;
+
+    /// <summary>
+    /// What is LEFT of a reviewer's deadline — what a retry launch is allowed to take.
+    /// </summary>
+    /// <remarks>
+    /// A retry used to carry the reviewer's whole timeout again, so a first launch that spent nine
+    /// minutes of a ten-minute deadline could be followed by a second with ten more: a reviewer
+    /// running nineteen minutes against a deadline of ten. Never negative — a deadline already past
+    /// is no time at all, and a negative timeout is not a thing a process can be given.
+    /// </remarks>
+    public static TimeSpan Remaining(TimeSpan elapsed, TimeSpan budget) =>
+        elapsed >= budget ? TimeSpan.Zero : budget - elapsed;
 }

--- a/src_mcp/runners/Reviewers/ReviewerExecutor.cs
+++ b/src_mcp/runners/Reviewers/ReviewerExecutor.cs
@@ -38,7 +38,17 @@ public abstract record ReviewerOutcome
     /// bare "exit 1" made: a per-minute throttle a retry clears and a DAILY quota that no retry
     /// can clear read identically, and only one of them is worth waiting for.
     /// </param>
-    public sealed record RateLimited(string Reason = "") : ReviewerOutcome;
+    /// <param name="Attempts">
+    /// How many launches it actually took before this was the answer — one when the limit was
+    /// hopeless from the first word, up to one more than the ladder has steps.
+    /// </param>
+    /// <remarks>
+    /// It travels ON the outcome because the summary is built from outcomes alone, and the number
+    /// is known only inside the scheduler's retry loop. Without it the round said "after one retry"
+    /// however many launches there had been — a sentence that was true when there was one step and
+    /// became a confident wrong number the moment there were four.
+    /// </remarks>
+    public sealed record RateLimited(string Reason = "", int Attempts = 1) : ReviewerOutcome;
 
     /// <summary>
     /// The process never ran: the CLI is not installed, or the configured path is wrong. Its own

--- a/src_mcp/src/Server/PanelService.cs
+++ b/src_mcp/src/Server/PanelService.cs
@@ -48,7 +48,8 @@ public sealed class PanelService
             settings.GlobalConcurrency,
             settings.PerProviderConcurrency,
             settings.RateLimitBackoff,
-            settings.LocalConcurrency);
+            settings.LocalConcurrency,
+            settings.RetryLadder);
         // Unparseable answers are kept beside the sessions, so "it would not parse" can be read
         // rather than guessed at.
         _executor = new ReviewerExecutor(launcher, Path.Combine(settings.DataDir, "unparseable"));

--- a/src_mcp/src/Server/PanelSettings.cs
+++ b/src_mcp/src/Server/PanelSettings.cs
@@ -60,7 +60,27 @@ public sealed record PanelSettings
     public TimeSpan ReviewerTimeout { get; init; } = TimeSpan.FromMinutes(10);
 
     /// <summary>How long a rate-limited reviewer waits before its one retry.</summary>
+    /// <remarks>
+    /// Kept as the panel's own setting and as the older way of saying "one retry, at this
+    /// interval": setting it, and nothing else, still means exactly that — see
+    /// <see cref="RetryLadder"/> for the precedence.
+    /// </remarks>
     public TimeSpan RateLimitBackoff { get; init; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// The waits a rate-limited reviewer climbs, in order.
+    /// </summary>
+    /// <remarks>
+    /// <para>Four steps by default — 5 s, 30 s, 60 s, 120 s — because one interval is the wrong
+    /// number for both cases it has to serve: a transient <c>429</c> clears in seconds, and a usage
+    /// window does not clear at all within a round.</para>
+    /// <para><b>An operator who set the old variable keeps the old behaviour.</b> With
+    /// <c>COAI_RETRY_BACKOFF</c> unset and <c>COAI_RATE_LIMIT_BACKOFF_SECONDS</c> set, this is a
+    /// ONE-step ladder at that number: a deployment that deliberately chose 45 seconds must not
+    /// silently become four retries, and nothing would have said so. Raised twice, by two vendors,
+    /// on this change's plan round.</para>
+    /// </remarks>
+    public IReadOnlyList<TimeSpan> RetryLadder { get; init; } = Runners.Reviewers.RetryLadder.Default;
 
     /// <summary>
     /// How long an escalation waits for a person before answering "nobody answered yet".
@@ -212,6 +232,7 @@ public sealed record PanelSettings
         LocalConcurrency = IntVar(env, "COAI_LOCAL_CONCURRENCY", 1),
         ReviewerTimeout = TimeSpan.FromMinutes(IntVar(env, "COAI_REVIEWER_TIMEOUT_MINUTES", 10)),
         RateLimitBackoff = TimeSpan.FromSeconds(IntVar(env, "COAI_RATE_LIMIT_BACKOFF_SECONDS", 15)),
+        RetryLadder = LadderFrom(env),
         // Seconds win when set: minutes are the setting a person configures, seconds are for a
         // short budget a test or a scripted run needs. One knob would have had to lie about one
         // of the two.
@@ -271,9 +292,36 @@ public sealed record PanelSettings
     /// likely cure — because the likely cause is a panel newer than the server, and "unknown value"
     /// alone sends somebody back into the settings file where the answer is not.
     /// </remarks>
+    /// <summary>
+    /// The ladder this server climbs: the new setting, else the old one as a single step, else the
+    /// shipped four.
+    /// </summary>
+    private static IReadOnlyList<TimeSpan> LadderFrom(Func<string, string?> env)
+    {
+        if (Runners.Reviewers.RetryLadder.Parse(env("COAI_RETRY_BACKOFF")) is { Count: > 0 } ladder)
+        {
+            return ladder;
+        }
+
+        // Absent is not the same as unreadable, and neither is the same as "nobody has an opinion":
+        // only a value somebody wrote gets to override the default.
+        return env("COAI_RATE_LIMIT_BACKOFF_SECONDS") is { Length: > 0 }
+            ? [TimeSpan.FromSeconds(IntVar(env, "COAI_RATE_LIMIT_BACKOFF_SECONDS", 15))]
+            : Runners.Reviewers.RetryLadder.Default;
+    }
+
     private static IReadOnlyList<string> UnknownValues(Func<string, string?> env)
     {
         var unknown = new List<string>();
+        if (env("COAI_RETRY_BACKOFF") is { Length: > 0 } backoff
+            && Runners.Reviewers.RetryLadder.Parse(backoff).Count == 0)
+        {
+            unknown.Add(
+                $"COAI_RETRY_BACKOFF is '{backoff}', which this server cannot read as a list of "
+                + "seconds — it is using the waits it would have used anyway. The form is "
+                + "'5,30,60,120', and one number means one retry at that interval.");
+        }
+
         if (env("COAI_ON_EXHAUSTED") is { Length: > 0 } policy
             && PolicyOf(policy) == StagePolicy.Human
             && !string.Equals(policy, "human", StringComparison.OrdinalIgnoreCase))

--- a/src_mcp/tests/BoundedSchedulerTests.cs
+++ b/src_mcp/tests/BoundedSchedulerTests.cs
@@ -55,6 +55,11 @@ public sealed class BoundedSchedulerTests
             "with one vendor, its own cap is the binding one");
     }
 
+    /// <summary>
+    /// A configured single step still means a single retry — the behaviour
+    /// <c>COAI_RATE_LIMIT_BACKOFF_SECONDS</c> has always bought, pinned so the ladder cannot take
+    /// it away from a deployment that asked for it by name.
+    /// </summary>
     [Fact]
     public async Task RateLimited_RetriesExactlyOnce_ThenSucceeds()
     {
@@ -87,6 +92,97 @@ public sealed class BoundedSchedulerTests
             "a quota is a distinct outcome, never a timeout in disguise");
         (await File.ReadAllLinesAsync(counter, TestContext.Current.CancellationToken)).Should().HaveCount(2);
     }
+
+    /// <summary>
+    /// The ladder: a limit that clears on the second wait is a reviewer that ANSWERS, where the
+    /// single retry reported it as failed for the round.
+    /// </summary>
+    [Fact]
+    public async Task RateLimitedTwice_ClimbsTheLadder_ThenAnswers()
+    {
+        var counter = Path.Combine(_dir, "ladder-count.txt");
+        var work = new ReviewerWork(FakeCliInvocations.Invoke(
+            "codex",
+            ["count", counter, "fail-until", counter, "2", "429 Too Many Requests", "1", FakeCliInvocations.CleanReview]));
+
+        var results = await new BoundedScheduler(retryLadder: Tiny(3))
+            .RunAllAsync([work], _executor, TestContext.Current.CancellationToken);
+
+        results.Single().Outcome.Should().BeOfType<ReviewerOutcome.Ok>(
+            "the third attempt was not rate limited, and the ladder had a step left for it");
+        (await File.ReadAllLinesAsync(counter, TestContext.Current.CancellationToken))
+            .Should().HaveCount(3, "two limits, two waits, three launches");
+    }
+
+    /// <summary>
+    /// A ladder that is spent is the answer, and the count of attempts travels with it — the
+    /// summary used to say "after one retry" whatever had happened.
+    /// </summary>
+    [Fact]
+    public async Task RateLimitedThroughout_IsNamed_WithTheAttemptsItActuallyTook()
+    {
+        var counter = Path.Combine(_dir, "ladder-spent.txt");
+        var work = new ReviewerWork(FakeCliInvocations.Invoke(
+            "codex",
+            ["count", counter, "stderr-exit", "429 Too Many Requests", "1"]));
+
+        var results = await new BoundedScheduler(retryLadder: Tiny(2))
+            .RunAllAsync([work], _executor, TestContext.Current.CancellationToken);
+
+        results.Single().Outcome.Should().BeOfType<ReviewerOutcome.RateLimited>()
+            .Which.Attempts.Should().Be(3, "one launch plus a step each for the two waits");
+        (await File.ReadAllLinesAsync(counter, TestContext.Current.CancellationToken)).Should().HaveCount(3);
+        ReviewerSummaryFactory.From(results).Failures.Single()
+            .Should().Contain("after 3 attempts", "a person reading the round gets the real number");
+    }
+
+    /// <summary>
+    /// The one limit no ladder may climb. Measured before this existed: gemini answered "you have
+    /// exhausted your daily quota", the scheduler waited and launched a second doomed reviewer, and
+    /// the round took 157 seconds instead of 19. A four-step ladder would have made it worse.
+    /// </summary>
+    [Fact]
+    public async Task AHopelessLimit_IsNotRetriedAtAll_HoweverLongTheLadder()
+    {
+        var counter = Path.Combine(_dir, "hopeless-count.txt");
+        var work = new ReviewerWork(FakeCliInvocations.Invoke(
+            "gemini",
+            ["count", counter, "stderr-exit", "You have exhausted your daily quota on this model", "1"]));
+
+        var results = await new BoundedScheduler(retryLadder: Tiny(4))
+            .RunAllAsync([work], _executor, TestContext.Current.CancellationToken);
+
+        results.Single().Outcome.Should().BeOfType<ReviewerOutcome.RateLimited>()
+            .Which.Attempts.Should().Be(1);
+        (await File.ReadAllLinesAsync(counter, TestContext.Current.CancellationToken))
+            .Should().HaveCount(1, "a daily allowance clears at midnight, not after a wait");
+    }
+
+    /// <summary>
+    /// A reviewer whose own deadline is shorter than the ladder stops when the deadline does,
+    /// rather than waiting past it to fail once more.
+    /// </summary>
+    [Fact]
+    public async Task ALadderLongerThanTheReviewersDeadline_StopsAtTheDeadline()
+    {
+        var counter = Path.Combine(_dir, "budget-count.txt");
+        var work = new ReviewerWork(FakeCliInvocations.Invoke(
+            "codex",
+            ["count", counter, "stderr-exit", "429 Too Many Requests", "1"],
+            timeout: TimeSpan.FromMilliseconds(250)));
+
+        var results = await new BoundedScheduler(
+                retryLadder: [TimeSpan.FromMilliseconds(1), TimeSpan.FromSeconds(30)])
+            .RunAllAsync([work], _executor, TestContext.Current.CancellationToken);
+
+        results.Single().Outcome.Should().BeOfType<ReviewerOutcome.RateLimited>();
+        (await File.ReadAllLinesAsync(counter, TestContext.Current.CancellationToken))
+            .Should().HaveCount(2, "the 1ms step fits a 250ms deadline and the 30s step cannot");
+    }
+
+    /// <summary>A ladder of n steps, each too short to slow a test down.</summary>
+    private static IReadOnlyList<TimeSpan> Tiny(int steps) =>
+        [.. Enumerable.Repeat(TimeSpan.FromMilliseconds(1), steps)];
 
     [Fact]
     public async Task FourOfSixAnswer_TheSummaryNamesWhoFailedAndWhy()

--- a/src_mcp/tests/BoundedSchedulerTests.cs
+++ b/src_mcp/tests/BoundedSchedulerTests.cs
@@ -180,6 +180,33 @@ public sealed class BoundedSchedulerTests
             .Should().HaveCount(2, "the 1ms step fits a 250ms deadline and the 30s step cannot");
     }
 
+    /// <summary>
+    /// A reviewer that is waiting out a rate limit SAYS so, with the attempt and the wait.
+    /// </summary>
+    /// <remarks>
+    /// The ladder can hold a reviewer for over three minutes, and the panel's only report until now
+    /// was "running" — indistinguishable from a model that is thinking. Raised on this change's code
+    /// round, and it is the same lesson the queued-reviewer note already learned.
+    /// </remarks>
+    [Fact]
+    public async Task AReviewerWaitingOutALimit_SaysWhatItIsWaitingFor()
+    {
+        var counter = Path.Combine(_dir, "note-count.txt");
+        var work = new ReviewerWork(FakeCliInvocations.Invoke(
+            "codex",
+            ["count", counter, "fail-until", counter, "1", "429 Too Many Requests", "1", FakeCliInvocations.CleanReview]));
+        var notes = new List<string>();
+
+        await new BoundedScheduler(retryLadder: Tiny(2))
+            .RunAllAsync(
+                [work],
+                _executor,
+                TestContext.Current.CancellationToken,
+                p => { lock (notes) { notes.Add($"{p.Status}|{p.Note}"); } });
+
+        notes.Should().ContainMatch("*rate limited*", "the status alone reads as a model thinking");
+    }
+
     /// <summary>A ladder of n steps, each too short to slow a test down.</summary>
     private static IReadOnlyList<TimeSpan> Tiny(int steps) =>
         [.. Enumerable.Repeat(TimeSpan.FromMilliseconds(1), steps)];

--- a/src_mcp/tests/RetryLadderSettingsTests.cs
+++ b/src_mcp/tests/RetryLadderSettingsTests.cs
@@ -1,0 +1,73 @@
+using CoaiMcp.Runners.Reviewers;
+using CoaiMcp.Server;
+using FluentAssertions;
+using Xunit;
+
+namespace CoaiMcp.Tests;
+
+/// <summary>
+/// Which ladder a running server climbs, given what the operator has actually set.
+/// </summary>
+/// <remarks>
+/// The precedence exists because of a real hazard the plan round named twice, from two vendors: a
+/// deployment that had deliberately set <c>COAI_RATE_LIMIT_BACKOFF_SECONDS=45</c> would silently
+/// stop meaning "one retry at 45 seconds" and start meaning four retries at the shipped ladder, and
+/// nothing anywhere would say so. A setting somebody wrote down outranks a default.
+/// </remarks>
+public sealed class RetryLadderSettingsTests
+{
+    private static Func<string, string?> Env(params (string Name, string Value)[] set) =>
+        name => set.FirstOrDefault(e => e.Name == name).Value;
+
+    [Fact]
+    public void NothingConfigured_ClimbsTheShippedLadder()
+    {
+        PanelSettings.FromEnvironment(Env()).RetryLadder.Should().Equal(RetryLadder.Default);
+    }
+
+    [Fact]
+    public void TheLegacyBackoffAlone_StaysOneRetryAtThatNumber()
+    {
+        var settings = PanelSettings.FromEnvironment(Env(("COAI_RATE_LIMIT_BACKOFF_SECONDS", "45")));
+
+        settings.RetryLadder.Should().Equal(TimeSpan.FromSeconds(45));
+        settings.RateLimitBackoff.Should().Be(TimeSpan.FromSeconds(45), "the panel's own setting is unchanged");
+        settings.Unrecognised.Should().BeEmpty("nothing here is unknown — it is the older way of saying it");
+    }
+
+    [Fact]
+    public void TheLadderWins_WhenBothAreSet()
+    {
+        PanelSettings.FromEnvironment(Env(
+                ("COAI_RETRY_BACKOFF", "5,30"),
+                ("COAI_RATE_LIMIT_BACKOFF_SECONDS", "45")))
+            .RetryLadder.Should().Equal(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>
+    /// A ladder nobody can read falls back — and SAYS so, in the one place a person already looks
+    /// when a setting seems not to have applied.
+    /// </summary>
+    [Fact]
+    public void ALadderThatCannotBeRead_FallsBackAndIsReported()
+    {
+        var settings = PanelSettings.FromEnvironment(Env(("COAI_RETRY_BACKOFF", "5,nonsense,60")));
+
+        settings.RetryLadder.Should().Equal(RetryLadder.Default);
+        settings.Unrecognised.Should().ContainSingle()
+            .Which.Should().Contain("COAI_RETRY_BACKOFF").And.Contain("5,nonsense,60");
+    }
+
+    [Fact]
+    public void AnUnreadableLadder_StillDefersToTheLegacyBackoff()
+    {
+        var settings = PanelSettings.FromEnvironment(Env(
+            ("COAI_RETRY_BACKOFF", "nonsense"),
+            ("COAI_RATE_LIMIT_BACKOFF_SECONDS", "45")));
+
+        settings.RetryLadder.Should().Equal(
+            [TimeSpan.FromSeconds(45)],
+            "an unreadable new setting must not overrule a readable old one");
+        settings.Unrecognised.Should().ContainSingle();
+    }
+}

--- a/src_mcp/tests/RetryLadderTests.cs
+++ b/src_mcp/tests/RetryLadderTests.cs
@@ -1,0 +1,132 @@
+using CoaiMcp.Runners.Reviewers;
+using FluentAssertions;
+using Xunit;
+
+namespace CoaiMcp.Tests;
+
+/// <summary>
+/// The ladder a rate-limited reviewer climbs, and the two things that stop it: a spent ladder and
+/// a deadline it would outrun.
+/// </summary>
+/// <remarks>
+/// Pure, so every property here is a table rather than a wall-clock observation — the jitter
+/// especially, which is exactly the kind of thing a test would otherwise assert by sleeping and
+/// then fail on a loaded runner.
+/// </remarks>
+public sealed class RetryLadderTests
+{
+    private static readonly TimeSpan Hour = TimeSpan.FromHours(1);
+
+    [Fact]
+    public void TheDefaultLadder_IsFiveThirtySixtyAndTwoMinutes()
+    {
+        RetryLadder.Default.Should().Equal(
+            TimeSpan.FromSeconds(5),
+            TimeSpan.FromSeconds(30),
+            TimeSpan.FromSeconds(60),
+            TimeSpan.FromSeconds(120));
+    }
+
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(1, 30)]
+    [InlineData(2, 60)]
+    [InlineData(3, 120)]
+    public void EachAttempt_TakesItsOwnStep(int attempt, int seconds)
+    {
+        // roll 0.5 is the middle of the jitter band, so the step arrives unmodified.
+        RetryLadder.NextWait(attempt, RetryLadder.Default, roll: 0.5, elapsed: TimeSpan.Zero, budget: Hour)
+            .Should().Be(TimeSpan.FromSeconds(seconds));
+    }
+
+    [Fact]
+    public void AspentLadder_HasNoNextStep()
+    {
+        RetryLadder.NextWait(4, RetryLadder.Default, roll: 0.5, elapsed: TimeSpan.Zero, budget: Hour)
+            .Should().BeNull("four steps mean four waits, and the fifth failure is the answer");
+    }
+
+    /// <summary>
+    /// The whole point of the jitter: nine reviewers of one round hit the same limit at the same
+    /// instant, and without it they would all retry at the same instant too.
+    /// </summary>
+    [Theory]
+    [InlineData(0.0, 24)]     // the bottom of the band: 30s - 20%
+    [InlineData(0.5, 30)]
+    [InlineData(1.0, 36)]     // the top: 30s + 20%
+    public void Jitter_SpreadsTheStepByAFifthEitherWay(double roll, int seconds)
+    {
+        RetryLadder.NextWait(1, RetryLadder.Default, roll, TimeSpan.Zero, Hour)
+            .Should().Be(TimeSpan.FromSeconds(seconds));
+    }
+
+    [Fact]
+    public void EveryRoll_StaysInsideTheBand()
+    {
+        for (var i = 0; i <= 100; i += 1)
+        {
+            var wait = RetryLadder.NextWait(1, RetryLadder.Default, i / 100.0, TimeSpan.Zero, Hour);
+
+            // The band IS "the step, give or take a fifth" — six seconds either side of thirty.
+            wait!.Value.Should().BeCloseTo(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(6));
+        }
+    }
+
+    /// <summary>
+    /// The budget is WALL CLOCK since the first launch, not the sum of the waits — the launches
+    /// are most of it. A reviewer that has already spent its deadline failing does not then wait
+    /// two minutes to fail once more.
+    /// </summary>
+    /// <remarks>
+    /// Raised by codex, gemini and the local model on this change's plan round, each from a
+    /// different angle: waits alone fit a 60 s budget while the attempts that produced them have
+    /// already taken 95 s.
+    /// </remarks>
+    [Fact]
+    public void AstepThatWouldOutrunTheDeadline_IsNotTaken()
+    {
+        RetryLadder.NextWait(
+                attempt: 2,
+                RetryLadder.Default,
+                roll: 0.5,
+                elapsed: TimeSpan.FromSeconds(50),
+                budget: TimeSpan.FromSeconds(60))
+            .Should().BeNull("50s gone of a 60s deadline leaves no room for a 60s wait");
+    }
+
+    [Fact]
+    public void TimeAlreadySpentLaunching_CountsAgainstTheBudget()
+    {
+        var steps = new[] { TimeSpan.FromSeconds(5) };
+
+        RetryLadder.NextWait(0, steps, 0.5, TimeSpan.FromSeconds(58), TimeSpan.FromSeconds(60))
+            .Should().BeNull("two attempts of 29s each leave no room, however small the step");
+        RetryLadder.NextWait(0, steps, 0.5, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(60))
+            .Should().Be(TimeSpan.FromSeconds(5));
+    }
+
+    [Theory]
+    [InlineData("5,30,60,120", new[] { 5, 30, 60, 120 })]
+    [InlineData("5, 30", new[] { 5, 30 })]
+    [InlineData("15", new[] { 15 })]
+    public void Parse_ReadsTheStepsInSeconds(string csv, int[] expected)
+    {
+        RetryLadder.Parse(csv).Should().Equal(expected.Select(s => TimeSpan.FromSeconds(s)));
+    }
+
+    /// <summary>
+    /// A half-parsed ladder is worse than no ladder: it would silently be a DIFFERENT policy from
+    /// the one somebody wrote down, and nothing would say so. The caller falls back and reports it.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("nonsense")]
+    [InlineData("5,nonsense,60")]
+    [InlineData("5,0,60")]
+    [InlineData("5,-30")]
+    public void Parse_RefusesAnythingItCannotReadWhole(string csv)
+    {
+        RetryLadder.Parse(csv).Should().BeEmpty();
+    }
+}

--- a/src_mcp/tests/RetryLadderTests.cs
+++ b/src_mcp/tests/RetryLadderTests.cs
@@ -125,8 +125,40 @@ public sealed class RetryLadderTests
     [InlineData("5,nonsense,60")]
     [InlineData("5,0,60")]
     [InlineData("5,-30")]
+    // A missing element is a typo, and dropping it quietly would run a ladder nobody wrote —
+    // `5,,60` is not `5,60`. Raised by codex on this change's code round.
+    [InlineData("5,,60")]
+    [InlineData("5, ,60")]
+    [InlineData(",5")]
+    [InlineData("5,")]
+    // Parseable as a double and not expressible as a wait: `TimeSpan.FromSeconds` throws on these,
+    // and a settings read that throws takes the whole server's configuration with it instead of
+    // falling back and saying so. Also codex, same round.
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    [InlineData("NaN")]
+    [InlineData("1e20")]
+    [InlineData("5,1e400")]
     public void Parse_RefusesAnythingItCannotReadWhole(string csv)
     {
         RetryLadder.Parse(csv).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// What a RETRY is allowed to take: what is left of the deadline, never the whole of it again.
+    /// </summary>
+    /// <remarks>
+    /// The finding this pins, from the code round: a first launch that spends nine minutes of a
+    /// ten-minute deadline and comes back rate limited would otherwise wait five seconds and start
+    /// a second launch carrying a fresh ten-minute timeout — a reviewer running for nineteen
+    /// minutes against a deadline of ten.
+    /// </remarks>
+    [Fact]
+    public void ARetry_GetsWhatIsLeftOfTheDeadline_NotTheWholeOfItAgain()
+    {
+        RetryLadder.Remaining(TimeSpan.FromMinutes(9), TimeSpan.FromMinutes(10))
+            .Should().Be(TimeSpan.FromMinutes(1));
+        RetryLadder.Remaining(TimeSpan.FromMinutes(11), TimeSpan.FromMinutes(10))
+            .Should().Be(TimeSpan.Zero, "a deadline already past leaves nothing, never a negative timeout");
     }
 }

--- a/src_mcp/tests_fakecli/Program.cs
+++ b/src_mcp/tests_fakecli/Program.cs
@@ -10,6 +10,13 @@
 //   flip <flag> <firstStderr> <firstExit> <thenStdout>
 //                                        — first launch: create <flag>, stderr, exit <firstExit>;
 //                                          later launches: <thenStdout> to stdout, exit 0
+//   fail-until <counter> <n> <stderr> <exit> <thenStdout>
+//                                        — while <counter> has <n> lines or fewer: stderr, exit
+//                                          <exit>; after that: <thenStdout> to stdout, exit 0.
+//                                          Pair it with the `count <counter>` prefix, which is what
+//                                          writes those lines. `flip` is the same idea for n=1 and
+//                                          stays because half the suite uses it; a ladder needs a
+//                                          stand-in that can fail more than once.
 //
 // Deliberately dumb: every behaviour a test needs, none it does not.
 
@@ -171,7 +178,38 @@ switch (args0)
         Console.Out.Write(thenStdout);
         return 0;
 
+    case ["fail-until", var counter, var times, var stderrText, var exitCode, var thenStdout]:
+        // The counter is read, never written, here: the `count` prefix above has already appended
+        // this launch's line, so a launch sees its own attempt number.
+        if (LinesIn(counter) <= int.Parse(times))
+        {
+            Console.Error.WriteLine(stderrText);
+            return int.Parse(exitCode);
+        }
+
+        Console.Out.Write(thenStdout);
+        return 0;
+
     default:
         Console.Error.WriteLine($"fake-cli: unknown verb [{string.Join(' ', args0)}]");
         return 64;
+}
+
+/// <summary>
+/// How many launches the counter file has recorded — with a share mode that tolerates the writer
+/// above, since on Windows a plain read of a file another handle has open throws.
+/// </summary>
+static int LinesIn(string path)
+{
+    try
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+
+        return reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries).Length;
+    }
+    catch (FileNotFoundException)
+    {
+        return 0;
+    }
 }

--- a/todo/PLAN_team_server.md
+++ b/todo/PLAN_team_server.md
@@ -284,10 +284,9 @@ for it answers `404 lost — the server restarted while this review ran`, which 
 | The vendor, transient (`429 Too Many Requests`, `503 high demand`, no time) | next slot without waiting; none free → **5 s → 30 s → 60 s → 120 s**, jitter ±20 % (nine reviewers start together and would otherwise retry together), `Retry-After` overrides a step upward, all inside the reviewer's deadline (3 m 35 s of 10 min); then `RateLimited` + 5 min cooldown |
 | This server (per-caller cap or the rate limiter) | the client shim honours `Retry-After` and re-submits; polling never reaches the limiter (≤ 1 request per 25 s per reviewer) |
 
-The steps are configuration, `COAI_RETRY_BACKOFF=5,30,60,120`, read into `RetryLadder` in Runners.
-`BoundedScheduler.RunWithOneRetryAsync` (`:364`) — one retry after `RateLimitBackoff`, skipped when
-`Hopeless` (`:374`) — becomes a call to the same ladder, so the developer's own `coai-mcp` gets the same
-protection against a local codex 429.
+The steps are configuration, `COAI_RETRY_BACKOFF=5,30,60,120`, read into `RetryLadder` in Runners —
+**already shipped** ahead of this plan, so what the server adds is the slot rotation around it, not the
+waiting itself.
 
 ### Usage and admins
 
@@ -385,7 +384,7 @@ suites, the same guard `LocalRuntime.OpenAiBaseOf` / `openAiBaseOf` live under.
 | `VendorHealth.ProbeAsync` | `PanelService.cs:134` | the catalog's health column |
 | `RuntimeResolution` — `RuntimeNameOf`, `RuntimeFor`, `AuthOf` | `PanelService.cs:231-262` | the "third copy of one decision" that already shipped a defect must not get a fourth |
 | `UsageLedger` | `src_mcp/src/Server/UsageLedger.cs` | it references nothing MCP-shaped today |
-| `RetryLadder` | new, replacing `BoundedScheduler.RunWithOneRetryAsync`'s single step (`:364`) | the same ladder on both machines |
+| ~~`RetryLadder`~~ | **done** — shipped separately, `Reviewers/RetryLadder.cs`; `BoundedScheduler` climbs it and `COAI_RATE_LIMIT_BACKOFF_SECONDS` still means one step | the same ladder on both machines |
 
 `PanelService.cs` shrinks to one-line delegations. `CoaiMcp.Tests` must pass **unchanged** after the move —
 that is the proof it was a move.
@@ -641,7 +640,7 @@ The split was made on Fable; stories marked **F** run on Fable because being wro
 
 | Epic | Story | Delivers | Model |
 |---|---|---|---|
-| **1 · One library for two binaries** | 1.1 | `ReviewerExecutor.LaunchAsync` out of `RunOnceAsync`; `RetryLadder` replacing the single retry; `CoaiMcp.Tests` unchanged | Opus |
+| **1 · One library for two binaries** | 1.1 | `ReviewerExecutor.LaunchAsync` out of `RunOnceAsync`; `CoaiMcp.Tests` unchanged. (`RetryLadder` **shipped ahead of this epic**, on its own — it fixes the local `coai-mcp` today, where a transient 429 gets one retry at fifteen seconds and then fails the round.) | Opus |
 | | 1.2 | `RuntimeResolution` + `VendorHealth` out of `PanelService`; `UsageLedger` moved | Opus |
 | | 1.3 | `RemoteRuntime`, `RemoteAsk`, `TeamServerAuth` (with URL normalisation and the shared vector), `--ask-remote`, every registry point, `ProbeAsync`'s remote arm | Opus |
 | **2 · `coai-server`** | 2.1 | skeleton, logging, guards, the mirrored auth, sessions, `X-Coai-Contract`, the harness | **F** |


### PR DESCRIPTION
## The symptom

A reviewer that met a transient rate limit got **exactly one** retry, fifteen seconds later, and was then reported as failed for the round.

Fifteen seconds is the wrong single number for the two cases it has to serve: a plain `429 Too Many Requests` or a `503 ... high demand` clears in seconds, while a usage window — codex and claude meter a five-hour rolling window plus a weekly cap — does not clear inside a round at all. Raising the number would make every rate-limited reviewer of a round wait that long for nothing.

There is a sharper failure the fixed interval creates: a code round launches nine reviewers at once, so nine meet the limit in the same instant — and all nine retried in the same instant too. The retry was a synchronised second wave into the same limit.

## What changes

Waits of **5 s → 30 s → 60 s → 120 s** (`COAI_RETRY_BACKOFF`), each spread by up to a fifth either way.

Three things end the climb:

- the ladder is spent;
- the limit is **hopeless** — a daily allowance, still not retried at all. That is the case measured before this existed: gemini answered "you have exhausted your daily quota", the scheduler waited and launched a second doomed reviewer, and the round took 157 s instead of 19. A four-step ladder would have made it worse;
- the next wait would outrun the reviewer's **own deadline**. That budget counts wall clock from the first launch rather than the sum of the waits, because the failed launches are most of the time spent — 5 s + 30 s of waiting fits a 60-second deadline that the two attempts producing them have already blown. Three reviewers raised exactly this on the plan round, from three different angles.

`COAI_RATE_LIMIT_BACKOFF_SECONDS` **keeps meaning what it meant**: set alone, it is a one-step ladder at that number. A deployment that deliberately chose 45 seconds must not silently become four retries with nothing saying so. An unreadable `COAI_RETRY_BACKOFF` falls back and is reported through `PanelSettings.Unrecognised` rather than half-applied — a half-parsed ladder is a policy nobody wrote.

The round summary now carries the attempts it actually took (`RateLimited.Attempts`): *"after one retry"* was true with one step and a confident wrong number with four.

## Deliberately not here

Parsing a vendor's own *"resets 3:45pm"* out of its stderr. Those sentences have not been collected from a real machine yet, and `RateLimit`'s phrase list is built **entirely** of observed strings — inventing a time parser for text nobody has seen would be the same mistake in a new place. It belongs to the Team-server plan, where a real HTTP `Retry-After` exists on our own 429.

## Test plan — and the RED that proves the tests have teeth

- `RetryLadderTests` — the four steps in order, a spent ladder, the jitter band at roll 0 / 0.5 / 1 and across a hundred rolls, the budget refusing a step that outruns the deadline, and the all-or-nothing parse.
- `RetryLadderSettingsTests` — the precedence: nothing set, the legacy variable alone, both set, an unreadable ladder, and an unreadable ladder beside a readable legacy value.
- Four new `BoundedSchedulerTests` driving the **real** fake CLI: rate-limited twice then answering (3 launches, `Ok`), the ladder spent (3 launches, the attempt count in the summary), a hopeless limit (1 launch), and a ladder longer than the reviewer's deadline (2 launches). The fake CLI gains a `fail-until` verb because `flip` can only fail once.
- **Watched failing first**, with the ladder reverted to a single retry: the reviewer that answers on its third attempt came back `RateLimited`, and the attempt count read 2 where the test asks for 3 — the defect itself, not a setup error. Restored, green.
- **645 of 645** from the test executable (`./src_mcp/tests/bin/Debug/net10.0/CoaiMcp.Tests`), never `dotnet test`.

`research/module_runners.md` gains the ladder where it described the single retry; `todo/PLAN_team_server.md` records that its story 1.1 no longer carries this — it landed early because it fixes the local `coai-mcp` today.

Reviewed by this product's own gate before it was written: plan round `good_enough`, seven findings accepted (the wall-clock budget, the settings precedence, how the attempt count reaches the summary, millisecond ladders in tests) and two rejected with reasons — a jitter "state" nothing observable depends on, and a startup validation that cannot know a per-reviewer timeout the runtime guard already handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
