### PR TITLE
ci(release): the extension job needs the shared rules on disk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The suite this job runs includes a test that compares the MOUNTED shared rule with the
+      # snippet the menu hands out, so it needs the submodule on disk — and it fails rather than
+      # skips without it, deliberately. CI and the Sonar job both do this; the release did not, and
+      # the first tag after that test landed could not be built (extension-v0.29.13, 2026-09-05).
+      - name: Conventions submodule
+        working-directory: .
+        run: git submodule update --init --depth 1 .claude/rules/shared
+
       - uses: actions/setup-node@v7
         with:
           node-version: 20


### PR DESCRIPTION
**extension-v0.29.13 could not be built.** The release job failed on `not ok 324 - the mounted shared rule is byte-identical to what the menu hands out`.

That test compares the mounted shared rule with the snippet the menu hands out, and it fails rather than skips when the submodule is absent — deliberately, so a drifted rule is a red build rather than a silent skip. CI and the SonarCloud job both check the submodule out first; the release job never did, and the first tag after that test landed is where it showed.

One step, in the same shape as the other two jobs.

**The gate:** not applicable — a workflow-only change, which is the case the pull-request rule names. It is also blocking a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)