### PR TITLE
fix(bench): the corpus points at a file that exists in a clone

### DIFF
--- a/src_bench/README.md
+++ b/src_bench/README.md
@@ -9,6 +9,22 @@ It drives the **published** `coai-mcp` over stdio, one server process per run. T
 five windows is five processes, and the failures worth measuring here — a shared data directory, a
 lock held across processes, one GPU behind them all — do not exist inside a single one.
 
+## Where it runs: THIS checkout
+
+`--repo .` — the repository you are standing in, and nothing else is needed. The bench only ever
+writes refs (`git branch -f bench/<arm>/<case>-r<n>`); the server makes its own worktree, detached
+at a SHA, so no branch of yours is touched and no file in your tree moves. Afterwards:
+
+```bash
+git branch --list 'bench/*' | xargs -r git branch -D    # the refs a campaign leaves behind
+```
+
+The campaigns of 2026-09 ran from a temporary clone instead, and the reason was a defect rather than
+a preference: one corpus case pointed at `artifacts/bench/plan-B.md`, and `artifacts/` is
+git-ignored — so the file existed only in the folder where it had been written, and a fresh clone
+could not run that case at all. Case texts live in `src_bench/cases/` now, which is what makes the
+corpus portable.
+
 ## The runs it exists for
 
 ```bash

--- a/src_bench/cases/split-once.md
+++ b/src_bench/cases/split-once.md
@@ -1,0 +1,28 @@
+# SCOPE — the split order needs a floor, and the caller is what supplies it
+
+With *Split the plan* on, a plan that passes is told to split into 2–4 epics and each into stories.
+Each epic then comes back for its own plan review — correctly — and the gate, with no memory, told
+each one to split into epics as well. Epics of epics, with no floor.
+
+Our session cannot hold that memory: it is keyed repo+branch and its plan stage happens once, so an
+epic returns as a DIFFERENT session on its own branch. The caller is what crosses them, and Claude
+Code exports `CLAUDE_CODE_SESSION_ID` to every child it spawns.
+
+## What must be true
+
+1. A caller is ordered to split ONCE. A plan that is already a piece is told so instead: build as one
+   unit, review its diff, fix, document, test, commit — and say so if it is genuinely too big.
+2. A piece's shape is not re-measured and the Fable order is not issued to it; the autonomy order is.
+3. Switch off → no command at all. A plan that did not pass → no command at all.
+4. The claim is atomic across processes: two servers sharing a data directory cannot both give it.
+5. An unwritable store fails OPEN with a warning rather than silently disabling the feature.
+6. A client that exports no session id is still followed across the branches of one checkout.
+7. The split verdict is measured from the plan THIS round reviewed.
+
+## Constraints
+
+- No change to what the gate decides: verdicts, thresholds and the resolve loop are untouched.
+- The condition that issues the order and the condition that claims it are ONE question asked once.
+- A caller id is somebody else's string and reaches a file name: it must not escape the directory.
+- Everything off by default; an empty command list stays the behaviour of every earlier release.
+- Nothing may be added that requires the calling AI to remember and pass an identifier.

--- a/src_bench/corpus.json
+++ b/src_bench/corpus.json
@@ -7,7 +7,7 @@
   },
   {
     "name": "split-once",
-    "planFile": "artifacts/bench/plan-B.md",
+    "planFile": "src_bench/cases/split-once.md",
     "commit": "7133c2f",
     "baseRef": "4a27a17"
   },


### PR DESCRIPTION
One case's plan text lived at `artifacts/bench/plan-B.md`, and `artifacts/` is git-ignored — so it existed only in the folder where somebody had written it, and **a fresh clone could not run that case at all**.

That, and not a preference, is why every campaign of 2026-09 ran from a temporary clone, and why the log's Repository column reads `coai-round-card` instead of the repository being measured. You asked about that directly.

Case texts live in `src_bench/cases/` now. The README says where the bench runs (this checkout), what it touches (**refs only** — `git branch -f bench/<arm>/<case>-r<n>`; the server's own worktree is detached at a SHA, so no branch of yours is held and no file in your tree moves), and how to delete the refs a campaign leaves behind.

**The gate:** not applicable — a corpus path and a README, with no behaviour for another vendor's model to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)