### PR TITLE
refactor(runners): the launch is a seam of its own, and the parse is pure beside it

### DIFF
--- a/research/module_runners.md
+++ b/research/module_runners.md
@@ -41,7 +41,7 @@ sequenceDiagram
 | `DiffExclusions`, `ContextAssembler` | `Context/ContextAssembler.cs` | numstat → per-file diffs with `:(exclude,glob)` pathspecs; binary sizes via `cat-file -s` |
 | `IReviewerRuntime`: `CodexRuntime`, `DeepseekRuntime`, `GeminiRuntime`, `ClaudeRuntime`, `AntigravityRuntime`, `CustomCodexRuntime` | `Reviewers/ReviewerRuntime.cs`, `ClaudeRuntime.cs`, `CustomRuntime.cs` | THE vendor adapter: `Build` (argv, pure) + `ReadAnswer` + `ReadUsage`, the last two with working defaults. Flags verified against codex 0.147.0 / gemini 0.55.1 / claude 2.1.197 / agy 1.1.22; keys ride env, never argv; DeepSeek = Codex config-shifted |
 | `ReviewerRuntimeSelector` | same | unknown provider refuses naming the catalog |
-| `ReviewerOutcome` (closed), `ReviewerExecutor`, `RateLimit` | `Reviewers/ReviewerExecutor.cs` | one launch + one repair; SIX named outcomes incl. NotStarted; `Ok` carries the run's `Usage`, both launches counted when repaired |
+| `ReviewerOutcome` (closed), `ReviewerExecutor`, `RateLimit`, `ReviewerLaunch` | `Reviewers/ReviewerExecutor.cs` | one launch + one repair; SIX named outcomes incl. NotStarted; `Ok` carries the run's `Usage`, both launches counted when repaired. **`LaunchAsync` is the public half**: launch → classify → the vendor's RAW answer + usage, with the parse left to the caller |
 | `Usage`, `UsageParser` | `core/Findings/UsageParser.cs` | schema-less scan over any vendor envelope; MAX per key name then sum per category, so a streamed cumulative total is never summed with itself; money only when the vendor priced the run |
 | `BoundedScheduler`, `ReviewerWork`, `ReviewerSummaryFactory` | `Reviewers/BoundedScheduler.cs` | global + per-provider semaphores; a rate limit climbs the ladder below |
 | `RetryLadder` | `Reviewers/RetryLadder.cs` | the waits and when to stop: four steps, jittered, bounded by the reviewer's own deadline; pure, so the jitter is a table rather than a stopwatch |
@@ -61,6 +61,19 @@ sequenceDiagram
   in the prompt, that rules it was not shown exist. Failing the round instead would turn an
   infrastructure hiccup into an outage — a code-round finding that was rejected on exactly that
   ground, with the visibility half accepted.
+- **The launch and the parse are two things, and the seam between them is public.**
+  `LaunchAsync` answers what the PROCESS said — the terminal outcome when there is one, otherwise the
+  vendor's raw answer, its usage, and the transcript as evidence when the envelope came back empty.
+  `RunOnceAsync` is that plus `ParseAnswer`, which is pure and takes exactly what it reads: the text
+  and the provider that stamps each finding's origin. The seam exists because a second binary needs
+  the first half without the second — the planned Team server runs the same CLIs through the same
+  adapters and hands the raw answer back over HTTP, while parsing, the repair launch and
+  de-duplication stay with the client that asked. A copy of this classification over there is how the
+  vendor-set drift in this repository happened twice.
+  **`Terminal == null` means the process ran and exited zero — never that there is an answer**: an
+  adapter whose output file never appeared says so with a null answer, and what that means is the
+  caller's judgement. An EMPTY answer takes the same path as a missing one, so an envelope that came
+  back blank still leaves its transcript as evidence.
 - **Provider cap beside the global cap** — a rate limit is per vendor; a global cap alone puts all
   its slots on one provider.
 - **A rate limit gets a LADDER, not one retry** — 5 s, 30 s, 60 s, 120 s (`COAI_RETRY_BACKOFF`),

--- a/src_mcp/runners/Reviewers/ReviewerExecutor.cs
+++ b/src_mcp/runners/Reviewers/ReviewerExecutor.cs
@@ -263,6 +263,34 @@ public sealed class ReviewerExecutor(IProcessLauncher launcher, string? keepUnpa
     /// <summary>One launch. A non-null outcome is terminal; a null review means "unparseable".</summary>
     private async Task<(ReviewerOutcome? Outcome, NormalisedReview? Review, Usage Usage, string? Answer, string Evidence)> RunOnceAsync(ReviewerInvocation invocation, CancellationToken ct)
     {
+        var launch = await LaunchAsync(invocation, ct);
+
+        return launch.Terminal is not null
+            ? (launch.Terminal, null, launch.Usage, null, string.Empty)
+            : (null, ParseAnswer(launch.Answer, invocation.Provider), launch.Usage, launch.Answer, launch.Evidence);
+    }
+
+    /// <summary>
+    /// One launch, as far as "what the process said" — and no further.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Public because a second binary needs exactly this half.</b> The Team server runs the
+    /// same vendor CLIs through the same adapters and hands the vendor's RAW answer back over HTTP;
+    /// parsing, the repair launch and de-duplication stay with the client that asked for the review,
+    /// which already does all three for a local reviewer. A copy of this classification in the
+    /// server is how the vendor-set drift in this repository happened twice.</para>
+    /// <para><b><c>Terminal == null</c> means the process ran and exited zero</b> — it is not a
+    /// promise that there is an answer. An adapter whose output file never appeared says so with a
+    /// null <see cref="ReviewerLaunch.Answer"/>, and what that means is the caller's judgement.</para>
+    /// <para>Cancellation and the kill belong to <see cref="IProcessLauncher"/>, which takes the
+    /// token and terminates the whole process tree; a cancelled launch throws out of here and
+    /// <c>BoundedScheduler</c> reports the reviewer as abandoned. Nothing about that changes here.
+    /// A vendor adapter that THROWS out of its own read is a defect in that adapter — every shipped
+    /// one catches its IO and JSON failures and answers with a null answer or
+    /// <see cref="Usage.None"/>.</para>
+    /// </remarks>
+    public async Task<ReviewerLaunch> LaunchAsync(ReviewerInvocation invocation, CancellationToken ct)
+    {
         ProcessResult result;
         try
         {
@@ -279,34 +307,40 @@ public sealed class ReviewerExecutor(IProcessLauncher launcher, string? keepUnpa
         catch (System.ComponentModel.Win32Exception e)
         {
             // One reviewer that cannot start is one reviewer's failure, never the round's.
-            return (new ReviewerOutcome.NotStarted($"'{invocation.Request.Executable}' could not be started: {e.Message}"), null, Usage.None, null, string.Empty);
+            return new ReviewerLaunch(
+                new ReviewerOutcome.NotStarted($"'{invocation.Request.Executable}' could not be started: {e.Message}"),
+                null,
+                Usage.None,
+                string.Empty);
         }
 
         if (result.TimedOut)
         {
-            return (new ReviewerOutcome.TimedOut(), null, Usage.None, null, string.Empty);
+            return new ReviewerLaunch(new ReviewerOutcome.TimedOut(), null, Usage.None, string.Empty);
         }
 
         if (RateLimit.Hit(result))
         {
-            return (new ReviewerOutcome.RateLimited(RateLimit.Reason(result)), null, Usage.None, null, string.Empty);
+            return new ReviewerLaunch(new ReviewerOutcome.RateLimited(RateLimit.Reason(result)), null, Usage.None, string.Empty);
         }
 
         if (result.ExitCode != 0)
         {
             var tail = result.StdErr.Length <= StdErrTail ? result.StdErr : result.StdErr[^StdErrTail..];
-            return (new ReviewerOutcome.NonZeroExit(result.ExitCode, tail.Trim()), null, Usage.None, null, string.Empty);
+            return new ReviewerLaunch(new ReviewerOutcome.NonZeroExit(result.ExitCode, tail.Trim()), null, Usage.None, string.Empty);
         }
 
         // Both reads go through the vendor's own adapter: where the answer lands and how the run
         // is billed are vendor knowledge, and keeping them here would have made every new vendor
         // an edit to this class.
         var usage = invocation.Adapter?.ReadUsage(invocation, result) ?? UsageParser.Parse(result.StdOut);
-        var (review, answer, evidence) = Parse(invocation, result);
-        return (null, review, usage, answer, evidence);
+        var (answer, evidence) = Read(invocation, result);
+
+        return new ReviewerLaunch(null, answer, usage, evidence);
     }
 
-    private static (NormalisedReview? Review, string? Answer, string Evidence) Parse(ReviewerInvocation invocation, ProcessResult result)
+    /// <summary>What the vendor said, and what is left to show when it said nothing.</summary>
+    private static (string? Answer, string Evidence) Read(ReviewerInvocation invocation, ProcessResult result)
     {
         var raw = invocation.Adapter is { } adapter
             ? adapter.ReadAnswer(invocation, result)
@@ -314,22 +348,55 @@ public sealed class ReviewerExecutor(IProcessLauncher launcher, string? keepUnpa
         // The EVIDENCE is not always the answer. When a vendor's envelope comes back empty there
         // is nothing in the field the adapter reads, and the diagnosis — its status, its error,
         // its own event stream — is sitting in stdout, which was being thrown away. A kept file
-        // of zero bytes is what that looked like from outside.
-        var evidence = string.IsNullOrWhiteSpace(raw) ? Transcript(result) : raw;
+        // of zero bytes is what that looked like from outside. An EMPTY answer takes the same path
+        // as a missing one, which is why the test is `IsNullOrWhiteSpace` and not `is null`.
+        return (raw, string.IsNullOrWhiteSpace(raw) ? Transcript(result) : raw);
+    }
+
+    /// <summary>
+    /// The vendor's answer as findings, or null when it is not findings at all.
+    /// </summary>
+    /// <remarks>
+    /// Pure, and it takes exactly what it reads: the text the adapter produced, and the provider,
+    /// which stamps each finding with where it came from. Every vendor-specific decision — which
+    /// file, which envelope, which NDJSON event — has already happened in the adapter's own
+    /// <c>ReadAnswer</c>, which is why nothing else from the invocation reaches here.
+    /// </remarks>
+    internal static NormalisedReview? ParseAnswer(string? raw, string provider)
+    {
         if (raw is null)
         {
-            return (null, null, evidence);
+            return null;
         }
 
         // Gemini answers through its envelope and its habits; codex's -o file is schema-bound
         // already, but the same balanced extraction costs nothing and forgives a stray banner.
-        if (GeminiPayload.Extract(raw) is not ExtractOutcome.Payload payload)
-        {
-            return (null, raw, evidence);
-        }
-
-        return ReviewParser.Parse(payload.Json, invocation.Provider) is ParseOutcome.Success success
-            ? (success.Review, raw, evidence)
-            : (null, raw, evidence);
+        return GeminiPayload.Extract(raw) is ExtractOutcome.Payload payload
+               && ReviewParser.Parse(payload.Json, provider) is ParseOutcome.Success success
+            ? success.Review
+            : null;
     }
 }
+
+/// <summary>
+/// What ONE launch produced, before anyone reads it as findings.
+/// </summary>
+/// <param name="Terminal">
+/// The outcome when the launch itself decided the answer — <c>NotStarted</c>, <c>TimedOut</c>,
+/// <c>RateLimited</c>, <c>NonZeroExit</c> — and null when the process ran and exited zero.
+/// </param>
+/// <param name="Answer">
+/// The vendor's own answer, as ITS adapter extracts it, unparsed. Null when there was nothing where
+/// this vendor puts one; that is a fact about the run, not a verdict on it.
+/// </param>
+/// <param name="Usage">What the run consumed, from the vendor's own reporting. Never null: an
+/// adapter that cannot read its own numbers answers <see cref="Usage.None"/>.</param>
+/// <param name="Evidence">
+/// The answer, or the process transcript when the envelope came back empty — the diagnosis, for the
+/// one failure whose raw text is the whole story.
+/// </param>
+public sealed record ReviewerLaunch(
+    ReviewerOutcome? Terminal,
+    string? Answer,
+    Usage Usage,
+    string Evidence);

--- a/src_mcp/tests/ReviewerExecutorTests.cs
+++ b/src_mcp/tests/ReviewerExecutorTests.cs
@@ -100,6 +100,31 @@ public sealed class ReviewerExecutorTests
         outcome.Should().BeOfType<ReviewerOutcome.Ok>().Which.Repaired.Should().BeTrue();
     }
 
+    /// <summary>
+    /// A repaired reviewer is billed for BOTH launches, end to end — the failed one included.
+    /// </summary>
+    /// <remarks>
+    /// A characterisation test rather than a bug's: it was written to hold `RunAsync` still while
+    /// the launch was split out from under it, and asked for by name on the story's plan round,
+    /// because the only thing pinning this before was the arithmetic of <c>Usage.Add</c> in
+    /// isolation — which cannot notice a refactor that stops calling it.
+    /// </remarks>
+    [Fact]
+    public async Task ARepairedReviewer_StillCountsTheLaunchThatFailed()
+    {
+        var outcome = await _executor.RunAsync(
+            FakeCliInvocations.Invoke(
+                "gemini",
+                ["emit", """{"note":"prose, not findings","input_tokens":1000,"output_tokens":50}"""]),
+            repair: FakeCliInvocations.Invoke("gemini", ["emit", FakeCliInvocations.CleanReview]),
+            ct: TestContext.Current.CancellationToken);
+
+        var ok = outcome.Should().BeOfType<ReviewerOutcome.Ok>().Which;
+        ok.Repaired.Should().BeTrue();
+        ok.Usage.TokensIn.Should().Be(1000, "the launch that failed cost tokens and they are still owed");
+        ok.Usage.TokensOut.Should().Be(50);
+    }
+
     [Fact]
     public async Task UnparseableAfterTheOneRepair_IsItsOwnOutcome()
     {

--- a/src_mcp/tests/ReviewerLaunchTests.cs
+++ b/src_mcp/tests/ReviewerLaunchTests.cs
@@ -1,0 +1,129 @@
+using CoaiMcp.Runners.Processes;
+using CoaiMcp.Runners.Reviewers;
+using FluentAssertions;
+using Xunit;
+
+namespace CoaiMcp.Tests;
+
+/// <summary>
+/// What ONE launch produced, before anyone reads it as findings.
+/// </summary>
+/// <remarks>
+/// <para>The seam exists because a second binary needs the first half of a reviewer run and not the
+/// second: the planned Team server launches the same vendor CLIs through the same adapters and hands
+/// the vendor's RAW answer back over HTTP, while parsing, the repair launch and de-duplication stay
+/// on the client that asked for the review.</para>
+/// <para>So <c>Terminal == null</c> means exactly one thing — the process ran and exited zero. It is
+/// NOT a promise that there is an answer to read: an adapter whose output file never appeared says
+/// so with a null <c>Answer</c>, and deciding what that means is the caller's job, which is the
+/// whole point of the split.</para>
+/// </remarks>
+[Collection("fakecli-env")]
+public sealed class ReviewerLaunchTests
+{
+    private readonly ReviewerExecutor _executor = new(new ProcessLauncher());
+    private readonly string _dir = Directory.CreateTempSubdirectory("coai-launch-").FullName;
+
+    [Fact]
+    public async Task AnAnswerComesBackRaw_NotParsed()
+    {
+        var launch = await _executor.LaunchAsync(
+            FakeCliInvocations.Invoke("gemini", ["emit", FakeCliInvocations.CleanReview]),
+            TestContext.Current.CancellationToken);
+
+        launch.Terminal.Should().BeNull("the process ran and exited zero");
+        // Trimmed, and only for the line ending the capture adds: the launcher joins the child's
+        // stdout lines, so a one-line answer arrives with a newline the vendor did not write.
+        launch.Answer!.Trim().Should().Be(FakeCliInvocations.CleanReview,
+            "the launch hands over what the vendor said, not what it means");
+    }
+
+    /// <summary>
+    /// The distinction the whole seam is for: nonsense is still an ANSWER at this level.
+    /// </summary>
+    /// <remarks>
+    /// "This is not findings" is a judgement the caller makes — and the Team server must not make it,
+    /// because it does not hold the schema and its client already does this work for local reviewers.
+    /// </remarks>
+    [Fact]
+    public async Task GarbageIsAnAnswerToo_AndTheLaunchDoesNotJudgeIt()
+    {
+        var launch = await _executor.LaunchAsync(
+            FakeCliInvocations.Invoke("gemini", ["emit", "this is not JSON at all"]),
+            TestContext.Current.CancellationToken);
+
+        launch.Terminal.Should().BeNull("the process was fine; its answer is somebody else's problem");
+        launch.Answer!.Trim().Should().Be("this is not JSON at all");
+    }
+
+    [Fact]
+    public async Task ANonZeroExit_CarriesTheCodeAndWhatWasSaid()
+    {
+        var launch = await _executor.LaunchAsync(
+            FakeCliInvocations.Invoke("codex", ["stderr-exit", "boom", "3"]),
+            TestContext.Current.CancellationToken);
+
+        launch.Terminal.Should().BeOfType<ReviewerOutcome.NonZeroExit>()
+            .Which.Should().Match<ReviewerOutcome.NonZeroExit>(e => e.ExitCode == 3 && e.StdErrTail.Contains("boom"));
+    }
+
+    [Fact]
+    public async Task ARateLimit_IsItsOwnOutcome_WithTheVendorsOwnLine()
+    {
+        var launch = await _executor.LaunchAsync(
+            FakeCliInvocations.Invoke("codex", ["stderr-exit", "429 Too Many Requests", "1"]),
+            TestContext.Current.CancellationToken);
+
+        launch.Terminal.Should().BeOfType<ReviewerOutcome.RateLimited>()
+            .Which.Reason.Should().Contain("429");
+    }
+
+    [Fact]
+    public async Task AnExecutableThatIsNotThere_IsNotStarted_AndNamesIt()
+    {
+        var missing = new ReviewerInvocation(
+            "codex",
+            ReviewRole.Architecture,
+            new ProcessRequest(Path.Combine(_dir, "no-such-cli.exe"), ["--version"], _dir));
+
+        var launch = await _executor.LaunchAsync(missing, TestContext.Current.CancellationToken);
+
+        launch.Terminal.Should().BeOfType<ReviewerOutcome.NotStarted>()
+            .Which.Reason.Should().Contain("no-such-cli");
+    }
+
+    /// <summary>
+    /// An envelope that came back empty leaves the diagnosis on the streams, and that is what the
+    /// evidence must carry — a kept file of zero bytes is what the alternative looked like.
+    /// </summary>
+    [Fact]
+    public async Task AnAnswerFileThatNeverAppeared_LeavesTheTranscriptAsEvidence()
+    {
+        var launch = await _executor.LaunchAsync(
+            FakeCliInvocations.Invoke(
+                "codex",
+                ["stderr-emit", "the vendor complained here", ""],
+                outputFile: Path.Combine(_dir, "answer-that-was-never-written.json")),
+            TestContext.Current.CancellationToken);
+
+        launch.Terminal.Should().BeNull("exit zero is exit zero, whatever the file says");
+        launch.Answer.Should().BeNull("there is nothing where this vendor puts its answer");
+        launch.Evidence.Should().Contain("the vendor complained here",
+            "the streams are the only diagnosis left");
+    }
+
+    /// <summary>
+    /// An EMPTY answer takes the same path as a missing one — an adapter that returns "" rather
+    /// than null must not cost the transcript. Raised on this story's plan round.
+    /// </summary>
+    [Fact]
+    public async Task AnEmptyAnswer_KeepsTheTranscriptToo()
+    {
+        var launch = await _executor.LaunchAsync(
+            FakeCliInvocations.Invoke("gemini", ["stderr-emit", "nothing to say, and here is why", ""]),
+            TestContext.Current.CancellationToken);
+
+        launch.Answer.Should().BeEmpty();
+        launch.Evidence.Should().Contain("nothing to say, and here is why");
+    }
+}

--- a/src_mcp/tests/ReviewerLaunchTests.cs
+++ b/src_mcp/tests/ReviewerLaunchTests.cs
@@ -113,6 +113,32 @@ public sealed class ReviewerLaunchTests
     }
 
     /// <summary>
+    /// The other half of the seam: nothing, and nonsense, are both "not findings".
+    /// </summary>
+    /// <remarks>
+    /// Pure, and asked for on this change's code round: the evidence rule treats an empty answer
+    /// like a missing one, and the PARSE has to agree — an empty string is not a review, and it must
+    /// not reach <c>ReviewParser</c> as though it might be.
+    /// </remarks>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("prose, not findings")]
+    public void ParseAnswer_AnswersNothing_ForAnythingThatIsNotAReview(string? raw)
+    {
+        ReviewerExecutor.ParseAnswer(raw, "codex").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseAnswer_ReadsARealReview_AndStampsWhoSaidIt()
+    {
+        var review = ReviewerExecutor.ParseAnswer(FakeCliInvocations.CleanReview, "codex");
+
+        review.Should().NotBeNull();
+    }
+
+    /// <summary>
     /// An EMPTY answer takes the same path as a missing one — an adapter that returns "" rather
     /// than null must not cost the transcript. Raised on this story's plan round.
     /// </summary>

--- a/todo/PLAN_team_server.md
+++ b/todo/PLAN_team_server.md
@@ -640,7 +640,7 @@ The split was made on Fable; stories marked **F** run on Fable because being wro
 
 | Epic | Story | Delivers | Model |
 |---|---|---|---|
-| **1 · One library for two binaries** | ~~1.1~~ **done** | `ReviewerExecutor.LaunchAsync` out of `RunOnceAsync`, with `ParseAnswer` pure beside it; every existing test passed unedited. (`RetryLadder` shipped ahead of the epic, on its own — it fixes the local `coai-mcp` today, where a transient 429 got one retry at fifteen seconds and then failed the round.) | Opus |
+| **1 · One library for two binaries** | ~~1.1~~ **done** | `ReviewerExecutor.LaunchAsync` out of `RunOnceAsync`, with `ParseAnswer` pure beside it; every existing test passed UNEDITED — which is what "unchanged" meant here, never "no new tests": new behaviour ships with its own, as the testing rule requires. (`RetryLadder` shipped ahead of the epic, on its own — it fixes the local `coai-mcp` today, where a transient 429 got one retry at fifteen seconds and then failed the round.) | Opus |
 | | 1.2 | `RuntimeResolution` + `VendorHealth` out of `PanelService`; `UsageLedger` moved | Opus |
 | | 1.3 | `RemoteRuntime`, `RemoteAsk`, `TeamServerAuth` (with URL normalisation and the shared vector), `--ask-remote`, every registry point, `ProbeAsync`'s remote arm | Opus |
 | **2 · `coai-server`** | 2.1 | skeleton, logging, guards, the mirrored auth, sessions, `X-Coai-Contract`, the harness | **F** |

--- a/todo/PLAN_team_server.md
+++ b/todo/PLAN_team_server.md
@@ -380,7 +380,7 @@ suites, the same guard `LocalRuntime.OpenAiBaseOf` / `openAiBaseOf` live under.
 
 | What | From | Why both need it |
 |---|---|---|
-| `ReviewerExecutor.LaunchAsync` | `ReviewerExecutor.cs:254` (`RunOnceAsync`, the launch + classification, without the parse) | the server launches and classifies; the client parses |
+| ~~`ReviewerExecutor.LaunchAsync`~~ | **done** — public on `ReviewerExecutor`, returning `ReviewerLaunch(Terminal, Answer, Usage, Evidence)`; `ParseAnswer(raw, provider)` is pure beside it | the server launches and classifies; the client parses |
 | `VendorHealth.ProbeAsync` | `PanelService.cs:134` | the catalog's health column |
 | `RuntimeResolution` — `RuntimeNameOf`, `RuntimeFor`, `AuthOf` | `PanelService.cs:231-262` | the "third copy of one decision" that already shipped a defect must not get a fourth |
 | `UsageLedger` | `src_mcp/src/Server/UsageLedger.cs` | it references nothing MCP-shaped today |
@@ -621,7 +621,7 @@ Four of them touch this, and each is a decision rather than a note:
 
 | Open plan | The overlap | The decision |
 |---|---|---|
-| **the local database** under the rounds log (`coai.db`: sessions, rounds, reviewers, findings, usage, FTS) | it projects the LOCAL `usage.jsonl`; this plan adds spending that lives on a server | **A Team server's usage is fetched live and is never written into `coai.db`.** The server is the source of truth precisely because a person has two machines, and a copy in a local projection would disagree with it the moment they use the other one. The rounds log stays a local view; the Team-server block stays a remote one, under its own subheading. If the two are ever wanted in one table, that is a `remote_usage` table the server's numbers are refreshed into, and a plan of its own. |
+| **the local database** under the rounds log (`coai.db`: sessions, rounds, reviewers, findings, usage, FTS — the writing half shipped 2026-09-05, [research/PLAN_local_db.md](../research/PLAN_local_db.md); the reader is [PLAN_local_db_reader.md](PLAN_local_db_reader.md)) | it projects the LOCAL `usage.jsonl`; this plan adds spending that lives on a server | **A Team server's usage is fetched live and is never written into `coai.db`.** The server is the source of truth precisely because a person has two machines, and a copy in a local projection would disagree with it the moment they use the other one. The rounds log stays a local view; the Team-server block stays a remote one, under its own subheading. If the two are ever wanted in one table, that is a `remote_usage` table the server's numbers are refreshed into, and a plan of its own. |
 | **family CI hardening** (`main` PR-only everywhere, required checks with `strict`, semantic titles) | this plan adds a project, a test executable, an `http/` suite and a `server-v*` release | The new CI job runs on **every** PR — never a path filter — because a required check that does not run blocks every merge for ever; its name is added to the required set in the same change that adds the job. This plan ships as PRs into `main` like everything else. |
 | **provider liveness** (three states instead of `--version` exit 0) | the catalog's health column repeats the same question, one hop further away | The catalog answers what it can prove: the CLI is present at a version, the slot has credentials on disk, the last real run's outcome. A slot that has never run is *unknown*, not *healthy* — the same distinction that plan draws, applied per slot rather than per vendor. |
 | **multi-repo / uncommitted** (one round over several repositories, a working tree snapshotted into a commit) | it changes what the CLIENT assembles into the prompt | Nothing here has to change: the server receives an assembled prompt and a schema and never learns which repositories it came from. Recorded because it is the natural next question. |
@@ -640,7 +640,7 @@ The split was made on Fable; stories marked **F** run on Fable because being wro
 
 | Epic | Story | Delivers | Model |
 |---|---|---|---|
-| **1 · One library for two binaries** | 1.1 | `ReviewerExecutor.LaunchAsync` out of `RunOnceAsync`; `CoaiMcp.Tests` unchanged. (`RetryLadder` **shipped ahead of this epic**, on its own — it fixes the local `coai-mcp` today, where a transient 429 gets one retry at fifteen seconds and then fails the round.) | Opus |
+| **1 · One library for two binaries** | ~~1.1~~ **done** | `ReviewerExecutor.LaunchAsync` out of `RunOnceAsync`, with `ParseAnswer` pure beside it; every existing test passed unedited. (`RetryLadder` shipped ahead of the epic, on its own — it fixes the local `coai-mcp` today, where a transient 429 got one retry at fifteen seconds and then failed the round.) | Opus |
 | | 1.2 | `RuntimeResolution` + `VendorHealth` out of `PanelService`; `UsageLedger` moved | Opus |
 | | 1.3 | `RemoteRuntime`, `RemoteAsk`, `TeamServerAuth` (with URL normalisation and the shared vector), `--ask-remote`, every registry point, `ProbeAsync`'s remote arm | Opus |
 | **2 · `coai-server`** | 2.1 | skeleton, logging, guards, the mirrored auth, sessions, `X-Coai-Contract`, the harness | **F** |


### PR DESCRIPTION
Story 1.1 of [todo/PLAN_team_server.md](todo/PLAN_team_server.md) — epic 1, "one library for two binaries". Its sibling 1.2 (`RuntimeResolution`, `VendorHealth`, `UsageLedger` out of `PanelService`) is a separate story and deliberately not here.

## Why

A reviewer run lived in one private method: launch, classify the exit, read usage through the vendor's adapter — and then, in the same breath, extract the payload and run `ReviewParser`.

The planned Team server needs the **first half and must not do the second**: it runs the same CLIs through the same adapters and hands the vendor's raw answer back over HTTP, while parsing, the repair launch and de-duplication stay with the client that asked for the review — which already does all three for a local reviewer. A copy of that classification in a second binary is exactly how the vendor-set drift in this repository happened twice.

## What changed

`LaunchAsync` is public and answers what the **process** said:

```csharp
public sealed record ReviewerLaunch(ReviewerOutcome? Terminal, string? Answer, Usage Usage, string Evidence);
```

`RunOnceAsync` is that plus `ParseAnswer`, now **pure** and taking exactly what it reads — the raw text, and the provider that stamps each finding's origin. Everything vendor-specific still happens earlier, inside the adapter's own `ReadAnswer`.

`Terminal == null` means the process ran and exited zero. It is deliberately **not** a promise that there is an answer: an adapter whose output file never appeared says so with a null answer, and what that means is the caller's judgement — which is the whole point of the seam.

Nothing else changes. `RunAsync`, the repair, the kept evidence and the six outcomes are untouched.

## Tests

`ReviewerLaunchTests` drives the real fake CLI through the six shapes: a raw answer that is not parsed, garbage that is still an answer, a non-zero exit, a rate limit, a missing executable, and an answer file that never appeared leaving the transcript as evidence. Two more came from the gate — an empty answer takes the same path as a missing one, and `ParseAnswer` answers nothing for null, empty, whitespace or prose.

**Its teeth were checked** by narrowing the evidence rule to `raw is null`: the empty-envelope test went red with the real symptom, an evidence field of `""` where the diagnosis should be.

`ReviewerExecutorTests` gains a **characterisation** test the plan round asked for by name — a repaired reviewer still counts the launch that failed — and it was run green against the *unrefactored* code first, which is what a characterisation test is for. The only thing pinning that before was `Usage.Add`'s arithmetic in isolation, which cannot notice a refactor that stops calling it.

**Every existing test passes unedited** — that is the proof this was a move. 735 tests, 734 green, 1 skipped, from the MTP executable on freshly stamped binaries.

## Reviewed by the gate, both stages

Plan round: 13 findings, three accepted (the repair characterisation test, the empty-answer path, the `Terminal == null` contract written down rather than implied), ten rejected with reasons — among them a cancellation contract that belongs to `IProcessLauncher`, a parse signature said to drop context the current parse does not read, and a pre-flight `File.Exists` that would add a TOCTOU answer to a question `Win32Exception` → `NotStarted` already answers.

Code round: verdict `proceed`, eight findings, two accepted — codex caught that the plan's own wording ("`CoaiMcp.Tests` unchanged") reads as a contradiction next to a diff that adds tests, so the plan now says what it meant; and the parse needed the same empty-string rule the evidence half has.

Docs: `research/module_runners.md` describes the seam; the plan marks story 1.1 done and its stale link to the local-database plan is fixed — that plan shipped its writing half and moved to `research/` while this was open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
