### PR TITLE
feat(panel): the antigravity model list is asked for, not remembered

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.30.3 — 2026-09-05 (server 0.18.1)
+
+**The antigravity model list is asked for, not remembered.** The dropdown offered Gemini 3.7 Flash
+and nothing newer while `agy models` on the same machine listed **3.8 first** — along with 3.6 and a
+Pro (Low) the panel had never heard of. The list was a hand-written constant, and the line under it
+said *"what `agy models` lists for this subscription"*, which made a snapshot look like an answer.
+The test that guarded that line asserted the sentence and carried a comment claiming the provenance
+was admitted; the two disagreed, and the constant went a model generation stale behind them.
+
+`agy models` is now read the way the CLI versions are — at most once an hour, only when a vendor is
+actually set to that runtime, and never fatally: if it does not answer, the old list is offered and
+the line says so instead of claiming the CLI said it.
+
 ## 0.30.2 — 2026-09-05 (server 0.18.1)
 
 **A rate you typed in prices the round.** The Cost column works a round out from the usage ledger and

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it \u2014 the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {

--- a/src_vs_code/src/models.ts
+++ b/src_vs_code/src/models.ts
@@ -31,6 +31,21 @@ export const RUNTIMES = ['codex', 'gemini', 'claude', 'antigravity', 'local'] as
 
 export type Runtime = (typeof RUNTIMES)[number];
 
+/**
+ * `agy models` → the ids it lists, in its order.
+ *
+ * <p>Two columns separated by a tab: the id, then the label a person reads. Anything else on the
+ * line — the "Fetching available models..." it prints first, a blank line, a warning — is not two
+ * columns and is skipped, so a CLI that greets you does not become a model called "Fetching".</p>
+ */
+export function parseAgyModels(text: string): ModelChoice[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.split('\t'))
+    .filter((columns) => columns.length >= 2 && columns[0]!.trim().length > 0 && columns[1]!.trim().length > 0)
+    .map((columns) => ({ id: columns[0]!.trim(), label: columns[1]!.trim() }));
+}
+
 /** `~/.codex/models_cache.json` → the slugs it lists. A missing or broken cache is simply none. */
 export function parseCodexModels(text: string): ModelChoice[] {
   try {
@@ -81,6 +96,7 @@ export function modelsFor(
   discoveredCodex: readonly ModelChoice[],
   current: string,
   localEngine?: LocalEngine,
+  discoveredAgy: readonly ModelChoice[] = [],
 ): ModelChoice[] {
   // A local engine's list is DISCOVERED, and that is the whole difference from the others: what can
   // be picked is what is installed on this machine this minute. A list compiled when this extension
@@ -106,7 +122,7 @@ export function modelsFor(
       : runtime === 'claude'
         ? [...CURATED_CLAUDE_MODELS]
         : runtime === 'antigravity'
-          ? [...ANTIGRAVITY_MODELS]
+          ? [...(discoveredAgy.length > 0 ? discoveredAgy : ANTIGRAVITY_MODELS)]
           : [...CURATED_GEMINI_MODELS];
   if (current.length > 0 && !base.some((m) => m.id === current)) {
     base.unshift({ id: current, label: `${current} (yours)` });
@@ -115,12 +131,17 @@ export function modelsFor(
 }
 
 /**
- * What `agy models` lists on a Google AI Pro subscription.
+ * What `agy models` listed on a Google AI Pro subscription WHEN THIS WAS WRITTEN.
  *
  * <p>One subscription, three families: the effort level is part of the model id rather than a
  * separate setting, which is why `-high` and `-low` are listed as distinct choices.</p>
+ *
+ * <p><b>A fallback, not the answer.</b> It is what the panel offers when the CLI cannot be asked,
+ * and it goes stale in silence — the operator found Gemini 3.8 Flash missing from this list on
+ * 2026-09-05 while `agy models` had listed it, along with 3.6 and a Pro (Low), for some time. The
+ * discovered list comes first now.</p>
  */
-const ANTIGRAVITY_MODELS: readonly ModelChoice[] = [
+export const ANTIGRAVITY_MODELS: readonly ModelChoice[] = [
   { id: 'gemini-3.7-flash-high', label: 'Gemini 3.7 Flash (High)' },
   { id: 'gemini-3.7-flash-medium', label: 'Gemini 3.7 Flash (Medium)' },
   { id: 'gemini-3.7-flash-low', label: 'Gemini 3.7 Flash (Low)' },
@@ -135,6 +156,7 @@ export function modelsProvenance(
   runtime: Runtime,
   discoveredCodex: readonly ModelChoice[],
   localEngine?: LocalEngine,
+  discoveredAgy: readonly ModelChoice[] = [],
 ): string {
   if (runtime === 'local') {
     // The engine's own note carries the reason when nothing answered, which is the case this line
@@ -148,7 +170,12 @@ export function modelsProvenance(
     return 'aliases the Claude CLI resolves to the latest of each family. Any exact id can be typed in.';
   }
   if (runtime === 'antigravity') {
-    return 'what `agy models` lists for this subscription — Gemini, Claude and GPT-OSS through one CLI.';
+    // The truth about where the list came from, which this line used to state wrongly: it claimed
+    // the CLI's own answer while offering a snapshot taken when the file was written — and the
+    // snapshot was a model generation behind before anybody noticed.
+    return discoveredAgy.length > 0
+      ? `${discoveredAgy.length} models \`agy models\` lists for this subscription.`
+      : 'a list from when this was written — `agy` did not answer, so it may be behind. Any id can be typed in.';
   }
   return discoveredCodex.length > 0
     ? `${discoveredCodex.length} models the Codex CLI has cached for this machine.`

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { pastedSnippetStatus } from './snippetInWorkspace';
 import { discoverEngine, LocalEngine, openAiBaseOf, probeEngine } from './localEngines';
 import { EscalationWatcher } from './escalationWatcher';
-import { ModelChoice, parseCodexModels } from './models';
+import { ModelChoice, parseAgyModels, parseCodexModels } from './models';
 import {
   isPanelCommand,
   liveRegions,
@@ -18,10 +18,11 @@ import { parseUsage, priceOf, UsageEntry, Window } from './usage';
 import {
   CliStatus,
   latestCliVersion,
+  unquoted,
   versionProbeCandidates,
   versionSourceFor,
 } from './cliVersions';
-import { askVersion } from './versionProbe';
+import { askVersion, capture } from './versionProbe';
 import { latestServerVersion, serverOnThisSide, serverPath } from './installer';
 import { DbLog, EMPTY_LOG } from './roundsDb';
 import { readLog } from './roundsDbRead';
@@ -74,6 +75,16 @@ export class PanelProvider implements vscode.WebviewViewProvider {
 
   private view?: vscode.WebviewView;
   private codexModels: ModelChoice[] = [];
+  /**
+   * What `agy models` last listed, and when it was asked.
+   *
+   * <p>Asked rather than remembered, because the remembered list went a model generation stale in
+   * silence — the operator found Gemini 3.8 Flash missing from the dropdown while the CLI had been
+   * listing it. Asked at most once an hour, because it is a process and a network call, and a
+   * subscription does not gain models between two repaints.</p>
+   */
+  private agyModels: ModelChoice[] = [];
+  private agyCheckedAt = 0;
   /** What the last repaint was drawn from, so only a real change to the controls repaints. */
   private paintedKey = '';
   /** One nonce per panel instance: the CSP admits our one script, and a repaint reuses it. */
@@ -248,6 +259,7 @@ export class PanelProvider implements vscode.WebviewViewProvider {
     const settings = settingsFrom((section) => config.get(section));
     const vendors = vendorsFrom(config.get('vendors'));
     this.codexModels = await this.readCodexModels();
+    this.agyModels = await this.readAgyModels(vendors);
     // The published version is read FIRST because the server's status is stated against it — and
     // both belong to the side this extension host is running on, never to "the machine".
     const published = await this.publishedVersion();
@@ -256,6 +268,7 @@ export class PanelProvider implements vscode.WebviewViewProvider {
       settings,
       vendors,
       codexModels: this.codexModels,
+      agyModels: this.agyModels,
       server: await serverOnThisSide(this.context.globalStorageUri, this.context.globalState, published),
       side: sideLabel(vscode.env.remoteName, process.env['WSL_DISTRO_NAME']),
       questions: this.watcher.openQuestions,
@@ -1036,6 +1049,28 @@ export class PanelProvider implements vscode.WebviewViewProvider {
    * The Codex CLI's own model cache — what this machine can actually reach today, rather than a
    * list we would have to keep up to date by hand.
    */
+  /**
+   * The models this subscription actually has, from the CLI that knows.
+   *
+   * <p>Only when a vendor is set to that runtime — an installed `agy` nobody uses is not worth a
+   * process on every repaint — and only once an hour. Anything at all going wrong leaves the list
+   * empty, which the dropdown reads as "use the fallback and say so".</p>
+   */
+  private async readAgyModels(vendors: readonly Vendor[]): Promise<ModelChoice[]> {
+    const AN_HOUR = 60 * 60 * 1000;
+    if (!vendors.some((v) => v.runtime === 'antigravity')) {
+      return [];
+    }
+    if (Date.now() - this.agyCheckedAt < AN_HOUR && this.agyModels.length > 0) {
+      return this.agyModels;
+    }
+    this.agyCheckedAt = Date.now();
+    const agy = vendors.find((v) => v.runtime === 'antigravity')?.executablePath || 'agy';
+    const { code, output } = await capture(unquoted(agy), ['models'], false, 20_000);
+
+    return code === 0 ? parseAgyModels(output) : [];
+  }
+
   private async readCodexModels(): Promise<ModelChoice[]> {
     const home = process.env['USERPROFILE'] ?? process.env['HOME'];
     const codexHome = process.env['CODEX_HOME'] ?? (home === undefined ? undefined : `${home}/.codex`);

--- a/src_vs_code/src/panelView.ts
+++ b/src_vs_code/src/panelView.ts
@@ -34,6 +34,8 @@ export interface PanelState {
   readonly settings: CoaiSettings;
   readonly vendors: readonly Vendor[];
   readonly codexModels: readonly ModelChoice[];
+  /** What `agy models` lists on this machine, or none when it could not be asked. */
+  readonly agyModels: readonly ModelChoice[];
   /**
    * The server binary on the side this panel is running on — the disk, then the binary's own
    * `--version`, then this side's record. Never a record made on another side.
@@ -258,7 +260,7 @@ function updateLabel(id: string, cli: CliStatus): string {
 }
 
 function reviewersBody(state: PanelState): string {
-  return `${state.vendors.map((v) => vendorCard(v, state.codexModels, state.cliStatus[v.id] ?? UNKNOWN_CLI, state.modelPrices[v.model], state.localEngines[v.id])).join('\n')}
+  return `${state.vendors.map((v) => vendorCard(v, state.codexModels, state.cliStatus[v.id] ?? UNKNOWN_CLI, state.modelPrices[v.model], state.localEngines[v.id], state.agyModels)).join('\n')}
 <button class="add" data-command="addVendor" title="${escapeHtml(HELP.addVendor)}">＋&nbsp; Add a reviewer</button>`;
 }
 
@@ -278,10 +280,11 @@ function vendorCard(
   cli: CliStatus,
   price: ModelPrice | undefined,
   localEngine?: LocalEngine,
+  agyModels: readonly ModelChoice[] = [],
 ): string {
   const id = escapeHtml(vendor.id);
   const local = vendor.runtime === 'local';
-  const models = modelsFor(vendor.runtime, codexModels, vendor.model, localEngine);
+  const models = modelsFor(vendor.runtime, codexModels, vendor.model, localEngine, agyModels);
   // Who is asked for an endpoint: everybody except the shipped vendors that already know where
   // they go. It used to be "everybody with a baseUrl already set, plus local" — which hid the field
   // from the one preset whose entire purpose is to be given a base URL ("Another OpenAI-compatible
@@ -344,7 +347,7 @@ ${local ? remoteNotice(vendor.baseUrl) : ''}
     <select data-setting="model" data-vendor="${id}" title="${escapeHtml(local ? HELP.localModel : HELP.vendorModel)}">
       ${modelOptions(models, vendor.model, local ? 'whatever the engine answers with' : "the CLI's default")}
     </select>
-    <div class="hint">${escapeHtml(vendor.runtime)} · ${escapeHtml(modelsProvenance(vendor.runtime, codexModels, localEngine))}</div>
+    <div class="hint">${escapeHtml(vendor.runtime)} · ${escapeHtml(modelsProvenance(vendor.runtime, codexModels, localEngine, agyModels))}</div>
   </div>${endpoint}${executable}
 </div>`;
 }

--- a/src_vs_code/src/test/activeRounds.test.ts
+++ b/src_vs_code/src/test/activeRounds.test.ts
@@ -51,7 +51,7 @@ function state(sessions: readonly SessionFile[]): PanelState {
   return {
     settings: DEFAULTS,
     vendors: [],
-    codexModels: [],
+    codexModels: [], agyModels: [],
     localEngines: {},
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '',

--- a/src_vs_code/src/test/agyModels.test.ts
+++ b/src_vs_code/src/test/agyModels.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { ANTIGRAVITY_MODELS, modelsFor, modelsProvenance, parseAgyModels } from '../models';
+
+/**
+ * The antigravity model list is read from the CLI, not remembered from the day this was written.
+ *
+ * <p>Found by the operator on 2026-09-05: the dropdown offered Gemini 3.7 Flash and nothing newer,
+ * while `agy models` on the same machine listed 3.8 first — along with 3.6 and a Pro (Low) the panel
+ * had never heard of. The list was a hand-written constant, and the line under it said <i>"what
+ * `agy models` lists for this subscription"</i>, which made a snapshot look like an answer.</p>
+ *
+ * <p>The fixture below is that machine's real output, kept verbatim: a test written from what the
+ * parser expects would only prove the parser agrees with itself.</p>
+ */
+
+/** `agy models` on a Google AI Pro subscription, 2026-09-05, copied exactly. */
+const AGY_OUTPUT = [
+  'Fetching available models...',
+  'gemini-3.8-flash-high\tGemini 3.8 Flash (High)',
+  'gemini-3.8-flash-medium\tGemini 3.8 Flash (Medium)',
+  'gemini-3.8-flash-low\tGemini 3.8 Flash (Low)',
+  'gemini-3.7-flash-high\tGemini 3.7 Flash (High)',
+  'gemini-3.7-flash-medium\tGemini 3.7 Flash (Medium)',
+  'gemini-3.7-flash-low\tGemini 3.7 Flash (Low)',
+  'gemini-3.6-flash-high\tGemini 3.6 Flash (High)',
+  'gemini-3.6-flash-medium\tGemini 3.6 Flash (Medium)',
+  'gemini-3.6-flash-low\tGemini 3.6 Flash (Low)',
+  'gemini-3.1-pro-high\tGemini 3.1 Pro (High)',
+  'gemini-3.1-pro-low\tGemini 3.1 Pro (Low)',
+  'claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)',
+  'claude-opus-4-6-thinking\tClaude Opus 4.6 (Thinking)',
+  'gpt-oss-120b-medium\tGPT-OSS 120B (Medium)',
+  '',
+].join('\n');
+
+test('every model the CLI lists is offered, in its order', () => {
+  const models = parseAgyModels(AGY_OUTPUT);
+
+  assert.equal(models.length, 14);
+  assert.deepEqual(models[0], { id: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)' });
+  assert.ok(models.some((m) => m.id === 'gemini-3.6-flash-low'), 'including the ones the constant never had');
+  assert.ok(models.some((m) => m.id === 'gemini-3.1-pro-low'));
+});
+
+test('what the CLI says before its list is not a model', () => {
+  // "Fetching available models..." is one column, and a model called Fetching in the dropdown would
+  // be the panel's own doing.
+  const models = parseAgyModels(AGY_OUTPUT);
+
+  assert.ok(!models.some((m) => m.id.startsWith('Fetching')), 'the greeting is not a model');
+  assert.ok(!models.some((m) => m.label.length === 0), 'and neither is a blank line');
+});
+
+test('nothing at all from the CLI is no models, not a broken list', () => {
+  assert.deepEqual(parseAgyModels(''), []);
+  assert.deepEqual(parseAgyModels('agy: command not found'), []);
+  assert.deepEqual(parseAgyModels('\t\n \t \n'), [], 'two empty columns are not a model either');
+});
+
+test('the discovered list is what the dropdown offers; the constant is only the fallback', () => {
+  const discovered = parseAgyModels(AGY_OUTPUT);
+
+  const offered = modelsFor('antigravity', [], '', undefined, discovered);
+  assert.equal(offered[0]?.id, 'gemini-3.8-flash-high', 'the newest the CLI knows leads');
+
+  const fallback = modelsFor('antigravity', [], '', undefined, []);
+  assert.deepEqual(fallback.map((m) => m.id), ANTIGRAVITY_MODELS.map((m) => m.id));
+});
+
+test('a model already chosen never vanishes from its own dropdown', () => {
+  // It is what the vendor is set to; a list that dropped it would silently change the setting.
+  const offered = modelsFor('antigravity', [], 'gemini-9.9-flash-high', undefined, parseAgyModels(AGY_OUTPUT));
+
+  assert.equal(offered[0]?.id, 'gemini-9.9-flash-high');
+  assert.match(offered[0]?.label ?? '', /yours/);
+});
+
+test('the line under the dropdown says where the list actually came from', () => {
+  // It used to claim the CLI's answer while offering a snapshot. That is what made a list a model
+  // generation behind look like the truth.
+  assert.match(modelsProvenance('antigravity', [], undefined, parseAgyModels(AGY_OUTPUT)), /14 models/);
+  assert.match(modelsProvenance('antigravity', [], undefined, []), /did not answer/);
+});

--- a/src_vs_code/src/test/foundByTheGate.test.ts
+++ b/src_vs_code/src/test/foundByTheGate.test.ts
@@ -28,7 +28,7 @@ const engine = (over: Partial<LocalEngine> = {}): LocalEngine => ({
 const state = (over: Partial<PanelState> = {}): PanelState => ({
   settings: DEFAULTS,
   vendors: DEFAULT_VENDORS,
-  codexModels: [],
+  codexModels: [], agyModels: [],
   localEngines: {},
   server: { kind: 'known', version: '0.12.0', remembered: false, updateOffered: false },
   side: '',

--- a/src_vs_code/src/test/liveRepaint.test.ts
+++ b/src_vs_code/src/test/liveRepaint.test.ts
@@ -23,7 +23,7 @@ const usage = [
 const state = (over: Partial<PanelState> = {}): PanelState => ({
   settings: DEFAULTS,
   vendors: DEFAULT_VENDORS,
-  codexModels: [],
+  codexModels: [], agyModels: [],
   localEngines: {},
   server: { kind: 'known', version: '0.6.0', remembered: false, updateOffered: true },
   side: '',

--- a/src_vs_code/src/test/localTrust.test.ts
+++ b/src_vs_code/src/test/localTrust.test.ts
@@ -27,7 +27,7 @@ const LOCAL: LocalEngine = {
 
 function html(vendor: Vendor): string {
   return panelHtml({
-    settings: DEFAULTS, vendors: [vendor], codexModels: [], localEngines: { [vendor.id]: LOCAL },
+    settings: DEFAULTS, vendors: [vendor], codexModels: [], agyModels: [], localEngines: { [vendor.id]: LOCAL },
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '', latestServerVersion: '', questions: [], sessions: [],
     openSections: ['reviewers'],

--- a/src_vs_code/src/test/localVendor.test.ts
+++ b/src_vs_code/src/test/localVendor.test.ts
@@ -36,7 +36,7 @@ function html(vendors: readonly Vendor[], engine: LocalEngine): string {
   return panelHtml({
     settings: DEFAULTS,
     vendors,
-    codexModels: [],
+    codexModels: [], agyModels: [],
     localEngines: Object.fromEntries(vendors.filter((v) => v.runtime === 'local').map((v) => [v.id, engine])),
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '',

--- a/src_vs_code/src/test/localWording.test.ts
+++ b/src_vs_code/src/test/localWording.test.ts
@@ -24,7 +24,7 @@ const ENGINE: LocalEngine = {
 
 function html(vendors: readonly Vendor[]): string {
   return panelHtml({
-    settings: DEFAULTS, vendors, codexModels: [],
+    settings: DEFAULTS, vendors, codexModels: [], agyModels: [],
     localEngines: Object.fromEntries(vendors.filter((v) => v.runtime === 'local').map((v) => [v.id, ENGINE])),
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '', latestServerVersion: '', questions: [], sessions: [],

--- a/src_vs_code/src/test/panelView.test.ts
+++ b/src_vs_code/src/test/panelView.test.ts
@@ -11,6 +11,7 @@ import { DEFAULT_VENDORS } from '../vendors';
 const state = (over: Partial<PanelState> = {}): PanelState => ({
   settings: DEFAULTS,
   vendors: DEFAULT_VENDORS,
+  agyModels: [],
   codexModels: [
     { id: 'gpt-5.6-sol', label: 'GPT-5.6-Sol' },
     { id: 'gpt-5.4-mini', label: 'GPT-5.4-Mini' },
@@ -113,7 +114,12 @@ test("codex offers the CLI's own cached models; antigravity offers what agy list
   assert.ok(html.includes('value="gpt-5.6-sol"'), 'discovered from ~/.codex/models_cache.json');
   assert.ok(html.includes('models the Codex CLI has cached'));
   assert.ok(html.includes('value="gemini-3.7-flash-high"'));
-  assert.ok(html.includes('one CLI'), 'the provenance of the list is admitted, never passed off as discovery');
+  // This used to assert the sentence "what `agy models` lists for this subscription" while the list
+  // was a hand-written constant — and the assertion's own comment claimed the provenance was
+  // admitted. The two disagreed, and the constant went a model generation stale behind that.
+  assert.ok(
+    html.includes('did not answer'),
+    'with nothing discovered, the line says the list may be behind rather than claiming the CLI said it');
 });
 
 test('the picker is a SELECT with every model visible, never a filtering datalist', () => {

--- a/src_vs_code/src/test/pricesInPanel.test.ts
+++ b/src_vs_code/src/test/pricesInPanel.test.ts
@@ -28,7 +28,7 @@ function vendor(over: Partial<Vendor> = {}): Vendor {
 
 function html(v: Vendor, prices: Record<string, ModelPrice>): string {
   return panelHtml({
-    settings: DEFAULTS, vendors: [v], codexModels: [], localEngines: {}, server: { kind: 'absent', version: '', remembered: false, updateOffered: false }, side: '',
+    settings: DEFAULTS, vendors: [v], codexModels: [], agyModels: [], localEngines: {}, server: { kind: 'absent', version: '', remembered: false, updateOffered: false }, side: '',
     latestServerVersion: '', questions: [], sessions: [], openSections: [], usage: [],
     usageWindow: 'week', cliStatus: {}, modelPrices: prices,
     snippetStatus: { kind: 'current', current: SNIPPET_VERSION },

--- a/src_vs_code/src/test/recentAndForget.test.ts
+++ b/src_vs_code/src/test/recentAndForget.test.ts
@@ -68,7 +68,7 @@ function html(over: {
   return panelHtml({
     settings: DEFAULTS,
     vendors: DEFAULT_VENDORS,
-    codexModels: [],
+    codexModels: [], agyModels: [],
     localEngines: {},
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '',

--- a/src_vs_code/src/test/settingWrite.test.ts
+++ b/src_vs_code/src/test/settingWrite.test.ts
@@ -53,7 +53,7 @@ test('no control that writes a role-keyed setting is labelled as a vendor', () =
   const html = panelHtml({
     settings: DEFAULTS,
     vendors: DEFAULT_VENDORS,
-    codexModels: [],
+    codexModels: [], agyModels: [],
     localEngines: {},
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '',
@@ -86,7 +86,7 @@ test('every role id the panel writes to is a role, and no vendor shares the name
   const html = panelHtml({
     settings: DEFAULTS,
     vendors: DEFAULT_VENDORS,
-    codexModels: [],
+    codexModels: [], agyModels: [],
     localEngines: {},
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '',
@@ -129,7 +129,7 @@ test('the number of prompt pickers follows that role\u2019s rounds', () => {
     panelHtml({
       settings: { ...DEFAULTS, rounds },
       vendors: DEFAULT_VENDORS,
-      codexModels: [],
+      codexModels: [], agyModels: [],
     localEngines: {},
       server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
       side: '',

--- a/src_vs_code/src/test/settingsAreDeclared.test.ts
+++ b/src_vs_code/src/test/settingsAreDeclared.test.ts
@@ -23,7 +23,7 @@ import { DEFAULT_VENDORS } from '../vendors';
 const state = (): PanelState => ({
   settings: DEFAULTS,
   vendors: DEFAULT_VENDORS,
-  codexModels: [],
+  codexModels: [], agyModels: [],
   localEngines: {},
   server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
   side: '',

--- a/src_vs_code/src/test/updateButton.test.ts
+++ b/src_vs_code/src/test/updateButton.test.ts
@@ -33,7 +33,7 @@ function html(vendors: readonly Vendor[], cliStatus: Record<string, CliStatus>):
   return panelHtml({
     settings: DEFAULTS,
     vendors,
-    codexModels: [],
+    codexModels: [], agyModels: [],
     localEngines: {},
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '',

--- a/src_vs_code/src/test/updateButtonColour.test.ts
+++ b/src_vs_code/src/test/updateButtonColour.test.ts
@@ -26,7 +26,7 @@ function css(): string {
   return panelHtml({
     settings: DEFAULTS,
     vendors: DEFAULT_VENDORS,
-    codexModels: [],
+    codexModels: [], agyModels: [],
     localEngines: {},
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '',

--- a/src_vs_code/src/test/vendorClassIsNotACard.test.ts
+++ b/src_vs_code/src/test/vendorClassIsNotACard.test.ts
@@ -46,7 +46,7 @@ function state(): PanelState {
   return {
     settings: DEFAULTS,
     vendors: [],
-    codexModels: [],
+    codexModels: [], agyModels: [],
     localEngines: {},
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '',

--- a/src_vs_code/src/test/vendorColour.test.ts
+++ b/src_vs_code/src/test/vendorColour.test.ts
@@ -83,7 +83,7 @@ function state(): PanelState {
   return {
     settings: DEFAULTS,
     vendors: [],
-    codexModels: [],
+    codexModels: [], agyModels: [],
     localEngines: {},
     server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
     side: '',


### PR DESCRIPTION
You asked why Flash 3.8 was not in the dropdown. It was on your machine the whole time:

```
gemini-3.8-flash-high    Gemini 3.8 Flash (High)      ← agy lists it, the panel did not
gemini-3.8-flash-medium  Gemini 3.8 Flash (Medium)    ← same
gemini-3.8-flash-low     Gemini 3.8 Flash (Low)       ← same
gemini-3.6-flash-*       Gemini 3.6 Flash             ← never in the panel either
gemini-3.1-pro-low       Gemini 3.1 Pro (Low)         ← nor this
```

The list was a **hand-written constant** in `models.ts` — a snapshot of what `agy models` printed when the file was written.

**Worse than stale.** The line under the dropdown said *"what `agy models` lists for this subscription"*: a snapshot presented as an answer. And the test guarding that line asserted the sentence while its own comment claimed *"the provenance of the list is admitted, never passed off as discovery"*. The two disagreed with each other, and the constant went a model generation behind them both.

## What it does now

`agy models` is read the way the CLI versions already are: at most **once an hour**, only when a vendor is actually set to that runtime (an installed `agy` nobody uses is not worth a process on every repaint), through the same hardened `capture()` the version probe uses. If it does not answer, the old list is offered and the line says **the list may be behind** rather than claiming the CLI said it.

The parser's fixture is that machine's real output, kept verbatim — a fixture written from what the parser expects would only prove the parser agrees with itself.

## Verified

**439 tests pass**, six of them new:

- every model the CLI lists is offered, in its order;
- the CLI's greeting (`Fetching available models...`) is not a model;
- nothing at all from the CLI is no models rather than a broken list;
- the discovered list is what the dropdown offers and the constant is only the fallback;
- a model already chosen never vanishes from its own dropdown;
- the line under it says where the list actually came from.

**The gate:** not run — the CLI this change reads is busy in the running 0.18.0 benchmark, and a gate round would put three reviewers in competition with it for the same subscription. Saying so rather than quietly skipping it; happy to run it before merge if you would rather wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
