### PR TITLE
feat: the log page shows the findings, and what the AI keeps missing

### DIFF
--- a/research/module_server.md
+++ b/research/module_server.md
@@ -298,8 +298,12 @@ migration step throwing something unlisted must not take down a review it only r
   repository builds advisories as errors. **Native AOT publishes clean with it** — measured
   2026-09-05: 17.7 MB, zero IL or trim warnings.
 
-The extension does not read it yet; the log page still flattens the session files. That half is
-[todo/PLAN_local_db_reader.md](../todo/PLAN_local_db_reader.md).
+**The page reads it through `--log`.** `coai-mcp --log [--limit N]` prints the database as JSON and
+exits: rounds with their findings and resolutions, the accepted/total counts grouped by category,
+role and vendor, and the findings raised again over a standing rejection (`Store/RoundsQuery`). The
+extension owns no SQLite for the same reason it owns no native module — the alternative was a
+WebAssembly build in the VSIX to query a file this binary already writes. Version skew is ordinary:
+a server without the flag exits 64 and the page shows what it always showed.
 
 ## The audit trail
 

--- a/src_mcp/src/Program.cs
+++ b/src_mcp/src/Program.cs
@@ -60,6 +60,17 @@ internal static class Program
         /// moment somebody copies the one they were told to install.
         /// </remarks>
         AskLocal,
+
+        /// <summary>
+        /// Print the rounds database as JSON and leave.
+        /// </summary>
+        /// <remarks>
+        /// For the panel, which owns no SQLite of its own and should not have to: the alternative
+        /// was a WebAssembly build in the VSIX or a native module per platform, to ask questions of
+        /// a file this binary already writes and whose schema it owns. A read-only mode costs
+        /// nothing and keeps every query beside its table.
+        /// </remarks>
+        Log,
     }
 
     /// <summary>Which of the three this invocation is. Pure, so it is a unit test.</summary>
@@ -69,6 +80,7 @@ internal static class Program
             : args[0] is "--help" or "-h" or "help" ? Startup.Help
             : args[0] is "--version" or "-v" or "version" ? Startup.Version
             : args[0] == "--ask-local" ? Startup.AskLocal
+            : args[0] == "--log" ? Startup.Log
             : Startup.Usage;
 
     private static async Task<int> Main(string[] args)
@@ -93,6 +105,9 @@ internal static class Program
             case Startup.AskLocal:
                 return await AskLocalAsync(args);
 
+            case Startup.Log:
+                return LogJson(args);
+
             default:
                 return await ServeAsync();
         }
@@ -112,6 +127,43 @@ internal static class Program
     /// <para>Exit 0 with no answer file is not possible: a failure exits non-zero AND says why on
     /// stderr, so the round reports the reason rather than "the vendor returned an empty answer".</para>
     /// </remarks>
+    /// <summary>
+    /// The rounds database on stdout, as JSON. Never the protocol, so stdout is a person's terminal.
+    /// </summary>
+    /// <remarks>
+    /// An empty log — no database yet, or one that cannot be read — is an empty result and exit 0,
+    /// not an error: a panel asking a machine that has never run a round is asking a fair question
+    /// and deserves an answer it can render.
+    /// </remarks>
+    private static int LogJson(string[] args)
+    {
+        var settings = Server.PanelSettings.FromEnvironment(Environment.GetEnvironmentVariable);
+        try
+        {
+            Console.Out.WriteLine(System.Text.Json.JsonSerializer.Serialize(
+                Store.RoundsQuery.Read(settings.DataDir, Limit(args)),
+                Server.ServerJsonContext.Default.LoggedLog));
+        }
+        catch (Exception e) when (e is Microsoft.Data.Sqlite.SqliteException or IOException or UnauthorizedAccessException)
+        {
+            Note($"the rounds database could not be read: {e.Message}");
+            Console.Out.WriteLine(System.Text.Json.JsonSerializer.Serialize(
+                new Store.LoggedLog([], [], []), Server.ServerJsonContext.Default.LoggedLog));
+        }
+
+        return 0;
+    }
+
+    /// <summary>`--log --limit 50`, or the default. A number nobody can read is the default too.</summary>
+    internal static int Limit(string[] args)
+    {
+        var at = Array.IndexOf(args, "--limit");
+
+        return at >= 0 && at + 1 < args.Length && int.TryParse(args[at + 1], out var limit) && limit > 0
+            ? limit
+            : Store.RoundsQuery.DefaultLimit;
+    }
+
     internal static async Task<int> AskLocalAsync(string[] args)
     {
         var flags = Flags(args);

--- a/src_mcp/src/Server/ServerJsonContext.cs
+++ b/src_mcp/src/Server/ServerJsonContext.cs
@@ -111,6 +111,7 @@ public sealed record DecisionDto(int Finding, string Action, string Reason = "")
 [JsonSerializable(typeof(ErrorAnswer))]
 [JsonSerializable(typeof(HumanAnswer))]
 [JsonSerializable(typeof(List<DecisionDto>))]
+[JsonSerializable(typeof(Store.LoggedLog))]
 internal sealed partial class ServerJsonContext : JsonSerializerContext;
 
 /// <summary>

--- a/src_mcp/src/Store/RoundsQuery.cs
+++ b/src_mcp/src/Store/RoundsQuery.cs
@@ -28,6 +28,15 @@ public sealed record LoggedRound(
     string StartedUtc,
     int Accepted,
     int Rejected,
+    /// <summary>
+    /// Which session it belonged to — the half of the key that makes it unique.
+    /// </summary>
+    /// <remarks>
+    /// Round numbers restart per session, so one repository and branch reviewed twice has two
+    /// "CodeReview round 1" records; without this the second overwrote the first and a row showed
+    /// another review's findings. Found by the code gate, two vendors independently.
+    /// </remarks>
+    string SessionId,
     IReadOnlyList<LoggedFinding> Findings);
 
 /// <summary>How often one kind of thing was accepted — a category, a role, or a vendor.</summary>
@@ -66,7 +75,9 @@ public static class RoundsQuery
             return new LoggedLog([], [], []);
         }
 
-        using var db = new SqliteConnection($"Data Source={file};Pooling=False;Mode=ReadOnly");
+        // Read-only, unpooled, and with a busy timeout rather than the default of none: a reader
+        // never blocks a WAL writer, but the open itself can still meet a checkpoint.
+        using var db = new SqliteConnection($"Data Source={file};Pooling=False;Mode=ReadOnly;Default Timeout=5");
         db.Open();
 
         return new LoggedLog(Rounds(db, limit), BlindSpots(db), Defended(db));
@@ -77,7 +88,7 @@ public static class RoundsQuery
         var findings = FindingsByRound(db, limit);
         using var read = db.CreateCommand();
         read.CommandText = """
-            SELECT r.id, s.repo_path, s.branch, r.stage, r.number, r.started_utc, r.accepted, r.rejected
+            SELECT r.id, s.repo_path, s.branch, r.stage, r.number, r.started_utc, r.accepted, r.rejected, r.session_id
             FROM rounds r JOIN sessions s ON s.id = r.session_id
             ORDER BY r.started_utc DESC LIMIT $limit
             """;
@@ -94,6 +105,7 @@ public static class RoundsQuery
                 rows.GetString(5),
                 rows.GetInt32(6),
                 rows.GetInt32(7),
+                rows.GetString(8),
                 findings.TryGetValue(rows.GetInt64(0), out var mine) ? mine : []));
         }
 
@@ -164,11 +176,11 @@ public static class RoundsQuery
     private static List<BlindSpot> GroupedBy(SqliteConnection db, string column)
     {
         using var read = db.CreateCommand();
-        // The column is one of three names written HERE, never anything a caller sends — the only
-        // way a column name can be interpolated safely, and it is worth saying out loud.
+        // The column is one of three names written HERE, never anything a caller sends — and it is
+        // quoted anyway, so the shape cannot become an injection the day somebody makes it dynamic.
         read.CommandText = $"""
-            SELECT {column}, SUM(resolution = 'accept'), COUNT(*)
-            FROM findings WHERE resolution <> '' GROUP BY {column} ORDER BY 2 DESC
+            SELECT "{column}", SUM(resolution = 'accept'), COUNT(*)
+            FROM findings WHERE resolution <> '' GROUP BY "{column}" ORDER BY 2 DESC
             """;
         using var rows = read.ExecuteReader();
         var spots = new List<BlindSpot>();
@@ -187,9 +199,13 @@ public static class RoundsQuery
     /// Findings a reviewer raised again over a rejection that still stood.
     /// </summary>
     /// <remarks>
-    /// Capped, and the cap is REPORTED rather than silent: a list that was cut and looks whole is
-    /// worse than no list, because somebody counts it later and reads the cap as the measurement.
-    /// One extra row is fetched so the caller can tell "exactly two hundred" from "more than that".
+    /// <para>Rejected AGAIN, not merely raised again: a finding the caller rejected once, had put to
+    /// it a second time, and rejected once more. Without that condition the list also held the ones
+    /// it was persuaded by — a repeat that was then ACCEPTED is the opposite of a defended
+    /// disagreement, and it is the case this tab exists to tell apart. Found by the code gate.</para>
+    /// <para>Capped, and the cap is REPORTED rather than silent: a list that was cut and looks whole
+    /// is worse than no list, because somebody counts it later and reads the cap as the measurement.
+    /// One extra row is fetched so the caller can tell "exactly two hundred" from "more than that".</para>
     /// </remarks>
     private static List<LoggedFinding> Defended(SqliteConnection db)
     {
@@ -197,7 +213,7 @@ public static class RoundsQuery
         read.CommandText = """
             SELECT ordinal, severity, category, file, line, title, why, fix, role, is_gating,
                    providers, resolution, reason, re_raised
-            FROM findings WHERE re_raised = 1 ORDER BY id DESC LIMIT $limit
+            FROM findings WHERE re_raised = 1 AND resolution = 'reject' ORDER BY id DESC LIMIT $limit
             """;
         read.Parameters.AddWithValue("$limit", DefendedCap + 1);
         using var rows = read.ExecuteReader();

--- a/src_mcp/src/Store/RoundsQuery.cs
+++ b/src_mcp/src/Store/RoundsQuery.cs
@@ -1,0 +1,201 @@
+using Microsoft.Data.Sqlite;
+
+namespace CoaiMcp.Store;
+
+/// <summary>One finding as the log page shows it — what it said, and what was decided about it.</summary>
+public sealed record LoggedFinding(
+    int Ordinal,
+    string Severity,
+    string Category,
+    string File,
+    int Line,
+    string Title,
+    string Why,
+    string Fix,
+    string Role,
+    bool IsGating,
+    string Providers,
+    string Resolution,
+    string Reason,
+    bool ReRaised);
+
+/// <summary>One round, with the findings it produced. Keyed the way the page keys its own rows.</summary>
+public sealed record LoggedRound(
+    string RepoPath,
+    string Branch,
+    string Stage,
+    int Number,
+    string StartedUtc,
+    int Accepted,
+    int Rejected,
+    IReadOnlyList<LoggedFinding> Findings);
+
+/// <summary>How often one kind of thing was accepted — a category, a role, or a vendor.</summary>
+public sealed record BlindSpot(string Kind, string Name, int Accepted, int Total);
+
+/// <summary>What the page asks for in one go.</summary>
+public sealed record LoggedLog(
+    IReadOnlyList<LoggedRound> Rounds,
+    IReadOnlyList<BlindSpot> BlindSpots,
+    IReadOnlyList<LoggedFinding> Defended);
+
+/// <summary>
+/// Reading the rounds database, for the page and for the two questions it exists to answer.
+/// </summary>
+/// <remarks>
+/// <para><b>Why the server reads it and not the extension.</b> The extension would need SQLite of its
+/// own — a WebAssembly build in the VSIX, or a native module per platform — to ask questions of a
+/// file this binary already has open and whose schema it owns. One read-only mode here costs sixty
+/// lines and no dependency, and it keeps every query beside the table it queries.</para>
+/// <para><b>The two questions</b> come from what the data is for (operator, 2026-09-05): finding the
+/// blind spots in an AI's own reasoning. An ACCEPTED finding is something the caller had not seen
+/// and then agreed was worth having, so accepted-by-category, by-role and by-vendor is the shape of
+/// what it habitually misses. A REJECTED finding that a later round raised again is a disagreement
+/// the caller is defending, which is the more interesting kind and a much shorter list.</para>
+/// </remarks>
+public static class RoundsQuery
+{
+    /// <summary>How many rounds the page is given, newest first.</summary>
+    public const int DefaultLimit = 300;
+
+    public static LoggedLog Read(string dataDir, int limit = DefaultLimit)
+    {
+        var file = Path.Combine(dataDir, RoundsDb.FileName);
+        if (!File.Exists(file))
+        {
+            return new LoggedLog([], [], []);
+        }
+
+        using var db = new SqliteConnection($"Data Source={file};Pooling=False;Mode=ReadOnly");
+        db.Open();
+
+        return new LoggedLog(Rounds(db, limit), BlindSpots(db), Defended(db));
+    }
+
+    private static List<LoggedRound> Rounds(SqliteConnection db, int limit)
+    {
+        var findings = FindingsByRound(db, limit);
+        using var read = db.CreateCommand();
+        read.CommandText = """
+            SELECT r.id, s.repo_path, s.branch, r.stage, r.number, r.started_utc, r.accepted, r.rejected
+            FROM rounds r JOIN sessions s ON s.id = r.session_id
+            ORDER BY r.started_utc DESC LIMIT $limit
+            """;
+        read.Parameters.AddWithValue("$limit", limit);
+        using var rows = read.ExecuteReader();
+        var rounds = new List<LoggedRound>();
+        while (rows.Read())
+        {
+            rounds.Add(new LoggedRound(
+                rows.GetString(1),
+                rows.GetString(2),
+                rows.GetString(3),
+                rows.GetInt32(4),
+                rows.GetString(5),
+                rows.GetInt32(6),
+                rows.GetInt32(7),
+                findings.TryGetValue(rows.GetInt64(0), out var mine) ? mine : []));
+        }
+
+        return rounds;
+    }
+
+    private static Dictionary<long, List<LoggedFinding>> FindingsByRound(SqliteConnection db, int limit)
+    {
+        using var read = db.CreateCommand();
+        read.CommandText = """
+            SELECT f.round_id, f.ordinal, f.severity, f.category, f.file, f.line, f.title, f.why, f.fix,
+                   f.role, f.is_gating, f.providers, f.resolution, f.reason, f.re_raised
+            FROM findings f
+            WHERE f.round_id IN (SELECT id FROM rounds ORDER BY started_utc DESC LIMIT $limit)
+            ORDER BY f.round_id, f.ordinal
+            """;
+        read.Parameters.AddWithValue("$limit", limit);
+        using var rows = read.ExecuteReader();
+        var byRound = new Dictionary<long, List<LoggedFinding>>();
+        while (rows.Read())
+        {
+            var round = rows.GetInt64(0);
+            if (!byRound.TryGetValue(round, out var mine))
+            {
+                byRound[round] = mine = [];
+            }
+
+            mine.Add(FindingFrom(rows, 1));
+        }
+
+        return byRound;
+    }
+
+    private static LoggedFinding FindingFrom(SqliteDataReader rows, int at) =>
+        new(rows.GetInt32(at),
+            rows.GetString(at + 1),
+            rows.GetString(at + 2),
+            rows.GetString(at + 3),
+            rows.GetInt32(at + 4),
+            rows.GetString(at + 5),
+            rows.GetString(at + 6),
+            rows.GetString(at + 7),
+            rows.GetString(at + 8),
+            rows.GetInt32(at + 9) == 1,
+            rows.GetString(at + 10),
+            rows.GetString(at + 11),
+            rows.GetString(at + 12),
+            rows.GetInt32(at + 13) == 1);
+
+    /// <summary>
+    /// What the caller accepts, grouped three ways.
+    /// </summary>
+    /// <remarks>
+    /// Accepted over TOTAL rather than accepted alone, because a category that produces fifty
+    /// findings and gets two accepted says something different from one that produces two and gets
+    /// both — and only the second is a blind spot worth acting on.
+    /// </remarks>
+    private static List<BlindSpot> BlindSpots(SqliteConnection db)
+    {
+        var spots = new List<BlindSpot>();
+        spots.AddRange(GroupedBy(db, "category"));
+        spots.AddRange(GroupedBy(db, "role"));
+        spots.AddRange(GroupedBy(db, "providers"));
+
+        return spots;
+    }
+
+    private static List<BlindSpot> GroupedBy(SqliteConnection db, string column)
+    {
+        using var read = db.CreateCommand();
+        // The column is one of three names written HERE, never anything a caller sends — the only
+        // way a column name can be interpolated safely, and it is worth saying out loud.
+        read.CommandText = $"""
+            SELECT {column}, SUM(resolution = 'accept'), COUNT(*)
+            FROM findings WHERE resolution <> '' GROUP BY {column} ORDER BY 2 DESC
+            """;
+        using var rows = read.ExecuteReader();
+        var spots = new List<BlindSpot>();
+        while (rows.Read())
+        {
+            spots.Add(new BlindSpot(column, rows.GetString(0), rows.GetInt32(1), rows.GetInt32(2)));
+        }
+
+        return spots;
+    }
+
+    /// <summary>Findings a reviewer raised again over a rejection that still stood.</summary>
+    private static List<LoggedFinding> Defended(SqliteConnection db)
+    {
+        using var read = db.CreateCommand();
+        read.CommandText = """
+            SELECT ordinal, severity, category, file, line, title, why, fix, role, is_gating,
+                   providers, resolution, reason, re_raised
+            FROM findings WHERE re_raised = 1 ORDER BY id DESC LIMIT 200
+            """;
+        using var rows = read.ExecuteReader();
+        var defended = new List<LoggedFinding>();
+        while (rows.Read())
+        {
+            defended.Add(FindingFrom(rows, 0));
+        }
+
+        return defended;
+    }
+}

--- a/src_mcp/src/Store/RoundsQuery.cs
+++ b/src_mcp/src/Store/RoundsQuery.cs
@@ -180,15 +180,26 @@ public static class RoundsQuery
         return spots;
     }
 
-    /// <summary>Findings a reviewer raised again over a rejection that still stood.</summary>
+    /// <summary>How many defended disagreements are listed before the list says it was cut.</summary>
+    private const int DefendedCap = 200;
+
+    /// <summary>
+    /// Findings a reviewer raised again over a rejection that still stood.
+    /// </summary>
+    /// <remarks>
+    /// Capped, and the cap is REPORTED rather than silent: a list that was cut and looks whole is
+    /// worse than no list, because somebody counts it later and reads the cap as the measurement.
+    /// One extra row is fetched so the caller can tell "exactly two hundred" from "more than that".
+    /// </remarks>
     private static List<LoggedFinding> Defended(SqliteConnection db)
     {
         using var read = db.CreateCommand();
         read.CommandText = """
             SELECT ordinal, severity, category, file, line, title, why, fix, role, is_gating,
                    providers, resolution, reason, re_raised
-            FROM findings WHERE re_raised = 1 ORDER BY id DESC LIMIT 200
+            FROM findings WHERE re_raised = 1 ORDER BY id DESC LIMIT $limit
             """;
+        read.Parameters.AddWithValue("$limit", DefendedCap + 1);
         using var rows = read.ExecuteReader();
         var defended = new List<LoggedFinding>();
         while (rows.Read())

--- a/src_mcp/src/Store/Schema.cs
+++ b/src_mcp/src/Store/Schema.cs
@@ -99,6 +99,8 @@ internal static class Schema
 
         CREATE INDEX IF NOT EXISTS rounds_by_time   ON rounds (started_utc DESC);
         CREATE INDEX IF NOT EXISTS findings_by_round ON findings (round_id);
+        -- The defended list reads this and nothing else, over the whole table, on every refresh.
+        CREATE INDEX IF NOT EXISTS findings_re_raised ON findings (re_raised, resolution);
         """;
 
     /// <summary>

--- a/src_mcp/tests/RoundsQueryTests.cs
+++ b/src_mcp/tests/RoundsQueryTests.cs
@@ -1,0 +1,191 @@
+using System.Collections.Immutable;
+using CoaiMcp.Core.Findings;
+using CoaiMcp.Core.Rounds;
+using CoaiMcp.Server;
+using CoaiMcp.Store;
+using FluentAssertions;
+using Xunit;
+
+namespace CoaiMcp.Tests;
+
+/// <summary>
+/// Reading the rounds database back — for the log page, and for the two questions it exists for.
+/// </summary>
+/// <remarks>
+/// The page shows counts because counts were all there was. Now there are findings, and this is the
+/// read side of them: the round with its findings, what was decided about each, and the two
+/// aggregates the operator asked for on 2026-09-05 — what the caller ACCEPTS (a blind spot it
+/// admitted) grouped by category, role and vendor, and what it rejected and had raised again.
+/// </remarks>
+public sealed class RoundsQueryTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "coai-q-" + Guid.NewGuid().ToString("N")[..8]);
+    private readonly Serilog.ILogger _log = Serilog.Core.Logger.None;
+
+    private static readonly SessionState Session =
+        new("s1", "D:/repo", "feat/x", new PanelConfig()) { Stage = Stage.CodeReview };
+
+    private static Finding Found(
+        string title,
+        Category category = Category.Reliability,
+        string role = "SecurityReliability",
+        string provider = "codex") =>
+        new(Severity.Major, category, "src/Panel.cs", 40, title, title + " — because", "do this", [provider])
+        {
+            Role = role,
+        };
+
+    private static RoundRecord Round(int number = 1) =>
+        new("CodeReview", number, "proceed", 2, "all 3 reviewers answered", DateTime.UtcNow)
+        {
+            StartedUtc = DateTime.UtcNow.AddMinutes(-4),
+            Subject = "SCOPE — something",
+            ReviewerStates = [new ReviewerState("codex", "Architecture", ReviewerState.Done, 2, "", 23.4)],
+        };
+
+    [Fact]
+    public void ARoundComesBackWithTheFindingsItProduced_AndWhatWasDecided()
+    {
+        using (var db = RoundsDb.Open(_dir, _log)!)
+        {
+            var findings = new[] { Found("session file opened without FileShare"), Found("the retry never gives up") };
+            db.RecordRound(Session, Round(), findings);
+            db.RecordDecisions("s1", "CodeReview", 1,
+                [new Decision.Accepted(findings[0]), new Decision.Rejected(findings[1], "the loop has a timeout")]);
+        }
+
+        var round = RoundsQuery.Read(_dir).Rounds.Should().ContainSingle().Subject;
+        round.RepoPath.Should().Be("D:/repo");
+        round.Branch.Should().Be("feat/x");
+        round.Stage.Should().Be("CodeReview");
+        round.Number.Should().Be(1);
+        round.Accepted.Should().Be(1);
+        round.Rejected.Should().Be(1);
+        round.Findings.Should().HaveCount(2);
+        round.Findings[0].Title.Should().Be("session file opened without FileShare");
+        round.Findings[0].Why.Should().NotBeEmpty("the page shows what the finding SAID, not that it existed");
+        round.Findings[0].Resolution.Should().Be("accept");
+        round.Findings[1].Resolution.Should().Be("reject");
+        round.Findings[1].Reason.Should().Be("the loop has a timeout");
+    }
+
+    [Fact]
+    public void WhatTheCallerACCEPTS_IsGroupedByCategoryRoleAndVendor()
+    {
+        // The blind-spot corpus: an accepted finding is something the caller had not seen and then
+        // agreed was worth having. Accepted over TOTAL, because a category that produces fifty and
+        // gets two accepted says something different from one that produces two and gets both.
+        using (var db = RoundsDb.Open(_dir, _log)!)
+        {
+            var findings = new[]
+            {
+                Found("a", Category.Security, "SecurityReliability", "codex"),
+                Found("b", Category.Security, "SecurityReliability", "codex"),
+                Found("c", Category.Ux, "UxDxPerformance", "gemini"),
+            };
+            db.RecordRound(Session, Round(), findings);
+            db.RecordDecisions("s1", "CodeReview", 1,
+            [
+                new Decision.Accepted(findings[0]),
+                new Decision.Accepted(findings[1]),
+                new Decision.Rejected(findings[2], "not worth the machinery"),
+            ]);
+        }
+
+        var spots = RoundsQuery.Read(_dir).BlindSpots;
+
+        spots.Should().Contain(s => s.Kind == "category" && s.Name == "Security" && s.Accepted == 2 && s.Total == 2);
+        spots.Should().Contain(s => s.Kind == "category" && s.Name == "Ux" && s.Accepted == 0 && s.Total == 1);
+        spots.Should().Contain(s => s.Kind == "role" && s.Name == "SecurityReliability" && s.Accepted == 2);
+        spots.Should().Contain(s => s.Kind == "providers" && s.Name == "codex" && s.Accepted == 2);
+    }
+
+    [Fact]
+    public void AnUndecidedFinding_CountsTowardsNeither()
+    {
+        using (var db = RoundsDb.Open(_dir, _log)!)
+        {
+            db.RecordRound(Session, Round(), [Found("nobody has judged this")]);
+        }
+
+        RoundsQuery.Read(_dir).BlindSpots.Should().BeEmpty("a finding nobody decided is not evidence either way");
+    }
+
+    [Fact]
+    public void AFindingRaisedAgainOverAStandingRejection_IsListedOnItsOwn()
+    {
+        // The more interesting kind of disagreement, and a much shorter list than the accepted one.
+        var standing = Found("session file opened without FileShare");
+        using (var db = RoundsDb.Open(_dir, _log)!)
+        {
+            db.RecordRound(Session, Round(2), [standing, Found("something new")],
+                new RoundContext("SCOPE", "7133c2f", "claude-code", [standing]));
+        }
+
+        var defended = RoundsQuery.Read(_dir).Defended;
+
+        defended.Should().ContainSingle().Which.Title.Should().Be("session file opened without FileShare");
+        defended[0].ReRaised.Should().BeTrue();
+    }
+
+    [Fact]
+    public void NewestRoundsFirst_AndNoMoreThanAsked()
+    {
+        using (var db = RoundsDb.Open(_dir, _log)!)
+        {
+            for (var number = 1; number <= 5; number++)
+            {
+                db.RecordRound(
+                    Session,
+                    Round(number) with { StartedUtc = DateTime.UtcNow.AddMinutes(-10 + number) },
+                    [Found("round " + number)]);
+            }
+        }
+
+        var rounds = RoundsQuery.Read(_dir, limit: 2).Rounds;
+
+        rounds.Should().HaveCount(2);
+        rounds[0].Number.Should().Be(5, "newest first, because that is what a log page opens on");
+    }
+
+    [Fact]
+    public void ADatabaseThatIsNotThereIsAnEmptyLog_NotAFailure()
+    {
+        // A machine that has never run a round is asking a fair question and deserves an answer it
+        // can render.
+        var log = RoundsQuery.Read(Path.Combine(_dir, "nothing here"));
+
+        log.Rounds.Should().BeEmpty();
+        log.BlindSpots.Should().BeEmpty();
+        log.Defended.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TheLimitFlagIsReadFromTheCommandLine_OrItsDefault()
+    {
+        Program.Limit(["--log", "--limit", "50"]).Should().Be(50);
+        Program.Limit(["--log"]).Should().Be(RoundsQuery.DefaultLimit);
+        Program.Limit(["--log", "--limit", "not a number"]).Should().Be(RoundsQuery.DefaultLimit);
+        Program.Limit(["--log", "--limit", "0"]).Should().Be(RoundsQuery.DefaultLimit, "nothing is not a page size");
+    }
+
+    [Fact]
+    public void TheLogIsAWholeStartupMode_LikeVersionAndHelp()
+    {
+        Program.Classify(["--log"]).Should().Be(Program.Startup.Log);
+        Program.Classify([]).Should().Be(Program.Startup.Serve, "and an MCP client still gets the protocol");
+    }
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        try
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not a failing test.
+        }
+    }
+}

--- a/src_mcp/tests/RoundsQueryTests.cs
+++ b/src_mcp/tests/RoundsQueryTests.cs
@@ -112,7 +112,7 @@ public sealed class RoundsQueryTests : IDisposable
     }
 
     [Fact]
-    public void AFindingRaisedAgainOverAStandingRejection_IsListedOnItsOwn()
+    public void AFindingRaisedAgainAndRejectedAgain_IsListedOnItsOwn()
     {
         // The more interesting kind of disagreement, and a much shorter list than the accepted one.
         var standing = Found("session file opened without FileShare");
@@ -120,12 +120,43 @@ public sealed class RoundsQueryTests : IDisposable
         {
             db.RecordRound(Session, Round(2), [standing, Found("something new")],
                 new RoundContext("SCOPE", "7133c2f", "claude-code", [standing]));
+            db.RecordDecisions("s1", "CodeReview", 2,
+                [new Decision.Rejected(standing, "still no"), new Decision.Accepted(Found("something new"))]);
         }
 
         var defended = RoundsQuery.Read(_dir).Defended;
 
         defended.Should().ContainSingle().Which.Title.Should().Be("session file opened without FileShare");
         defended[0].ReRaised.Should().BeTrue();
+        defended[0].Reason.Should().Be("still no");
+    }
+
+    [Fact]
+    public void AFindingRaisedAgainAndThenACCEPTED_IsNotADefendedDisagreement()
+    {
+        // The opposite case, and the one the code gate caught: a repeat the caller was PERSUADED by
+        // is not a disagreement it is defending. Listing it there would report a false one.
+        var persuaded = Found("session file opened without FileShare");
+        using (var db = RoundsDb.Open(_dir, _log)!)
+        {
+            db.RecordRound(Session, Round(2), [persuaded],
+                new RoundContext("SCOPE", "7133c2f", "claude-code", [persuaded]));
+            db.RecordDecisions("s1", "CodeReview", 2, [new Decision.Accepted(persuaded)]);
+        }
+
+        RoundsQuery.Read(_dir).Defended.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AFindingRaisedAgainAndNotYetDecided_IsNotListedEither()
+    {
+        var open = Found("session file opened without FileShare");
+        using (var db = RoundsDb.Open(_dir, _log)!)
+        {
+            db.RecordRound(Session, Round(2), [open], new RoundContext("SCOPE", "7133c2f", "claude-code", [open]));
+        }
+
+        RoundsQuery.Read(_dir).Defended.Should().BeEmpty("nobody has argued with it a second time yet");
     }
 
     [Fact]

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.30.1 — 2026-09-05 (server 0.18.1)
+
+**The log shows the findings themselves, not only how many.** Expand a round and the sentences are
+there — severity, file and line, what the reviewer said, what it proposed, and **what was decided
+about it, with the reason a rejection carried**. A finding that repeats one already rejected is
+marked *raised again*.
+
+**A third tab: what it keeps missing.** The two questions this data exists to answer.
+*What the caller ACCEPTS*, by category, by reviewer role and by vendor — an accepted finding is by
+definition something the AI had not seen and then agreed was worth having, which is the blind-spot
+corpus. Shown as accepted **over total**, because a category that produces eleven findings and gets
+none taken says something quite different from one that produces nine and gets seven. And *rejected,
+and raised again anyway*: the shorter, sharper list of disagreements the caller is defending.
+
+**No SQLite in the extension.** The alternative was a WebAssembly build in the VSIX or a native
+module per platform, to ask questions of a file the server already writes and whose schema it owns.
+The server answers `--log` with JSON instead. A server older than the flag answers nothing, which
+reads to the page exactly like a machine that has run no rounds — everything built from the session
+files carries on as before.
+
+## Server 0.18.1 — 2026-09-05
+
+`--log [--limit N]` prints the rounds database as JSON and leaves: rounds with their findings and
+resolutions, what the caller accepted and rejected grouped three ways, and the findings raised again
+over a standing rejection. Read-only, and an empty answer for a machine with no database rather than
+an error.
 ## 0.30.0 — 2026-09-05 (server 0.18.0)
 
 **The gate's own rule stopped being a paste, and the panel can see where it went.** The block that

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -1,8 +1,8 @@
 {
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
-  "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.30.0",
+  "description": "Your AI writes the code; other vendors' models review it \u2014 the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
+  "version": "0.30.1",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {
@@ -31,7 +31,7 @@
       },
       {
         "command": "coai.installServer",
-        "title": "Install the MCP server…",
+        "title": "Install the MCP server\u2026",
         "category": "ConnectOtherAIs"
       },
       {
@@ -52,14 +52,14 @@
       },
       {
         "command": "coai.answerQuestion",
-        "title": "Answer the open question…",
+        "title": "Answer the open question\u2026",
         "icon": "$(comment-discussion)",
         "category": "ConnectOtherAIs"
       },
       {
         "command": "coai.answerQuestionWaiting",
         "category": "ConnectOtherAIs",
-        "title": "Answer the open question…",
+        "title": "Answer the open question\u2026",
         "icon": "media/question-waiting.svg"
       }
     ],
@@ -69,7 +69,7 @@
         "coai.promptsPerRound": {
           "type": "object",
           "default": {},
-          "markdownDescription": "Which prompt each role uses on each round, by catalog id — `{ \"Architecture\": [\"architecture\", \"arch-boundaries\"] }`. Index 0 is round 1. An empty or unknown entry is treated as *not chosen*: round 1 of a code role falls back to the conventions pass when the repository has written rules, and every other round to that role's universal prompt.",
+          "markdownDescription": "Which prompt each role uses on each round, by catalog id \u2014 `{ \"Architecture\": [\"architecture\", \"arch-boundaries\"] }`. Index 0 is round 1. An empty or unknown entry is treated as *not chosen*: round 1 of a code role falls back to the conventions pass when the repository has written rules, and every other round to that role's universal prompt.",
           "additionalProperties": {
             "type": "array",
             "items": {
@@ -86,7 +86,7 @@
             "escalate"
           ],
           "default": "human",
-          "markdownDescription": "When rounds run out with findings still gating: `continue` as-is (said out loud), call a `human`, or `escalate` the ladder (reviewer effort → reviewer model → arbiter model)."
+          "markdownDescription": "When rounds run out with findings still gating: `continue` as-is (said out loud), call a `human`, or `escalate` the ladder (reviewer effort \u2192 reviewer model \u2192 arbiter model)."
         },
         "coai.maxConcurrency": {
           "type": "integer",
@@ -98,7 +98,7 @@
           "type": "integer",
           "default": 2,
           "minimum": 1,
-          "description": "Reviewer CLI processes per vendor at once — a rate limit is per vendor."
+          "description": "Reviewer CLI processes per vendor at once \u2014 a rate limit is per vendor."
         },
         "coai.reviewerTimeoutMinutes": {
           "type": "integer",
@@ -109,7 +109,7 @@
         "coai.credsKey": {
           "type": "string",
           "default": "",
-          "markdownDescription": "The CredsForDevs **config-entry key** (minted by *Enable Code Access…* on the entry holding vendor API keys). A pass to one vault entry — revocable, useless while VS Code is closed — not a secret itself. Empty = keyless vendors only."
+          "markdownDescription": "The CredsForDevs **config-entry key** (minted by *Enable Code Access\u2026* on the entry holding vendor API keys). A pass to one vault entry \u2014 revocable, useless while VS Code is closed \u2014 not a secret itself. Empty = keyless vendors only."
         },
         "coai.escalationMinutes": {
           "type": "integer",
@@ -141,7 +141,7 @@
               "pricePerMillionOut": 0
             }
           ],
-          "markdownDescription": "The reviewers. Edit them in the **ConnectOtherAIs** panel — add a vendor, remove one, or point it at another model. `runtime` is which CLI shape it uses (`codex` or `gemini`); `baseUrl` makes it an OpenAI-compatible endpoint driven through the Codex CLI.",
+          "markdownDescription": "The reviewers. Edit them in the **ConnectOtherAIs** panel \u2014 add a vendor, remove one, or point it at another model. `runtime` is which CLI shape it uses (`codex` or `gemini`); `baseUrl` makes it an OpenAI-compatible endpoint driven through the Codex CLI.",
           "items": {
             "type": "object",
             "required": [
@@ -198,7 +198,7 @@
         "coai.dealPlanLenses": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Deal the plan stage’s lenses across the vendors instead of giving every vendor the same one. **Off** (the default): every vendor answers the same question, so two vendors agreeing on a finding is a fact the gate can use. **On**: every lens gets asked once at half the launches, and that agreement is gone."
+          "markdownDescription": "Deal the plan stage\u2019s lenses across the vendors instead of giving every vendor the same one. **Off** (the default): every vendor answers the same question, so two vendors agreeing on a finding is a fact the gate can use. **On**: every lens gets asked once at half the launches, and that agreement is gone."
         },
         "coai.dealCodeLenses": {
           "type": "boolean",
@@ -212,8 +212,8 @@
             "worktree"
           ],
           "enumDescriptions": [
-            "Fast — the reviewer gets the diff, the plan and the project's rules, in an empty directory.",
-            "Full — the reviewer also gets the checkout of the commit under review."
+            "Fast \u2014 the reviewer gets the diff, the plan and the project's rules, in an empty directory.",
+            "Full \u2014 the reviewer also gets the checkout of the commit under review."
           ],
           "default": "none",
           "markdownDescription": "What a code reviewer is given. **Fast** (default) sends the composed prompt with nothing to explore; measured, every hosted model found more useful defects that way at a fraction of the input tokens. **Full** also hands it the checkout of the commit under review."
@@ -223,7 +223,7 @@
           "default": 0,
           "minimum": -5,
           "maximum": 5,
-          "markdownDescription": "Text size on the ConnectOtherAIs help page, in steps of 10% from the base — `5` is about ×1.6, `-5` about ÷1.6. The ± buttons on the page write this same setting, and it syncs with your other machines."
+          "markdownDescription": "Text size on the ConnectOtherAIs help page, in steps of 10% from the base \u2014 `5` is about \u00d71.6, `-5` about \u00f71.6. The \u00b1 buttons on the page write this same setting, and it syncs with your other machines."
         },
         "coai.helpLanguage": {
           "type": "string",
@@ -234,7 +234,7 @@
           ],
           "enumDescriptions": [
             "English",
-            "Русский"
+            "\u0420\u0443\u0441\u0441\u043a\u0438\u0439"
           ],
           "markdownDescription": "The language of the **Help** pages only. Articles not yet translated show English with a note. The switch at the top of the help page writes this same setting."
         },
@@ -246,12 +246,12 @@
         "coai.splitPlan": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "After a plan passes, tell the assistant to break it into 2-4 epics and each into 2-4 logically complete stories, and to close every story properly: review its diff through this gate, fix, document, test, commit. The order is given once per assistant — an epic coming back for its own review is told it is a piece, not told to split again."
+          "markdownDescription": "After a plan passes, tell the assistant to break it into 2-4 epics and each into 2-4 logically complete stories, and to close every story properly: review its diff through this gate, fix, document, test, commit. The order is given once per assistant \u2014 an epic coming back for its own review is told it is a piece, not told to split again."
         },
         "coai.splitWithFable": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Do the split itself with Fable at its highest version, and send the stories where being wrong is expensive — payments, security, architecture, data migration — back to it; the ordinary ones run on Opus. Fable here is a model of YOUR assistant, not a reviewer in the list."
+          "markdownDescription": "Do the split itself with Fable at its highest version, and send the stories where being wrong is expensive \u2014 payments, security, architecture, data migration \u2014 back to it; the ordinary ones run on Opus. Fable here is a model of YOUR assistant, not a reviewer in the list."
         }
       }
     },

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -8,7 +8,7 @@ import { EscalationWatcher } from './escalationWatcher';
 import { PanelProvider } from './panelProvider';
 import { showHelp } from './helpPanel';
 import { parseSession, SessionFile } from './rounds';
-import { rowsFrom } from './roundsLog';
+import { blindSpotsHtml, rowsFrom } from './roundsLog';
 import { RoundsLogPanel } from './roundsLogPanel';
 import { envBlock, settingsFrom } from './settingsShape';
 import { ServerSettingsSync } from './serverSettingsSync';
@@ -233,10 +233,12 @@ async function copyClaudeSnippet(): Promise<void> {
  */
 async function showRoundsLog(log: RoundsLogPanel, watcher: EscalationWatcher, panel: PanelProvider): Promise<void> {
   await watcher.refresh();
+  const opened = await panel.roundsLog();
   log.show(
-    rowsFrom(await readSessions(), Date.now(), await panel.modelPrice(), await panel.usageLines()),
+    rowsFrom(await readSessions(), Date.now(), await panel.modelPrice(), await panel.usageLines(), opened),
     watcher.openQuestions,
-    await panel.usageTab());
+    await panel.usageTab(),
+    blindSpotsHtml(opened));
 }
 
 /** Keeps an OPEN log current while a round runs. Nothing is read when nobody is looking. */
@@ -244,11 +246,13 @@ async function refreshRoundsLog(log: RoundsLogPanel, watcher: EscalationWatcher,
   if (!log.isOpen) {
     return;
   }
+  const fresh = await panel.roundsLog();
   log.update(
-    rowsFrom(await readSessions(), Date.now(), await panel.modelPrice(), await panel.usageLines()),
+    rowsFrom(await readSessions(), Date.now(), await panel.modelPrice(), await panel.usageLines(), fresh),
     watcher.openQuestions,
     await panel.usageTab(),
-    force);
+    force,
+    blindSpotsHtml(fresh));
 }
 
 /** The server's own session files: its data dir, or `COAI_DATA_DIR` when the person set one. */

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -233,12 +233,16 @@ async function copyClaudeSnippet(): Promise<void> {
  */
 async function showRoundsLog(log: RoundsLogPanel, watcher: EscalationWatcher, panel: PanelProvider): Promise<void> {
   await watcher.refresh();
-  const opened = await panel.roundsLog();
+
+  // The page FIRST, from the session files alone — everything it has ever shown comes from those, so
+  // it is complete without the database. Reading the database spawns the server, and a person who
+  // opened a log should not wait on a process to see it: the findings arrive in the next push, a
+  // moment later. Raised by the gate as blocking the panel on an unannounced read.
   log.show(
-    rowsFrom(await readSessions(), Date.now(), await panel.modelPrice(), await panel.usageLines(), opened),
+    rowsFrom(await readSessions(), Date.now(), await panel.modelPrice(), await panel.usageLines()),
     watcher.openQuestions,
-    await panel.usageTab(),
-    blindSpotsHtml(opened));
+    await panel.usageTab());
+  await refreshRoundsLog(log, watcher, panel, true);
 }
 
 /** Keeps an OPEN log current while a round runs. Nothing is read when nobody is looking. */

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -107,6 +107,9 @@ export class PanelProvider implements vscode.WebviewViewProvider {
   private openRouterPrices: PriceTable = {};
   private liteLlmPrices: PriceTable = {};
   private pricesCheckedAt = 0;
+  /** The rounds database as last read, and when — a read is a process spawn. */
+  private roundsLogCache: DbLog = EMPTY_LOG;
+  private roundsLogAt = 0;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -181,9 +184,19 @@ export class PanelProvider implements vscode.WebviewViewProvider {
    * showing everything it builds from the session files.</p>
    */
   async roundsLog(): Promise<DbLog> {
+    // Cached for a few seconds, because the log page refreshes every tick while a round runs and
+    // each read is a process spawn plus a walk of the whole findings table. The gate called that
+    // out twice: a hot path is not where a child process belongs. A few seconds is shorter than any
+    // round and longer than any burst of ticks.
+    const AGE_MS = 10_000;
+    if (Date.now() - this.roundsLogAt < AGE_MS) {
+      return this.roundsLogCache;
+    }
     const server = serverPath(this.context.globalStorageUri);
+    this.roundsLogAt = Date.now();
+    this.roundsLogCache = server === undefined ? EMPTY_LOG : await readLog(server.fsPath);
 
-    return server === undefined ? EMPTY_LOG : readLog(server.fsPath);
+    return this.roundsLogCache;
   }
 
   /**

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -22,7 +22,9 @@ import {
   versionSourceFor,
 } from './cliVersions';
 import { askVersion } from './versionProbe';
-import { latestServerVersion, serverOnThisSide } from './installer';
+import { latestServerVersion, serverOnThisSide, serverPath } from './installer';
+import { DbLog, EMPTY_LOG } from './roundsDb';
+import { readLog } from './roundsDbRead';
 import { sideLabel } from './coaiInstall';
 import {
   fetchTable,
@@ -168,6 +170,20 @@ export class PanelProvider implements vscode.WebviewViewProvider {
 
       return seen.get(model);
     };
+  }
+
+  /**
+   * The rounds database, as the installed server reads it.
+   *
+   * <p>Through the server rather than through SQLite of our own: it owns the schema, it already has
+   * the file, and the alternative was a WebAssembly build in the VSIX. A server too old for the flag
+   * answers nothing, which is the same to the page as a machine that has run no rounds — it goes on
+   * showing everything it builds from the session files.</p>
+   */
+  async roundsLog(): Promise<DbLog> {
+    const server = serverPath(this.context.globalStorageUri);
+
+    return server === undefined ? EMPTY_LOG : readLog(server.fsPath);
   }
 
   /**

--- a/src_vs_code/src/roundsDb.ts
+++ b/src_vs_code/src/roundsDb.ts
@@ -39,6 +39,8 @@ export interface DbRound {
   readonly stage: string;
   readonly number: number;
   readonly startedUtc: string;
+  /** Which session it belonged to — the half of the key that makes it unique. */
+  readonly sessionId: string;
   /** How the caller closed the gate; -1 until it did. */
   readonly accepted: number;
   readonly rejected: number;
@@ -89,6 +91,7 @@ function round(raw: Partial<DbRound>): DbRound {
     stage: raw.stage ?? '',
     number: raw.number ?? 0,
     startedUtc: raw.startedUtc ?? '',
+    sessionId: raw.sessionId ?? '',
     accepted: raw.accepted ?? -1,
     rejected: raw.rejected ?? -1,
     findings: (raw.findings ?? []).map(finding),
@@ -118,12 +121,24 @@ function finding(raw: Partial<DbFinding>): DbFinding {
  * The key a round is found by, from either side.
  *
  * <p>The page builds its rows from the session files and the database knows nothing of them, so the
- * two are matched on what both record: the repository, the branch, the stage and the round number.
- * Paths are compared the way this family compares them everywhere — separators normalised, case
- * ignored, because Windows writes the same folder three ways in one afternoon.</p>
+ * two are matched on what both record: the SESSION, the repository, the branch, the stage and the
+ * round number. Paths are compared the way this family compares them everywhere — separators
+ * normalised, case ignored, because Windows writes the same folder three ways in one afternoon.</p>
+ *
+ * <p><b>The session is part of it because round numbers restart.</b> One repository and branch
+ * reviewed twice has two "CodeReview round 1" records; keyed without the session, the second
+ * overwrote the first and a row showed another review's findings. Two of the gate's reviewers found
+ * that independently.</p>
  */
-export function roundKeyOf(repoPath: string, branch: string, stage: string, number: number): string {
+export function roundKeyOf(
+  sessionId: string,
+  repoPath: string,
+  branch: string,
+  stage: string,
+  number: number,
+): string {
   return [
+    sessionId,
     repoPath.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase(),
     branch.toLowerCase(),
     stage.toLowerCase().replace(/\s+/g, ''),
@@ -135,7 +150,7 @@ export function roundKeyOf(repoPath: string, branch: string, stage: string, numb
 export function findingsByRound(log: DbLog): Map<string, readonly DbFinding[]> {
   const byRound = new Map<string, readonly DbFinding[]>();
   for (const one of log.rounds) {
-    byRound.set(roundKeyOf(one.repoPath, one.branch, one.stage, one.number), one.findings);
+    byRound.set(roundKeyOf(one.sessionId, one.repoPath, one.branch, one.stage, one.number), one.findings);
   }
 
   return byRound;

--- a/src_vs_code/src/roundsDb.ts
+++ b/src_vs_code/src/roundsDb.ts
@@ -1,0 +1,142 @@
+/**
+ * The rounds database, read through the server that owns it.
+ *
+ * <p><b>Why not SQLite in here.</b> The alternative was a WebAssembly build of SQLite in the VSIX or
+ * a native module per platform, to ask questions of a file the server already writes and whose
+ * schema it owns. The server answers `--log` with JSON instead: no dependency, no platform build,
+ * and every query stays beside its table.</p>
+ *
+ * <p><b>Version skew is normal and is not an error.</b> A server older than the database answers
+ * `unknown argument` and exit 64; one that has never run a round answers an empty log. Both mean the
+ * same thing to the page — no findings to show — and the page keeps rendering everything it builds
+ * from the session files, which is what it always had.</p>
+ */
+
+/** One finding, as the log page shows it. */
+export interface DbFinding {
+  readonly ordinal: number;
+  readonly severity: string;
+  readonly category: string;
+  readonly file: string;
+  readonly line: number;
+  readonly title: string;
+  readonly why: string;
+  readonly fix: string;
+  readonly role: string;
+  readonly isGating: boolean;
+  /** Comma-separated, as the database stores them: one vendor in practice. */
+  readonly providers: string;
+  /** `accept`, `reject`, or empty while nobody has decided. */
+  readonly resolution: string;
+  readonly reason: string;
+  /** The caller had already rejected this, and a reviewer raised it again. */
+  readonly reRaised: boolean;
+}
+
+export interface DbRound {
+  readonly repoPath: string;
+  readonly branch: string;
+  readonly stage: string;
+  readonly number: number;
+  readonly startedUtc: string;
+  /** How the caller closed the gate; -1 until it did. */
+  readonly accepted: number;
+  readonly rejected: number;
+  readonly findings: readonly DbFinding[];
+}
+
+/** How often one kind of thing was accepted — by category, by role, or by vendor. */
+export interface BlindSpot {
+  readonly kind: string;
+  readonly name: string;
+  readonly accepted: number;
+  readonly total: number;
+}
+
+export interface DbLog {
+  readonly rounds: readonly DbRound[];
+  readonly blindSpots: readonly BlindSpot[];
+  readonly defended: readonly DbFinding[];
+}
+
+export const EMPTY_LOG: DbLog = { rounds: [], blindSpots: [], defended: [] };
+
+/**
+ * The server's JSON, believed only as far as its shape.
+ *
+ * <p>Pure, so it is a test rather than a hope: this reads a file written by another program, and a
+ * page that throws on one unexpected field is a page that goes blank for a reason nobody can see
+ * from the outside.</p>
+ */
+export function parseLog(text: string): DbLog {
+  try {
+    const raw = JSON.parse(text) as Partial<DbLog>;
+
+    return {
+      rounds: (raw.rounds ?? []).map(round),
+      blindSpots: (raw.blindSpots ?? []).filter((s) => typeof s?.name === 'string'),
+      defended: (raw.defended ?? []).map(finding),
+    };
+  } catch {
+    return EMPTY_LOG;
+  }
+}
+
+function round(raw: Partial<DbRound>): DbRound {
+  return {
+    repoPath: raw.repoPath ?? '',
+    branch: raw.branch ?? '',
+    stage: raw.stage ?? '',
+    number: raw.number ?? 0,
+    startedUtc: raw.startedUtc ?? '',
+    accepted: raw.accepted ?? -1,
+    rejected: raw.rejected ?? -1,
+    findings: (raw.findings ?? []).map(finding),
+  };
+}
+
+function finding(raw: Partial<DbFinding>): DbFinding {
+  return {
+    ordinal: raw.ordinal ?? 0,
+    severity: raw.severity ?? '',
+    category: raw.category ?? '',
+    file: raw.file ?? '',
+    line: raw.line ?? 0,
+    title: raw.title ?? '',
+    why: raw.why ?? '',
+    fix: raw.fix ?? '',
+    role: raw.role ?? '',
+    isGating: raw.isGating === true,
+    providers: raw.providers ?? '',
+    resolution: raw.resolution ?? '',
+    reason: raw.reason ?? '',
+    reRaised: raw.reRaised === true,
+  };
+}
+
+/**
+ * The key a round is found by, from either side.
+ *
+ * <p>The page builds its rows from the session files and the database knows nothing of them, so the
+ * two are matched on what both record: the repository, the branch, the stage and the round number.
+ * Paths are compared the way this family compares them everywhere — separators normalised, case
+ * ignored, because Windows writes the same folder three ways in one afternoon.</p>
+ */
+export function roundKeyOf(repoPath: string, branch: string, stage: string, number: number): string {
+  return [
+    repoPath.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase(),
+    branch.toLowerCase(),
+    stage.toLowerCase().replace(/\s+/g, ''),
+    number,
+  ].join('|');
+}
+
+/** Every round's findings, by that key. */
+export function findingsByRound(log: DbLog): Map<string, readonly DbFinding[]> {
+  const byRound = new Map<string, readonly DbFinding[]>();
+  for (const one of log.rounds) {
+    byRound.set(roundKeyOf(one.repoPath, one.branch, one.stage, one.number), one.findings);
+  }
+
+  return byRound;
+}

--- a/src_vs_code/src/roundsDbRead.ts
+++ b/src_vs_code/src/roundsDbRead.ts
@@ -1,0 +1,30 @@
+import { DbLog, EMPTY_LOG, parseLog } from './roundsDb';
+import { capture } from './versionProbe';
+
+/**
+ * Asking the server for its rounds database.
+ *
+ * <p>Apart from {@link roundsDb} on purpose: that module is types and pure functions, and the page
+ * module imports it. A spawn in the same file would drag `node:child_process` into the bundle the
+ * webview page is built from — which is exactly what the bundled-page test caught, with
+ * `require is not defined`, the first time this was written as one file.</p>
+ */
+
+/** Reading is slower than a version probe and still must not hold up a repaint. */
+const CAP_MS = 8_000;
+
+/**
+ * What the server says, or an empty log.
+ *
+ * <p>Anything at all going wrong is an empty log: a server too old for the flag, a database that is
+ * not there, a binary that has been replaced mid-read. The page shows what it can either way.</p>
+ */
+export async function readLog(executable: string, limit = 300): Promise<DbLog> {
+  if (executable.length === 0) {
+    return EMPTY_LOG;
+  }
+  const { code, output } = await capture(executable, ['--log', '--limit', String(limit)], false, CAP_MS);
+
+  return code === 0 ? parseLog(output) : EMPTY_LOG;
+}
+

--- a/src_vs_code/src/roundsLog.ts
+++ b/src_vs_code/src/roundsLog.ts
@@ -581,11 +581,15 @@ function share(spot: BlindSpot): string {
   return spot.total === 0 ? '—' : `${Math.round((100 * spot.accepted) / spot.total)}`;
 }
 
+/** What the server caps that list at; it sends one more so the page can say there are more. */
+const DEFENDED_CAP = 200;
+
 function defendedHtml(defended: readonly DbFinding[]): string {
   if (defended.length === 0) {
     return '';
   }
   const items = defended
+    .slice(0, DEFENDED_CAP)
     .map((f) => `<div class="finding declined"><span class="sev">${escapeHtml(f.severity)}</span> `
       + `<span class="where">${escapeHtml(f.file ? `${f.file}:${f.line}` : 'no file')}</span> `
       + `<b>${escapeHtml(f.title)}</b><div class="why">${escapeHtml(f.why)}</div>`
@@ -593,9 +597,15 @@ function defendedHtml(defended: readonly DbFinding[]): string {
       + `${f.reason ? ` &middot; the standing reason: ${escapeHtml(f.reason)}` : ''}</div></div>`)
     .join('');
 
+  // The server fetches one more than it will show, so "exactly two hundred" and "more than that"
+  // are different answers. A list that was cut and looks whole is worse than no list.
+  const cut = defended.length > DEFENDED_CAP
+    ? ` The most recent ${DEFENDED_CAP} of them; there are more.`
+    : '';
+
   return '<h2>Rejected, and raised again anyway</h2>'
     + '<div class="hint">A disagreement the caller is defending — the rejection still stood when'
-    + ' another reviewer made the same case.</div>'
+    + ` another reviewer made the same case.${cut}</div>`
     + `<div class="findings">${items}</div>`;
 }
 

--- a/src_vs_code/src/roundsLog.ts
+++ b/src_vs_code/src/roundsLog.ts
@@ -161,7 +161,8 @@ function rowFrom(
     vendors: [...new Set(states.map((s) => s.provider))],
     reviewers: reviewerLines(round),
     reviewerColours: rows.map((r) => vendorColour(r.provider)),
-    found: byRound.get(roundKeyOf(session.state.repoPath, session.state.branch, round.stage, round.number)) ?? [],
+    found: byRound.get(roundKeyOf(
+      session.state.sessionId, session.state.repoPath, session.state.branch, round.stage, round.number)) ?? [],
   };
 }
 

--- a/src_vs_code/src/roundsLog.ts
+++ b/src_vs_code/src/roundsLog.ts
@@ -5,6 +5,7 @@ import { UsageEntry, Window, WINDOWS } from './usage';
 import { Vendor } from './vendors';
 import { MAX_PLAUSIBLE_SECONDS, reviewerLines, reviewerRows, RoundRecord, SessionFile, stageName } from './rounds';
 import { vendorColour } from './vendorColour';
+import { BlindSpot, DbFinding, DbLog, EMPTY_LOG, findingsByRound, roundKeyOf } from './roundsDb';
 import { escapeHtml, jsonForScript } from './webviewHtml';
 
 /**
@@ -66,6 +67,14 @@ export interface LogRow {
   readonly reviewers: readonly string[];
   /** Parallel to `reviewers`: the vendor word's colour, so the page needs no palette of its own. */
   readonly reviewerColours: readonly string[];
+  /**
+   * What this round FOUND, from the rounds database — empty when the server predates it.
+   *
+   * <p>The session files record that a reviewer produced four findings and not what they were, so
+   * the Findings column was a number with nothing behind it. These are the sentences. Named apart
+   * from `findings`, which is that count and stays what it is.</p>
+   */
+  readonly found: readonly DbFinding[];
 }
 
 /** The columns a header click can sort by. */
@@ -107,9 +116,12 @@ export function rowsFrom(
   nowMs: number = Date.now(),
   priceOf: PriceOfModel = () => undefined,
   usage: readonly UsageEntry[] = [],
+  log: DbLog = EMPTY_LOG,
 ): LogRow[] {
+  const byRound = findingsByRound(log);
+
   return sessions
-    .flatMap((session) => session.rounds.map((round) => rowFrom(session, round, nowMs, priceOf, usage)))
+    .flatMap((session) => session.rounds.map((round) => rowFrom(session, round, nowMs, priceOf, usage, byRound)))
     .sort((a, b) => (b.startedUtc || b.completedUtc).localeCompare(a.startedUtc || a.completedUtc));
 }
 
@@ -119,6 +131,7 @@ function rowFrom(
   nowMs: number,
   priceOf: PriceOfModel,
   usage: readonly UsageEntry[],
+  byRound: Map<string, readonly DbFinding[]> = new Map(),
 ): LogRow {
   const cost = costOf(round, priceOf, usage, nowMs);
   const status = round.status === 'running' ? 'running' : round.status === 'interrupted' ? 'interrupted' : 'done';
@@ -148,6 +161,7 @@ function rowFrom(
     vendors: [...new Set(states.map((s) => s.provider))],
     reviewers: reviewerLines(round),
     reviewerColours: rows.map((r) => vendorColour(r.provider)),
+    found: byRound.get(roundKeyOf(session.state.repoPath, session.state.branch, round.stage, round.number)) ?? [],
   };
 }
 
@@ -520,7 +534,78 @@ function facetOptions(rows: readonly LogRow[], key: Facet): string {
  * questions block is rendered here and re-posted as HTML by the same function, so there is one
  * renderer for it.</p>
  */
-export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escalation[], nonce: string, usageHtml = ''): string {
+/**
+ * The two questions this data exists to answer, as a region of the page.
+ *
+ * <p>Operator, 2026-09-05: <i>"я хочу сначала идентифицировать [белые пятна], а потом уже или рагом
+ * или математикой дать инструмент, который закроет эти пятна"</i>. Identifying them is this.</p>
+ *
+ * <p><b>What it accepted</b> is the blind-spot corpus: a finding the caller took is by definition
+ * something it had not seen and then agreed was worth having. Shown as accepted OVER total, because
+ * a category that produces fifty findings and gets two taken says something quite different from
+ * one that produces two and gets both — the second is the blind spot; the first is noise.</p>
+ *
+ * <p><b>What it argued with and got again</b> is the shorter and sharper list: the caller rejected
+ * it with a reason, the rejection still stood, and a reviewer raised it anyway.</p>
+ */
+export function blindSpotsHtml(log: DbLog): string {
+  if (log.blindSpots.length === 0 && log.defended.length === 0) {
+    return '<div class="empty">Nothing decided yet. This fills in as gates are closed —'
+      + ' every accepted finding is something the AI had not seen and then agreed was worth having.</div>';
+  }
+
+  return '<div class="spots">'
+    + spotTable('By category', log.blindSpots.filter((s) => s.kind === 'category'))
+    + spotTable('By reviewer role', log.blindSpots.filter((s) => s.kind === 'role'))
+    + spotTable('By vendor', log.blindSpots.filter((s) => s.kind === 'providers'))
+    + '</div>'
+    + defendedHtml(log.defended);
+}
+
+function spotTable(title: string, spots: readonly BlindSpot[]): string {
+  if (spots.length === 0) {
+    return '';
+  }
+  const rows = [...spots]
+    .sort((a, b) => b.accepted - a.accepted || b.total - a.total)
+    .map((s) => `<tr><td>${escapeHtml(s.name)}</td><td class="num">${s.accepted}</td>`
+      + `<td class="num">${s.total}</td><td class="num">${share(s)}</td></tr>`)
+    .join('');
+
+  return `<div><h2>${escapeHtml(title)}</h2><table><thead><tr><th></th>`
+    + '<th class="num">taken</th><th class="num">of</th><th class="num">%</th>'
+    + `</tr></thead><tbody>${rows}</tbody></table></div>`;
+}
+
+function share(spot: BlindSpot): string {
+  return spot.total === 0 ? '—' : `${Math.round((100 * spot.accepted) / spot.total)}`;
+}
+
+function defendedHtml(defended: readonly DbFinding[]): string {
+  if (defended.length === 0) {
+    return '';
+  }
+  const items = defended
+    .map((f) => `<div class="finding declined"><span class="sev">${escapeHtml(f.severity)}</span> `
+      + `<span class="where">${escapeHtml(f.file ? `${f.file}:${f.line}` : 'no file')}</span> `
+      + `<b>${escapeHtml(f.title)}</b><div class="why">${escapeHtml(f.why)}</div>`
+      + `<div class="verdict">${escapeHtml(f.providers)} / ${escapeHtml(f.role)}`
+      + `${f.reason ? ` &middot; the standing reason: ${escapeHtml(f.reason)}` : ''}</div></div>`)
+    .join('');
+
+  return '<h2>Rejected, and raised again anyway</h2>'
+    + '<div class="hint">A disagreement the caller is defending — the rejection still stood when'
+    + ' another reviewer made the same case.</div>'
+    + `<div class="findings">${items}</div>`;
+}
+
+export function roundsLogHtml(
+  rows: readonly LogRow[],
+  questions: readonly Escalation[],
+  nonce: string,
+  usageHtml = '',
+  spotsHtml = '',
+): string {
   const headers = COLUMNS
     .map((c) => `<th data-sort="${c.key}"${c.numeric ? ' class="num"' : ''}>${c.label}</th>`)
     .join('');
@@ -589,13 +674,24 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
   .warn { color: var(--vscode-charts-yellow); }
   .link { background: none; border: none; color: var(--vscode-textLink-foreground); padding: 0 4px; }
   .hint { opacity: .65; font-size: .9em; margin-top: 10px; }
+  .findings { margin-top: 8px; }
+  .finding { border-left: 3px solid var(--vscode-panel-border); padding: 2px 0 6px 10px; margin: 6px 0; }
+  .finding.took { border-left-color: var(--vscode-charts-green, var(--vscode-charts-blue)); }
+  .finding.declined { border-left-color: var(--vscode-charts-orange); }
+  .finding .sev { font-weight: 600; }
+  .finding .where { opacity: .75; font-family: var(--vscode-editor-font-family); font-size: .92em; }
+  .finding .why { opacity: .85; margin: 2px 0 0; }
+  .finding .verdict { opacity: .75; font-size: .92em; margin-top: 3px; }
+  .finding .again { color: var(--vscode-charts-orange); font-size: .9em; }
+  .spots { display: flex; flex-wrap: wrap; gap: 18px; }
+  .spots table { width: auto; min-width: 260px; }
 </style>
 </head>
 <body>
 <h1>Review rounds</h1>
 <div id="failed" class="failed" hidden></div>
 <div id="questions">${questionsHtml(questions)}</div>
-<div class="tabs"><button type="button" class="tab on" data-tab="rounds">Rounds</button><button type="button" class="tab" data-tab="usage">What each AI has used</button></div>
+<div class="tabs"><button type="button" class="tab on" data-tab="rounds">Rounds</button><button type="button" class="tab" data-tab="usage">What each AI has used</button><button type="button" class="tab" data-tab="spots">What it keeps missing</button></div>
 <section id="tab-rounds">
 <div class="toolbar">
       <input id="search" type="search" placeholder="Search subject, branch, repository, reviewers…" autocomplete="off">
@@ -617,6 +713,7 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
 <div class="hint">Showing <b>today</b> — <b>All dates</b> clears the range, and the pickers take a time as well as a day. Cost is <b>in / out / total</b> — <code>~</code> means worked out from a public price list rather than billed, <code>+</code> means one reviewer's model had no listed price so the total is a floor. Click a column to sort, a row to see its reviewers. The table advances by itself while a round runs; your sort, filters and search stay.</div>
 </section>
 <section id="tab-usage" hidden><div id="usage-body">${usageHtml}</div></section>
+<section id="tab-spots" hidden><div id="spots-body">${spotsHtml}</div></section>
 <script nonce="${nonce}">
 (function () {
   // A page that fails must say so on the page. The first release of this page came up as a header
@@ -692,7 +789,32 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
       var rest = slash < 0 ? '' : line.slice(slash);
       lines += '<div class="reviewer"><span class="who" style="color:' + esc(row.reviewerColours[i] || 'inherit') + '">' + esc(who) + '</span>' + esc(rest) + '</div>';
     }
-    return lines;
+    return lines + foundHtml(row);
+  }
+  // What the round FOUND, under the reviewers that found it. Severity first because that is how a
+  // person triages, then where, then what it said and what was decided about it - an accepted
+  // finding is something this repository's author had not seen, which is the whole point of keeping
+  // them.
+  function foundHtml(row) {
+    if (!row.found || row.found.length === 0) {
+      return '';
+    }
+    var out = '<div class="findings">';
+    for (var i = 0; i < row.found.length; i++) {
+      var f = row.found[i];
+      var mark = f.resolution === 'accept' ? 'took' : f.resolution === 'reject' ? 'declined' : 'open';
+      out += '<div class="finding ' + esc(mark) + '">'
+        + '<span class="sev">' + esc(f.severity) + '</span> '
+        + '<span class="where">' + esc(f.file ? f.file + ':' + f.line : 'no file') + '</span> '
+        + '<b>' + esc(f.title) + '</b>'
+        + (f.reRaised ? ' <span class="again">raised again</span>' : '')
+        + '<div class="why">' + esc(f.why) + '</div>'
+        + (f.fix ? '<div class="why"><i>fix:</i> ' + esc(f.fix) + '</div>' : '')
+        + '<div class="verdict">' + esc(f.providers) + ' / ' + esc(f.role) + ' &middot; <b>' + esc(mark) + '</b>'
+        + (f.reason ? ': ' + esc(f.reason) : '') + '</div>'
+        + '</div>';
+    }
+    return out + '</div>';
   }
   function render() {
     var shown = ROWS.filter(function (r) { return rowMatches(r, state.filters, state.search); });
@@ -745,6 +867,7 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
       }
       document.getElementById('tab-rounds').hidden = which !== 'rounds';
       document.getElementById('tab-usage').hidden = which !== 'usage';
+      document.getElementById('tab-spots').hidden = which !== 'spots';
       return;
     }
     var button = target.closest('[data-command]');
@@ -815,6 +938,10 @@ export function roundsLogHtml(rows: readonly LogRow[], questions: readonly Escal
   window.addEventListener('message', function (event) {
     var message = event.data;
     if (!message) { return; }
+    if (message.type === 'spots' && typeof message.html === 'string') {
+      document.getElementById('spots-body').innerHTML = message.html;
+      return;
+    }
     if (message.type === 'usage' && typeof message.html === 'string') {
       document.getElementById('usage-body').innerHTML = message.html;
       return;

--- a/src_vs_code/src/roundsLogPanel.ts
+++ b/src_vs_code/src/roundsLogPanel.ts
@@ -31,6 +31,8 @@ export class RoundsLogPanel {
   private panel: vscode.WebviewPanel | undefined;
   private lastPayload = '';
   private lastUsage = '';
+  /** The same for the blind-spot region: pushed only when it actually changed. */
+  private lastSpots = '';
 
   constructor(private readonly hooks: RoundsLogHooks) {}
 
@@ -39,10 +41,10 @@ export class RoundsLogPanel {
     return this.panel !== undefined;
   }
 
-  show(rows: readonly LogRow[], questions: readonly Escalation[], usageHtml: string): void {
+  show(rows: readonly LogRow[], questions: readonly Escalation[], usageHtml: string, spotsHtml = ''): void {
     if (this.panel !== undefined) {
       this.panel.reveal();
-      this.update(rows, questions, usageHtml, true);
+      this.update(rows, questions, usageHtml, true, spotsHtml);
       return;
     }
     const panel = vscode.window.createWebviewPanel(
@@ -54,9 +56,10 @@ export class RoundsLogPanel {
       { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [] },
     );
     this.panel = panel;
-    panel.webview.html = roundsLogHtml(rows, questions, crypto.randomBytes(16).toString('hex'), usageHtml);
+    panel.webview.html = roundsLogHtml(rows, questions, crypto.randomBytes(16).toString('hex'), usageHtml, spotsHtml);
     this.lastPayload = payloadOf(rows, questions);
     this.lastUsage = usageHtml;
+    this.lastSpots = spotsHtml;
     panel.webview.onDidReceiveMessage((message: { type?: string; command?: string; id?: string }) => {
       if (message.type !== 'command' || typeof message.id !== 'string') {
         return;
@@ -72,11 +75,12 @@ export class RoundsLogPanel {
       this.panel = undefined;
       this.lastPayload = '';
       this.lastUsage = '';
+      this.lastSpots = '';
     });
   }
 
   /** Pushes what changed — the rows, the spending region, or both — and nothing when nothing did. */
-  update(rows: readonly LogRow[], questions: readonly Escalation[], usageHtml: string, force = false): void {
+  update(rows: readonly LogRow[], questions: readonly Escalation[], usageHtml: string, force = false, spotsHtml = ''): void {
     if (this.panel === undefined) {
       return;
     }
@@ -88,6 +92,10 @@ export class RoundsLogPanel {
     if (force || usageHtml !== this.lastUsage) {
       this.lastUsage = usageHtml;
       void this.panel.webview.postMessage({ type: 'usage', html: usageHtml });
+    }
+    if (force || spotsHtml !== this.lastSpots) {
+      this.lastSpots = spotsHtml;
+      void this.panel.webview.postMessage({ type: 'spots', html: spotsHtml });
     }
   }
 }

--- a/src_vs_code/src/test/roundsDb.test.ts
+++ b/src_vs_code/src/test/roundsDb.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { DbLog, EMPTY_LOG, findingsByRound, parseLog, roundKeyOf } from '../roundsDb';
+import { blindSpotsHtml, LogRow, roundsLogHtml, rowsFrom } from '../roundsLog';
+import { RoundRecord, SessionFile } from '../rounds';
+
+/**
+ * The log page reads the rounds database — the findings themselves, not only how many.
+ *
+ * <p>Until the server grew `coai.db` there was nothing to read: a session file records that codex
+ * produced four findings and not what they were. The page therefore showed a number with nothing
+ * behind it, and the operator's question — "мы тут пишем сами находки в бд?" — had the answer no.</p>
+ *
+ * <p>The server reads the database and answers `--log` with JSON, so nothing here needs SQLite. That
+ * makes the extension's half two pure things: believing that JSON only as far as its shape, and
+ * matching a round in it to a row built from the session files.</p>
+ */
+
+function session(rounds: readonly RoundRecord[], repoPath = 'D:/repo', branch = 'main'): SessionFile {
+  return {
+    state: { sessionId: 's1', repoPath, branch, stage: 'CodeReview', awaitingResolve: false },
+    rounds: [...rounds],
+  } as unknown as SessionFile;
+}
+
+function round(over: Partial<RoundRecord> = {}): RoundRecord {
+  return {
+    stage: 'CodeReview',
+    number: 1,
+    verdict: 'proceed',
+    gatingCount: 1,
+    reviewers: 'all 3 reviewers answered',
+    status: 'done',
+    startedUtc: '2026-09-05T07:41:00.000Z',
+    completedUtc: '2026-09-05T07:43:10.000Z',
+    subject: 'SCOPE — something',
+    reviewerStates: [{ provider: 'codex', role: 'Architecture', status: 'done', findings: 1, note: '' }],
+    ...over,
+  } as RoundRecord;
+}
+
+const NOW = Date.parse('2026-09-05T08:00:00.000Z');
+
+const LOG: DbLog = {
+  rounds: [{
+    repoPath: 'D:\\repo', branch: 'main', stage: 'CodeReview', number: 1,
+    startedUtc: '2026-09-05T07:41:00.000Z', accepted: 1, rejected: 1,
+    findings: [
+      {
+        ordinal: 0, severity: 'Major', category: 'Reliability', file: 'src/Panel.cs', line: 40,
+        title: 'session file opened without FileShare', why: 'a reader forbids writing', fix: 'share it',
+        role: 'SecurityReliability', isGating: true, providers: 'codex',
+        resolution: 'accept', reason: '', reRaised: false,
+      },
+      {
+        ordinal: 1, severity: 'Minor', category: 'Ux', file: '', line: 0,
+        title: 'a name could be clearer', why: 'it reads oddly', fix: 'rename it',
+        role: 'UxDxPerformance', isGating: false, providers: 'gemini',
+        resolution: 'reject', reason: 'the name is the domain word', reRaised: true,
+      },
+    ],
+  }],
+  blindSpots: [
+    { kind: 'category', name: 'Reliability', accepted: 7, total: 9 },
+    { kind: 'category', name: 'Ux', accepted: 0, total: 11 },
+    { kind: 'role', name: 'SecurityReliability', accepted: 5, total: 8 },
+    { kind: 'providers', name: 'codex', accepted: 7, total: 12 },
+  ],
+  defended: [{
+    ordinal: 1, severity: 'Minor', category: 'Ux', file: '', line: 0,
+    title: 'a name could be clearer', why: 'it reads oddly', fix: 'rename it',
+    role: 'UxDxPerformance', isGating: false, providers: 'gemini',
+    resolution: 'reject', reason: 'the name is the domain word', reRaised: true,
+  }],
+};
+
+// ---------- believing another program's JSON, only as far as its shape ----------
+
+test('a round comes back with the findings it produced', () => {
+  const log = parseLog(JSON.stringify(LOG));
+
+  assert.equal(log.rounds.length, 1);
+  assert.equal(log.rounds[0]?.findings.length, 2);
+  assert.equal(log.rounds[0]?.findings[0]?.title, 'session file opened without FileShare');
+  assert.equal(log.rounds[0]?.findings[0]?.resolution, 'accept');
+  assert.equal(log.rounds[0]?.findings[1]?.reason, 'the name is the domain word');
+});
+
+test('nonsense, or a shape from a future server, is an empty log rather than a broken page', () => {
+  // This reads a file written by another program. A page that throws on one unexpected field is a
+  // page that goes blank for a reason nobody can see from the outside.
+  assert.deepEqual(parseLog('not json at all'), EMPTY_LOG);
+  assert.deepEqual(parseLog(''), EMPTY_LOG);
+  assert.deepEqual(parseLog('{"rounds":null}'), EMPTY_LOG);
+  assert.equal(parseLog('{"rounds":[{}]}').rounds[0]?.accepted, -1, 'nobody closed a gate we know nothing about');
+  assert.equal(parseLog('{"rounds":[{}]}').rounds[0]?.findings.length, 0);
+});
+
+// ---------- matching a database round to a page row ----------
+
+test('a round is matched however Windows spelled its path', () => {
+  assert.equal(
+    roundKeyOf('D:\\repo\\', 'MAIN', 'CodeReview', 1),
+    roundKeyOf('d:/repo', 'main', 'codereview', 1),
+    'separators, a trailing slash and case are not three different repositories');
+});
+
+test('the row a round belongs to carries its findings', () => {
+  const [row] = rowsFrom([session([round()])], NOW, () => undefined, [], LOG) as [LogRow];
+
+  assert.equal(row.found.length, 2);
+  assert.equal(row.found[0]?.title, 'session file opened without FileShare');
+});
+
+test('a row with nothing in the database keeps rendering, with no findings', () => {
+  // Every round recorded before the database existed, and every one on a machine whose server is
+  // older than it. The page shows what it always showed.
+  const [row] = rowsFrom([session([round({ number: 9 })])], NOW, () => undefined, [], LOG) as [LogRow];
+
+  assert.deepEqual(row.found, []);
+  assert.equal(row.findings, 1, 'the COUNT is still what the session file says');
+});
+
+test('findings are keyed one round at a time', () => {
+  assert.equal(findingsByRound(LOG).size, 1);
+  assert.equal(findingsByRound(EMPTY_LOG).size, 0);
+});
+
+// ---------- what the page does with them ----------
+
+test('the page can render a finding under its round', () => {
+  const html = roundsLogHtml(rowsFrom([session([round()])], NOW, () => undefined, [], LOG), [], 'n');
+  const script = html.slice(html.indexOf('<script'));
+
+  assert.match(script, /function foundHtml/, 'the detail region builds them');
+  assert.match(script, /session file opened without FileShare/, 'and the rows carry what they say');
+  assert.match(script, /raised again/, 'including that one was raised over a standing rejection');
+});
+
+// ---------- the two questions the data exists for ----------
+
+test('what the caller ACCEPTS is shown by category, by role and by vendor', () => {
+  const html = blindSpotsHtml(LOG);
+
+  assert.match(html, /By category/);
+  assert.match(html, /By reviewer role/);
+  assert.match(html, /By vendor/);
+  assert.match(html, /Reliability/);
+  // Accepted OVER total: a category that produces eleven findings and gets none taken says something
+  // quite different from one that produces nine and gets seven.
+  assert.match(html, /<td class="num">7<\/td><td class="num">9<\/td><td class="num">78<\/td>/);
+});
+
+test('what it argued with and got again is its own list, with the reason that still stood', () => {
+  const html = blindSpotsHtml(LOG);
+
+  assert.match(html, /Rejected, and raised again anyway/);
+  assert.match(html, /the name is the domain word/);
+});
+
+test('with nothing decided yet the tab says what will fill it', () => {
+  const html = blindSpotsHtml(EMPTY_LOG);
+
+  assert.match(html, /Nothing decided yet/);
+  assert.doesNotMatch(html, /By category/);
+});
+
+test('the page has the third tab, and it is not the one it opens on', () => {
+  const html = roundsLogHtml([], [], 'n', '', blindSpotsHtml(LOG));
+
+  assert.match(html, /data-tab="spots"/);
+  assert.match(html, /id="tab-spots"/);
+  assert.match(html, /<section id="tab-spots" hidden>/, 'the rounds tab is what opens');
+  assert.match(html.slice(html.indexOf('<script')), /message\.type === 'spots'/, 'and it is pushed live like the rest');
+});

--- a/src_vs_code/src/test/roundsDb.test.ts
+++ b/src_vs_code/src/test/roundsDb.test.ts
@@ -44,7 +44,7 @@ const NOW = Date.parse('2026-09-05T08:00:00.000Z');
 const LOG: DbLog = {
   rounds: [{
     repoPath: 'D:\\repo', branch: 'main', stage: 'CodeReview', number: 1,
-    startedUtc: '2026-09-05T07:41:00.000Z', accepted: 1, rejected: 1,
+    startedUtc: '2026-09-05T07:41:00.000Z', sessionId: 's1', accepted: 1, rejected: 1,
     findings: [
       {
         ordinal: 0, severity: 'Major', category: 'Reliability', file: 'src/Panel.cs', line: 40,
@@ -100,9 +100,15 @@ test('nonsense, or a shape from a future server, is an empty log rather than a b
 
 test('a round is matched however Windows spelled its path', () => {
   assert.equal(
-    roundKeyOf('D:\\repo\\', 'MAIN', 'CodeReview', 1),
-    roundKeyOf('d:/repo', 'main', 'codereview', 1),
+    roundKeyOf('s1', 'D:\\repo\\', 'MAIN', 'CodeReview', 1),
+    roundKeyOf('s1', 'd:/repo', 'main', 'codereview', 1),
     'separators, a trailing slash and case are not three different repositories');
+  // And the session is in the key because round numbers restart: one repository and branch reviewed
+  // twice has two "CodeReview round 1" records, and keyed without it the second overwrote the first.
+  assert.notEqual(
+    roundKeyOf('s1', 'D:/repo', 'main', 'CodeReview', 1),
+    roundKeyOf('s2', 'D:/repo', 'main', 'CodeReview', 1),
+    'two sessions each have a round 1');
 });
 
 test('the row a round belongs to carries its findings', () => {

--- a/src_vs_code/src/versionProbe.ts
+++ b/src_vs_code/src/versionProbe.ts
@@ -63,6 +63,22 @@ export async function askVersion(executable: string, platform: Platform = curren
  * why the try/catch is around the call and not only in an `error` handler.</p>
  */
 function run(target: string, args: readonly string[], shell: boolean): Promise<string> {
+  return capture(target, args, shell, CAP_MS).then(({ code, output }) => (code === 0 ? parseCliVersion(output) : ''));
+}
+
+/**
+ * Everything a binary printed, or nothing at all.
+ *
+ * <p>The version probe's own spawn, widened rather than copied: the hardening below — the tree kill,
+ * the synchronous-throw catch, the empty working directory for the shell branch — was written
+ * against real failures, and a second launcher would have to learn each of them again.</p>
+ */
+export function capture(
+  target: string,
+  args: readonly string[],
+  shell: boolean,
+  capMs: number,
+): Promise<{ code: number; output: string }> {
   return new Promise((resolve) => {
     let child: ReturnType<typeof spawn>;
     try {
@@ -74,7 +90,7 @@ function run(target: string, args: readonly string[], shell: boolean): Promise<s
         ...(shell ? { cwd: tmpdir() } : {}),
       });
     } catch {
-      resolve('');
+      resolve({ code: -1, output: '' });
       return;
     }
 
@@ -84,8 +100,8 @@ function run(target: string, args: readonly string[], shell: boolean): Promise<s
       // panel repaints. Both codex's and the local reviewer's rounds named this; the tree is what
       // has to go.
       killTree(child, shell);
-      resolve('');
-    }, CAP_MS);
+      resolve({ code: -1, output: '' });
+    }, capMs);
 
     let output = '';
     child.stdout?.on('data', (chunk: Buffer) => {
@@ -93,11 +109,11 @@ function run(target: string, args: readonly string[], shell: boolean): Promise<s
     });
     child.on('error', () => {
       clearTimeout(timer);
-      resolve('');
+      resolve({ code: -1, output: '' });
     });
     child.on('close', (code) => {
       clearTimeout(timer);
-      resolve(code === 0 ? parseCliVersion(output) : '');
+      resolve({ code: code ?? -1, output });
     });
   });
 }


### PR DESCRIPTION
The page showed counts because counts were all there was. The database landed in #25; this is the half that reads it.

## What you see now

**Expand a round and the findings are there** — severity, file and line, what the reviewer said, what it proposed, and **what was decided about it with the reason a rejection carried**. A finding repeating one already rejected is marked *raised again*.

**A third tab: what it keeps missing.** The two questions this data exists for.

- *What the caller ACCEPTS*, by category, by reviewer role and by vendor. An accepted finding is by definition something the AI had not seen and then agreed was worth having — that is the blind-spot corpus. Shown as accepted **over total**, because a category that produces eleven findings and gets none taken says something quite different from one that produces nine and gets seven.
- *Rejected, and raised again anyway* — the shorter, sharper list: the caller rejected it with a reason, the rejection still stood, and a reviewer made the same case regardless.

## No SQLite in the extension

The alternative was a WebAssembly build in the VSIX or a native module per platform, to query a file the server already writes and whose schema it owns. The server answers `--log [--limit N]` with JSON and exits (`Store/RoundsQuery`). A server older than the flag exits 64 and the page shows what it always showed — the same as a machine that has run no rounds.

## Two things the tests caught while this was written

- `roundsDb` was one file with the spawn in it, and the bundled-page test failed with `require is not defined`: the page module is pure by contract, and a process launcher in its import graph breaks the webview bundle. The reader is split from the types.
- the row field could not be called `findings` — that name is the COUNT the session file records, and it stays what it is.

The process launcher was widened rather than copied: `capture()` is the version probe's own spawn, whose tree-kill and synchronous-throw handling were written against real failures.

## Verified

**729 server tests and 431 extension tests pass**, 19 of them new — including that nonsense from a future server is an empty log rather than a broken page, and that a round is matched however Windows spelled its path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)