### PR TITLE
fix(tests): the suite sweeps its own temp directories, and a clone can be swept

### DIFF
--- a/src_mcp/src/Server/PanelService.cs
+++ b/src_mcp/src/Server/PanelService.cs
@@ -697,21 +697,62 @@ public sealed class PanelService
     private static readonly string[] ScratchPrefixes =
         ["coai-answers-*", "coai-repair-*", "coai-noworkspace-*"];
 
+    /// <summary>
+    /// Deletes a directory that git has been in.
+    /// </summary>
+    /// <remarks>
+    /// <c>Directory.Delete(recursive: true)</c> refuses a READ-ONLY file with
+    /// <c>UnauthorizedAccessException</c>, and git marks every object file read-only — so a scratch
+    /// directory that ever held a clone could not be swept, the exception was caught, and the
+    /// leftovers accumulated in silence. Measured 2026-09-05: 5,476 undeletable directories, almost
+    /// all of them a test's clone, the oldest five days old.
+    /// </remarks>
+    private static void DeleteEvenIfReadOnly(string dir)
+    {
+        foreach (var file in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+        {
+            var attributes = File.GetAttributes(file);
+            if ((attributes & FileAttributes.ReadOnly) != 0)
+            {
+                File.SetAttributes(file, attributes & ~FileAttributes.ReadOnly);
+            }
+        }
+
+        Directory.Delete(dir, recursive: true);
+    }
+
+    /// <summary>A downloaded server kept under its version — not scratch, and not ours to remove.</summary>
+    private static bool VersionCache(string dir) =>
+        Path.GetFileName(dir) is { Length: > 5 } name && char.IsDigit(name["coai-".Length]);
+
     private static void PruneOldAnswerDirs() =>
         PruneOldScratchDirs(Path.GetTempPath(), DateTime.UtcNow.AddHours(-6));
 
-    /// <summary>Removes this product's leftover scratch directories created before <paramref name="cutoff"/>.</summary>
-    internal static void PruneOldScratchDirs(string tempRoot, DateTime cutoff)
+    /// <summary>
+    /// Removes leftover scratch directories created before <paramref name="cutoff"/>.
+    /// </summary>
+    /// <remarks>
+    /// The prefixes are a parameter because the TEST suite leaks the same way and for the same
+    /// reason — a directory whose delete lost a race with a file still held open — and a second
+    /// sweeper would be a second thing to get wrong. Measured on this machine, 2026-09-05: the
+    /// product's own three prefixes had 3,395 directories and NOT ONE older than its six-hour
+    /// window, while the test prefixes had 6,220 with the oldest at five days.
+    /// </remarks>
+    internal static void PruneOldScratchDirs(string tempRoot, DateTime cutoff, IReadOnlyList<string>? prefixes = null)
     {
         try
         {
-            foreach (var dir in ScratchPrefixes.SelectMany(p => Directory.EnumerateDirectories(tempRoot, p)))
+            foreach (var dir in (prefixes ?? ScratchPrefixes).SelectMany(p => Directory.EnumerateDirectories(tempRoot, p)))
             {
                 try
                 {
-                    if (Directory.GetCreationTimeUtc(dir) < cutoff)
+                    // The LAST WRITE, not the creation: Windows file tunnelling hands a recreated
+                    // name its predecessor's creation time, so a directory made this minute under a
+                    // name used yesterday reads as a day old — and, the other way round, a long
+                    // campaign's directory looks fresh for as long as anything writes into it.
+                    if (Directory.GetLastWriteTimeUtc(dir) < cutoff && !VersionCache(dir))
                     {
-                        Directory.Delete(dir, recursive: true);
+                        DeleteEvenIfReadOnly(dir);
                     }
                 }
                 catch (IOException)

--- a/src_mcp/tests/TempDirsAreSwept.cs
+++ b/src_mcp/tests/TempDirsAreSwept.cs
@@ -1,0 +1,77 @@
+using CoaiMcp.Server;
+using Xunit;
+
+[assembly: AssemblyFixture(typeof(CoaiMcp.Tests.TempDirsAreSwept))]
+
+namespace CoaiMcp.Tests;
+
+/// <summary>
+/// The suite sweeps up after itself, once, before anything runs.
+/// </summary>
+/// <remarks>
+/// <para><b>Measured on this machine, 2026-09-05.</b> The temp folder held 21,857 directories this
+/// project had made. The product's own three prefixes accounted for 3,395 of them and <b>not one was
+/// older than its six-hour window</b> — its sweeper works. The rest were the TESTS: 4,650
+/// <c>coai-panel-*</c> older than six hours, the oldest at five days, plus 1,386 <c>coai-prompts-*</c>
+/// and 184 leftover worktree directories. Nothing had ever removed them.</para>
+/// <para><b>Why a sweep and not forty fixed Disposes.</b> Forty test classes create a temp directory
+/// and delete it in <c>Dispose</c>, and that delete loses a race whenever a file in it is still held
+/// open — a spawned CLI, a SQLite handle, a reader mid-poll. Each of those catches the exception, and
+/// correctly: a leftover temp directory is not a failing test. What was missing is anybody clearing
+/// the leftovers afterwards, which is one sweep rather than forty corrections.</para>
+/// <para>It runs ONCE per assembly, deletes only what this project named, and only what is a day
+/// old — so a directory another test run is using right now is never touched.</para>
+/// </remarks>
+public sealed class TempDirsAreSwept
+{
+    /// <summary>
+    /// Everything this suite makes, by the one thing they all share.
+    /// </summary>
+    /// <remarks>
+    /// A pattern rather than a list, because the list was wrong the first time it was written: the
+    /// thirteen prefixes it named left 6,759 directories behind, under twelve more nobody had
+    /// thought of (<c>coai-e2e-</c>, <c>coai-ctx-</c>, <c>coai-deal-</c>, <c>coai-bom-</c>…). A test
+    /// class that invents a fourteenth tomorrow is the normal case, and it is swept too.
+    /// </remarks>
+    private static readonly string[] Prefixes = ["coai-*"];
+
+    public TempDirsAreSwept() =>
+        PanelService.PruneOldScratchDirs(Path.GetTempPath(), DateTime.UtcNow.AddDays(-1), Prefixes);
+
+    [Fact]
+    public void TheSweepRemovesWhatIsOldAndLeavesWhatIsInUse()
+    {
+        var root = Directory.CreateTempSubdirectory("coai-sweep-test-").FullName;
+        var old = Directory.CreateDirectory(Path.Combine(root, "coai-panel-old")).FullName;
+        var fresh = Directory.CreateDirectory(Path.Combine(root, "coai-panel-fresh")).FullName;
+        // The LAST WRITE is what the sweep reads — Windows hands a recreated name its predecessor's
+        // creation time, so that one lies about exactly the case this is for.
+        Directory.SetLastWriteTimeUtc(old, DateTime.UtcNow.AddDays(-3));
+
+        PanelService.PruneOldScratchDirs(root, DateTime.UtcNow.AddDays(-1), ["coai-panel-*"]);
+
+        Assert.False(Directory.Exists(old), "a directory three days old is nobody's working state");
+        Assert.True(Directory.Exists(fresh), "and one made a moment ago may be another run's");
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public void ADirectoryGitHasBeenIn_IsSweptToo()
+    {
+        // The reason 5,476 of them survived every sweep: git marks its object files READ-ONLY, and
+        // Directory.Delete(recursive: true) refuses a read-only file with UnauthorizedAccessException
+        // — which the sweeper caught, correctly, and then left the directory for ever.
+        var root = Directory.CreateTempSubdirectory("coai-sweep-ro-").FullName;
+        var repo = Directory.CreateDirectory(Path.Combine(root, "coai-ctx-old")).FullName;
+        var objects = Directory.CreateDirectory(Path.Combine(repo, ".git", "objects", "27")).FullName;
+        var blob = Path.Combine(objects, "e9bb8d72");
+        File.WriteAllText(blob, "an object git would never let you write twice");
+        File.SetAttributes(blob, FileAttributes.ReadOnly);
+        Directory.SetLastWriteTimeUtc(repo, DateTime.UtcNow.AddDays(-3));
+
+        PanelService.PruneOldScratchDirs(root, DateTime.UtcNow.AddDays(-1), ["coai-ctx-*"]);
+
+        Assert.False(Directory.Exists(repo), "a clone three days old is nobody's working state either");
+        Directory.Delete(root, recursive: true);
+    }
+}


### PR DESCRIPTION
Reported from a neighbouring session as *"coai-prompts-\* leaking into Temp — so many that `ls` does not finish in 120 seconds"*. Measured here: **21,857 directories this project had made**, in a folder of 106,407.

## The report named the wrong half

The **product is fine.** `coai-answers`, `coai-repair` and `coai-noworkspace` numbered 3,395 and **not one was older than the six-hour window its own sweeper uses** — there were that many because today ran thousands of reviewer launches, and they age out.

The leak is the **tests**: 4,650 `coai-panel-*` older than six hours, the oldest at **five days**, plus 1,386 `coai-prompts-*` and 184 leftover worktrees. Nothing had ever removed them.

## Two fixes, and the second is the one that mattered

**One assembly-level sweep, not forty corrected `Dispose`s.** Forty test classes create a temp directory and delete it on dispose; that delete loses a race whenever a file inside is still held open, and each of them swallows the exception — correctly, because a leftover temp directory is not a failing test. What was missing is anybody clearing the leftovers afterwards. The sweep reuses the product's own `PruneOldScratchDirs`, widened to take the prefixes it sweeps, and touches only what is a day old.

**A directory git has been in can now be deleted at all.** `Directory.Delete(recursive: true)` refuses a READ-ONLY file with `UnauthorizedAccessException`, and git marks every object file read-only — so a scratch directory that ever held a clone could never be swept, the exception was caught, and the leftovers accumulated in silence. That was **5,476** of them.

Two smaller corrections in the same place: the sweep reads the **last write** rather than the creation time (Windows file tunnelling hands a recreated name its predecessor's creation time, so that clock lies about exactly this case), and a version cache like `coai-0.17.5` is left alone — it is a downloaded server, not scratch.

## Measured after

**21,857 → 8,952, of which two are older than a day.**

**723 tests pass.** Two new, both red first: the sweep spares a directory made a moment ago, and removes a three-day-old clone with a read-only object in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)