### PR TITLE
chore(release): extension 0.30.0

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.30.0 — 2026-09-05 (server 0.18.0)
+
+**The gate's own rule stopped being a paste, and the panel can see where it went.** The block that
+teaches a repository's main AI to call this gate used to be copied into each repository's
+`CLAUDE.md`, and a copy does not move when its source does: `dew_flow_creds_for_devs` was found
+carrying **v2** while this extension handed out **v5** — three revisions behind, missing the whole
+COMMANDS block, the "reject in round 1" rule and the enforced stop after `call_human`. It lives once
+now, as `common/coai-review-gate.md` in `dew_flow_conventions`, and reaches six repositories through
+the submodule they already mount.
+
+So the panel reads two more places after the four instruction files: the mounted rule and its
+unmounted twin. A repository whose only copy is the mount now reports **current** instead of the
+*absent* it would have reported before. The instruction files stay FIRST on that list deliberately —
+a paste in `CLAUDE.md` is what the AI there actually reads, so a stale one has to be the sentence
+the panel says; answering with the mounted rule's version instead would be a green light over text
+still being obeyed.
+
+**A drift between the two is a red build.** A test asserts the mounted rule is byte-identical to
+what the ⋯ menu hands out. It skips on a fresh clone without the submodule and **fails under CI**,
+where the workflow now checks that one submodule out — a skip there is exactly how a changed snippet
+would merge behind a green tick. `gate-snippet-check.mjs` fails the build of any consumer that keeps
+its own copy of the block, which is the half a panel can never do: a panel only sees a repository
+somebody has opened.
+
+**Server 0.18.0** carries the other half — a round's worktree now actually contains the shared rules
+it is meant to be judged against, instead of the empty directory git leaves in a linked worktree.
+
 ## 0.29.13 — 2026-09-05 (server 0.17.5)
 
 **The Review rounds page came up empty again, saying `R is not defined`.** The same class of defect

--- a/src_vs_code/package-lock.json
+++ b/src_vs_code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "connect-other-ais",
-  "version": "0.29.11",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "connect-other-ais",
-      "version": "0.29.11",
+      "version": "0.30.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.1",

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.29.13",
+  "version": "0.30.0",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Why

`src_vs_code/package.json` **is** the release version — the release workflow refuses a tag that
disagrees with the manifest — so the bump lands on `main` first and `extension-v0.30.0` follows.

A minor rather than a patch because the panel now answers a question differently: a repository whose
only copy of the gate block is the mounted shared rule reports **current** where it reported
*absent* before. That behaviour merged in #30; this is the release that carries it to anyone.

## What is in it

- `package.json` → `0.30.0`, and the lockfile's own version field along with it. That field had been
  left at `0.29.11` by the previous release; `npm ci` does not enforce it, which is why it drifted
  unnoticed rather than failing anything.
- A changelog entry saying what moved: the gate rule stopped being a paste (a copy in
  `dew_flow_creds_for_devs` was found three revisions behind what the ⋯ menu hands out), the panel
  reads the mounted rule and its unmounted twin after the four instruction files, and a drift
  between the mounted rule and the snippet is a red build — it skips on a fresh clone without the
  submodule and fails under CI, where the workflow now checks that submodule out.
- It names server **0.18.0** as the pair, which carries the other half: a round's worktree now
  actually contains the shared rules it is meant to be judged against.

## What the tests showed

```
npm test (src_vs_code) — tests 419, pass 419, fail 0, skipped 0
```

Nothing skipped: the conventions submodule is checked out in this tree, so the drift guard actually
compared the mounted rule with `claudeSnippet()` instead of standing aside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)