### PR TITLE
test(server): the separator conversion is asserted where no platform can fake it

### DIFF
--- a/src_mcp/tests/GitModulesTests.cs
+++ b/src_mcp/tests/GitModulesTests.cs
@@ -63,6 +63,7 @@ public sealed class GitModulesTests
     // case went green on Windows and red there, which is how the guard came to be platform-blind.
     [InlineData("C:/Windows")]
     [InlineData("\\\\server\\share")]
+    [InlineData("\\server\\share")]
     [InlineData("")]
     public void APathThatCanLeaveTheCheckout_IsNotAMount(string path)
     {
@@ -84,6 +85,27 @@ public sealed class GitModulesTests
         GitModules.IsSafeMountName(name).Should().BeFalse();
         GitModules.Parse($"[submodule \"{name}\"]\n\tpath = ok/here\n").Should().BeEmpty();
     }
+
+    /// <summary>
+    /// The separator is converted BEFORE anything judges the path, and that is what makes the guard
+    /// mean the same thing on both platforms.
+    /// </summary>
+    /// <remarks>
+    /// <para>Written after the backslash cases above were found to have no teeth here. On Windows
+    /// <c>Path.IsPathRooted</c> already refuses <c>\server\share</c>, so the theory row passes with
+    /// normalisation deleted — it asserts the truth of the machine it runs on, which is the exact
+    /// shape of the defect this whole guard exists for. On Linux nothing but this conversion stands
+    /// between a Windows-rooted path and the leading-slash check.</para>
+    /// <para>So the conversion is asserted directly, on the one public method that performs it: no
+    /// platform can make this pass by accident.</para>
+    /// </remarks>
+    [Theory]
+    [InlineData("\\server\\share", "/server/share")]
+    [InlineData("\\\\server\\share", "//server/share")]
+    [InlineData("C:\\Windows", "C:/Windows")]
+    [InlineData(".claude\\rules\\shared", ".claude/rules/shared")]
+    public void EverySeparatorIsAForwardSlashBeforeAnythingJudgesThePath(string written, string expected) =>
+        GitModules.Normalise(written).Should().Be(expected);
 
     [Fact]
     public void TheNamesThisFamilyActuallyUses_AreAccepted()


### PR DESCRIPTION
## Why

A code round asked for the single-backslash form (`\server\share`) beside the UNC one in
`GitModulesTests`. Adding another theory row was the obvious move, and it was **decoration**.

With `GitModules.Normalise`'s `Replace('\', '/')` deleted, that row still passed: on Windows
`Path.IsPathRooted` refuses `\server\share` on its own, so the row asserts the truth of the machine
it runs on and says nothing about the conversion it was meant to pin. That is the exact shape of the
defect the guard itself exists for — a platform-dependent answer taken for a universal one —
reappearing one level up, inside the test written to catch it.

## What shipped

`EverySeparatorIsAForwardSlashBeforeAnythingJudgesThePath`: a four-row theory over `Normalise`, the
one public method that performs the conversion. The drive form, the single-slash form, the UNC form,
and a relative path written the Windows way — all four contain backslashes, which is why deleting
the conversion turns all four red.

**No production code changes.** The guard is correct; only its test was weak.

## What the tests showed

Red first, in the only way available for a guard whose fix landed before its test — delete the
conversion and watch:

```
failed …EverySeparatorIsAForwardSlashBeforeAnythingJudgesThePath(written: "\server\share", expected: "//server/share")
failed …EverySeparatorIsAForwardSlashBeforeAnythingJudgesThePath(written: ".claude\rules\shared", expected: ".claude/rules/shared")
failed …EverySeparatorIsAForwardSlashBeforeAnythingJudgesThePath(written: "C:\Windows", expected: "C:/Windows")
failed …EverySeparatorIsAForwardSlashBeforeAnythingJudgesThePath(written: "\server\share", expected: "/server/share")
  Expected GitModules.Normalise(written) to be the same string, but they differ at index 0
```

The pre-existing single-backslash row stayed **green** through that — which is what proved it was
decoration. Restored: `GitModulesTests` 22/22, full suite **727 total, 726 passed, 1 skipped** (the
reparse-point test needs a directory link this machine cannot create without elevation).
`git status` after restoring showed one modified file, the test, which is what this commit stages.

## Review gate

Plan round: all 3 reviewers, `proceed`, 6 findings — 0 accepted, 6 rejected with reasons. Two of
them called the Definition of Done "mathematically false" on the belief that one row has no
backslash; it is `.claude\rules\shared`, and the observed red run named all four.

Code round: all 9 reviewers, `proceed`, 7 findings — 0 accepted, 7 rejected with reasons. The one
worth naming asked for a `Console.WriteLine` to identify the failing row; xUnit already puts every
parameter in the test name, as the output above shows, and this repository's logging rule forbids
exactly that reach for stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)