### PR TITLE
fix(bench): a judgement survives being stopped, and the report says who found it alone

### DIFF
--- a/research/RESULTS_vendor_overlap_2026-09-06.md
+++ b/research/RESULTS_vendor_overlap_2026-09-06.md
@@ -1,0 +1,66 @@
+# RESULTS — what each vendor found that the others did not
+
+> Status: **measured, 2026-09-06.** Data: [data/bench-2026-09-06/](data/bench-2026-09-06/) (server
+> 0.18.0, one repeat, seven arms × two cases). The six campaigns that preceded it, on 0.17.1–0.17.4,
+> are in [data/bench-2026-09-05/](data/bench-2026-09-05/).
+>
+> Judged by `claude-opus-5`, one CLI turn per finding, over the code as reviewed (`git show` at the
+> commit, windowed around the cited line). Related: [RESULTS_model_comparison.md](RESULTS_model_comparison.md),
+> [module_bench.md](module_bench.md).
+
+## The question the per-arm table cannot answer
+
+A provider whose every finding repeats another's scores exactly as well on hit-rate as one that
+found things by itself — and the second is the only thing a second provider is worth paying for.
+So the overlap pass clusters findings across every arm and repeat, per case and stage, and asks of
+each vendor: what did it write, how many distinct things were those, how many did somebody else
+also name, how many did nobody else name, and how many of *those* were worth having.
+
+Matching is deliberately generous — two findings close enough to argue about are counted as one —
+because erring the other way inflates "only I found this", which is the number a purchase is made on.
+
+## Who found it alone
+
+| provider | findings written | distinct | also found by another | found by it alone | of those, worth having |
+|---|---|---|---|---|---|
+| `codex` | 75 | 60 | 5 (8 %) | **55 (92 %)** | **22** |
+| `gemini` | 52 | 43 | 4 (9 %) | **39 (91 %)** | **19** |
+| `local` | 118 | 59 | 3 (5 %) | **56 (95 %)** | **5** |
+
+**The overlap is 5–9 %.** Three reviewers reading the same diff almost never name the same defect.
+Whatever else this measurement says, it settles the first question: a second vendor is not a second
+opinion on the same findings, it is a different set of findings. Redundancy is not what is being
+bought, and it is not what is being paid for either.
+
+## Where each one earns its place — and where it does not
+
+| provider | plan stage | code stage |
+|---|---|---|
+| `codex` | 17 / 35 (49 %) | 13 / 40 (33 %) |
+| `gemini` | 17 / 28 (61 %) | 9 / 24 (38 %) |
+| `local` | 9 / 48 (19 %) | **2 / 70 (3 %)** |
+
+`local` writes the most of anyone — 118 findings, more than codex and gemini together — and two of
+its seventy code-stage findings were worth having. On a PLAN it is a fifth useful, which is a real
+contribution at no marginal cost. On CODE it is noise with a 3 % signal, and each of those findings
+costs a person the time to read and resolve it.
+
+`gemini` is the opposite shape: the fewest findings and the highest hit rate in both stages.
+
+## What this changes
+
+1. **Keep more than one vendor.** At 5–9 % overlap the arms are additive, and the all-three arm's
+   twenty findings per code round are twenty different things.
+2. **`local` belongs in the plan stage.** Its code-stage output is a 3 % signal that a person pays
+   for in reading time. The gate's per-stage vendor selection is the switch that already exists.
+3. **The useful findings are not nits**: 42 Major, 14 Blocking, 11 Minor. What the judge kept is
+   what would have changed the change.
+
+## What this measurement cost to get twice
+
+The first pass of this judgement was lost — the pass wrote its file once, after the loop, and it
+died on its fourteenth run of fourteen when a reviewer cited a line past the end of a file
+(`Enumerable.Range` with a negative count). Thirteen judged runs, about a hundred paid CLI turns,
+existed only in memory. Both holes are closed: the file is written after every run and a restart
+skips what this judge already answered ([PLAN_bench_campaign_after_the_store_fix.md](PLAN_bench_campaign_after_the_store_fix.md)),
+and a cited line the file does not have yields no window instead of taking down the process.

--- a/research/data/bench-2026-09-05/epic1-v0.17.1/runs.json
+++ b/research/data/bench-2026-09-05/epic1-v0.17.1/runs.json
@@ -1,0 +1,2062 @@
+[
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T08:27:44.5147674Z",
+    "finishedUtc": "2026-09-05T08:36:49.773071Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 39.2,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 10,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 38272,
+        "tokensOut": 5743,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping requirement is not covered for every session-file field that is rendered",
+            "why": "A session containing a malicious reviewer/model/status/message field such as \u0060\u003Cimg src=x onerror=...\u003E\u0060 can still reach the generated panel HTML if only the vendor span is escaped; the single test for a vendor name does not establish the stated guarantee that nothing from a session file is unescaped.",
+            "fix": "Inventory every session-derived value used by panelView, escape each at the final HTML boundary (or render through one escaping helper), and add field-specific tests for every rendered text field, not just vendor names.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real, specific risk (session-file text reaching webview HTML through fields other than the one tested) and asks for the proportionate fix this family\u0027s own rules require: enumerate the sites and route them through one escaping helper rather than trusting a single-field test as proof of a blanket guarantee."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The auto-open ownership design does not define how user opens are distinguished from panel opens",
+            "why": "The proposed second set only says that a person\u0027s toggle removes a key, but it does not specify the event/state transition that records a person opening a card. If a person opens a running round through the existing reveal path, the set can remain absent and the finish transition can close it, violating the promise that a person-opened round stays open; conversely, treating any reveal as panel-owned can close a manually reopened card.",
+            "fix": "Specify and test explicit transition handlers: panel auto-open adds ownership, user open clears ownership and marks the card user-owned, user close clears panel ownership, and finish only collapses entries still owned by the panel.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real gap in a state design: with a shared reveal path, the plan never says whether ownership is recorded at the auto-open trigger or inside reveal, and the two placements give opposite behaviour for a person-opened card at finish, so specifying and testing the transitions is a proportionate ask even though the first of its two scenarios is muddled."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define behavior for polling races and panel reloads around completion",
+            "why": "If a round is running in one refresh and finished in the next while a user toggle or extension-host/view reload occurs between those operations, the ownership set and expanded state can be updated in different orders; the finished card may remain expanded or a user-opened card may be collapsed. The tests cover a simple transition but not the failure-prone interleavings the feature depends on.",
+            "fix": "Define the state update as an atomic/idempotent refresh transition keyed by round identity, and add tests for finish-versus-toggle and finish-versus-view recreation, including killed/restarted panel state.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about interleavings that a single-threaded webview processes in order, names no concrete defect in the plan, and asks for atomic transitions plus a battery of race tests for a risk whose worst case is a card left in the wrong expanded state, one click from fixed."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The colour plan leaves collisions and palette evolution unspecified",
+            "why": "A deterministic index into a finite palette gives the same colour after restart, but two vendors whose hashes map to the same slot render identically, and changing the palette order or length in a later release changes existing vendors\u0027 colours. The only test uses two common names and therefore does not verify the broader stability promise.",
+            "fix": "Document collision as an accepted property or define a stable collision strategy, and test a collision pair plus palette changes; if cross-version stability is required, use a versioned palette and stable mapping contract.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "Hashing a handful of vendors into a small palette collides more often than not, and two vendors sharing a colour defeats the colour\u0027s only purpose, so naming the collision case is worth a sentence in the plan even though the versioned-palette half of the fix is more machinery than the risk warrants."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Constraints: Single reviewer row renderer injects HTML spans into plain-text test consumers.",
+            "why": "The plan requires a single renderer for reviewer rows (\u0027One renderer for a reviewer row, not a text one and an HTML one that drift. The text version is what the tests read today.\u0027) while step 5 introduces \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022...\u0022\u003E\u0060 wrapping. Existing tests asserting on plain-text format (e.g., \u0027codex/PlanCritique \u2014 running\u0027) will receive raw HTML markup and fail.",
+            "fix": "Separate the raw text row model from the HTML markup decorator, or sanitize/strip tags in the shared renderer when evaluated in plain-text test contexts.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It exposes a real contradiction inside the plan\u0027s own constraints: one renderer whose text form the tests read, and a step that makes that renderer emit HTML spans, so the author must decide up front whether tests move to markup assertions or the row model is split from its decoration."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Build order (panelProvider/panelView): Card expansion state changes trigger full panel telemetry probes.",
+            "why": "When a card transitions between open and closed, invoking the general panel view rebuild causes the panel to re-stat binaries, probe vendor CLIs, fetch GitHub release data, and download pricing tables, causing multi-second freezes on simple click or auto-collapse events.",
+            "fix": "Decouple expansion state handling and DOM toggle rendering from the heavy panel background data fetch and vendor probe lifecycle.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Build order (rounds.ts): Placing theme color resolution in session parser creates an inverted dependency.",
+            "why": "Placing \u0060vendorColour(name)\u0060 in \u0060rounds.ts\u0060 ties session log parsing to UI theme palette concerns (\u0060--vscode-charts-*\u0060), forcing external UI consumers like spending tables to import the session parser.",
+            "fix": "Define \u0060vendorColour\u0060 in an independent UI view utility module (e.g., \u0060vendorColour.ts\u0060) consumed by both round cards and spending rows.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real, cheap-to-fix coupling: a theme-palette lookup living in the session parser forces UI-only consumers to depend on parsing, and moving it to its own small module is proportionate and matches the repo\u0027s low-coupling and one-road-in rules."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "The risk it names is real and matches the family\u0027s durable-status rule: an in-memory \u0027opened by the panel\u0027 set dies with the extension host, so a restart mislabels who owns a round and the auto-close logic goes wrong in one direction or the other, which the plan must answer with persisted state even though the proposed fix (adding an ID) is aimed at identity rather than at the persistence gap that actually causes it."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding rests on an unsupported premise that contradicts this product\u0027s design: a Claude model is a configured reviewer row on the claude CLI, so gating on the provider list is the expected check, and the proposed fix asks the gate to detect which model is calling it, which neither the MCP server nor the extension can do."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It manufactures the defect from the quoted phrase: a webview \u0027repaint\u0027 rebuilds HTML from state the extension already holds, extension-host I/O is asynchronous and cannot freeze VS Code\u0027s UI, and the \u002720 seconds\u0027 is invented, so the only surviving content is generic caching advice the plan\u0027s wording already implies."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "A dead round rendered with a start-to-now duration is a real stuck-in-flight display that this family\u0027s durable-status rule forbids, and the plan\u0027s own admission that no completion time exists is exactly why the card needs a heartbeat stamp or an explicit absence marker; the fix is half-misdirected (a completion flag cannot be written by a round that died) but the risk it names is genuine."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "A border, radius and padding inherited by an inline span render as a box around the text, not as a line through it, so the strikethrough artifact is invented and the fix addresses a defect that does not exist."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads the plan\u0027s own symptom description (legacy rounds as disclosures opening into an apology) as the proposed design, then asks for the distinct legacy state the plan already introduces, and the hand-cursor claim is asserted without any evidence."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": null
+      },
+      {
+        "stage": "code",
+        "seconds": 505.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "8 of 9 reviewers answered; failed: local/Architecture: unparseable: the answer was not the schema\u0027s JSON after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\local-Architecture-20260905-083347-621.txt)",
+        "tokensIn": 489104,
+        "tokensOut": 40870,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 808,
+            "title": "The reviewer span uses the forbidden \u0060vendor\u0060 class",
+            "why": "The plan explicitly records: \u0022The span\u0027s class is \u0060who\u0060, not the planned \u0060vendor\u0060 \u2014 \u0060.vendor\u0060 already meant the settings card in this stylesheet.\u0022 This diff renders reviewer names with \u0060class=\u0022vendor\u0022\u0060, reintroducing the documented styling collision.",
+            "fix": "Use \u0060class=\u0022who\u0022\u0060 for the reviewer vendor span and update the related assertions.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 2,
+            "title": "The change adds an obsolete plan marked as unimplemented",
+            "why": "The plan\u0027s Definition of Done requires: \u0022docs, help and CHANGELOG updated; the plan promoted.\u0022 The added file instead says \u0022Status: plan only, nothing implemented yet\u0022 even though the corresponding research plan is marked implemented, leaving contradictory plan-lifecycle state.",
+            "fix": "Remove this obsolete todo copy or promote it to the authoritative completed plan with a matching implemented status.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 154,
+            "title": "Unique scratch files prevent collisions but allow concurrent stale snapshots to overwrite each other",
+            "why": "Two server processes can load the same session, independently append progress, and call \u0060Save\u0060; the last \u0060File.Move(..., overwrite: true)\u0060 replaces the complete session with its older snapshot. For example, a completion/findings update from one round can be silently erased by another reviewer-transition save, leaving the session with missing history or a permanently running status.",
+            "fix": "Serialize the full load-modify-save operation per session across processes, or perform a locked compare-and-merge/compare-and-swap so a stale save cannot replace newer session state.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The code\u0027s own comment records two processes saving the same session file concurrently, and the unique scratch name only removed the crash: a whole-file replace with no lock or version check still lets a stale snapshot silently erase the other process\u0027s round progress, which is a real lost-update risk a careful engineer would want closed or at least documented."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 137,
+            "title": "Toggling a round triggers the full expensive panel refresh synchronously",
+            "why": "When a person opens or closes one card, the handler immediately repaints the entire panel; the render path re-reads configuration, probes CLIs, checks releases, and fetches price data, so one click can leave the panel unchanged for up to about 20 seconds with no progress or terminal error state.",
+            "fix": "Update only the round disclosure state and render its body locally, or split the lightweight card repaint from the expensive background data refresh.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding ignores the timestamped caches visible in the same excerpt (latestCheckedAt, cliCheckedAt, pricesCheckedAt, localCheckedAt) and the five-second tick that already runs this same render, so a click repaints from warm state and the claimed 20-second stall is not supported by this code; the immediate render is also explicitly justified by the comment beside it."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 805,
+            "title": "Reviewer vendor names use the existing settings-card \u0060vendor\u0060 class",
+            "why": "The new span is assigned \u0060class=\u0022vendor\u0022\u0060, but this stylesheet class already represents a settings card and adds its card border, radius, and padding; every reviewer row therefore inherits card styling around a single vendor word and disrupts the compact reviewer line.",
+            "fix": "Use the dedicated reviewer-name class (the documented \u0060who\u0060 class) or add a distinct class with no settings-card styles.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 67,
+            "title": "Closing and removing an active branch purges user-pinned round disclosures from memory",
+            "why": "In nextOpenRounds, open, autoOpened, and panelOpened are strictly filtered by alive (which only contains cards present in current session files: const alive = new Set(cards.map(roundKey))). If a user manually expanded a round on a branch or session that temporarily disappears (e.g. branch switch in git, session purge, or workspace filter update), their explicit toggle state is permanently discarded rather than preserved if the branch/session is returned to, reverting user manual state upon reload/re-render.",
+            "fix": "Only prune autoOpened and panelOpened keys if necessary, or prune open state against known repository sessions rather than discarding user preference on every intermediate tick.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 180,
+            "title": "Synchronous Thread.Sleep in retry loop blocks MCP server async request execution threads",
+            "why": "MoveOverExisting uses synchronous Thread.Sleep(20 * attempt) on IOException/UnauthorizedAccessException (up to 300ms total blocking sleep across 5 attempts). When multiple concurrent MCP requests or background saves hit contention on Windows file handles, worker threads on the thread pool or stdio handler are synchronously blocked.",
+            "fix": "Make MoveOverExisting async with await Task.Delay(20 * attempt, cancellationToken) if called from async paths, or keep retry backoff minimal without synchronous thread blocking.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The sleep is bounded (at most 200 ms, not 300, since the last attempt does not sleep), happens only on a rare Windows contention path inside an already fully synchronous store whose file reads and writes block the same threads, and in a server whose rounds take minutes per reviewer, so converting the store to async is machinery out of proportion to a negligible, deliberate, well-commented trade."
+          },
+          {
+            "severity": "Nit",
+            "category": "Ux",
+            "file": "src_vs_code/src/vendorColour.ts",
+            "line": 57,
+            "title": "Vendor palette fallback color lacks explicit contrast guarantee for unknown vendors on non-standard themes",
+            "why": "For custom/unanchored vendors, vendorColour uses FNV-1a modulo over the 6 chart colors (--vscode-charts-*). If a custom vendor string hashes to a chart color that has low contrast in certain edge themes (or if the theme defines pale chart colors), the inline style color overrides the row text color entirely without a fallback class.",
+            "fix": "Add a CSS class alongside the inline style so theme-specific CSS rules can override chart variable contrast if needed.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The palette is already the theme\u0027s own chart colours, defined by each theme to be legible on its background, so the contrast risk is speculative; it applies equally to the anchored vendors the finding exempts, and the proposed extra CSS-class hook is machinery out of proportion to a hypothetical pale theme."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Retry loop in MoveOverExisting may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a sleep of \u006020 * attempt\u0060 milliseconds. If a file lock (e.g., from an antivirus scanner or a slow indexer) persists longer than the total retry window (approx 150ms), the method throws. However, if the lock is transient but the system is under heavy load, the retry logic might not be sufficient, or worse, if the \u0060Thread.Sleep\u0060 is interrupted or the process is killed during the sleep, the temporary file might be left behind if the \u0060finally\u0060 block logic is not robust. More critically, if the \u0060File.Move\u0060 throws a different exception (e.g., \u0060PathTooLongException\u0060) that isn\u0027t caught by the \u0060catch\u0060 block, the loop exits early, potentially leaving the temp file orphaned if the \u0060TryDelete\u0060 isn\u0027t called. The specific risk is a race condition where the file is held by a scanner; the retry might succeed, but if it fails after 5 attempts, the exception is thrown, but the \u0060finally\u0060 block ensures cleanup. The real risk is if the \u0060MoveOverExisting\u0060 is called in a tight loop without sufficient delay, or if the OS file system state is inconsistent. The finding is that the retry logic is hardcoded and might not cover all edge cases of file locking on Windows, leading to silent failures if the exception handling is too broad or too narrow.",
+            "fix": "Ensure the retry loop in MoveOverExisting uses a bounded, non-exponential backoff or a maximum total duration to prevent indefinite hanging during transient file system locks, and verify that the final exception is logged with full context before re-throwing.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The central claim is false: the loop is bounded to five attempts and about 200 ms of sleep, the \u0060finally\u0060 in \u0060Save\u0060 deletes the scratch file on every exit path including uncaught exception types, and the finding contradicts itself mid-paragraph before asking for a bound that already exists."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Vendor name color interpolation may allow style injection if not sanitized",
+            "why": "The code \u0060style=\u0022color:${vendorColour(r.provider)}\u0022\u0060 interpolates the result of \u0060vendorColour\u0060 directly into the HTML. While \u0060vendorColour\u0060 returns a CSS variable string (e.g., \u0060var(--vscode-charts-blue)\u0060), if the function were to return a raw hex value or if the input \u0060r.provider\u0060 contained a malicious string that bypassed the \u0060trim().toLowerCase()\u0060 logic (e.g., via a Unicode trick or a specific character encoding), it could inject a style property. The current implementation uses \u0060escapeHtml\u0060 for the text content, but the style attribute is constructed from a function that relies on the input. If \u0060vendorColour\u0060 were to return something like \u0060url(\u0027javascript:alert(1)\u0027)\u0060 (though unlikely given the palette), it could be exploited. The specific risk is if \u0060vendorColour\u0060 is modified in the future to return a hex value or if the input \u0060r.provider\u0060 is not strictly controlled, leading to a style injection vulnerability where an attacker could override the color or inject CSS properties.",
+            "fix": "Ensure \u0060vendorColour\u0060 is called with a sanitized string before being interpolated into the \u0060style\u0060 attribute, or use a CSS variable that is pre-validated, to prevent potential style injection if the vendor name contains unexpected characters.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Potential race condition in \u0060nextOpenRounds\u0060 if \u0060roundKey\u0060 is not unique",
+            "why": "The \u0060nextOpenRounds\u0060 function uses \u0060roundKey\u0060 to identify rounds. If two rounds have the same key (e.g., same stage, number, and branch), the \u0060Set\u0060 will treat them as the same entity. This could lead to one round\u0027s state (open/closed) overwriting the other\u0027s, causing a UI inconsistency where one round is closed while the other is open, or vice versa. The risk is low if \u0060roundKey\u0060 is guaranteed to be unique, but if the logic for generating \u0060roundKey\u0060 changes or if there\u0027s a bug in the data source, this could cause silent state corruption.",
+            "fix": "Add a check to ensure that \u0060roundKey\u0060 is unique across all rounds before adding to the \u0060open\u0060 set, or handle collisions by appending a suffix or using a composite key.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is speculative about a hypothetical future bug in roundKey rather than anything this code does, mislabels a key collision as a race condition, and the proposed uniqueness check is machinery out of proportion to a risk that would break the whole rounds list anyway, not just this policy."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Race condition in session file cleanup due to exception handling order",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060finally\u0060 block calls \u0060TryDelete(temp)\u0060 unconditionally after \u0060MoveOverExisting\u0060. If \u0060MoveOverExisting\u0060 throws an exception on its final attempt (line 175), the \u0060finally\u0060 block executes. However, if the file move succeeds but the \u0060TryDelete\u0060 fails (e.g., due to a race with another process that just acquired the file), the exception is swallowed. More critically, if \u0060MoveOverExisting\u0060 throws *before* the loop completes (e.g., on the first attempt), the \u0060finally\u0060 block runs, but the file might still be in a transient state. The current structure risks leaving \u0060.tmp\u0060 files behind if the move fails after the loop, or deleting a file that another process is still using if the timing is tight. The \u0060TryDelete\u0060 should be more robustly tied to the success of the move.",
+            "fix": "Move the \u0060TryDelete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs after the retry loop completes, rather than unconditionally after the loop. Currently, if \u0060MoveOverExisting\u0060 throws on the final attempt, the \u0060finally\u0060 block executes, but if the exception happens inside the loop before the final throw, the cleanup logic might be inconsistent or the \u0060finally\u0060 block might run before the file is fully moved in edge cases.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding misreads the code: the scratch name is unique per process and write so no other writer can hold it, File.Move is atomic so there is no transient state, File.Delete on an already-moved temp is a silent no-op, and the finally already runs after the retry loop completes, so none of the described races exist and the proposed fix restates the current structure."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 52,
+            "title": "Potential mutation of input Set in \u0060nextOpenRounds\u0060",
+            "why": "In \u0060nextOpenRounds\u0060, the code creates \u0060const panelOpened = new Set(previous.panelOpened);\u0060 (line 52). Later, it calls \u0060panelOpened.delete(key)\u0060 (line 63). While this creates a new Set, if \u0060previous.panelOpened\u0060 is a reference to a Set that is used elsewhere, and the code were to mutate the original \u0060previous.panelOpened\u0060 directly (which it doesn\u0027t here, but the pattern is risky), it could cause issues. More importantly, the logic \u0060const panelOpened = new Set(previous.panelOpened);\u0060 creates a shallow copy. If \u0060previous.panelOpened\u0060 contains objects (it contains strings, so this is fine), it\u0027s safe. However, the line \u0060const open = new Set(previous.open);\u0060 (line 51) and \u0060const autoOpened = new Set(previous.autoOpened);\u0060 (line 50) are also shallow copies. The main risk is if \u0060previous\u0060 is mutated elsewhere while this function runs, but the bigger issue is the logic: \u0060panelOpened.delete(key)\u0060 modifies the local \u0060panelOpened\u0060 Set. If \u0060previous.panelOpened\u0060 is a reference to a Set that is used by the caller, and the caller expects it to be immutable, this could be a problem. But since it\u0027s a new Set, it\u0027s mostly fine. The real issue is that \u0060open\u0060, \u0060autoOpened\u0060, and \u0060panelOpened\u0060 are all created as new Sets, but then \u0060open.add(key)\u0060 (line 56) and \u0060autoOpened.add(key)\u0060 (line 57) modify them. The return statement creates new arrays from these Sets. This is generally safe, but the logic \u0060const panelOpened = new Set(previous.panelOpened);\u0060 followed by \u0060panelOpened.delete(key)\u0060 is correct. The finding is minor because the code is mostly correct, but the pattern of creating new Sets and then modifying them could be clearer.",
+            "fix": "Add a check to ensure \u0060panelOpened\u0060 is not mutated directly in \u0060nextOpenRounds\u0060 before filtering, or use a new Set for the result to avoid potential mutation side effects if the input array is reused.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding concedes repeatedly that the code is correct, cites line numbers that do not match the file, and describes no real defect: the function copies the readonly input arrays into fresh local Sets, mutates only those, and returns new arrays, so there is no input mutation to guard against."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary recalculation of open rounds state on every tick",
+            "why": "In \u0060panelProvider.ts\u0060, the \u0060expanded\u0060 method calls \u0060nextOpenRounds(this.rounds, cards)\u0060 on every tick (line 165). If the \u0060cards\u0060 array (derived from \u0060sessions\u0060) hasn\u0027t changed, this recalculates the entire state machine. While the logic is fast, doing this on every 5-second tick for a large number of rounds could be optimized by checking if \u0060cards\u0060 has changed (e.g., by comparing lengths or hashes) before calling \u0060nextOpenRounds\u0060. This is a minor performance issue but could become significant if the number of rounds grows large.",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 if the input \u0060cards\u0060 hasn\u0027t changed, or debounce the call to avoid unnecessary recalculations on every tick.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The state machine runs over a handful of round cards every five seconds beside file reads, CLI probes and price fetches that dwarf it, and the finding itself only speculates about a large-list case that this panel never has, so the cache or debounce it asks for is machinery out of proportion to any risk."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": null
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[08:36:49 \u001B[32mINF\u001B[0m] coai-mcp#3100 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Race condition in session file cleanup due to exception handling order (from local) [gating] Round=1 Stage=CodeReview\r | [08:36:49 \u001B[32mINF\u001B[0m] coai-mcp#3100 finding [Minor/Ux] src_vs_code/src/openRounds.ts:52 - Potential mutation of input Set in \u0060nextOpenRounds\u0060 (from local) Round=1 Stage=CodeReview\r | [08:36:49 \u001B[32mINF\u001B[0m] coai-mcp#3100 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary recalculation of open rounds state on every tick (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|2",
+    "startedUtc": "2026-09-05T08:36:49.9281539Z",
+    "finishedUtc": "2026-09-05T08:45:39.7749205Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 54.3,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 40664,
+        "tokensOut": 5563,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Panel ownership can be lost when a refresh re-adds a manually closed running round.",
+            "why": "If the panel auto-opens a running round, the person closes it, and the next status refresh sees that it is still running, an implementation that auto-opens whenever the round is not expanded can add it back despite the requirement that the person\u0027s closed choice persist.",
+            "fix": "Specify and test transition-based auto-opening: add a round to the panel-owned set only when it first becomes running, and never re-add it after the person\u0027s toggle removes it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible failure (a status refresh re-opening a round the person deliberately closed) that a stateless \u0027auto-open when running and not expanded\u0027 rule would produce, and the proposed transition-based ownership is a proportionate, testable fix."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping requirement is broader than the only escaping test and the described renderer change.",
+            "why": "A session value such as \u0060\u003Cimg src=x onerror=...\u003E\u0060 in a live or spending-row field, or in any round metadata rendered outside the reviewer-row helper, can still become executable markup while the reviewer-row test passes.",
+            "fix": "Enumerate every session-derived HTML sink, route all of them through a context-appropriate escaping helper, and test malicious values in reviewer, live, spending, and round metadata views.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names the exact defect this repository\u0027s security rule is written around \u0393\u00C7\u00F6 an HTML escaper applied at one sink and tested at one sink while session-derived values reach other webview sinks unescaped \u0393\u00C7\u00F6 and asks for the enumeration and cross-view tests that turn a fixed file into a fixed class."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The admitted dead-round elapsed-time defect has no implementation step or acceptance test.",
+            "why": "When a round remains running after the ten-minute reviewer timeout and never receives a completion timestamp, the panel can display an elapsed duration such as \u0060361m 40s\u0060, falsely presenting a stale process as a completed long-running round.",
+            "fix": "Define stale-round handling and its displayed state/duration, then add a fixture with a missing completion time whose result is bounded and clearly marked rather than calculated indefinitely from its start.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, user-visible misrendering the plan itself admits (a dead round showing a growing elapsed time that reads as a completed long round), points out the plan has no step or test closing it, and asks for a proportionate fix: a bounded, clearly marked display plus one fixture with a missing completion time."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "The plan leaves the expensive toggle repaint path without a performance requirement or verification.",
+            "why": "On toggling a triangle, rebuilding the card can read configuration, stat the server, probe every vendor CLI, query GitHub, and fetch price tables, producing an interaction delay of up to twenty seconds even though the toggle itself needs only local state.",
+            "fix": "Separate expansion-state updates from card-body data loading, cache or defer unrelated probes, and add an interaction test or budget proving the toggle responds promptly while data loads asynchronously.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The Fable test does not prove that reviewer discovery is no longer consulted.",
+            "why": "A command can still query the reviewer-provider list and then issue the order when the mocked list returns codex and gemini, so the test passes even though a hanging or failing provider lookup would keep the checkbox inert.",
+            "fix": "Make the test provider lookup throw or hang and assert that the Fable order is still issued without invoking reviewer discovery.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete way the test stays green without the behaviour it claims to prove (the order is issued only because the mocked discovery happens to answer), and the fix is proportionate: make discovery throw or hang and assert the order is still issued, which is exactly the delete-the-line-and-watch-it-go-red check the test needs."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order and constraints: Rendering HTML tags inside text-tested reviewer rows breaks text-based tests or leaks raw HTML",
+            "why": "Constraint 1 mandates \u0027One renderer for a reviewer row, not a text one and an HTML one that drift. The text version is what the tests read today.\u0027 But Step 5 modifies this single renderer to wrap vendor names in \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:\u2026\u0022\u003E\u0060. Any test asserting exact text representation on reviewer rows will now receive raw HTML spans, causing test failures or forcing test drift, while anywhere expecting plain text will display raw markup.",
+            "fix": "Either decouple row view rendering from plain text extraction/parsing with dedicated formatting helpers or introduce a clean AST/token representation that renders to both plain text and sanitized HTML without duplicating business logic.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The plan already states there is one renderer whose output the tests read, so tests following the renderer to HTML is the ordinary consequence rather than a defect, the plain-text leak is asserted without naming any plain-text consumer, and a dual-target AST is machinery far out of proportion to colouring a vendor name."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order Step 3 \u0026 Test plan: Auto-open tracking based on alive-sets fails to track completed rounds when pruned before finish transition",
+            "why": "The plan states that auto-opened rounds are tracked in a set pruned to living rounds, and that a round that finishes is closed if it was opened by the panel. When a round finishes, if it is immediately dropped from the living rounds list during session refresh, the pruning logic purges it from the panel-opened set before the close/transition check can inspect whether the panel opened it, leaving the finished round expanded.",
+            "fix": "Specify the explicit sequence in \u0060panelProvider\u0060: on state transition to finished, check the panel-opened set and collapse the card first, and only prune dead rounds after transition handling completes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The hazard needs a finished round to vanish from the rounds list while its card stays rendered, which is self-contradictory (a pruned round has no card to be left expanded, and a round that still has a card is still in the set); it is a speculative ordering worry about an implementation detail, not a defect in the plan."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order Step 5: Inline style injection for vendor colours violates VS Code Webview Content Security Policy",
+            "why": "Step 5 specifies emitting inline \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:var(--vscode-charts-...)\u0022\u003E\u0060. Standard VS Code webview Content Security Policies disallow inline \u0060style=\u0022...\u0022\u0060 attributes without specific hashes or nonces, causing the browser engine to block the color styles and render unstyled text.",
+            "fix": "Use dedicated CSS classes mapped to palette index variables or assign styling via data-attributes/CSS variables defined in the stylesheet header rather than inline style attributes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "",
+            "line": 0,
+            "title": "Section 4 \u0026 Test plan: Vendor colour palette mapping lacks fallback for empty or malformed vendor names",
+            "why": "If a round session file records a missing, null, or empty string vendor name, running deterministic hashing or index lookup (e.g. \u0060vendorColour(\u0027\u0027)\u0060) will produce either index 0 collision, \u0060NaN\u0060, or an undefined CSS variable index \u0060--vscode-charts-undefined\u0060.",
+            "fix": "Define a safe fallback in \u0060vendorColour\u0060 that maps empty, unknown, or whitespace-only names to standard muted foreground colour.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It is a speculative edge case about an input the product\u0027s own server writes from a fixed vendor set, hedged across three failure modes the reviewer has not seen, with a cosmetic worst case and a one-line fix an implementer would add unprompted."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real restart-durability gap that this family\u0027s durable-status rule forbids outright, an in-memory \u0027opened by panel\u0027 set that dies with the extension host and leaves the close-or-keep decision wrong afterwards, even though the title overstates a stuck card as data loss and the proposed ID field is beside the point since persisting the marker, not identity, is the fix."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It rests on the unsupported premise that Fable cannot be a configured reviewer, which contradicts this repository\u0027s own vendor-routing rule (Claude models run as reviewer rows through the claude CLI), and its fix names machinery it invents rather than points at."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a mechanism and a number: a VS Code extension host cannot make CLI probes or GitHub fetches synchronous, a webview repaint does not freeze on extension-host async work, and the 20-second figure and the claim that a repaint re-runs every probe are inferred from one phrase rather than stated by the plan, so the finding asserts a defect it has not shown exists."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "A dead round whose duration is computed as now-minus-start renders a growing number for something that stopped, which is a real user-visible misreport (absent rendered as a value) that a careful engineer would want shown as unknown, even though the proposed completion-flag fix cannot cover a crashed process and only its last-seen-timestamp half applies."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a rendering mechanism that does not exist (an inline element\u0027s border and padding draw around the text box, not through the glyphs) and restates a class reuse the plan itself already notes, so it asks for CSS work against an artifact nobody observed."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It mislabels the plan\u0027s own chosen handling as the defect: a disclosure that opens into an explicit sentence saying the round predates per-reviewer detail is already the distinct, self-explaining fallback state the fix asks for, and nothing in the finding shows such a round is actually confusable with a failed load."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": null
+      },
+      {
+        "stage": "code",
+        "seconds": 475.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "8 of 9 reviewers answered; failed: local/Architecture: unparseable: the answer was not the schema\u0027s JSON after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\local-Architecture-20260905-084300-336.txt)",
+        "tokensIn": 515209,
+        "tokensOut": 44737,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The committed plan remains marked as unimplemented after the change shipped",
+            "why": "The plan\u2019s Definition of Done requires \u201Cdocs, help and CHANGELOG updated; the plan promoted,\u201D but this file says \u201CStatus: plan only, nothing implemented yet\u201D even though the implementation and documentation are in the same commit. This leaves plan lifecycle metadata inconsistent with the shipped state.",
+            "fix": "Promote or archive this plan and update its status/checklist to reflect the implemented change.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 162,
+            "title": "Concurrent saves can silently overwrite each other\u0027s session history",
+            "why": "Two MCP servers can load the same session, independently append different round progress, and then both successfully move their uniquely named scratch files over the destination. The later move replaces the earlier complete session, silently losing one server\u0027s round records or pending findings; the new concurrency test checks only that no exception is thrown.",
+            "fix": "Serialize the full session read-modify-write transaction per session, or add revision checks and merge/retry stale saves before replacing the destination.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The code\u0027s own comment establishes that two servers do write the same session file concurrently, so the unique scratch name converts a loud collision into a silent last-writer-wins that drops one server\u0027s round records, and the finding names both the risk and a proportionate fix (a revision check)."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/vendorColour.ts",
+            "line": 44,
+            "title": "A null provider from a malformed or legacy session crashes panel rendering",
+            "why": "A session JSON containing a reviewer state with \u0060provider: null\u0060 reaches \u0060reviewerRows\u0060, then \u0060vendorColour\u0060 calls \u0060trim()\u0060 on it. The five-second repaint throws instead of displaying the session, so one malformed persisted reviewer entry can take down the panel view.",
+            "fix": "Normalize or validate reviewer providers before rendering, and make \u0060vendorColour\u0060 accept non-string/null input by falling back to the foreground colour.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 139,
+            "title": "Toggling a round blocks on the full panel refresh",
+            "why": "Opening or closing one card calls \u0060this.repaint()\u0060, which reruns the panel\u0027s configuration, CLI, server-version, vendor-probe, and usage-loading work. On a configured panel this can leave the person waiting up to about 20 seconds before the disclosure reflects their click, with no immediate progress feedback.",
+            "fix": "Use a lightweight rounds-only repaint for toggle messages, or update the affected \u0060\u003Cdetails\u003E\u0060 state locally and reserve the full refresh for periodic/background updates.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The toggle calls \u0060render()\u0060 (there is no \u0060repaint()\u0060), whose expensive sources are TTL-cached per the \u0060*CheckedAt\u0060 fields and documented as cheap, so a click normally costs a few file reads; the 20-second figure is invented, the stall only occurs when a cache expiry happens to coincide with the click and is paid by the five-second tick anyway, and Major overstates a rounds-only-repaint nicety."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Inline vendor name span reuses \u0027.vendor\u0027 CSS class styled for card containers",
+            "why": "The stylesheet already defines \u0027.vendor\u0027 for full settings cards with borders, radius, and 8px padding. Applying class=\u0027vendor\u0027 to inline \u003Cspan\u003E tags inside tight reviewer rows causes each vendor name to render with thick borders and box padding that cuts through the text like a strikeout.",
+            "fix": "Change the inline span\u0027s class name from \u0027vendor\u0027 to \u0027who\u0027 in panelView.ts (and adjust matching test assertions).",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Retry loop in MoveOverExisting may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a sleep of \u006020 * attempt\u0060 milliseconds. If a file lock (e.g., from an antivirus scanner or a slow indexer) persists longer than the total retry window (approx 150ms), the method throws. However, if the lock is transient but the system is under heavy load, the retry logic might not be sufficient, or worse, if the \u0060Thread.Sleep\u0060 is interrupted or the process is killed during the sleep, the temporary file might be left behind if the \u0060finally\u0060 block logic is not robust. More critically, if the \u0060File.Move\u0060 throws a different exception (e.g., \u0060PathTooLongException\u0060) that isn\u0027t caught by the \u0060catch\u0060 block, the loop exits early, potentially leaving the temp file orphaned if the \u0060TryDelete\u0060 isn\u0027t called. The specific risk is a race condition where the file is held by a scanner; the retry might succeed, but if it fails after 5 attempts, the exception is thrown, but the \u0060finally\u0060 block ensures cleanup. The real risk is if the \u0060MoveOverExisting\u0060 is called in a tight loop without sufficient delay, or if the OS file system state is inconsistent. The finding is that the retry logic is hardcoded and might not cover all edge cases of file locking on Windows, leading to silent failures if the exception handling is too broad or too narrow.",
+            "fix": "Ensure the retry loop in MoveOverExisting uses a bounded, non-exponential backoff or a maximum total duration to prevent indefinite hanging during transient file system locks, and verify that the final exception is logged with full context before re-throwing.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about this code: the loop is bounded to five attempts with linear sleeps totalling about 200 ms and the last attempt rethrows, the temp file is deleted in Save\u0027s finally on every exception type, and the finding contradicts itself mid-paragraph, so it names no defect a careful engineer would change."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Vendor name color interpolation may allow style injection if not sanitized",
+            "why": "The code \u0060style=\u0022color:${vendorColour(r.provider)}\u0022\u0060 interpolates the result of \u0060vendorColour\u0060 directly into the HTML. While \u0060vendorColour\u0060 returns a CSS variable string (e.g., \u0060var(--vscode-charts-blue)\u0060), if the function were to return a raw hex value or if the input \u0060r.provider\u0060 contained a malicious string that bypassed the \u0060trim().toLowerCase()\u0060 logic (e.g., via a Unicode trick or a specific character encoding), it could inject a style property. The current implementation uses \u0060escapeHtml\u0060 for the text content, but the style attribute is constructed from a function that relies on the input. If \u0060vendorColour\u0060 were to return something like \u0060url(\u0027javascript:alert(1)\u0027)\u0060 (though unlikely given the palette), it could be exploited. The specific risk is if \u0060vendorColour\u0060 is modified in the future to return a hex value or if the input \u0060r.provider\u0060 is not strictly controlled, leading to a style injection vulnerability where an attacker could override the color or inject CSS properties.",
+            "fix": "Ensure \u0060vendorColour\u0060 is called with a sanitized string before being interpolated into the \u0060style\u0060 attribute, or use a CSS variable that is pre-validated, to prevent potential style injection if the vendor name contains unexpected characters.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding concedes that vendorColour returns a fixed palette CSS variable and only injects if the function or its input were changed in the future, so it names no defect in this code and asks for sanitisation out of proportion to a risk that does not exist here."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Potential race condition in \u0060nextOpenRounds\u0060 if \u0060roundKey\u0060 is not unique",
+            "why": "The \u0060nextOpenRounds\u0060 function uses \u0060roundKey\u0060 to identify rounds. If two rounds have the same key (e.g., same stage, number, and branch), the \u0060Set\u0060 will treat them as the same entity. This could lead to one round\u0027s state (open/closed) overwriting the other\u0027s, causing a UI inconsistency where one round is closed while the other is open, or vice versa. The risk is low if \u0060roundKey\u0060 is guaranteed to be unique, but if the logic for generating \u0060roundKey\u0060 changes or if there\u0027s a bug in the data source, this could cause silent state corruption.",
+            "fix": "Add a check to ensure that \u0060roundKey\u0060 is unique across all rounds before adding to the \u0060open\u0060 set, or handle collisions by appending a suffix or using a composite key.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is speculation about a hypothetical bug in roundKey rather than anything this code does, mislabels a key collision as a race, and asks for uniqueness machinery out of proportion to a risk the finding itself admits is low."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Race condition in session file cleanup due to exception handling order",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060finally\u0060 block calls \u0060TryDelete(temp)\u0060 unconditionally after \u0060MoveOverExisting\u0060. If \u0060MoveOverExisting\u0060 throws an exception on its final attempt (line 175), the \u0060finally\u0060 block executes. However, if the file move succeeds but the \u0060TryDelete\u0060 fails (e.g., due to a race with another process that just acquired the file), the exception is swallowed. More critically, if \u0060MoveOverExisting\u0060 throws *before* the loop completes (e.g., on the first attempt), the \u0060finally\u0060 block runs, but the file might still be in a transient state. The current structure risks leaving \u0060.tmp\u0060 files behind if the move fails after the loop, or deleting a file that another process is still using if the timing is tight. The \u0060TryDelete\u0060 should be more robustly tied to the success of the move.",
+            "fix": "Move the \u0060TryDelete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs after the retry loop completes, rather than unconditionally after the loop. Currently, if \u0060MoveOverExisting\u0060 throws on the final attempt, the \u0060finally\u0060 block executes, but if the exception happens inside the loop before the final throw, the cleanup logic might be inconsistent or the \u0060finally\u0060 block might run before the file is fully moved in edge cases.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The scratch file is unique per write (pid \u002B guid) and belongs to this writer alone, so the finally-delete is correct on every path: a no-op after a successful move and the right cleanup after a failed one, and no other process can be using it \u0393\u00C7\u00F6 the finding misreads the structure and describes races the code cannot have."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 52,
+            "title": "Potential mutation of input Set in \u0060nextOpenRounds\u0060",
+            "why": "In \u0060nextOpenRounds\u0060, the code creates \u0060const panelOpened = new Set(previous.panelOpened);\u0060 (line 52). Later, it calls \u0060panelOpened.delete(key)\u0060 (line 63). While this creates a new Set, if \u0060previous.panelOpened\u0060 is a reference to a Set that is used elsewhere, and the code were to mutate the original \u0060previous.panelOpened\u0060 directly (which it doesn\u0027t here, but the pattern is risky), it could cause issues. More importantly, the logic \u0060const panelOpened = new Set(previous.panelOpened);\u0060 creates a shallow copy. If \u0060previous.panelOpened\u0060 contains objects (it contains strings, so this is fine), it\u0027s safe. However, the line \u0060const open = new Set(previous.open);\u0060 (line 51) and \u0060const autoOpened = new Set(previous.autoOpened);\u0060 (line 50) are also shallow copies. The main risk is if \u0060previous\u0060 is mutated elsewhere while this function runs, but the bigger issue is the logic: \u0060panelOpened.delete(key)\u0060 modifies the local \u0060panelOpened\u0060 Set. If \u0060previous.panelOpened\u0060 is a reference to a Set that is used by the caller, and the caller expects it to be immutable, this could be a problem. But since it\u0027s a new Set, it\u0027s mostly fine. The real issue is that \u0060open\u0060, \u0060autoOpened\u0060, and \u0060panelOpened\u0060 are all created as new Sets, but then \u0060open.add(key)\u0060 (line 56) and \u0060autoOpened.add(key)\u0060 (line 57) modify them. The return statement creates new arrays from these Sets. This is generally safe, but the logic \u0060const panelOpened = new Set(previous.panelOpened);\u0060 followed by \u0060panelOpened.delete(key)\u0060 is correct. The finding is minor because the code is mostly correct, but the pattern of creating new Sets and then modifying them could be clearer.",
+            "fix": "Add a check to ensure \u0060panelOpened\u0060 is not mutated directly in \u0060nextOpenRounds\u0060 before filtering, or use a new Set for the result to avoid potential mutation side effects if the input array is reused.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The function already copies every input into a fresh Set and returns new arrays, so no input is mutated; the finding concedes this repeatedly, cites line numbers that do not match the file, and proposes a fix for a defect it never identifies."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary recalculation of open rounds state on every tick",
+            "why": "In \u0060panelProvider.ts\u0060, the \u0060expanded\u0060 method calls \u0060nextOpenRounds(this.rounds, cards)\u0060 on every tick (line 165). If the \u0060cards\u0060 array (derived from \u0060sessions\u0060) hasn\u0027t changed, this recalculates the entire state machine. While the logic is fast, doing this on every 5-second tick for a large number of rounds could be optimized by checking if \u0060cards\u0060 has changed (e.g., by comparing lengths or hashes) before calling \u0060nextOpenRounds\u0060. This is a minor performance issue but could become significant if the number of rounds grows large.",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 if the input \u0060cards\u0060 hasn\u0027t changed, or debounce the call to avoid unnecessary recalculations on every tick.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "A pure O(n) pass over a handful of round cards every five seconds is negligible beside the file reads, version checks and HTTP probes the same render already performs, and the proposed change-detection would cost about as much as the recalculation it avoids while adding state to keep consistent."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": null
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[08:45:39 \u001B[32mINF\u001B[0m] coai-mcp#39928 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Race condition in session file cleanup due to exception handling order (from local) [gating] Round=1 Stage=CodeReview\r | [08:45:39 \u001B[32mINF\u001B[0m] coai-mcp#39928 finding [Minor/Ux] src_vs_code/src/openRounds.ts:52 - Potential mutation of input Set in \u0060nextOpenRounds\u0060 (from local) Round=1 Stage=CodeReview\r | [08:45:39 \u001B[32mINF\u001B[0m] coai-mcp#39928 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary recalculation of open rounds state on every tick (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|split-once|1",
+    "startedUtc": "2026-09-05T08:45:39.8323432Z",
+    "finishedUtc": "2026-09-05T08:52:31.4914962Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 25,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 10,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 50651,
+        "tokensOut": 6042,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open unwritable-store requirement makes the atomic cross-process claim impossible.",
+            "why": "If the shared data directory is read-only, the first server cannot persist its claim but is required to continue; a second server can then issue the same split order, violating the guarantee that two servers cannot both give it.",
+            "fix": "Define the precedence explicitly: either fail closed when claiming is impossible, or weaken the atomicity guarantee for that case and specify the warning, repeated-command behavior, and recovery.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real contradiction between two stated requirements (continue when the store is unwritable versus a cross-process claim that must be atomic), and a spec that promises both will ship a duplicate split order in exactly the case it claims to prevent, so the precedence has to be decided before implementation."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how a sessionless client is correlated across branches of one checkout.",
+            "why": "A client without CLAUDE_CODE_SESSION_ID starts on branch A, then returns in a new process on branch B or a linked worktree; no stable key, discovery algorithm, persistence location, or handling for two simultaneous checkouts is specified, so the implementation may either reissue the split order or incorrectly suppress an unrelated caller.",
+            "fix": "Specify the fallback identity and its lifecycle, including checkout/worktree detection, branch transitions, concurrent callers, stale entries, and how the fallback remains independent of the caller\u0027s memory.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, unspecified design decision the feature hinges on \u0393\u00C7\u00F6 how a caller without a session id is identified across branches, worktrees and processes \u0393\u00C7\u00F6 and states the two real consequences of leaving it open (a repeated order or a wrongly suppressed unrelated caller), which is exactly what a plan reviewer should surface before implementation."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The claim operation has no crash or retry protocol between persistence and command delivery.",
+            "why": "If a process atomically records the claim and is killed before returning the command, a retry sees the claim and emits nothing; if it emits first and dies before recording, the retry emits again, leaving either a lost required order or a duplicate order.",
+            "fix": "Define a durable claim state machine or idempotency protocol covering claim, command delivery, process termination, retries, and stale/in-progress claims, then specify how each state is tested.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real crash window between recording a claim and delivering its command, where either a lost or a duplicated order results, which is exactly the in-flight state that a plan must give a sweep, a timeout and an idempotent retry to before it ships."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not identify the authoritative current-round verdict or the single decision point that consumes it.",
+            "why": "During a resolve loop, a prior failed verdict may remain available while the current round passes, or a prior passing result may be reused after the plan changes; the split order can therefore be issued for the wrong review round despite the stated requirement.",
+            "fix": "Name the verdict record/version passed from the gate, require the order-and-claim decision to consume that exact round\u0027s result once, and define invalidation when the plan or verdict changes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete gap a plan reviewer should catch: without one authoritative round verdict consumed once at a single decision point, a stale pass or fail can drive the split order after the plan has changed, and the fix asked for is a sentence of design, not machinery."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan promises behavior for disabled and failed plans without specifying observable acceptance checks for command suppression.",
+            "why": "With Split the plan off, or with a non-passing verdict, an implementation that merely skips persistence but still appends a command through an existing path will silently violate the no-command guarantee, and the plan provides no concrete check to catch it.",
+            "fix": "Add explicit acceptance cases asserting an empty command list for off, failed, and repeated/already-claimed inputs, alongside the corresponding warning behavior for store failures.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, checkable gap: a no-command guarantee stated only in prose can be silently violated by an existing append path, and asking the plan\u0027s test plan to assert an empty command list for the off, failed and already-claimed cases is a proportionate, actionable fix a careful engineer would want."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027What must be true\u0027 (Item 5): Failing open on an unwritable store triggers an infinite recursive split loop",
+            "why": "The split floor mechanism relies on recording that a session has claimed its one split. If the persistence store is unwritable and the gate fails open by issuing the split order anyway, the claim is never saved. Every child epic returning on a new branch will encounter the same unwritable store, find no recorded claim, and be ordered to split again recursively without a floor.",
+            "fix": "Fail closed when the store is unwritable by emitting a warning and issuing the autonomy/single-unit build order instead of the split order.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible failure where the one mechanism that bounds splitting depends on a write that can fail, so a fail-open path removes the floor entirely and turns a rare store fault into unbounded recursive splits; the proposed fail-closed fallback is a one-branch fix proportionate to that risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027What must be true\u0027 (Item 6): Checkout-level fallback without session IDs permanently blocks splitting for subsequent tasks",
+            "why": "When a client provides no CLAUDE_CODE_SESSION_ID, tracking across branches at the checkout level marks the repository/checkout as having consumed its split. Because the plan specifies no expiration, reset trigger, or boundary between distinct user tasks in that checkout, all future top-level plans in the same workspace will falsely register as sub-pieces and never receive a split order.",
+            "fix": "Scope checkout-level claims to a transient identifier (such as the base branch commit SHA or plan hash) rather than repo-wide checkout state, or define an explicit lifecycle boundary.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "A checkout-scoped \u0027split already issued\u0027 claim with no expiry or reset is a real lifecycle gap that would silently suppress split orders for every later task in that workspace, and the suggested fix (scope the claim to a plan hash or base SHA, or name the boundary) is proportionate."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027What must be true\u0027 (Items 1 \u0026 2): Contradiction between detecting oversized pieces and skipping shape measurement",
+            "why": "Item 1 mandates that a piece is told to \u0027say so if it is genuinely too big\u0027, but Item 2 explicitly forbids re-measuring a piece\u0027s shape. Without measuring the plan\u0027s shape upon return, the system has no input data or threshold check to determine whether the piece exceeds size limits.",
+            "fix": "Clarify that the instruction to \u0027say so if it is genuinely too big\u0027 is static guidance in the autonomy prompt for the AI to report during execution, or allow passive shape measurement without issuing split orders.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The two items are not in contradiction: \u0027say so if it is genuinely too big\u0027 is the executing piece self-reporting, which is exactly why the system need not re-measure shape, and the finding\u0027s own first proposed fix concedes this reading, leaving nothing to act on beyond restating what the text already says."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It conflates caller identity (the session id from the environment) with mutual exclusion (the atomic claim constraint 4 already specifies), speculates with \u0027may\u0027 about inheritance failures it never demonstrates, and its proposed fix is the lock-file claim the plan already has."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "A recursive \u0027split\u0027 rule whose only termination is a caller-supplied floor is a real design gap in a command-driven gate where the AI is told to obey every \u0027split\u0027, and asking the plan to state a default or persisted depth bound is a small, actionable fix even though the memory-exhaustion framing is overstated."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The constraint it attacks is a deliberate stateless design \u0393\u00C7\u00F6 each round judges the text it is handed, so re-reviewing the same oversized plan yields the same correct verdict, and \u0027Epics of Epics\u0027 would require feeding split output back as a plan, where sizing it on its own is exactly right; the finding invents a hypothetical, asserts unverified state (\u0027the floor was never recorded\u0027), and asks for persisted split-depth metadata out of proportion to a non-defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding misreads the actor \u0393\u00C7\u00F6 the \u0027caller\u0027 ordered to split once is the AI following a round\u0027s commands, not a person pasting a command \u0393\u00C7\u00F6 and its deep-nesting scenario is a hypothetical misuse that the \u0027split ONCE\u0027 instruction already forbids, so a dry-run preview is machinery out of proportion to the risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It objects to a behaviour the scope lists as an explicit constraint (fail open with a warning), so it re-litigates a stated design decision rather than finding a defect, and its proposed fix about reading split depth from history is unrelated to the concern it raises."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": null
+      },
+      {
+        "stage": "code",
+        "seconds": 386.5,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "8 of 9 reviewers answered; failed: local/SecurityReliability: unparseable: the answer was not the schema\u0027s JSON after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\local-SecurityReliability-20260905-085214-071.txt)",
+        "tokensIn": 296764,
+        "tokensOut": 31160,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 580,
+            "title": "The split-order predicate is evaluated more than once instead of being one question asked once",
+            "why": "The constraint says, \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 The code evaluates \u0060OrdersSplit(provisional)\u0060 to decide whether to claim, then evaluates \u0060OrdersSplit(context)\u0060 again to decide whether to issue the order.",
+            "fix": "Evaluate the predicate once, store its boolean result, and use that result for both claiming and command issuance.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The two calls take different inputs on purpose: \u0060OrdersSplit(provisional)\u0060 decides whether to spend the claim, and \u0060OrdersSplit(context)\u0060 reflects whether the claim succeeded (FirstPlanRound may now be false), so caching the first result would log \u0022split ordered\u0022 on rounds where no order was issued; the constraint means one predicate, not one evaluation, and the code already satisfies it."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 110,
+            "title": "Expired-claim replacement is not atomic across processes",
+            "why": "The requirement says, \u0022The claim is atomic across processes: two servers sharing a data directory cannot both give it.\u0022 Concurrent processes can both observe an expired file, race on \u0060File.Delete\u0060, and cause the loser to enter the fail-open handler and return \u0060true\u0060 while the winner creates the new claim.",
+            "fix": "Use an atomic expiration-replacement protocol that distinguishes delete contention from an unwritable store, and never grant the order for a claim-file race.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The Exists\u0393\u00E5\u00C6Delete\u0393\u00E5\u00C6CreateNew sequence on an expired stamp lets a second process delete the first process\u0027s freshly written claim (or hit a sharing-violation/pending-delete IOException with Exists false and fall into the fail-open branch), so both return true \u0393\u00C7\u00F6 contradicting the code\u0027s own \u0027the only race there is\u0027 comment and the stated cross-process atomicity requirement; the reliability rule\u0027s \u0027fence the release\u0027 point applies directly."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 92,
+            "title": "Deleting an expired claim is not atomic with creating its replacement",
+            "why": "Two processes can both read an expired stamp; process A pauses, process B deletes and creates a fresh claim, then A deletes B\u0027s fresh claim and creates its own. Both return true, so both callers issue the split order and the recursive split problem can recur.",
+            "fix": "Serialize the expired-claim replacement across processes, then re-read the stamp while holding the lock before deleting and creating the replacement.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew sequence on the expired path is a real TOCTOU that lets a second process discard a fresh claim and both return true, directly contradicting the code\u0027s own comment that CreateNew is the only race; the window is narrow and the failure soft, but it breaks the exact atomicity this class was written to provide, so an engineer would want to fix it (a rename-away of the expired file would do, cheaper than the proposed cross-process lock)."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 114,
+            "title": "Unconditional File.Delete in TryClaimSplitOrder creates a race condition where concurrent callers delete each other\u0027s claims and both issue split orders",
+            "why": "When two processes execute TryClaimSplitOrder concurrently for an unclaimed caller, both evaluate StillRemembered as false. If Process A creates the claim file first and closes the stream, Process B reaches File.Exists / File.Delete, deletes Process A\u0027s newly written claim file, and then creates its own via FileMode.CreateNew. Both processes return true and issue duplicate split orders, defeating the cross-process atomicity guarantee.",
+            "fix": "Avoid deleting the file before creation; attempt atomic creation first with FileMode.CreateNew, and only attempt cleanup/replacement if the existing file is confirmed expired under a shared lock or atomic rename.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional delete between the expiry check and CreateNew is a real TOCTOU that lets a second process erase a fresh claim and both return true, directly contradicting the code\u0027s own comment that CreateNew is the only race, and the fix (create first, delete only after re-confirming expiry) is small and proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 110,
+            "title": "Unsynchronized File.Delete followed by FileMode.CreateNew creates a race window on expired claims",
+            "why": "When a claim expires, two concurrent processes checking \u0060File.Exists(file)\u0060 both call \u0060File.Delete(file)\u0060 followed by \u0060new FileStream(file, FileMode.CreateNew...)\u0060. If Process A creates the file between Process B\u0027s check and Process B\u0027s \u0060File.Delete(file)\u0060, Process B will delete Process A\u0027s freshly created claim file and then create its own claim. Both processes succeed in claiming the split order (\u0060TryClaimSplitOrder\u0060 returns \u0060true\u0060 for both), violating atomicity and issuing duplicate split orders to the caller.",
+            "fix": "Open the file with \u0060FileMode.OpenOrCreate\u0060 with exclusive share (\u0060FileShare.None\u0060), read the timestamp from the locked stream, and update it in-place or recreate only within the held stream lock instead of deleting the file prior to \u0060FileMode.CreateNew\u0060.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional File.Delete before CreateNew is an unfenced release: on an expired stamp a second server can delete the first\u0027s fresh claim and both return true, so the code\u0027s own promise of atomicity and the line-111 comment that CreateNew is the only race are false, and although the window is narrow and the failure soft, it is exactly the two-run-again defect the family\u0027s lock rule names and the suggested exclusive open-read-write fix is proportionate."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 914,
+            "title": "Anonymous caller fallback keys memory against repo path rather than workspace/checkout root",
+            "why": "When \u0060RepoPath\u0060 is relative or varies by invocation (or when different branches/submodules under the same repo checkout share the literal \u0060session.State.RepoPath\u0060), multiple independent tasks or worktrees in the same checkout may collide on the exact same \u0060repo:{RepoPath}\u0060 key for up to 24 hours without any user notification or command parameter to override it.",
+            "fix": "Normalize \u0060session.State.RepoPath\u0060 to a canonical full root path or document \u0060COAI_CALLER_SESSION\u0060 in the fallback prompt so the caller can supply an explicit identifier if working on unrelated tasks in the same checkout.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The same-checkout collision it describes is the trade-off the remarks already state as deliberate and priced, the override it asks to document is the very identity the first branch reads, and a varying RepoPath would split callers rather than collide them, so the finding re-raises a documented decision without a new argument."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 87,
+            "title": "Method name \u0060TryClaimSplitOrder\u0060 implies a boolean return indicating success, but the method returns \u0060true\u0060 even on failure (fail-open) when a warning is issued.",
+            "why": "The method name \u0060Try...\u0060 conventionally implies that \u0060false\u0060 means the operation failed. However, the implementation returns \u0060true\u0060 when the store is unwritable (fail-open), meaning the caller got the order despite the write failing. This contradicts the standard semantic of \u0060Try\u0060 methods where \u0060false\u0060 indicates failure.",
+            "fix": "Rename \u0060TryClaimSplitOrder\u0060 to \u0060RecordSplitOrder\u0060 or ensure the method name reflects the atomic claim nature in the public API if the name is intended to be descriptive of the action rather than the return value.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The method\u0027s own summary defines the return as \u0027true means it is yours to give\u0027 and its remarks document the fail-open in bold with the reasoning, so the finding restates a stated decision as a naming quibble, and its proposed rename to \u0060RecordSplitOrder\u0060 would drop the boolean meaning the current name at least hints at."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 108,
+            "title": "The \u0060warn\u0060 action is only invoked in the \u0060catch (Exception e)\u0060 block, but not in the \u0060catch (IOException) when (File.Exists(file))\u0060 block.",
+            "why": "The \u0060catch (IOException) when (File.Exists(file))\u0060 block returns \u0060false\u0060 (someone else claimed it), but does not invoke the \u0060warn\u0060 action. This creates an inconsistency where a race condition (someone else claiming) is silent, while a store failure (unwritable) is warned. The rule states \u0027a warning rather than silently disabling\u0027, implying warnings should be consistent for failures.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked consistently for all failure cases or document that it is only invoked for specific exceptions.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The silent branch is a lost race, which is the atomic claim working as designed and already commented as such, not a failure like the unwritable-store case the fail-open warning is for, so the two cases are deliberately different rather than inconsistent."
+          },
+          {
+            "severity": "Nit",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "Variable name \u0060provisional\u0060 is used for a \u0060CommandContext\u0060 that is immediately used to create another \u0060context\u0060 variable, which may cause confusion.",
+            "why": "The code creates a \u0060provisional\u0060 context, then immediately creates a \u0060context\u0060 variable based on it. The naming convention in the project (e.g., \u0060CallerSessions\u0060, \u0060PanelService\u0060) suggests clear, descriptive names. Using \u0060provisional\u0060 for a temporary state that is immediately used to create the final state is less clear than using a more descriptive name or reusing the variable.",
+            "fix": "Rename \u0060provisional\u0060 to \u0060context\u0060 or \u0060commandContext\u0060 to avoid confusion with the final \u0060context\u0060 variable.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "\u0060provisional\u0060 is the apt name for a context whose FirstPlanRound has not yet been claimed, the comments explain the two-step shape, and the proposed fix either collides with the existing \u0060context\u0060 variable or replaces a meaningful name with a generic one."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Race condition in atomic claim due to pre-check deletion outside critical section",
+            "why": "The code checks \u0060StillRemembered\u0060 (read), then deletes the file (write), then attempts \u0060CreateNew\u0060 (write). If a second server deletes the file between the check and the delete, or if the delete fails silently, the \u0060CreateNew\u0060 might succeed for the second server while the first server\u0027s logic assumed it was the only one. More critically, if \u0060File.Delete\u0060 throws (e.g., file locked by another process), the code falls through to \u0060CreateNew\u0060 which might succeed, but the state is inconsistent. The specific race: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false). Server A deletes file. Server B deletes file (or tries to). Server A creates file. Server B creates file (fails with IOException). The \u0060catch\u0060 block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060. If Server B\u0027s delete succeeded, \u0060File.Exists\u0060 is true, so it returns false. If Server B\u0027s delete failed (file locked), \u0060File.Exists\u0060 is true, returns false. But if Server A\u0027s delete failed, Server B creates, then Server A creates (fails). The logic relies on \u0060File.Delete\u0060 being atomic or the \u0060CreateNew\u0060 failing if the file exists. The real issue is the \u0060File.Delete\u0060 is outside the \u0060try\u0060 block that catches the \u0060IOException\u0060 from \u0060CreateNew\u0060. If \u0060File.Delete\u0060 throws, the code falls to the \u0060catch (Exception e)\u0060 block, which returns \u0060true\u0060 (success) even though the claim might not have been written. Wait, looking closer: \u0060File.Delete\u0060 is outside the \u0060try\u0060. If it throws, it goes to \u0060catch (Exception e)\u0060. The \u0060catch\u0060 block returns \u0060true\u0060. This means if the delete fails (e.g. permission denied on the file itself), the method returns \u0060true\u0060 (claim succeeded) even though the file might not have been written. This is a silent failure where the claim is \u0027given\u0027 but not persisted.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or wrap it in its own try-catch before the \u0060CreateNew\u0060 attempt.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding\u0027s central claim is false \u0393\u00C7\u00F6 \u0060File.Delete\u0060 is already inside the \u0060try\u0060 (lines 108\u0393\u00C7\u00F4121), so its fix is a no-op \u0393\u00C7\u00F6 and the \u0060return true\u0060 on an unwritable claim is the documented, warned fail-open, not a silent failure; the one real hole in delete-then-CreateNew (a peer deleting a just-written fresh claim after its stream closes) is never actually named in the rambling scenario."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 106,
+            "title": "Warning message for unwritable store lacks context for debugging",
+            "why": "When the store is unwritable, the code logs a warning: \u0060the split-order memory at {Dir} could not be written\u0060. If a user or operator sees this, they don\u0027t know *which* caller triggered it or *which* specific file failed. The message is generic. In a multi-caller environment, this makes debugging \u0027why is my split order failing?\u0027 difficult without checking logs for every caller.",
+            "fix": "Ensure the \u0060warn\u0060 action is called with a specific, actionable message that includes the caller ID and the specific file path, not just a generic warning.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The failure it worries about is a property of the directory (unwritable, full disk), not of any caller, so naming the caller adds nothing; the exception message already carries the path, and the finding\u0027s premise that a split order is \u0027failing\u0027 misreads the documented fail-open, where the warning itself says the order is still given."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 90,
+            "title": "Potential redundant file system operations in high-concurrency scenarios",
+            "why": "The code calls \u0060File.Exists(file)\u0060 and then \u0060File.Delete(file)\u0060 and then \u0060new FileStream(file, FileMode.CreateNew...)\u0060. In a high-concurrency scenario with many servers, this involves multiple file system calls (stat, delete, create) for a single logical operation. While \u0060CreateNew\u0060 is atomic, the pre-checks and deletions add overhead. If the file is frequently accessed, this could be optimized by using a single \u0060FileStream\u0060 with \u0060FileMode.OpenOrCreate\u0060 and a lock, or by relying solely on \u0060CreateNew\u0060 and handling the exception if the file exists (which implies a race). The current approach is safe but potentially slower than necessary.",
+            "fix": "Cache the \u0060FileFor\u0060 result or ensure \u0060File.Exists\u0060 and \u0060CreateNew\u0060 are not called on the same path twice in rapid succession without proper locking if high concurrency is expected.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claim runs once per review round (minutes of vendor CLI time) across a handful of servers on one machine, so three syscalls are noise, and the proposed fixes are either pointless (caching a SHA-256 of a short string) or wrong (a lock instead of the CreateNew the code already relies on and documents)."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": null
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[08:52:31 \u001B[32mINF\u001B[0m] coai-mcp#20388 finding [Minor/Ux] src_mcp/src/Server/CallerSessions.cs:106 - Warning message for unwritable store lacks context for debugging (from local) Round=1 Stage=CodeReview\r | [08:52:31 \u001B[32mINF\u001B[0m] coai-mcp#20388 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:90 - Potential redundant file system operations in high-concurrency scenarios (from local) Round=1 Stage=CodeReview\r | [08:52:31 \u001B[32mINF\u001B[0m] coai-mcp#20388 settings reloaded - the panel\u0027s file changed on disk",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 1,
+    "key": "codex,gemini,local|split-once|2",
+    "startedUtc": "2026-09-05T08:52:31.5377516Z",
+    "finishedUtc": "2026-09-05T08:58:14.1993681Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 33.2,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 47553,
+        "tokensOut": 3907,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The claim is not defined transactionally with command delivery",
+            "why": "A server can atomically claim the split before emitting the command, then crash or time out while returning the response; later retries observe the claim and emit nothing, so the caller never receives the required order.",
+            "fix": "Specify an outbox/acknowledgement or lease protocol that permits a safely retryable claim until command delivery is confirmed, and define recovery for stale claims.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A claim that can be recorded before the command reaches the caller, with retries then seeing the claim and returning nothing, is a real lost-work window, and the family\u0027s own reliability and durable-status rules require exactly what it asks for: a named atomic operation, a stale-claim sweep, and a retry-safe path until delivery is confirmed."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The unwritable-store fail-open behavior is underspecified and can either duplicate orders or suppress them",
+            "why": "With the feature enabled and the shared store read-only, issuing the command on every request causes repeated split orders, while suppressing it violates the stated fail-open requirement; the plan gives no deterministic behavior for either outcome.",
+            "fix": "Define the exact degraded-mode behavior, including whether and how retries are deduplicated without persistence, and make it an acceptance test.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real, consequential ambiguity: with fail-open and no persistence, a read-only store forces a choice between repeated split orders and silent suppression, and asking the plan to fix that behavior and pin it with an acceptance test is proportionate to the risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Checkout identity for session-less clients is not defined well enough to prevent unrelated work from sharing a claim",
+            "why": "A user working on branch A and then branch B in the same checkout, or using multiple worktrees that share repository metadata, can have branch tracking incorrectly consume the one-time claim for the other plan, causing the second caller to receive no split order.",
+            "fix": "Specify a stable, canonical checkout identity and its branch/worktree scoping, including how identity changes and multiple worktrees are handled.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible collision \u0393\u00C7\u00F6 a one-time claim keyed on an underspecified checkout identity being consumed by the wrong branch or worktree \u0393\u00C7\u00F6 and asks only for the identity and its scoping to be defined, which a careful designer would want settled before building."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The caller-id filename rule does not require injective encoding or collision handling",
+            "why": "If an implementation merely strips path separators, caller IDs such as \u0060team/a\u0060 and \u0060teama\u0060 can map to the same claim file; one caller can consume the other caller\u0027s once-only order, and other filename edge cases can still behave inconsistently.",
+            "fix": "Require a bounded, injective representation such as a cryptographic hash of the caller ID (with a versioned namespace), while retaining the original ID only as metadata.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A lossy sanitisation of caller IDs into claim-file names is a genuine collision path that lets one caller consume another\u0027s once-only order, and requiring an injective bounded encoding such as a hash is a cheap, proportionate fix a careful engineer would want in the rule."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan has no verification for its cross-process and retry guarantees",
+            "why": "Two server processes can concurrently observe an absent claim and both issue the command, or a revised plan can reuse a cached verdict from the previous review round; without specified race, retry, and current-round tests, these promised guarantees can regress unnoticed.",
+            "fix": "Add acceptance scenarios for concurrent claims, process death/response timeout, read-only storage, missing session IDs across branches, and a failed-then-passing plan revision using the current round\u0027s verdict.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A plan that promises single-issuer claims across processes and fresh verdicts per round without naming tests for the race and the stale-verdict cases leaves exactly the guarantees the design rests on unverifiable, and the family\u0027s own rules require a plan to carry a test plan, so asking for concrete acceptance scenarios is proportionate and actionable."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true #5: Failing open on unwritable store causes infinite recursive plan splits",
+            "why": "If writing to the claim store fails (e.g. read-only permissions, full disk), failing open means claiming the split order always succeeds without recording persistent state. When child epics return for plan review, their claim attempts fail to write and fail open again, triggering an endless loop of \u0027split into 2-4 epics\u0027 on every branch review.",
+            "fix": "Fail safe on unwritable store by logging a warning and falling back to treating child sessions as already split (issue autonomy order) or disabling split order emission instead of re-issuing split orders.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real design hazard: a de-duplication claim that fails open under an unwritable store re-issues the split order on every child review, so the failure direction matters and the proposed fail-safe (suppress split orders when the claim cannot be recorded) is proportionate and concrete."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "What must be true #6: Undefined session fallback across branches collides concurrent runs",
+            "why": "When CLAUDE_CODE_SESSION_ID is missing, tracking \u0027across branches of one checkout\u0027 without a session identifier forces reliance on repository or working tree state. Concurrent or subsequent independent Claude runs within the same checkout will observe previous split claims, prematurely suppressing split orders for new unrelated plans.",
+            "fix": "Explicitly define the checkout-level fallback keying mechanism (e.g., scoping by parent process ID or timestamped run state) and define its TTL / clearing lifecycle.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real gap in the plan: the no-session fallback for tracking split state per checkout is left undefined, and stale claims leaking into unrelated concurrent or later runs would silently suppress operator commands, so asking for the keying and clearing lifecycle to be specified is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true #1 \u0026 #4: Atomic claim without rollback causes deadlocks if subsequent step fails",
+            "why": "If claiming the split order is executed atomically in one question/step, but the caller process crashes or fails to actually spawn the child epics, the session ID remains marked as split forever. Retrying the plan review will treat the plan as already a child piece and issue an autonomy order instead of retrying the split.",
+            "fix": "Include a retry/invalidation mechanism or lease expiration for claims that fail prior to child branch initialization.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete stuck-state failure: a persisted \u0027split\u0027 claim with no expiry or sweep, where a crash between claiming and spawning the children leaves retries taking the wrong branch forever, which is exactly the non-terminal-state-without-timeout defect this family\u0027s rules single out, and the proposed lease/invalidation fix is proportionate."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It conflates the caller identity (the session id in the environment) with the claim mechanism: a second server\u0027s process getting a different id is the expected case the atomic claim in the data directory already refuses, and the proposed fix, a lock in the data directory, is the mechanism constraint 4 already names."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The plan already states the no-floor choice and that the caller judges when to stop, and the runaway-recursion scenario is implausible in a workflow where every split is a deliberate, minutes-long, operator-visible round, so a persisted depth counter is machinery out of proportion to the risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The scenario is speculative and misreads the constraint: measuring the split verdict from the text actually reviewed is the correct design, since an already-split epic carries its own shape in the text, and a re-run of the original unsplit text should get the same answer; tracking split depth in a metadata file is stateful machinery out of proportion to a hypothetical re-run a year later."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads the \u0027caller\u0027 as the human typing a command rather than the AI receiving an order, invents a repeated-split scenario the \u0027split ONCE\u0027 clause already forbids, and asks for a preview mechanism out of proportion to that hypothetical."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It argues against a behaviour the scope lists as a deliberate constraint (fail open with a warning) and then proposes a fix about split-depth tracking that has nothing to do with the store being unwritable, so it neither identifies a real defect nor offers an actionable change."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": null
+      },
+      {
+        "stage": "code",
+        "seconds": 309.3,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "8 of 9 reviewers answered; failed: local/SecurityReliability: unparseable: the answer was not the schema\u0027s JSON after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\local-SecurityReliability-20260905-085800-595.txt)",
+        "tokensIn": 282788,
+        "tokensOut": 30301,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 99,
+            "title": "Deleting an expired claim before CreateNew makes the claim non-atomic across processes",
+            "why": "The scope requires: \u201CThe claim is atomic across processes: two servers sharing a data directory cannot both give it.\u201D Two processes can both observe an expired file; one can delete and recreate it, then the other can delete that fresh claim and successfully create its own, allowing duplicate orders.",
+            "fix": "Serialize expiry replacement with an exclusive lock, or use an atomic claim/renewal protocol that never deletes a file another process may have just created.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The interleaving is real on this code: with an expired stamp, process A can delete-then-CreateNew and close its handle, after which process B\u0027s File.Exists/Delete removes A\u0027s fresh claim and B\u0027s CreateNew also succeeds, so both return true \u0393\u00C7\u00F6 contradicting the scope\u0027s cross-process atomicity requirement and the line-111 comment claiming CreateNew is the only race, and it is fixable with a small change (atomic rename of the stale file, or an exclusive open-and-overwrite) rather than heavy machinery."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 576,
+            "title": "The order predicate is evaluated twice instead of once for issuing and claiming",
+            "why": "The constraint says: \u201CThe condition that issues the order and the condition that claims it are ONE question asked once.\u201D The code calls \u0060OrdersSplit(provisional)\u0060 to decide whether to claim, then calls \u0060OrdersSplit(context)\u0060 again to decide whether it issued the order.",
+            "fix": "Compute the split-order predicate once, use that result to conditionally claim, and derive logging/command handling from the same stored result.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The two calls evaluate different inputs \u0393\u00C7\u00F6 \u0060provisional\u0060 before the claim and \u0060context\u0060 after it \u0393\u00C7\u00F6 so the second is not a repeat but the check that a denied claim does not log an order that was never issued; the constraint is met by using one predicate function, and the proposed single-evaluation fix would log \u0027split ordered\u0027 when the claim failed."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Expired-claim replacement is not atomic across processes",
+            "why": "With an expired marker present, process A checks that it exists and pauses; process B deletes it and creates the new claim; A then deletes B\u0027s fresh claim and creates its own. Both calls return true, so two servers issue the split order despite the claimed atomic guarantee.",
+            "fix": "Serialize expiry replacement with a per-caller OS lock held across re-read, delete, and CreateNew, or use an atomic replacement protocol that never deletes a claim another process may have created.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The interleaving is real (A\u0027s File.Exists/Delete can remove B\u0027s freshly created claim on an expired marker, so both CreateNew calls succeed) and it directly contradicts the code\u0027s own line-111 claim that CreateNew is \u0027the only race there is\u0027, which the reliability rule requires a lock\u0027s header to state honestly even if the chosen fix is just to record the residual."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 121,
+            "title": "An I/O failure after claim-file creation is mistaken for a competing claim",
+            "why": "If CreateNew succeeds but writing the timestamp fails, for example because the disk fills, the file exists when the IOException is caught. The method returns false without warning, withholding the split order and silently failing closed; the same misclassification can occur for unrelated I/O errors while an old marker exists.",
+            "fix": "Treat only the specific CreateNew already-exists/share-violation error as a lost race; warn and return true for write or other I/O failures, cleaning up a partial marker when safe.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The catch filter \u0060when (File.Exists(file))\u0060 cannot distinguish a lost CreateNew race from a write/flush failure after CreateNew succeeded (or a failed Delete of a stale marker), so the very case the remarks promise fails OPEN \u0393\u00C7\u00F6 a full disk \u0393\u00C7\u00F6 instead returns false with no warning, silently withholding the order on every retry; narrowing the lost-race branch to the CreateNew call is a small, proportionate fix."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 111,
+            "title": "TOCTOU deletion of valid claim files during concurrent calls allows duplicate split claims",
+            "why": "When two concurrent processes or threads call TryClaimSplitOrder for the same caller, both may find that File.Exists(file) is true (or one process expired/recreating). Process A executes File.Delete(file). If Process B had just written a valid active claim right after File.Delete or before it, Process A deletes Process B\u0027s brand new active claim file and proceeds to FileMode.CreateNew successfully. Both processes then return true, violating the atomic split order guarantee.",
+            "fix": "Catch IOException and check File.Exists(file) inside a retry loop, or open with FileMode.Open and check if the existing file is still valid/remembered rather than unconditionally deleting before CreateNew.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional File.Delete between the stamp read and the CreateNew reintroduces exactly the read-then-write race the CreateNew was added to remove \u0393\u00C7\u00F6 a peer that claimed in the gap has its fresh, valid stamp deleted and both callers return true \u0393\u00C7\u00F6 so the comment \u0027the only race there is\u0027 is false, the release is unfenced in the way reliability.md\u0027s lock rule forbids, and a cheap fix (delete only the stamp you read, or move-then-create) exists."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "TryClaimSplitOrder consumes caller\u0027s split claim before checking if the round passes or produces commands",
+            "why": "TryClaimSplitOrder is called when constructing the CommandContext before the round verdict or final answer is fully determined. If GateCommands.OrdersSplit(provisional) is true based on settings/input, the file claim is permanently created on disk. If the plan round subsequently errors, fails validation, or crashes before returning the split order to the caller, the caller has permanently lost its split claim and subsequent retries will falsely treat it as already split (a piece), failing to ever split the plan.",
+            "fix": "Only execute TryClaimSplitOrder after verifying that the round actually passes and produces an answer with split commands, or compensate if the round fails/does not issue.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The claim is already gated on the verdict (PlanStage requires MayProceed(completed.Verdict) and OrdersSplit checks it), so the finding\u0027s main premise is wrong; the only residual is a Save or audit throw between line 581 and the return, a rare I/O failure whose compensation machinery is out of proportion to a Minor risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 914,
+            "title": "Unsanitized RepoPath used directly in caller identifier could cause invalid characters or path traversal in FileFor",
+            "why": "CallerFor formats the fallback identifier as \u0027repo:{session.State.RepoPath}\u0027. If RepoPath contains colons, slashes, or special path characters (e.g. \u0027C:\\foo\\bar\u0027 or \u0027/var/repo\u0027), FileFor(caller) which uses the caller string in Path.Combine without hashing or sanitizing may fail with illegal path exceptions or traverse outside the intended directory.",
+            "fix": "Hash or sanitize RepoPath (e.g. using SHA256 or removing invalid filename chars) when constructing the fallback caller identifier in CallerFor.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 87,
+            "title": "Method name \u0060TryClaimSplitOrder\u0060 implies a boolean return indicating success, but the method returns \u0060true\u0060 even on failure (fail-open) when a warning is issued.",
+            "why": "The method name \u0060Try...\u0060 conventionally implies that \u0060false\u0060 means the operation failed. However, the implementation returns \u0060true\u0060 when the store is unwritable (fail-open), meaning the caller got the order despite the write failing. This contradicts the standard semantic of \u0060Try\u0060 methods where \u0060false\u0060 indicates failure.",
+            "fix": "Rename \u0060TryClaimSplitOrder\u0060 to \u0060RecordSplitOrder\u0060 or ensure the method name reflects the atomic claim nature in the public API if the name is intended to be descriptive of the action rather than the return value.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The method\u0027s summary defines the return as \u0022true means it is yours to give\u0022 and a bold paragraph explains the fail-open choice and why, so the finding restates what the code already says, and its proposed rename to \u0060RecordSplitOrder\u0060 would drop the atomic-claim meaning that is the whole point of the method."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 108,
+            "title": "The \u0060warn\u0060 action is only invoked in the \u0060catch (Exception e)\u0060 block, but not in the \u0060catch (IOException) when (File.Exists(file))\u0060 block.",
+            "why": "The \u0060catch (IOException) when (File.Exists(file))\u0060 block returns \u0060false\u0060 (someone else claimed it), but does not invoke the \u0060warn\u0060 action. This creates an inconsistency where a race condition (someone else claiming) is silent, while a store failure (unwritable) is warned. The rule states \u0027a warning rather than silently disabling\u0027, implying warnings should be consistent for failures.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked consistently for all failure cases or document that it is only invoked for specific exceptions.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It treats losing the CreateNew race as a failure on par with an unwritable store, but a lost race is the claim\u0027s designed outcome (the other server already gave the order) and the inline comment on line 124 plus the remarks already say so, so nothing is inconsistent or undocumented."
+          },
+          {
+            "severity": "Nit",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "Variable name \u0060provisional\u0060 is used for a \u0060CommandContext\u0060 that is immediately used to create another \u0060context\u0060 variable, which may cause confusion.",
+            "why": "The code creates a \u0060provisional\u0060 context, then immediately creates a \u0060context\u0060 variable based on it. The naming convention in the project (e.g., \u0060CallerSessions\u0060, \u0060PanelService\u0060) suggests clear, descriptive names. Using \u0060provisional\u0060 for a temporary state that is immediately used to create the final state is less clear than using a more descriptive name or reusing the variable.",
+            "fix": "Rename \u0060provisional\u0060 to \u0060context\u0060 or \u0060commandContext\u0060 to avoid confusion with the final \u0060context\u0060 variable.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The name \u0060provisional\u0060 already says exactly what the value is (a context before the split-order claim is taken, with the final \u0060context\u0060 derived from it), the surrounding comments explain the two-step shape, and the proposed rename to \u0060context\u0060 would collide with the existing variable, so this is a style preference rather than something a careful engineer would want changed."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Race condition in atomic claim due to pre-check deletion outside critical section",
+            "why": "The code checks \u0060StillRemembered\u0060 (read), then deletes the file (write), then attempts \u0060CreateNew\u0060 (write). If a second server deletes the file between the check and the delete, or if the delete fails silently, the \u0060CreateNew\u0060 might succeed for the second server while the first server\u0027s logic assumed it was the only one. More critically, if \u0060File.Delete\u0060 throws (e.g., file locked by another process), the code falls through to \u0060CreateNew\u0060 which might succeed, but the state is inconsistent. The specific race: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false). Server A deletes file. Server B deletes file (or tries to). Server A creates file. Server B creates file (fails with IOException). The \u0060catch\u0060 block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060. If Server B\u0027s delete succeeded, \u0060File.Exists\u0060 is true, so it returns false. If Server B\u0027s delete failed (file locked), \u0060File.Exists\u0060 is true, returns false. But if Server A\u0027s delete failed, Server B creates, then Server A creates (fails). The logic relies on \u0060File.Delete\u0060 being atomic or the \u0060CreateNew\u0060 failing if the file exists. The real issue is the \u0060File.Delete\u0060 is outside the \u0060try\u0060 block that catches the \u0060IOException\u0060 from \u0060CreateNew\u0060. If \u0060File.Delete\u0060 throws, the code falls to the \u0060catch (Exception e)\u0060 block, which returns \u0060true\u0060 (success) even though the claim might not have been written. Wait, looking closer: \u0060File.Delete\u0060 is outside the \u0060try\u0060. If it throws, it goes to \u0060catch (Exception e)\u0060. The \u0060catch\u0060 block returns \u0060true\u0060. This means if the delete fails (e.g. permission denied on the file itself), the method returns \u0060true\u0060 (claim succeeded) even though the file might not have been written. This is a silent failure where the claim is \u0027given\u0027 but not persisted.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or wrap it in its own try-catch before the \u0060CreateNew\u0060 attempt.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Its central claim is false \u0393\u00C7\u00F6 File.Delete is already inside the try block, so the proposed fix is a no-op \u0393\u00C7\u00F6 and its walked-through interleavings all end correctly while missing the one real hazard (a peer\u0027s unconditional delete removing a freshly written claim), leaving nothing an engineer can act on."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 106,
+            "title": "Warning message for unwritable store lacks context for debugging",
+            "why": "When the store is unwritable, the code logs a warning: \u0060the split-order memory at {Dir} could not be written\u0060. If a user or operator sees this, they don\u0027t know *which* caller triggered it or *which* specific file failed. The message is generic. In a multi-caller environment, this makes debugging \u0027why is my split order failing?\u0027 difficult without checking logs for every caller.",
+            "fix": "Ensure the \u0060warn\u0060 action is called with a specific, actionable message that includes the caller ID and the specific file path, not just a generic warning.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The warning already names the directory and carries the exception\u0027s own message (which for IOException/UnauthorizedAccessException usually includes the failing path), the failure is environmental rather than per-caller so a caller id would not help diagnose it, and the finding misreads the consequence \u0393\u00C7\u00F6 the order is given, not withheld, so nothing is \u0027failing\u0027 for the caller."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 90,
+            "title": "Potential redundant file system operations in high-concurrency scenarios",
+            "why": "The code calls \u0060File.Exists(file)\u0060 and then \u0060File.Delete(file)\u0060 and then \u0060new FileStream(file, FileMode.CreateNew...)\u0060. In a high-concurrency scenario with many servers, this involves multiple file system calls (stat, delete, create) for a single logical operation. While \u0060CreateNew\u0060 is atomic, the pre-checks and deletions add overhead. If the file is frequently accessed, this could be optimized by using a single \u0060FileStream\u0060 with \u0060FileMode.OpenOrCreate\u0060 and a lock, or by relying solely on \u0060CreateNew\u0060 and handling the exception if the file exists (which implies a race). The current approach is safe but potentially slower than necessary.",
+            "fix": "Cache the \u0060FileFor\u0060 result or ensure \u0060File.Exists\u0060 and \u0060CreateNew\u0060 are not called on the same path twice in rapid succession without proper locking if high concurrency is expected.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "This path runs at most once per caller per day and the Exists/Delete pre-step is what clears an expired stamp so CreateNew can succeed, so the three syscalls are neither a measurable cost nor redundant, and the proposed OpenOrCreate-plus-lock alternative would discard the very atomicity the code was built around."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": null
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[08:58:14 \u001B[32mINF\u001B[0m] coai-mcp#22076 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:97 - Race condition in atomic claim due to pre-check deletion outside critical section (from local) [gating] Round=1 Stage=CodeReview\r | [08:58:14 \u001B[32mINF\u001B[0m] coai-mcp#22076 finding [Minor/Ux] src_mcp/src/Server/CallerSessions.cs:106 - Warning message for unwritable store lacks context for debugging (from local) Round=1 Stage=CodeReview\r | [08:58:14 \u001B[32mINF\u001B[0m] coai-mcp#22076 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:90 - Potential redundant file system operations in high-concurrency scenarios (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  }
+]

--- a/research/data/bench-2026-09-05/epic1-v0.17.1/tables.md
+++ b/research/data/bench-2026-09-05/epic1-v0.17.1/tables.md
@@ -1,0 +1,21 @@
+# Bench
+
+## Per arm
+
+| arm | stage | runs | verdicts | median time | median findings | gating | useful | tokens in / out | cost |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | code | 4 | proceed | 475.4s | 13 | 27 | 10/41 | 1.6M / 147.1k | not reported |
+| `codex,gemini,local` | plan-1 | 4 | good_enough | 39.2s | 13 | 44 | 29/51 | 177.1k / 21.3k | not reported |
+
+## Per run
+
+| arm | case | # | lane | stage | verdict | time | findings | gating | tokens in / out |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | plan-1 | good_enough | 39.2s | 13 | 10 | 38.3k / 5.7k |
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | code | proceed | 505.9s | 14 | 8 | 489.1k / 40.9k |
+| `codex,gemini,local` | rounds-collapse | 2 | 1 | plan-1 | good_enough | 54.3s | 15 | 12 | 40.7k / 5.6k |
+| `codex,gemini,local` | rounds-collapse | 2 | 1 | code | proceed | 475.4s | 11 | 7 | 515.2k / 44.7k |
+| `codex,gemini,local` | split-once | 1 | 1 | plan-1 | good_enough | 25s | 13 | 10 | 50.7k / 6k |
+| `codex,gemini,local` | split-once | 1 | 1 | code | proceed | 386.5s | 12 | 6 | 296.8k / 31.2k |
+| `codex,gemini,local` | split-once | 2 | 1 | plan-1 | good_enough | 33.2s | 13 | 12 | 47.6k / 3.9k |
+| `codex,gemini,local` | split-once | 2 | 1 | code | proceed | 309.3s | 13 | 6 | 282.8k / 30.3k |

--- a/research/data/bench-2026-09-05/epic1/runs.json
+++ b/research/data/bench-2026-09-05/epic1/runs.json
@@ -1,0 +1,1833 @@
+[
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|1",
+    "startedUtc": "2026-09-04T20:14:06.0040718Z",
+    "finishedUtc": "2026-09-04T20:20:02.9023972Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 79.4,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 39877,
+        "tokensOut": 8196,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "Session-file escaping is promised globally but scoped only to selected vendor renderers",
+            "why": "A crafted session containing a round title, provider label, or other interpolated field such as \u0060\u003Cimg src=x onerror=...\u003E\u0060 can still execute in the webview if those fields are rendered outside the named reviewer and spending-row paths.",
+            "fix": "Inventory every session-derived interpolation in panelView and escape or DOM-text-render each one; add a regression test for a malicious value in each distinct rendered field.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Removing a round from the auto-open set does not specify how later refreshes honor a person closing it",
+            "why": "If auto-open runs whenever a running round is absent from \u0060expanded\u0060, a person can close an auto-opened running round and then have it reopen on the next polling/update cycle, violating the promised closed state.",
+            "fix": "Define and implement a user-closed suppression state (or transition-only auto-open logic) that lasts while the round remains running, and test multiple refreshes after the close.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not cover or verify vendor colouring in the round cards and live section it explicitly promises",
+            "why": "A vendor name rendered by a separate round-card or live-section path can remain grey even though reviewer and spending rows use \u0060vendorColour\u0060, so the stated cross-panel colour guarantee is false.",
+            "fix": "Identify every vendor-name rendering path, route each through the shared renderer/function, and add assertions for round cards, live rows, reviewer rows, and spending rows.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Colour identity is based on an unspecified raw name rather than a canonical vendor identity",
+            "why": "If one source returns \u0060Gemini\u0060 and another returns \u0060gemini \u0060 or a differently cased alias, hashing the displayed strings assigns different colours to the same vendor, breaking the cross-location guarantee.",
+            "fix": "Define a canonicalization/identity rule (at least trimming and case normalization, with alias handling if applicable) before hashing while preserving the preferred display name.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Single reviewer row renderer producing HTML breaks existing text-based test assertions",
+            "why": "The plan requires a single shared renderer for reviewer rows to avoid drift (\u0027The text version is what the tests read today\u0027), but step 5 modifies this renderer to output HTML (\u003Cspan class=\u0022vendor\u0022 style=\u0022...\u0022\u003E). Existing tests asserting raw text reviewer strings will receive HTML tags and fail.",
+            "fix": "Explicitly update the test assertions to match the HTML output or separate the string composition from HTML decoration so both text tests and the HTML view have unambiguous contracts.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Vendor colour indexing without case normalization produces mismatched colours for the same vendor",
+            "why": "Round cards and logs use lowercased identifiers (e.g. \u0027codex\u0027) while spending rows and provider configurations frequently use capitalized names (e.g. \u0027Codex\u0027). If vendorColour computes an index from the raw string, the same vendor gets assigned different theme colours across views, violating Requirement 4.",
+            "fix": "Normalize the vendor string (e.g. name.trim().toLowerCase()) before indexing into the chart palette in vendorColour.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Finished rounds auto-close without verifying ownership origin",
+            "why": "The plan states \u0027A round that finishes closes itself if it was this panel that opened it\u0027 but relies on a set that is \u0027pruned to living rounds\u0027. If a user manually closes a round (removing it from the \u0027opened\u0027 set) while it is still running, and then the round finishes, the logic will see it as \u0027not in the opened set\u0027 and fail to close it, OR if the logic assumes \u0027not in the set\u0027 means \u0027person opened it\u0027, it will incorrectly close a round the user manually closed. Specifically: User opens Round A -\u003E Panel tracks it. User manually closes Round A (removes from tracking). Round A finishes. The system sees Round A is finished but not in the \u0027opened\u0027 set. Depending on the exact implementation of \u0027if it was this panel that opened it\u0027, it might leave it open (leaving a ghost) or close it (hiding user\u0027s manual state). The plan lacks the mechanism to distinguish \u0027user closed\u0027 from \u0027never opened\u0027.",
+            "fix": "Add a persistent state check (e.g., a timestamp or \u0027last_closed\u0027 flag) to the round object before auto-closing, ensuring the panel only closes rounds it explicitly opened.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Ownership state for rounds is ephemeral and lost on restart",
+            "why": "The plan requires \u0027A round the person opened stays open when it finishes\u0027 and \u0027A running round the person closed stays closed\u0027. The \u0027Build order\u0027 step 3 mentions \u0027A second set \u2014 the rounds THIS panel opened\u0027. If this set is purely in-memory (as implied by \u0027pruned to living rounds\u0027 and lack of persistence mention), a restart of the VS Code extension will lose the history of which rounds were opened by the panel vs the user. Upon restart, the system will treat all currently open rounds as \u0027person opened\u0027 (since the panel\u0027s set is empty), causing it to incorrectly preserve their state or fail to auto-close them when they finish.",
+            "fix": "Define a persistent storage key for \u0027opened_by_panel\u0027 state that survives extension host restarts, rather than relying on in-memory sets that are \u0027pruned to living rounds\u0027.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Vendor color stability relies on undefined palette behavior",
+            "why": "The plan mandates \u0027Every vendor name renders in a colour that is stable for that vendor... and stable across restarts, since it is derived from the name rather than from the order rows arrive in.\u0027 It also says \u0027The colours come from the editor\u0027s own chart palette\u0027. If the editor\u0027s chart palette (\u0060--vscode-charts-*\u0060) has fewer colors than the number of unique vendors, or if the palette is theme-dependent and the theme changes mid-session, the deterministic index into a \u0027fixed palette\u0027 might map to a different visual color or run out of colors, breaking the \u0027stable\u0027 requirement. Specifically: User has 10 vendors. Theme A has 5 colors. Theme B has 8 colors. The \u0027fixed palette\u0027 logic might fail to map 10 vendors to 5 colors consistently, or the \u0027stable across restarts\u0027 claim fails if the palette is re-evaluated on restart and the order of colors changes.",
+            "fix": "Explicitly define the color palette source and ensure the \u0060vendorColour\u0060 function handles the case where the palette is empty or the theme changes dynamically.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Fable command assumes immediate availability without fallback",
+            "why": "The plan removes the \u0060FableAvailable\u0060 check and relies solely on the switch. If the Fable model is temporarily down (network issue, service restart) at the exact moment the user clicks \u0027Split with Fable\u0027, the command will fail silently or throw an error without the safety net of the previous check. The user expects the action to work, but the system has no way to verify the model is actually ready to receive the order, leading to a \u0027ghost\u0027 command that appears to be issued but fails.",
+            "fix": "Add a timeout or retry mechanism for the \u0027Split with Fable\u0027 command if the Fable model is temporarily unavailable, rather than assuming it is always available.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "",
+            "line": 0,
+            "title": "Escaping and color mapping for special characters not explicitly tested",
+            "why": "The test plan mentions \u0027A reviewer row escapes a vendor name containing \u003C\u0027. However, it does not explicitly test the interaction between escaping and the color mapping. If a vendor name is \u0060\u003Cscript\u003E\u0060 and the color is derived from the name, the escaping might alter the string used for the color index, causing the color to be inconsistent or the HTML to break. Specifically: Vendor name is \u0060\u003Cscript\u003E\u0060. The system escapes it to \u0060\u0026lt;script\u0026gt;\u0060 for display. If the color index is calculated on the escaped string, it will differ from the color calculated on the raw string, breaking the \u0027stable\u0027 requirement.",
+            "fix": "Add a specific test case for the scenario where a vendor name contains a special character that might break the color mapping or the HTML escaping.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 91 lines, 6 build step(s), 11 file(s) named, 7 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ]
+      },
+      {
+        "stage": "code",
+        "seconds": 277.3,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 575247,
+        "tokensOut": 29492,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 4,
+            "title": "The change leaves its plan marked as unimplemented instead of promoting it",
+            "why": "The plan\u0027s Definition of Done requires: \u0022[ ] ... docs, help and CHANGELOG updated; the plan promoted;\u0022 Yet this diff adds the plan under \u0060todo/\u0060 with \u0022Status: plan only, nothing implemented yet.\u0022 That contradicts the completed implementation and leaves the project documentation in a stale, explicitly unfinished state.",
+            "fix": "Promote the plan out of \u0060todo/\u0060 to the project\u0027s completed-plan location, and update its status and Definition of Done checklist to reflect the implemented change.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 151,
+            "title": "Concurrent saves still overwrite each other and lose session progress",
+            "why": "Two MCP servers can load the same session, each append a different reviewer transition, and then call Save concurrently. Unique scratch names prevent temp-file collisions, but overwrite moves still let the later writer replace the earlier complete JSON, silently discarding round records or status.",
+            "fix": "Serialize saves per session across processes, or reload and merge the persisted state while holding an OS file lock before replacing the destination.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 149,
+            "title": "A process killed during a save leaves permanent session scratch files",
+            "why": "The per-write scratch file is deleted only by the finally block. If the server is terminated during serialization or the move, its uniquely named .tmp file remains in the sessions directory; repeated interrupted writes can accumulate full session copies and eventually consume storage.",
+            "fix": "Prune stale session scratch files during store initialization, using an age threshold and the \u0060.tmp\u0060 naming pattern.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 180,
+            "title": "Synchronous retry backoff stalls reviewer progress saves",
+            "why": "If the destination is briefly locked, each save sleeps 20\u002B40\u002B60\u002B80 ms synchronously before succeeding. A nine-reviewer round with contention on each transition can delay progress by roughly 1.8 seconds, so the panel continues showing stale status while the persistence thread is blocked.",
+            "fix": "Use asynchronous delays or serialize/coalesce per-session saves so transient file contention does not block the round\u0027s progress path.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 193,
+            "title": "Missing blank line between method definitions",
+            "why": "The diff shows \u0060Save\u0060 method ending at line 193 and \u0060MoveOverExisting\u0060 starting immediately at line 195 without a blank line separator, violating the project\u0027s convention of separating method definitions with a blank line for readability.",
+            "fix": "Add a newline after the closing brace of the \u0060Save\u0060 method, before the \u0060MoveOverExisting\u0060 method definition.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 217,
+            "title": "Missing blank line between method definitions",
+            "why": "The diff shows \u0060MoveOverExisting\u0060 method ending at line 217 and \u0060TryDelete\u0060 starting immediately at line 219 without a blank line separator, violating the project\u0027s convention of separating method definitions with a blank line for readability.",
+            "fix": "Add a blank line between the \u0060MoveOverExisting\u0060 method and the \u0060TryDelete\u0060 method.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may block indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms). If a file lock (e.g., from an antivirus scanner or Windows Indexer) persists longer than the total retry window (~250ms) or if the lock is held by a process that doesn\u0027t release it quickly, the operation will fail. While the code allows the last attempt to throw, the lack of a hard time limit means the server could hang waiting for a transient lock if the retry logic is insufficient for the specific OS environment, potentially stalling the round progress reporting.",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite timeout or a maximum total duration, rather than just a fixed number of attempts with increasing sleep intervals, to prevent indefinite blocking if the destination file is held by a long-running process (e.g., an antivirus scanner or indexer) that never releases it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 806,
+            "title": "Potential attribute injection in vendor colour style if vendor name contains quotes",
+            "why": "The code constructs \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:${vendorColour(row.provider)}\u0022\u003E${escapeHtml(row.provider)}\u003C/span\u003E\u0060. While \u0060row.provider\u0060 is escaped for the *content*, the \u0060vendorColour\u0060 function returns a CSS variable string (e.g., \u0060var(--vscode-charts-blue)\u0060). If a vendor name somehow contained a quote character (e.g., \u0060O\u0027Reilly\u0060), and if \u0060vendorColour\u0060 were to return a value derived from the name that included quotes (though currently it returns fixed palette values), it could break the style attribute. More critically, if \u0060vendorColour\u0060 were to return a hex value or a variable with a value containing quotes, it would break the HTML. The current implementation is safe, but the pattern \u0060style=\u0022color:${...}\u0022\u0060 is fragile if the function returns dynamic content. The specific risk is if \u0060vendorColour\u0060 returns a value like \u0060var(--vscode-foreground)\u0060 and the vendor name is \u0060test",
+            "fix": "Verify that \u0060vendorColour\u0060 is called *after* \u0060escapeHtml\u0060 or that the HTML structure ensures the escaped string is the content of the span, not the attribute value, to prevent attribute injection if the vendor name contains quotes.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Potential duplicate entries in open rounds set if cards array has duplicates",
+            "why": "The \u0060nextOpenRounds\u0060 function iterates over \u0060cards\u0060 and adds keys to the \u0060open\u0060 set. If the \u0060cards\u0060 array passed to this function contains duplicate entries for the same round (e.g., due to a bug in the caller or a race condition in data fetching), the \u0060Set\u0060 will deduplicate them, but the logic for \u0060autoOpened\u0060 and \u0060panelOpened\u0060 might not handle this correctly if the same key is processed multiple times in the loop. Specifically, the \u0060autoOpened.add(key)\u0060 logic runs for every occurrence, which is fine for a Set, but the \u0060panelOpened.delete(key)\u0060 logic runs for every occurrence of a finished round. If a round appears twice in \u0060cards\u0060 and is finished, it might be deleted twice, which is harmless, but the logic assumes a 1:1 mapping between \u0060cards\u0060 and unique rounds. If the caller passes duplicates, the \u0060alive\u0060 filter might not work as intended if the duplicates are not handled consistently.",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all cards before adding to the \u0060open\u0060 set, or handle collisions explicitly, to prevent a single round from being added multiple times if the \u0060cards\u0060 array contains duplicates.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Scratch file leak on final retry failure in SessionStore.Save",
+            "why": "When \u0060MoveOverExisting\u0060 exhausts its 5 retries and throws (e.g., a persistent lock on the destination file), the \u0060finally\u0060 block executes. However, the \u0060File.Delete(temp)\u0060 call inside \u0060TryDelete\u0060 is wrapped in a \u0060catch\u0060 that swallows \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060. If the file is still locked by another process (the cause of the failure), \u0060File.Delete\u0060 might succeed in removing the *link* but the underlying file handle might remain open, or more critically, if the \u0060Move\u0060 fails on the last attempt, the \u0060temp\u0060 file is left behind because the \u0060try\u0060 block for the move completes, but the \u0060finally\u0060 block\u0027s \u0060TryDelete\u0060 might fail silently if the file is still held. Wait, looking closer: \u0060TryDelete\u0060 swallows exceptions. If \u0060MoveOverExisting\u0060 throws, the \u0060finally\u0060 runs. \u0060TryDelete\u0060 tries to delete \u0060temp\u0060. If \u0060temp\u0060 is still locked, \u0060File.Delete\u0060 throws. \u0060TryDelete\u0060 catches it and swallows it. The file \u0060temp\u0060 remains on disk. This happens on every failed save. Over time, \u0060COAI_DATA_DIR\u0060 fills with orphaned \u0060.tmp\u0060 files, causing disk exhaustion or \u0060ENOENT\u0060 errors if the directory limit is hit.",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of the \u0060Save\u0060 method, or ensure \u0060TryDelete\u0060 is called in a \u0060finally\u0060 block that executes even if \u0060MoveOverExisting\u0060 throws on the final attempt.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 75,
+            "title": "Ambiguous state transition for manually closed running rounds",
+            "why": "When a user manually closes a running round (via \u0060afterToggle\u0060), the key is removed from \u0060panelOpened\u0060 but remains in \u0060autoOpened\u0060. The logic in \u0060nextOpenRounds\u0060 checks \u0060!autoOpened.has(key)\u0060 to decide if a running round should be auto-opened. If the user closes a running round, it stays in \u0060autoOpened\u0060. On the next tick, \u0060!autoOpened.has(key)\u0060 is false, so it won\u0027t be re-opened automatically. This is correct. However, if the user re-opens it, it is added to \u0060open\u0060 and \u0060panelOpened\u0060 (via \u0060afterToggle\u0060 logic? No, \u0060afterToggle\u0060 adds to \u0060open\u0060 if \u0060open\u0060 is true, but \u0060panelOpened\u0060 is filtered by \u0060k !== key\u0060. Wait, \u0060afterToggle\u0060 removes from \u0060panelOpened\u0060. So if the user re-opens it, it is NOT in \u0060panelOpened\u0060. The next tick will see it is running, check \u0060!autoOpened.has(key)\u0060 (true, because it was never removed from \u0060autoOpened\u0060? No, \u0060autoOpened\u0060 is not modified in \u0060afterToggle\u0060. So it remains in \u0060autoOpened\u0060. So \u0060!autoOpened.has(key)\u0060 is false. So it won\u0027t be auto-opened. This seems correct. But the comment says",
+            "fix": "Add a check to ensure \u0060panelOpened\u0060 keys are removed from \u0060autoOpened\u0060 when the user toggles a card, or explicitly document that \u0060autoOpened\u0060 persists even after manual closure to prevent confusion in the logic flow.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ]
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:20:02 \u001B[32mINF\u001B[0m] coai-mcp#43648 finding [Minor/Reliability] src_vs_code/src/openRounds.ts:45 - Potential duplicate entries in open rounds set if cards array has duplicates (from local) Round=1 Stage=CodeReview\r | [20:20:02 \u001B[32mINF\u001B[0m] coai-mcp#43648 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Scratch file leak on final retry failure in SessionStore.Save (from local) [gating] Round=1 Stage=CodeReview\r | [20:20:02 \u001B[32mINF\u001B[0m] coai-mcp#43648 finding [Minor/Ux] src_vs_code/src/openRounds.ts:75 - Ambiguous state transition for manually closed running rounds (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 94,
+      "stillRunning": 1,
+      "pending": 40,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "resolvable": false
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|2",
+    "startedUtc": "2026-09-04T20:20:02.9869963Z",
+    "finishedUtc": "2026-09-04T20:27:43.3809773Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 248.8,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 52261,
+        "tokensOut": 5675,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping work does not cover every session-derived value rendered by the panel",
+            "why": "A session containing a malicious round title, error string, or spending label can still inject HTML/script if only the reviewer vendor name is escaped, violating the stated guarantee that no session-file data reaches the page unescaped.",
+            "fix": "Inventory every session-derived interpolation in panelView and escape text/attribute contexts (or use DOM text APIs), with named tests for each rendered field.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The auto-open state can reopen a round that the person explicitly closed",
+            "why": "When a running round is auto-opened, the person closes it and the plan removes its key from the auto-open set; the next refresh can see a running, collapsed round and auto-open it again, violating the requirement that a person-closed round stays closed.",
+            "fix": "Track explicit user-closed rounds separately, or otherwise record the user override so auto-open skips that round until the person reopens it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan has no recovery behavior when the state refresh fails at the running-to-finished transition",
+            "why": "If the server finishes a round while the panel request times out or the extension host is interrupted, the panel receives no finished state and the auto-opened card can remain expanded indefinitely; the only test assumes a successful transition.",
+            "fix": "Define and implement retry/reconciliation behavior for failed refreshes, including recovery after host interruption, and verify that a later successful refresh applies the correct close/ownership rule.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Constraint violations between HTML span markup and text-based reviewer row tests",
+            "why": "The constraints state \u0027One renderer for a reviewer row, not a text one and an HTML one that drift. The text version is what the tests read today.\u0027 Step 5 then introduces \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:\u2026\u0022\u003E\u0060 wrapping the vendor word in \u0060panelView\u0060. If there is strictly one renderer used by both the HTML view and existing text-based unit tests, existing tests asserting on plain text row contents (e.g., \u0060codex/PlanCritique \u2014 running\u0060) will fail or be polluted with HTML tags. If HTML is stripped or rendered separately, it directly violates the single-renderer constraint without budgeting the parser/strip step or test updates.",
+            "fix": "Specify how row rendering is structured (e.g., structured data model rendered to HTML in view, or separating string format from HTML markup) and update text-based test assertions accordingly.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Pruning of auto-opened/user-opened sets breaks state retention across transitions",
+            "why": "Build order step 3 and constraints mandate that the tracked sets (\u0060userOpened\u0060 / \u0060autoOpened\u0060) are pruned to \u0027living rounds\u0027. When a round finishes, if it is immediately pruned as no longer \u0027living\u0027 before or during the state check, a round that the person opened while running loses its record upon completion and will either fail to stay open across the finished state transition or cannot distinguish manual toggle intent from previous auto-open state.",
+            "fix": "Define the exact lifecycle and pruning condition: retain user-opened state for finished rounds as long as the round exists in the panel/session, only pruning IDs when rounds are removed/evicted from the active session.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Hash collisions in \u0060vendorColour\u0060 produce indistinguishable UI for distinct vendors",
+            "why": "Using deterministic string hashing (e.g., modulo palette size) on vendor names creates unavoidable hash collisions across small palettes (like \u0060--vscode-charts-*\u0060 which typically has 4-8 slots), causing two active vendors (e.g., two custom providers) to be assigned the exact same color in the same round view.",
+            "fix": "Map well-known/standard vendors (\u0060codex\u0060, \u0060gemini\u0060, etc.) to reserved distinct palette indices first, falling back to deterministic hashing only for unknown or dynamic vendor names.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Finished rounds auto-close without verifying ownership origin",
+            "why": "The plan states \u0027A round that finishes closes itself if it was this panel that opened it\u0027 but relies on a set that is \u0027pruned to living rounds\u0027. If a user manually closes a round (removing it from the \u0027opened\u0027 set) while it is still running, and then the round finishes, the logic will see it as \u0027not in the opened set\u0027 and fail to close it, OR if the logic assumes \u0027not in the set\u0027 means \u0027person opened it\u0027, it will incorrectly close a round the user manually closed. Specifically: User opens Round A -\u003E Panel tracks it. User manually closes Round A (removes from tracking). Round A finishes. The system sees Round A is finished but not in the \u0027opened\u0027 set. Depending on the exact implementation of \u0027if it was this panel that opened it\u0027, it might leave it open (leaving a ghost) or close it (hiding user\u0027s manual state). The plan lacks the mechanism to distinguish \u0027user closed\u0027 from \u0027never opened\u0027.",
+            "fix": "Add a persistent state check (e.g., a timestamp or \u0027last_closed\u0027 flag) to the round object before auto-closing, ensuring the panel only closes rounds it explicitly opened.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Ownership state for rounds is ephemeral and lost on restart",
+            "why": "The plan requires \u0027A round the person opened stays open when it finishes\u0027 and \u0027A running round the person closed stays closed\u0027. The \u0027Build order\u0027 step 3 mentions \u0027A second set \u2014 the rounds THIS panel opened\u0027. If this set is purely in-memory (as implied by \u0027pruned to living rounds\u0027 and lack of persistence mention), a restart of the VS Code extension will lose the history of which rounds were opened by the panel vs the user. Upon restart, the system will treat all currently open rounds as \u0027person opened\u0027 (since the panel\u0027s set is empty), causing it to incorrectly preserve their state or fail to auto-close them when they finish.",
+            "fix": "Define a persistent storage key for \u0027opened_by_panel\u0027 state that survives extension host restarts, rather than relying on in-memory sets that are \u0027pruned to living rounds\u0027.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Vendor color stability relies on undefined palette behavior",
+            "why": "The plan mandates \u0027Every vendor name renders in a colour that is stable for that vendor... and stable across restarts, since it is derived from the name rather than from the order rows arrive in.\u0027 It also says \u0027The colours come from the editor\u0027s own chart palette\u0027. If the editor\u0027s chart palette (\u0060--vscode-charts-*\u0060) has fewer colors than the number of unique vendors, or if the palette is theme-dependent and the theme changes mid-session, the deterministic index into a \u0027fixed palette\u0027 might map to a different visual color or run out of colors, breaking the \u0027stable\u0027 requirement. Specifically: User has 10 vendors. Theme A has 5 colors. Theme B has 8 colors. The \u0027fixed palette\u0027 logic might fail to map 10 vendors to 5 colors consistently, or the \u0027stable across restarts\u0027 claim fails if the palette is re-evaluated on restart and the order of colors changes.",
+            "fix": "Explicitly define the color palette source and ensure the \u0060vendorColour\u0060 function handles the case where the palette is empty or the theme changes dynamically.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Fable command assumes immediate availability without fallback",
+            "why": "The plan removes the \u0060FableAvailable\u0060 check and relies solely on the switch. If the Fable model is temporarily down (network issue, service restart) at the exact moment the user clicks \u0027Split with Fable\u0027, the command will fail silently or throw an error without the safety net of the previous check. The user expects the action to work, but the system has no way to verify the model is actually ready to receive the order, leading to a \u0027ghost\u0027 command that appears to be issued but fails.",
+            "fix": "Add a timeout or retry mechanism for the \u0027Split with Fable\u0027 command if the Fable model is temporarily unavailable, rather than assuming it is always available.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "",
+            "line": 0,
+            "title": "Escaping and color mapping for special characters not explicitly tested",
+            "why": "The test plan mentions \u0027A reviewer row escapes a vendor name containing \u003C\u0027. However, it does not explicitly test the interaction between escaping and the color mapping. If a vendor name is \u0060\u003Cscript\u003E\u0060 and the color is derived from the name, the escaping might alter the string used for the color index, causing the color to be inconsistent or the HTML to break. Specifically: Vendor name is \u0060\u003Cscript\u003E\u0060. The system escapes it to \u0060\u0026lt;script\u0026gt;\u0060 for display. If the color index is calculated on the escaped string, it will differ from the color calculated on the raw string, breaking the \u0027stable\u0027 requirement.",
+            "fix": "Add a specific test case for the scenario where a vendor name contains a special character that might break the color mapping or the HTML escaping.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "This plan is a PIECE of a split that is already under way, so do NOT split it again: build it as one unit, review its diff through this gate, fix, document, test and commit. If it is genuinely too big for one unit, say so in your summary and say what you would have cut it into \u2014 but do not start a second round of splitting on your own.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ]
+      },
+      {
+        "stage": "code",
+        "seconds": 211.5,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 409411,
+        "tokensOut": 27156,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 4,
+            "title": "The implemented change leaves its plan marked as unimplemented",
+            "why": "The plan\u2019s Definition of Done requires: \u201CCoaiMcp.Tests.exe and npm test pass; docs, help and CHANGELOG updated; the plan promoted.\u201D This diff keeps the plan marked \u201CStatus: plan only, nothing implemented yet,\u201D so the completed change is recorded as unfinished.",
+            "fix": "Promote or archive the plan according to the project\u2019s lifecycle convention and remove the stale plan-only status.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 153,
+            "title": "Concurrent saves can silently overwrite a newer session with stale state",
+            "why": "With two MCP servers sharing the same session, each can load the same trail, then save different progress using distinct scratch files. The later \u0060File.Move(..., overwrite: true)\u0060 replaces the destination wholesale, so a save containing reviewer/round state from before the other server\u0027s update can erase that update; the round continues successfully but its durable history or status disappears after restart.",
+            "fix": "Serialize saves per session with a cross-process lock, or merge/reload the current destination before replacing it, while retaining unique scratch names.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 805,
+            "title": "Closed running cards still rebuild every reviewer row on each repaint",
+            "why": "With 100 concurrent running rounds and 9 reviewers each, every five-second refresh allocates and escapes about 900 reviewer rows even when the person has closed all cards; the resulting large HTML patch is generated and sent despite those rows being hidden by \u003Cdetails\u003E.",
+            "fix": "Only build reviewer rows when the card is open (\u0060open ? reviewerRows(round) : []\u0060); keep any separately visible live-section rendering on its own path.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 193,
+            "title": "Missing blank line between method definitions",
+            "why": "The diff shows \u0060Save\u0060 method ending at line 193 and \u0060MoveOverExisting\u0060 starting immediately at line 195 without a blank line separator, violating the project\u0027s convention of separating method definitions with a blank line for readability.",
+            "fix": "Add a newline after the closing brace of the \u0060Save\u0060 method, before the \u0060MoveOverExisting\u0060 method definition.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 217,
+            "title": "Missing blank line between method definitions",
+            "why": "The diff shows \u0060MoveOverExisting\u0060 method ending at line 217 and \u0060TryDelete\u0060 starting immediately at line 219 without a blank line separator, violating the project\u0027s convention of separating method definitions with a blank line for readability.",
+            "fix": "Add a blank line between the \u0060MoveOverExisting\u0060 method and the \u0060TryDelete\u0060 method.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may block indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms). If a file lock (e.g., from an antivirus scanner or Windows Indexer) persists longer than the total retry window (~250ms) or if the lock is held by a process that doesn\u0027t release it quickly, the operation will fail. While the code allows the last attempt to throw, the lack of a hard time limit means the server could hang waiting for a transient lock if the retry logic is insufficient for the specific OS environment, potentially stalling the round progress reporting.",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite timeout or a maximum total duration, rather than just a fixed number of attempts with increasing sleep intervals, to prevent indefinite blocking if the destination file is held by a long-running process (e.g., an antivirus scanner or indexer) that never releases it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 806,
+            "title": "Potential attribute injection in vendor colour style if vendor name contains quotes",
+            "why": "The code constructs \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:${vendorColour(row.provider)}\u0022\u003E${escapeHtml(row.provider)}\u003C/span\u003E\u0060. While \u0060row.provider\u0060 is escaped for the *content*, the \u0060vendorColour\u0060 function returns a CSS variable string (e.g., \u0060var(--vscode-charts-blue)\u0060). If a vendor name somehow contained a quote character (e.g., \u0060O\u0027Reilly\u0060), and if \u0060vendorColour\u0060 were to return a value derived from the name that included quotes (though currently it returns fixed palette values), it could break the style attribute. More critically, if \u0060vendorColour\u0060 were to return a hex value or a variable with a value containing quotes, it would break the HTML. The current implementation is safe, but the pattern \u0060style=\u0022color:${...}\u0022\u0060 is fragile if the function returns dynamic content. The specific risk is if \u0060vendorColour\u0060 returns a value like \u0060var(--vscode-foreground)\u0060 and the vendor name is \u0060test",
+            "fix": "Verify that \u0060vendorColour\u0060 is called *after* \u0060escapeHtml\u0060 or that the HTML structure ensures the escaped string is the content of the span, not the attribute value, to prevent attribute injection if the vendor name contains quotes.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Potential duplicate entries in open rounds set if cards array has duplicates",
+            "why": "The \u0060nextOpenRounds\u0060 function iterates over \u0060cards\u0060 and adds keys to the \u0060open\u0060 set. If the \u0060cards\u0060 array passed to this function contains duplicate entries for the same round (e.g., due to a bug in the caller or a race condition in data fetching), the \u0060Set\u0060 will deduplicate them, but the logic for \u0060autoOpened\u0060 and \u0060panelOpened\u0060 might not handle this correctly if the same key is processed multiple times in the loop. Specifically, the \u0060autoOpened.add(key)\u0060 logic runs for every occurrence, which is fine for a Set, but the \u0060panelOpened.delete(key)\u0060 logic runs for every occurrence of a finished round. If a round appears twice in \u0060cards\u0060 and is finished, it might be deleted twice, which is harmless, but the logic assumes a 1:1 mapping between \u0060cards\u0060 and unique rounds. If the caller passes duplicates, the \u0060alive\u0060 filter might not work as intended if the duplicates are not handled consistently.",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all cards before adding to the \u0060open\u0060 set, or handle collisions explicitly, to prevent a single round from being added multiple times if the \u0060cards\u0060 array contains duplicates.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Scratch file leak on final retry failure in SessionStore.Save",
+            "why": "When \u0060MoveOverExisting\u0060 exhausts its 5 retries and throws (e.g., a persistent lock on the destination file), the \u0060finally\u0060 block executes. However, the \u0060File.Delete(temp)\u0060 call inside \u0060TryDelete\u0060 is wrapped in a \u0060catch\u0060 that swallows \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060. If the file is still locked by another process (the cause of the failure), \u0060File.Delete\u0060 might succeed in removing the *link* but the underlying file handle might remain open, or more critically, if the \u0060Move\u0060 fails on the last attempt, the \u0060temp\u0060 file is left behind because the \u0060try\u0060 block for the move completes, but the \u0060finally\u0060 block\u0027s \u0060TryDelete\u0060 might fail silently if the file is still held. Wait, looking closer: \u0060TryDelete\u0060 swallows exceptions. If \u0060MoveOverExisting\u0060 throws, the \u0060finally\u0060 runs. \u0060TryDelete\u0060 tries to delete \u0060temp\u0060. If \u0060temp\u0060 is still locked, \u0060File.Delete\u0060 throws. \u0060TryDelete\u0060 catches it and swallows it. The file \u0060temp\u0060 remains on disk. This happens on every failed save. Over time, \u0060COAI_DATA_DIR\u0060 fills with orphaned \u0060.tmp\u0060 files, causing disk exhaustion or \u0060ENOENT\u0060 errors if the directory limit is hit.",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of the \u0060Save\u0060 method, or ensure \u0060TryDelete\u0060 is called in a \u0060finally\u0060 block that executes even if \u0060MoveOverExisting\u0060 throws on the final attempt.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 75,
+            "title": "Ambiguous state transition for manually closed running rounds",
+            "why": "When a user manually closes a running round (via \u0060afterToggle\u0060), the key is removed from \u0060panelOpened\u0060 but remains in \u0060autoOpened\u0060. The logic in \u0060nextOpenRounds\u0060 checks \u0060!autoOpened.has(key)\u0060 to decide if a running round should be auto-opened. If the user closes a running round, it stays in \u0060autoOpened\u0060. On the next tick, \u0060!autoOpened.has(key)\u0060 is false, so it won\u0027t be re-opened automatically. This is correct. However, if the user re-opens it, it is added to \u0060open\u0060 and \u0060panelOpened\u0060 (via \u0060afterToggle\u0060 logic? No, \u0060afterToggle\u0060 adds to \u0060open\u0060 if \u0060open\u0060 is true, but \u0060panelOpened\u0060 is filtered by \u0060k !== key\u0060. Wait, \u0060afterToggle\u0060 removes from \u0060panelOpened\u0060. So if the user re-opens it, it is NOT in \u0060panelOpened\u0060. The next tick will see it is running, check \u0060!autoOpened.has(key)\u0060 (true, because it was never removed from \u0060autoOpened\u0060? No, \u0060autoOpened\u0060 is not modified in \u0060afterToggle\u0060. So it remains in \u0060autoOpened\u0060. So \u0060!autoOpened.has(key)\u0060 is false. So it won\u0027t be auto-opened. This seems correct. But the comment says",
+            "fix": "Add a check to ensure \u0060panelOpened\u0060 keys are removed from \u0060autoOpened\u0060 when the user toggles a card, or explicitly document that \u0060autoOpened\u0060 persists even after manual closure to prevent confusion in the logic flow.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ]
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:27:43 \u001B[32mINF\u001B[0m] coai-mcp#21856 finding [Minor/Reliability] src_vs_code/src/openRounds.ts:45 - Potential duplicate entries in open rounds set if cards array has duplicates (from local) Round=1 Stage=CodeReview\r | [20:27:43 \u001B[32mINF\u001B[0m] coai-mcp#21856 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Scratch file leak on final retry failure in SessionStore.Save (from local) [gating] Round=1 Stage=CodeReview\r | [20:27:43 \u001B[32mINF\u001B[0m] coai-mcp#21856 finding [Minor/Ux] src_vs_code/src/openRounds.ts:75 - Ambiguous state transition for manually closed running rounds (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 94,
+      "stillRunning": 0,
+      "pending": 50,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "resolvable": true
+    },
+    "settings": {
+      "mismatches": [
+        "COAI_SPLIT_WITH_FABLE is on, but the round handed back no order mentioning \u0027Fable\u0027"
+      ],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": false
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|split-once|1",
+    "startedUtc": "2026-09-04T20:27:43.442119Z",
+    "finishedUtc": "2026-09-04T20:36:57.8561197Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 46.7,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 50097,
+        "tokensOut": 5166,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open unwritable-store requirement contradicts the atomic single-claim guarantee",
+            "why": "When two eligible processes share an unwritable data directory, neither can persist a claim; if both fail open as required, both issue the split command, violating the stated guarantee.",
+            "fix": "Define the precedence explicitly: require a durable atomic claim before issuing any command and fail closed on storage failure, or remove the cross-process exactly-once guarantee and specify duplicate behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define crash recovery between claiming and issuing the command",
+            "why": "If a process persists the claim and is killed before launching the command, a retry suppresses the only command; if it launches the command and dies before persisting the claim, a retry issues it twice.",
+            "fix": "Specify an outbox/idempotency protocol or explicitly choose at-most-once versus at-least-once semantics, including recovery of an in-progress claim.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Sessionless callers have no defined identity that can survive branch changes without conflating checkouts",
+            "why": "A caller without CLAUDE_CODE_SESSION_ID can invoke on branch A, switch to branch B, and invoke again, while another process uses the same repository or a separate worktree; the plan provides no stable checkout key or rules to distinguish these cases, so orders can be lost or incorrectly shared.",
+            "fix": "Define and persist a stable checkout/worktree identity, its creation and cleanup rules, and behavior for concurrent invocations and branch switches; add scenarios covering those transitions.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The caller-id filename constraint lacks a collision-safe representation",
+            "why": "Raw or ad hoc sanitization can turn distinct ids such as \u0060a/b\u0060 and \u0060a_b\u0060 into the same file, while ids such as \u0060..\u0060 or very long values can escape intended semantics or exceed filesystem limits, causing one caller to suppress another or access an unintended path.",
+            "fix": "Never use the caller string directly as a path component; encode a bounded cryptographic digest (with a version/namespace), and specify tests for traversal, separators, Unicode, length, and collisions.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not establish how the command is tied to the verdict from this review round",
+            "why": "If a prior round passed and the resolve loop changes the plan, or a stale verdict is read from persisted state, the caller can issue a split command for text that was not reviewed and passed in the current round.",
+            "fix": "Carry an immutable current-round plan digest together with the verdict and require that exact digest at command-claim time; specify rejection when it differs.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "SCOPE \u2014 Long-lived caller sessions permanently suppress splitting on subsequent independent plans",
+            "why": "CLAUDE_CODE_SESSION_ID remains constant for the entire lifetime of an interactive Claude Code session across multiple user prompts and tasks. Once a first plan splits and claims the session ID, any subsequent, unrelated large plan created later in the same Claude session will match the claimed session ID and be incorrectly forced into the single-unit autonomy path.",
+            "fix": "Key the split claim by a combination of the caller session ID and the root plan\u0027s hash or unique identifier instead of session ID alone.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true (Item 5) \u2014 Failing open on unwritable storage restores infinite recursive epic splitting",
+            "why": "When the backing store is unwritable (e.g., read-only filesystem or restricted permissions), failing open allows review rounds to proceed without persisting claims. Child epics returning on new branches will find no recorded claim and will be repeatedly commanded to split into sub-epics without floor.",
+            "fix": "Fail closed on unwritable storage by defaulting to the single-unit autonomy order or in-memory tracking with a warning rather than re-issuing split orders.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true (Item 6) \u2014 Checkout-level fallback collides across independent runs in the same workspace",
+            "why": "For callers that export no session ID, tracking across branches of one checkout requires shared checkout-level state. Subsequent runs on the same checkout will observe the prior run\u0027s claim, causing future top-level plans in that checkout to bypass splitting entirely.",
+            "fix": "Derive identity from caller process tree lineage (PPID) or transient run tokens rather than static repository checkout identity when session ID is absent.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or before the session ID is written to a persistent store, both may read the same \u0027unclaimed\u0027 state. Specifically, if the \u0027claim\u0027 is only held in memory or a transient env var, a restart of the child process or a race condition where two processes read the directory simultaneously will result in both servers issuing split orders for the same epic, causing duplicate work and conflicting commits.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to verify the \u0027floor\u0027 for splitting epics of epics.",
+            "why": "The plan promises \u0027no epics of epics, with no floor\u0027 (Scope section) and that a caller is ordered to split ONCE. However, the mechanism described relies on the \u0027caller\u0027 crossing sessions. If the \u0027caller\u0027 (the parent process) is killed or times out after issuing the split command but before the child process completes its review, the child process (now a \u0027caller\u0027 for its own sub-epics) may re-evaluate the plan. Without a persistent counter or a \u0027depth\u0027 flag written to the plan file itself, the child process might re-apply the split logic to its own output, creating an infinite recursion of \u0027epics of epics\u0027 because the \u0027floor\u0027 is only a logical concept in the text, not a verified state in the system.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state file that is incremented on every split and checked before issuing a new split command.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Silent feature disablement on unwritable store leads to undetected state drift.",
+            "why": "Constraint 5 states an unwritable store fails OPEN with a warning rather than silently disabling. If the store is unwritable due to a disk full error or permission change, the system logs a warning but continues. If the \u0027split\u0027 logic relies on writing the \u0027session ID\u0027 or \u0027split depth\u0027 to this store to prevent re-splitting (as implied by the need for a floor), the system will proceed to split again on the next run because the state wasn\u0027t persisted. This results in the system repeatedly splitting the same plan into smaller and smaller units, eventually hitting the \u0027floor\u0027 (or lack thereof) and causing a cascade of tiny, unmanageable tasks.",
+            "fix": "Define a specific timeout and retry strategy for the \u0027OPEN\u0027 failure in Constraint 5, and ensure the \u0027warning\u0027 is logged to a persistent audit trail, not just stdout.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Missing session ID causes silent failure or incorrect branching logic.",
+            "why": "Constraint 6 states \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 If a user manually triggers a split (e.g., via a CLI flag) without the \u0060CLAUDE_CODE_SESSION_ID\u0060 being set (perhaps because they ran the command in a shell where the variable wasn\u0027t exported), the system assumes it is a \u0027new\u0027 session. It will treat the plan as a \u0027caller\u0027 that hasn\u0027t been split yet, potentially re-splitting a plan that was already split in a previous session, or failing to link the child branch back to the parent, breaking the \u0027crossing\u0027 logic described in the Scope section.",
+            "fix": "Add a step to verify the \u0027caller\u0027 ID matches the current session ID before processing the split, or explicitly handle the case where the ID is missing.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Caller ID escaping the directory creates potential for cross-project contamination.",
+            "why": "Constraint 4 states \u0027A caller id is somebody else\u0027s string and reaches a file name: it must not escape the directory.\u0027 If the \u0060CLAUDE_CODE_SESSION_ID\u0060 contains a path separator (e.g., \u0060user/repo/branch\u0060) or a special character, and the system uses it directly as a filename without sanitization, it could create a file structure like \u0060data/user/repo/branch/split.lock\u0060. If the \u0027data directory\u0027 is shared across multiple projects, this could lead to a file being written in a subdirectory that wasn\u0027t intended, or a collision where two different projects write to the same file path, causing one project to overwrite the other\u0027s split state.",
+            "fix": "Add a validation step that checks the \u0027caller\u0027 ID against the directory name or a lock file before allowing the split to proceed.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "This plan is a PIECE of a split that is already under way, so do NOT split it again: build it as one unit, review its diff through this gate, fix, document, test and commit. If it is genuinely too big for one unit, say so in your summary and say what you would have cut it into \u2014 but do not start a second round of splitting on your own.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ]
+      },
+      {
+        "stage": "code",
+        "seconds": 507.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "7 of 9 reviewers answered; failed: local/SecurityReliability: unparseable: the answer was not the schema\u0027s JSON after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\local-SecurityReliability-20260904-203323-595.txt), local/UxDxPerformance: unparseable: the answer was not the schema\u0027s JSON after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\local-UxDxPerformance-20260904-203657-773.txt)",
+        "tokensIn": 303892,
+        "tokensOut": 45785,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Replacing an expired claim is not atomic across processes",
+            "why": "Two servers can both observe an expired stamp, delete it, and recreate it. One server can delete the other server\u0027s newly created claim, so both return true and issue the split order, violating the one-claim guarantee.",
+            "fix": "Serialize expiry replacement with a per-caller lock or atomic compare-and-replace, rechecking the stamp while holding the lock.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 111,
+            "title": "Write failures after file creation are misclassified as another process\u0027s claim",
+            "why": "If CreateNew succeeds but writing the timestamp fails, such as when the disk fills, the file exists and the IOException filter returns false. The current order is therefore withheld instead of failing open, and an invalid marker remains behind.",
+            "fix": "Track whether this process created the file; only return false for CreateNew contention, and treat write/flush failures as fail-open warnings with cleanup of the partial marker.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 112,
+            "title": "Unsynchronized File.Delete of expired claims creates a TOCTOU race allowing duplicate claims",
+            "why": "When two server instances concurrently attempt to claim an expired split order, both pass StillRemembered check. Process A deletes the expired file and creates a new claim file with FileMode.CreateNew. Process B, executing concurrently, runs File.Delete(file), which deletes Process A\u0027s newly created active claim file, and then Process B\u0027s FileMode.CreateNew also succeeds. Both processes return true from TryClaimSplitOrder, violating the atomic single-claim requirement.",
+            "fix": "Avoid pre-deleting the file prior to FileMode.CreateNew; manage expiration updates using file stream sharing locks or atomic temporary file replace/rename operations so that an active claim cannot be unlinked by a concurrent claimant.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 88,
+            "title": "Method naming convention deviation",
+            "why": "The method \u0060TryClaimSplitOrder\u0060 introduces a \u0060Try\u0060 prefix pattern that is inconsistent with the existing \u0060RecordSplitOrder\u0060 method it replaces and the \u0060SplitAlreadyOrdered\u0060 method it complements. The project\u0027s existing convention uses \u0060Record\u0060 for state changes and \u0060SplitAlreadyOrdered\u0060 for queries.",
+            "fix": "Rename \u0060TryClaimSplitOrder\u0060 to \u0060RecordSplitOrder\u0060 or \u0060ClaimSplitOrder\u0060 to match the existing naming convention of \u0060SplitAlreadyOrdered\u0060 and \u0060ReadStamp\u0060.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "Variable naming convention deviation",
+            "why": "The variable \u0060provisional\u0060 is a temporary name that deviates from the standard \u0060context\u0060 naming used elsewhere in the file (e.g., \u0060var context = Core.Commands.GateCommands.For(context)\u0060). While functional, it breaks the established naming pattern for command context objects.",
+            "fix": "Rename the local variable \u0060provisional\u0060 to \u0060context\u0060 or \u0060commandContext\u0060 to align with the existing variable naming convention in the file.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Nit",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 48,
+            "title": "Test method naming convention deviation",
+            "why": "The test method name uses \u0060ATOMIC\u0060 in all caps, which is inconsistent with the project\u0027s standard PascalCase naming convention for test methods (e.g., \u0060ADifferentCaller_IsNotTheSameTask\u0060). The word \u0060Atomic\u0060 should be capitalized normally.",
+            "fix": "Rename the test method \u0060TheClaimIsATOMIC_SoTwoServersCannotBothGiveTheOrder\u0060 to \u0060TheClaimIsAtomic_SoTwoServersCannotBothGiveTheOrder\u0060.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ]
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:36:57 \u001B[32mINF\u001B[0m] coai-mcp#37784 finding [Minor/Convention] src_mcp/src/Server/CallerSessions.cs:88 - Method naming convention deviation (from local) Round=1 Stage=CodeReview\r | [20:36:57 \u001B[32mINF\u001B[0m] coai-mcp#37784 finding [Minor/Convention] src_mcp/src/Server/PanelService.cs:554 - Variable naming convention deviation (from local) Round=1 Stage=CodeReview\r | [20:36:57 \u001B[32mINF\u001B[0m] coai-mcp#37784 finding [Nit/Convention] src_mcp/tests/CallerSessionsTests.cs:48 - Test method naming convention deviation (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 96,
+      "stillRunning": 0,
+      "pending": 40,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "resolvable": true
+    },
+    "settings": {
+      "mismatches": [
+        "COAI_SPLIT_WITH_FABLE is on, but the round handed back no order mentioning \u0027Fable\u0027"
+      ],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": false
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 1,
+    "key": "codex,gemini,local|split-once|2",
+    "startedUtc": "2026-09-04T20:36:57.9227009Z",
+    "finishedUtc": "2026-09-04T20:42:22.6342808Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 46.7,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 48843,
+        "tokensOut": 5141,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open unwritable-store requirement makes the cross-process exactly-once guarantee impossible",
+            "why": "With split enabled and two servers sharing a directory whose store is read-only, both can warn and continue without recording a claim, then both issue the split order.",
+            "fix": "Define an atomic fallback coordination mechanism, or make failure to claim block order issuance while emitting the required warning; the plan must choose one behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "A process crash between claiming and emitting the command permanently loses the required order",
+            "why": "A server can record the caller as claimed and die before returning the split command; a retry then sees the claim and treats the plan as a piece, so the split order is never issued.",
+            "fix": "Use a pending/issued state with a lease or durable outbox, and specify recovery behavior for claims left pending after timeout or process death.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback cannot distinguish concurrent callers in the same checkout",
+            "why": "Two independent plans run from one checkout without CLAUDE_CODE_SESSION_ID; if checkout identity is the fallback key, the second caller observes the first caller\u0027s claim and is incorrectly treated as an already-split piece.",
+            "fix": "Generate and propagate an invocation token automatically through the caller\u0027s process environment, or explicitly define and reject/serialize concurrent no-ID invocations.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not bind the one-time claim to the verdict from the current review round",
+            "why": "A passing plan can claim its split, then be edited to fail and reviewed again under the same persistent identity; stale claim state can select the piece/autonomy path despite the current round not passing.",
+            "fix": "Store a review-round identifier or plan digest with the claim and evaluate the current verdict before selecting either command path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Persistent checkout-based state has no expiry or completion lifecycle",
+            "why": "A caller returns to the same checkout a year later for unrelated work, and an old claim remains, causing the new plan to receive the autonomy order instead of the required split instruction.",
+            "fix": "Define claim cleanup/expiry and a new-run or checkout-generation boundary, with a safe way to retain only active child-branch lineage.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails open, causing infinite recursion into epics of epics on read-only filesystems",
+            "why": "Requirement 5 demands that an unwritable store fails open with a warning. When the store is unwritable (e.g. read-only permissions, full disk, container sandbox), the claim attempt fails and the server proceeds without persisting the split claim. When the epic is spawned on a new branch and comes back for plan review, the new session also attempts to write to the unwritable store, fails open, and issues another split order, reproducing the exact infinite split recursion loop the plan was created to stop.",
+            "fix": "Fail closed on unwritable store for the split command (treat unrecorded/unwritable state as already split or emit the autonomy order instead of the split order), or log an error and refuse to issue a recursive split order if the state cannot be recorded.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Fallback tracking for clients without session IDs collides across independent runs in the same checkout",
+            "why": "Requirement 6 specifies that clients without CLAUDE_CODE_SESSION_ID are tracked across branches of one checkout (e.g., using checkout path or repo hash). If a developer runs a second, unrelated task or runs a fresh plan review on the same repository checkout later, the persisted claim from the previous run will match the checkout key, incorrectly classifying the brand-new root plan as an existing piece and silently suppressing the split order.",
+            "fix": "Scope non-session tracking to an ephemeral process/parent-PID tree or require an explicit run/invocation token rather than keying solely on checkout path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "Caller session ID sanitized for filenames without handling collisions or path length limits",
+            "why": "The constraints state that external caller ID reaches a file name and must not escape the directory. If naive sanitization (e.g. replacing non-alphanumeric chars or stripping slashes) is used, different session IDs (e.g. \u0060foo/bar\u0060 and \u0060foo_bar\u0060, or extremely long UUIDs/strings exceeding OS MAX_PATH) will either collide to the same claim file (blocking valid splits) or trigger filesystem IO errors on Windows/Linux long paths.",
+            "fix": "Hash the caller ID (e.g. SHA-256) to generate fixed-length, safe alphanumeric filenames within the claim directory.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Stale split claims prevent re-running plan reviews on rejected or aborted split plans",
+            "why": "Requirement 4 \u0026 Constraint 2 dictate that the split verdict and atomic claim happen in one step during the first passed review. If the user or agent cancels, re-prompts, or restarts the parent session after a split was issued, the caller session ID remains claimed in the store, preventing the plan from ever receiving a split order again during that session even if the user explicitly re-runs plan generation.",
+            "fix": "Define a time-to-live (TTL) or a reset/clear mechanism for claims tied to session IDs or allow explicit re-split overrides.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or before the session ID is written to a persistent store, both may read the same \u0027unclaimed\u0027 state. Specifically, if the \u0027claim\u0027 is only held in memory or a transient env var, a restart of the child process or a race condition where two processes read the directory simultaneously will result in both servers issuing split orders for the same epic, causing duplicate work and conflicting commits.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to verify the \u0027floor\u0027 for splitting epics of epics.",
+            "why": "The plan promises \u0027no epics of epics, with no floor\u0027 (Scope section) and that a caller is ordered to split ONCE. However, the mechanism described relies on the \u0027caller\u0027 crossing sessions. If the \u0027caller\u0027 (the parent process) is killed or times out after issuing the split command but before the child process completes its review, the child process (now a \u0027caller\u0027 for its own sub-epics) may re-evaluate the plan. Without a persistent counter or a \u0027depth\u0027 flag written to the plan file itself, the child process might re-apply the split logic to its own output, creating an infinite recursion of \u0027epics of epics\u0027 because the \u0027floor\u0027 is only a logical concept in the text, not a verified state in the system.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state file that is incremented on every split and checked before issuing a new split command.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Silent feature disablement on unwritable store leads to undetected state drift.",
+            "why": "Constraint 5 states an unwritable store fails OPEN with a warning rather than silently disabling. If the store is unwritable due to a disk full error or permission change, the system logs a warning but continues. If the \u0027split\u0027 logic relies on writing the \u0027session ID\u0027 or \u0027split depth\u0027 to this store to prevent re-splitting (as implied by the need for a floor), the system will proceed to split again on the next run because the state wasn\u0027t persisted. This results in the system repeatedly splitting the same plan into smaller and smaller units, eventually hitting the \u0027floor\u0027 (or lack thereof) and causing a cascade of tiny, unmanageable tasks.",
+            "fix": "Define a specific timeout and retry strategy for the \u0027OPEN\u0027 failure in Constraint 5, and ensure the \u0027warning\u0027 is logged to a persistent audit trail, not just stdout.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Missing session ID causes silent failure or incorrect branching logic.",
+            "why": "Constraint 6 states \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 If a user manually triggers a split (e.g., via a CLI flag) without the \u0060CLAUDE_CODE_SESSION_ID\u0060 being set (perhaps because they ran the command in a shell where the variable wasn\u0027t exported), the system assumes it is a \u0027new\u0027 session. It will treat the plan as a \u0027caller\u0027 that hasn\u0027t been split yet, potentially re-splitting a plan that was already split in a previous session, or failing to link the child branch back to the parent, breaking the \u0027crossing\u0027 logic described in the Scope section.",
+            "fix": "Add a step to verify the \u0027caller\u0027 ID matches the current session ID before processing the split, or explicitly handle the case where the ID is missing.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Caller ID escaping the directory creates potential for cross-project contamination.",
+            "why": "Constraint 4 states \u0027A caller id is somebody else\u0027s string and reaches a file name: it must not escape the directory.\u0027 If the \u0060CLAUDE_CODE_SESSION_ID\u0060 contains a path separator (e.g., \u0060user/repo/branch\u0060) or a special character, and the system uses it directly as a filename without sanitization, it could create a file structure like \u0060data/user/repo/branch/split.lock\u0060. If the \u0027data directory\u0027 is shared across multiple projects, this could lead to a file being written in a subdirectory that wasn\u0027t intended, or a collision where two different projects write to the same file path, causing one project to overwrite the other\u0027s split state.",
+            "fix": "Add a validation step that checks the \u0027caller\u0027 ID against the directory name or a lock file before allowing the split to proceed.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "This plan is a PIECE of a split that is already under way, so do NOT split it again: build it as one unit, review its diff through this gate, fix, document, test and commit. If it is genuinely too big for one unit, say so in your summary and say what you would have cut it into \u2014 but do not start a second round of splitting on your own.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ]
+      },
+      {
+        "stage": "code",
+        "seconds": 277.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "8 of 9 reviewers answered; failed: local/SecurityReliability: unparseable: the answer was not the schema\u0027s JSON after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\local-SecurityReliability-20260904-204214-080.txt)",
+        "tokensIn": 289623,
+        "tokensOut": 28739,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 570,
+            "title": "The split-order predicate is evaluated twice instead of once",
+            "why": "The written rule says: \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 \u0060OrdersSplit(provisional)\u0060 gates claiming, then \u0060OrdersSplit(context)\u0060 is evaluated again for logging. Compute the predicate once and reuse the result for claiming and logging.",
+            "fix": "Store the first \u0060OrdersSplit(provisional)\u0060 result in a local boolean and use that boolean, plus the claim result, for the later log condition.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 106,
+            "title": "Expired-claim cleanup is not atomic across processes",
+            "why": "The scope requires: \u0022The claim is atomic across processes: two servers sharing a data directory cannot both give it.\u0022 Two processes can both observe an expired file; one can delete it while the other gets \u0060FileNotFound\u0060, then the second catch treats the missing file as an unwritable-store case and returns \u0060true\u0060, while the first subsequently succeeds with \u0060CreateNew\u0060. Both therefore receive the order.",
+            "fix": "Coordinate expired-claim replacement atomically, such as by acquiring an exclusive cross-process lock before checking/deleting the expired claim and creating the replacement.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 114,
+            "title": "Some unwritable-store errors fail closed without a warning",
+            "why": "The scope requires: \u0022An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0022 Any \u0060IOException\u0060 caught while the claim file still exists returns \u0060false\u0060, including an \u0060IOException\u0060 from \u0060writer.Write\u0060 such as a full disk; it emits no warning and withholds the order.",
+            "fix": "Handle only the expected \u0060CreateNew\u0060 name-collision as an already-claimed result; let write and other I/O failures reach the warning-and-return-true path.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 102,
+            "title": "Expired claims are renewed with a delete-then-create race",
+            "why": "Two servers can both observe an expired claim, then one can delete the newly recreated file after the other has created it; both \u0060TryClaimSplitOrder\u0060 calls return true and both issue the split order.",
+            "fix": "Serialize expiry replacement with a per-caller lock or use an atomic OS-level replace protocol; do not delete the claim outside that serialization.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 109,
+            "title": "Write failures can be mistaken for a successful competing claim and fail closed",
+            "why": "If \u0060CreateNew\u0060 succeeds but the subsequent write fails, such as a full disk, the file exists, so the filtered IOException handler returns false without warning. The caller with the order is therefore told not to split, violating the fail-open requirement and potentially leaving an unusable claim file.",
+            "fix": "Distinguish an IOException from \u0060CreateNew\u0060 caused by an existing file from exceptions during stream creation or writing; warn and return true for write failures.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 111,
+            "title": "Unconditional File.Delete before FileMode.CreateNew creates a race condition allowing concurrent callers to both claim the split order",
+            "why": "When two processes concurrently invoke TryClaimSplitOrder for an unclaimed or expired caller, both pass StillRemembered as false. Process A reaches File.Delete and opens the file with FileMode.CreateNew, successfully creating the claim file and closing it. Process B, having already evaluated StillRemembered as false, executes File.Delete(file) immediately after, deleting Process A\u0027s newly established claim. Process B then successfully creates the file via FileMode.CreateNew and also returns true. Both callers believe they claimed the order and both issue split orders, defeating cross-process atomicity.",
+            "fix": "Do not delete the existing file before attempting FileMode.CreateNew; attempt atomic creation first and only handle file cleanup/replacement if the file on disk is confirmed expired.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Unwritable caller session store emits warning on every single claim attempt without recovery or clear resolution guidance",
+            "why": "When the data directory is unwritable or permissions fail, every split-eligible plan review triggers an IOException/UnauthorizedAccessException and emits a warning log for each round. The log string describes the symptom and says \u0027the order is being given, and may be given again\u0027, but does not inform the developer/operator what path failed or how to resolve the directory permission issue, cluttering logs on every round.",
+            "fix": "Include actionable remediation in the log message (e.g., directory path and permission check guidance) or cache the unwritable state/back off logging so repeated rounds on an unwritable directory do not spam duplicate unresolvable warnings.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 102,
+            "title": "File.Exists check before File.Delete introduces a redundant disk metadata roundtrip on the hot claim path",
+            "why": "In \u0060TryClaimSplitOrder\u0060, \u0060File.Exists(file)\u0060 is checked before calling \u0060File.Delete(file)\u0060 when clearing an expired claim. \u0060File.Delete\u0060 in .NET is already a no-op / does not throw if the file does not exist, so performing \u0060File.Exists\u0060 first adds an unnecessary extra filesystem metadata query on every claim attempt.",
+            "fix": "Remove the \u0060if (File.Exists(file))\u0060 guard and call \u0060File.Delete(file)\u0060 directly inside the try block.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 88,
+            "title": "Method naming convention deviation",
+            "why": "The method \u0060TryClaimSplitOrder\u0060 introduces a \u0060Try\u0060 prefix pattern that is inconsistent with the existing \u0060RecordSplitOrder\u0060 method it replaces and the \u0060SplitAlreadyOrdered\u0060 method it complements. The project\u0027s existing convention uses \u0060Record\u0060 for state changes and \u0060SplitAlreadyOrdered\u0060 for queries.",
+            "fix": "Rename \u0060TryClaimSplitOrder\u0060 to \u0060RecordSplitOrder\u0060 or \u0060ClaimSplitOrder\u0060 to match the existing naming convention of \u0060SplitAlreadyOrdered\u0060 and \u0060ReadStamp\u0060.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "Variable naming convention deviation",
+            "why": "The variable \u0060provisional\u0060 is a temporary name that deviates from the standard \u0060context\u0060 naming used elsewhere in the file (e.g., \u0060var context = Core.Commands.GateCommands.For(context)\u0060). While functional, it breaks the established naming pattern for command context objects.",
+            "fix": "Rename the local variable \u0060provisional\u0060 to \u0060context\u0060 or \u0060commandContext\u0060 to align with the existing variable naming convention in the file.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Nit",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 48,
+            "title": "Test method naming convention deviation",
+            "why": "The test method name uses \u0060ATOMIC\u0060 in all caps, which is inconsistent with the project\u0027s standard PascalCase naming convention for test methods (e.g., \u0060ADifferentCaller_IsNotTheSameTask\u0060). The word \u0060Atomic\u0060 should be capitalized normally.",
+            "fix": "Rename the test method \u0060TheClaimIsATOMIC_SoTwoServersCannotBothGiveTheOrder\u0060 to \u0060TheClaimIsAtomic_SoTwoServersCannotBothGiveTheOrder\u0060.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Atomic claim race condition due to pre-check file deletion outside the critical section",
+            "why": "The code checks \u0060StillRemembered\u0060 (line 93), then deletes the file (line 97), then attempts \u0060FileMode.CreateNew\u0060 (line 100). If a second server deletes the file between the check and the delete, or if the delete fails silently, the \u0060CreateNew\u0060 might fail or succeed unexpectedly. More critically, if the file exists but is locked by another process, \u0060File.Delete\u0060 might throw or hang, causing the \u0060CreateNew\u0060 to fail or the method to return false incorrectly. The race window is widened by the explicit delete before the atomic write.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or wrap the delete in its own try-catch to ensure the atomic \u0060CreateNew\u0060 is not blocked by a stale file handle or race condition.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 108,
+            "title": "Generic warning message obscures the specific caller and file path on write failure",
+            "why": "When the store is unwritable, the warning \u0060the split-order memory at {Dir} could not be written\u0060 is generic. It doesn\u0027t tell the operator *which* caller failed or *which* file path was attempted, making debugging difficult in a multi-caller environment.",
+            "fix": "Add a specific error message to the \u0060warn\u0060 callback that includes the caller ID and the specific file path, e.g., \u0060warn?.Invoke($",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Nit",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 100,
+            "title": "FileStream options not optimized for sequential, low-frequency writes",
+            "why": "The \u0060FileStream\u0060 is created without specific options. For a file that is written once per day per caller, \u0060FileOptions.SequentialScan\u0060 can improve performance by hinting to the OS that the file will be accessed sequentially, reducing random I/O overhead.",
+            "fix": "Use \u0060FileOptions.SequentialScan\u0060 or \u0060FileOptions.WriteThrough\u0060 in the \u0060FileStream\u0060 constructor to optimize for sequential writes and reduce OS-level caching overhead for this specific use case.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ]
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:42:22 \u001B[32mINF\u001B[0m] coai-mcp#44136 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:97 - Atomic claim race condition due to pre-check file deletion outside the critical section (from local) [gating] Round=1 Stage=CodeReview\r | [20:42:22 \u001B[32mINF\u001B[0m] coai-mcp#44136 finding [Minor/Ux] src_mcp/src/Server/CallerSessions.cs:108 - Generic warning message obscures the specific caller and file path on write failure (from local) Round=1 Stage=CodeReview\r | [20:42:22 \u001B[32mINF\u001B[0m] coai-mcp#44136 finding [Nit/Performance] src_mcp/src/Server/CallerSessions.cs:100 - FileStream options not optimized for sequential, low-frequency writes (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 96,
+      "stillRunning": 0,
+      "pending": 40,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "resolvable": true
+    },
+    "settings": {
+      "mismatches": [
+        "COAI_SPLIT_WITH_FABLE is on, but the round handed back no order mentioning \u0027Fable\u0027"
+      ],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": false
+    }
+  }
+]

--- a/research/data/bench-2026-09-05/epic1/tables.md
+++ b/research/data/bench-2026-09-05/epic1/tables.md
@@ -1,0 +1,21 @@
+# Bench
+
+## Per arm
+
+| arm | stage | runs | verdicts | median time | median findings | gating | useful | tokens in / out | cost |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | code | 4 | proceed | 277.9s | 11 | 21 | — | 1.6M / 131.2k | not reported |
+| `codex,gemini,local` | plan-1 | 4 | good_enough | 79.4s | 13 | 39 | — | 191.1k / 24.2k | not reported |
+
+## Per run
+
+| arm | case | # | lane | stage | verdict | time | findings | gating | tokens in / out |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | plan-1 | good_enough | 79.4s | 11 | 7 | 39.9k / 8.2k |
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | code | proceed | 277.3s | 11 | 5 | 575.2k / 29.5k |
+| `codex,gemini,local` | rounds-collapse | 2 | 1 | plan-1 | good_enough | 248.8s | 11 | 8 | 52.3k / 5.7k |
+| `codex,gemini,local` | rounds-collapse | 2 | 1 | code | proceed | 211.5s | 10 | 5 | 409.4k / 27.2k |
+| `codex,gemini,local` | split-once | 1 | 1 | plan-1 | good_enough | 46.7s | 13 | 12 | 50.1k / 5.2k |
+| `codex,gemini,local` | split-once | 1 | 1 | code | proceed | 507.6s | 6 | 3 | 303.9k / 45.8k |
+| `codex,gemini,local` | split-once | 2 | 1 | plan-1 | good_enough | 46.7s | 14 | 12 | 48.8k / 5.1k |
+| `codex,gemini,local` | split-once | 2 | 1 | code | proceed | 277.9s | 14 | 8 | 289.6k / 28.7k |

--- a/research/data/bench-2026-09-05/epic1b-v0.17.3/runs.json
+++ b/research/data/bench-2026-09-05/epic1b-v0.17.3/runs.json
@@ -1,0 +1,2222 @@
+[
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T09:50:33.223379Z",
+    "finishedUtc": "2026-09-05T09:53:09.3761705Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 48.5,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 39011,
+        "tokensOut": 7345,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The auto-close algorithm does not define what happens when a panel-opened round disappears before a finished state is observed",
+            "why": "If a running round is deleted, rotated out of session data, or the server is killed before the next poll, the round can remain in expanded while ownership is merely pruned, leaving a stale expanded card.",
+            "fix": "Specify and test disappearance and server-failure handling, removing missing rounds from both expansion and ownership state consistently.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how panel ownership survives refreshes, provider recreation, or extension restarts",
+            "why": "The behavior depends on an in-memory second set. Restarting the extension while a person has opened a running round loses that fact, so completion can collapse the round against the person\u0027s choice.",
+            "fix": "Define the ownership state lifetime, persist or reconstruct person-owned state, and test reload/recreation/restart during a running round.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping requirement is not specified for every rendered context or renderer path",
+            "why": "Testing only a vendor containing \u003C does not catch values such as \u003C/span\u003E\u003Cscript\u003E or quotes and ampersands in other output contexts; a shared renderer could still emit malformed markup or executable content.",
+            "fix": "Specify context-appropriate escaping at the renderer boundary, prohibit raw vendor interpolation, and test closing tags, quotes, ampersands, and both text and HTML paths.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The Fable command path has no failure or retry contract",
+            "why": "With the checkbox enabled and the server unavailable, timing out, or killed after accepting the request but before persisting the round, the plan does not define whether the UI reports failure or whether a retry can duplicate the order.",
+            "fix": "Specify acknowledgement, timeout, retry, and idempotency behavior, and test unavailable-server, timeout, and partial-submission retries.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "[Build order #3 / panelProvider] Toggling round cards re-evaluates the full panel refresh pipeline instead of isolating UI expansion state.",
+            "why": "Expanding or collapsing a card triggers a complete view rebuild that probes vendor CLIs, stats server binaries, and executes network fetches, causing up to twenty-second UI freezes on a simple disclosure toggle.",
+            "fix": "Isolate card expansion/collapse state mutations so toggling disclosure renders only the card body from cached state without invoking external probes or network requests.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true #2 / Build order #3] Unfinished or crashed rounds lack completion timestamps, causing elapsed time calculations to grow unbounded.",
+            "why": "When a round crashes, terminates abruptly, or times out without writing a completion record, the panel calculates duration as \u0060now - startTime\u0060, displaying runtimes in the hundreds of minutes on rounds that failed or timed out after ten minutes.",
+            "fix": "Detect dead rounds by comparing elapsed time against the reviewer timeout threshold or active process heartbeat, capping duration and marking the round as timed out or aborted.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "[Build order #5 / panelView] Reusing CSS class \u0027.vendor\u0027 for inline text spans collides with existing card container styling.",
+            "why": "The stylesheet already defines \u0060.vendor\u0060 with card-level borders, border-radius, and padding, causing inline \u0060\u003Cspan\u003E\u0060 elements around vendor names to render with box borders across the text.",
+            "fix": "Use a distinct inline class name such as \u0060who\u0060 or \u0060vendor-label\u0060 that carries no inherited card-level box model styles.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true #2, #3] Legacy rounds recorded prior to per-reviewer metadata render as interactive disclosures with empty bodies.",
+            "why": "Historical session records without detailed reviewer breakdowns still render with expansion triangles and interactive hand cursors, opening into empty containers.",
+            "fix": "Conditionally render disclosure controls only for rounds that contain reviewer detail, rendering legacy rounds as non-collapsible flat summary rows.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "[Build order #4 / rounds.ts] Placing theme palette resolution \u0027vendorColour\u0027 in session parser creates an inverted dependency.",
+            "why": "\u0060rounds.ts\u0060 handles session log file parsing; placing VS Code chart palette resolution inside it forces independent view components (such as spending rows) to depend on session parser modules.",
+            "fix": "Extract \u0060vendorColour\u0060 into a separate presentation utility module (\u0060vendorColour.ts\u0060) accessible to all view components.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 107.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 445237,
+        "tokensOut": 13724,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 811,
+            "title": "Reviewer vendor spans use the forbidden \u0060vendor\u0060 class instead of the documented \u0060who\u0060 class",
+            "why": "The plan explicitly records that the shipped span class is \u0060who\u0060 because \u0060.vendor\u0060 already styles the settings card; using \u0060class=\u0022vendor\u0022\u0060 applies that existing card styling to inline reviewer names.",
+            "fix": "Change the reviewer span class from \u0060vendor\u0060 to \u0060who\u0060, and update the corresponding tests to expect \u0060class=\u0022who\u0022\u0060.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 154,
+            "title": "Concurrent saves can still overwrite newer session state with an older snapshot",
+            "why": "If writer A loads round 1, writer B adds round 2 and saves, then writer A saves afterward, each unique scratch file moves successfully but A replaces B\u0027s newer session with its stale snapshot, silently losing round 2 and its progress.",
+            "fix": "Serialize the read/merge/write/move sequence per session across processes, or add revision checking and merge/retry before replacing the destination.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 809,
+            "title": "A malformed session reviewer provider can crash panel rendering",
+            "why": "A hand-edited or partially malformed session containing \u0060\u0022provider\u0022: null\u0060 reaches \u0060vendorColour(row.provider)\u0060, whose \u0060trim()\u0060 call throws; the repaint then fails instead of displaying the session safely.",
+            "fix": "Validate or normalize reviewer providers while parsing session files, or make \u0060vendorColour\u0060 accept non-string values and fall back to the foreground colour.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 140,
+            "title": "Clicking a round disclosure still waits for the provider\u0027s full refresh before showing the card body",
+            "why": "When a person opens or closes a round, the handler immediately repaints through the full refresh path; on a machine where configuration reads, CLI probes, server checks, GitHub checks, and price-table requests take up to 20 seconds, the click appears inert with no busy or terminal error state.",
+            "fix": "Update the disclosure state and render the round body locally first, then refresh unrelated sections asynchronously; expose a busy/error state if the full refresh is unavoidable.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 159,
+            "title": "Transient save contention synchronously stalls reviewer progress for up to 200 ms per save",
+            "why": "During concurrent servers writing the same session, each reviewer transition can sleep 20, 40, 60, and 80 ms before retrying; a nine-reviewer round can therefore accumulate seconds of blocked progress-path time, while the person sees the round stop advancing without any status explaining the delay.",
+            "fix": "Move persistence off the reviewer-transition path or make the bounded retry asynchronous; report a persistence-in-progress/error state when saving cannot complete promptly.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 180,
+            "title": "Synchronous Thread.Sleep in retry loop blocks calling threads during concurrent file moves",
+            "why": "When concurrent writers or file locks on Windows trigger IOException/UnauthorizedAccessException, SessionStore.Save executes a synchronous Thread.Sleep(20 * attempt) on the current thread for up to 5 attempts (total ~300ms sleep). Under burst traffic across multiple active reviewer transitions or MCP requests, this blocks thread-pool/server execution threads synchronously instead of yielding or using asynchronous backoff.",
+            "fix": "If SessionStore remains synchronous, keep backoff minimal/non-spinning or use Task.Delay in an async SaveAsync pipeline; alternatively use a short SpinWait or minimal yield (e.g. Thread.Yield() / short sleep) to avoid holding server execution threads.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Vendor span uses class \u0027vendor\u0027 which conflicts with existing card styles",
+            "why": "The plan deviations document explicitly noted that \u0027.vendor already meant the settings card in this stylesheet, so the word came out wearing a border, a radius and eight pixels of padding, which on a single word inside a tight line reads as a line THROUGH the text\u0027 and required the class to be \u0027who\u0027. However, roundCard in panelView.ts still renders \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022...\u0022\u003E\u0060 instead of \u0060\u003Cspan class=\u0022who\u0022 style=\u0022...\u0022\u003E\u0060, re-triggering unwanted padding/border styling around the vendor name.",
+            "fix": "Replace \u0060class=\u0022vendor\u0022\u0060 with \u0060class=\u0022who\u0022\u0060 in \u0060roundCard\u0060 inside \u0060src_vs_code/src/panelView.ts\u0060 and update related unit tests.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may silently swallow a final failure",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 states: \u0027The server refuses one without it\u0027 (referring to scope) and implies strict adherence to protocol. More critically, the \u0060vendor-routing.md\u0060 rule states \u0027breaking it is invisible in the output\u0027. The \u0060MoveOverExisting\u0060 method retries 5 times. If the 5th attempt fails, the \u0060catch\u0060 block inside the loop (line 183) catches the exception but the loop exits. The method then returns. The caller (\u0060Save\u0060) has a \u0060try...finally\u0060 block. If \u0060MoveOverExisting\u0060 throws, it propagates. If it succeeds, it returns. However, the logic \u0060catch (Exception e) when (...) \u0026\u0026 attempt \u003C attempts\u0060 means on the 5th attempt, if it fails, the loop exits *without* re-throwing or handling the exception explicitly in a way that guarantees visibility. Wait, looking closer: \u0060catch\u0060 block has \u0060Thread.Sleep\u0060. If \u0060attempt\u0060 reaches 5, the loop condition \u0060attempt \u003C= attempts\u0060 is true. Inside, if it throws, it hits the catch. \u0060attempt \u003C attempts\u0060 (5 \u003C 5) is false. So it *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method\u0027s retry loop uses a bounded number of attempts and that the final attempt throws if it fails, rather than silently swallowing the error.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Concurrent save race condition leaves orphaned scratch files and silent failures",
+            "why": "In \u0060SessionStore.Save\u0060, the code generates a unique scratch filename using \u0060Environment.ProcessId\u0060 and a GUID. However, if two processes (or threads in a multi-threaded scenario) happen to generate the same GUID or if the process ID is reused rapidly, they could collide. More critically, the \u0060MoveOverExisting\u0060 method retries 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms). If the destination file is held by a virus scanner or another process for longer than ~250ms, the move fails. The code then enters the \u0060finally\u0060 block and calls \u0060TryDelete(temp)\u0060. If the move failed, \u0060temp\u0060 still exists. If the \u0060TryDelete\u0060 fails (e.g., file locked), it swallows the exception. The result is a session file that never updated (stale data) and a temporary file left behind, potentially filling the disk or causing future collisions if the temp name generation isn\u0027t perfectly unique. The comment admits \u0027a save that never lands is a real problem\u0027 but the \u0060finally\u0060 block\u0027s \u0060TryDelete\u0060 might *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite backoff and that the final exception is re-thrown or logged with context, rather than silently swallowed if the file is held by a scanner.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 806,
+            "title": "Potential HTML injection in vendor name rendering if escaping order is flawed",
+            "why": "In \u0060roundCard\u0060, the code constructs the reviewer row as: \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:${vendorColour(row.provider)}\u0022\u003E\u0060 \u002B \u0060${escapeHtml(row.provider)}\u0060 \u002B \u0060\u003C/span\u003E${escapeHtml(row.rest)}\u0060. If \u0060row.provider\u0060 contains a string like \u0060\u003Cscript\u003E\u0060, \u0060escapeHtml\u0060 converts it to \u0060\u0026lt;script\u0026gt;\u0060. However, if the \u0060vendorColour\u0060 function (or the caller) relies on the raw provider name for the style, and the style attribute is interpolated directly into the HTML string without escaping, an attacker could inject a style attribute. Wait, the style is \u0060color:var(...)\u0060, so it\u0027s safe. The real risk is if \u0060row.provider\u0060 is used in a context where it\u0027s not escaped *before* being placed inside the span, or if \u0060row.rest\u0060 contains unescaped HTML. The code escapes \u0060row.provider\u0060 and \u0060row.rest\u0060 separately. The risk is if \u0060row.provider\u0060 is *not* escaped before being used in the \u0060style\u0060 attribute (e.g., if \u0060vendorColour\u0060 returned a hex value that wasn\u0027t quoted, but it returns a CSS variable). The actual flaw",
+            "fix": "Ensure \u0060vendorColour\u0060 is called *after* \u0060escapeHtml\u0060 or that the HTML structure wraps the escaped text correctly, preventing a scenario where a vendor name like \u0060\u003Cscript\u003E\u0060 renders as an active tag if the escaping logic is applied to the wrong part of the string.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Race condition in round state management could lead to duplicate keys or lost state",
+            "why": "The \u0060nextOpenRounds\u0060 function builds a \u0060Set\u0060 of keys from \u0060cards\u0060. If two rounds have the same \u0060roundKey\u0060 (e.g., same repo, branch, stage, number), the second one will overwrite the first in the Set. This means if a user has two rounds with identical metadata (perhaps from different branches or a bug in ID generation), only one will be tracked in the \u0060open\u0060 state. If the user interacts with the \u0027wrong\u0027 one (the one that was processed last), the state update might not reflect the actual round they clicked. This is a subtle data loss scenario where the UI state diverges from the actual session data.",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all rounds before adding to the \u0060open\u0060 set, or handle collisions explicitly.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:53:09 \u001B[32mINF\u001B[0m] coai-mcp#27060 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Concurrent save race condition leaves orphaned scratch files and silent failures (from local) [gating] Round=1 Stage=CodeReview\r | [09:53:09 \u001B[32mINF\u001B[0m] coai-mcp#27060 finding [Major/Security] src_vs_code/src/panelView.ts:806 - Potential HTML injection in vendor name rendering if escaping order is flawed (from local) [gating] Round=1 Stage=CodeReview\r | [09:53:09 \u001B[32mINF\u001B[0m] coai-mcp#27060 finding [Minor/Reliability] src_vs_code/src/openRounds.ts:45 - Race condition in round state management could lead to duplicate keys or lost state (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|2",
+    "startedUtc": "2026-09-05T09:53:09.4882874Z",
+    "finishedUtc": "2026-09-05T09:57:34.1116866Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 50.3,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 10,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 40582,
+        "tokensOut": 5114,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping requirement is broader than the only specified escaping test",
+            "why": "A session file containing \u0060\u003Cimg src=x onerror=...\u003E\u0060 in a round title, reviewer metadata, or a spending-row field can still execute if those interpolations use innerHTML; the test only covers a vendor name in one reviewer row.",
+            "fix": "Define and audit every session-derived HTML sink, centralize escaping or use textContent/DOM construction, and test malicious values in every rendered field and section.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not specify compatibility or rollout handling for the required server version",
+            "why": "If the extension updates to 0.29.x while the installed server remains below 0.16.0, ticking the checkbox can send an unsupported Fable command and leave the user with no order or an unhandled command error.",
+            "fix": "Specify the minimum server version and upgrade/handshake behavior, including a user-visible failure for an incompatible server and a tested mixed-version path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The dead-round duration correction is asserted but absent from the build and test work",
+            "why": "A round that never records a completion time can still be displayed as running for the elapsed time since it started, producing values such as \u0060361m 40s\u0060 after a ten-minute reviewer timeout; none of the listed tests exercises this state or defines the fallback duration.",
+            "fix": "Specify the timeout/unknown-completion state and add a test for a round with no completion timestamp after the reviewer is killed or times out.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds without reviewer detail are not covered by the implementation or verification steps",
+            "why": "Opening a pre-detail session can still present a clickable disclosure that expands to an apology or empty body, despite the plan claiming those rows became flat lines; the test plan contains no legacy-session fixture.",
+            "fix": "Define the render rule for missing detail, make the disclosure non-interactive, and test a pre-detail session file.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Build order 3: Toggle repaint re-evaluates heavy machine state during card expansion/collapse",
+            "why": "The plan relies on toggling cards open/closed via the standard panel repaint, but the panel render path synchronously stat-checks server binaries, probes all vendor CLIs, queries GitHub releases, and fetches pricing tables. When a person toggles a round card or an auto-collapse triggers, the UI freezes or delays for up to 20 seconds instead of toggling state instantly.",
+            "fix": "Decouple panel fold/expansion rendering from backend vendor probing and network fetches, or cache environment stats so toggling state only re-renders the DOM.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true #2: Dead or interrupted rounds lack completion timestamps, causing stale \u0027running\u0027 state and inflated durations",
+            "why": "A round that crashes or is killed never writes a completion timestamp to its session file. The auto-collapse logic in step 3 checks whether a round is no longer running, but without explicit timeout/dead-round detection, the panel treats the round as indefinitely running and auto-expanded, reporting elapsed time of hundreds of minutes past the reviewer timeout.",
+            "fix": "Add a dead/timeout round check that considers rounds older than the reviewer timeout as stopped/failed so they collapse and stop calculating elapsed time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order 5: CSS class conflict on \u0060.vendor\u0060 card styling corrupts inline span layout",
+            "why": "Wrapping the vendor name in \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060 collides with existing CSS rules for \u0060.vendor\u0060 (which define card borders, border-radius, and 8px padding). When rendered inline inside reviewer rows, the text appears struck through or misaligned with broken line-height.",
+            "fix": "Use a distinct class name such as \u0060who\u0060 or \u0060vendor-tag\u0060 that does not conflict with existing card styles in the stylesheet.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "What must be true #3: Opening legacy session records without reviewer details creates empty interactive disclosure cards",
+            "why": "Legacy session files recorded before per-reviewer breakdown existed are rendered as expandable disclosure cards with pointer cursor. Clicking them expands an empty card body with no review information.",
+            "fix": "Render historical session rounds that lack reviewer details as flat non-expandable rows rather than disclosure cards.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 214.2,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "8 of 9 reviewers answered; failed: local/Architecture: unparseable: the answer was not the schema\u0027s JSON after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\local-Architecture-20260905-095713-796.txt)",
+        "tokensIn": 404789,
+        "tokensOut": 24336,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The committed plan remains marked as unimplemented after the change shipped",
+            "why": "The file says \u0022Status: plan only, nothing implemented yet\u0022 even though this diff implements the plan, contrary to its Definition of Done: \u0022the plan promoted.\u0022 This leaves repository planning metadata describing the opposite state.",
+            "fix": "Promote or remove this TODO plan by updating its status and checklist to reflect the shipped implementation, or replace it with the canonical completed plan under research/.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 158,
+            "title": "Concurrent saves still use last-writer-wins and can silently delete session history",
+            "why": "With two MCP servers sharing the data directory, both can load the same session, then append different round records and call Save. The unique scratch names prevent the move collision, but the later \u0060File.Move(..., overwrite: true)\u0060 replaces the earlier complete JSON with its stale snapshot, so one server\u0027s newly completed round (and its status/findings) disappears without an error; the next load presents an apparently valid but incomplete session.",
+            "fix": "Serialize saves per session or perform a compare/merge under a lock (at minimum reload the destination immediately before replacement and merge round records/pending state), so a successful concurrent save cannot overwrite newer session data.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 145,
+            "title": "A failed scratch-file write bypasses cleanup and leaves abandoned files behind",
+            "why": "\u0060File.WriteAllText\u0060 runs before the \u0060try/finally\u0060. If the file is created and the write then fails, for example because the disk fills, the per-write \u0060.tmp\u0060 remains permanently in \u0060sessions\u0060; repeated failed progress saves can accumulate scratch files and may consume the remaining space, making recovery harder.",
+            "fix": "Move the \u0060File.WriteAllText\u0060 call inside the \u0060try/finally\u0060 (or track whether the scratch path was created) so partial scratch files are deleted on write failures too.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 807,
+            "title": "Reviewer vendor spans still use the stylesheet\u0027s settings-card class",
+            "why": "The plan notes that \u0060.vendor\u0060 already styles settings cards with borders, radius, and padding, but this renderer emits \u0060class=\u0022vendor\u0022\u0060. Every reviewer name rendered in an open card therefore receives those card styles, making the compact reviewer row visibly malformed instead of colouring only the vendor word.",
+            "fix": "Use the dedicated \u0060who\u0060 class for reviewer and spending vendor spans, or rename the existing settings-card selector so the vendor-name span has no card styling.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 138,
+            "title": "Opening or closing one card still performs the full expensive refresh synchronously from the user\u0027s action",
+            "why": "Each round toggle immediately calls \u0060refresh()\u0060. The refresh path still performs configuration reads, server-binary stat/probing, GitHub version lookup, vendor CLI probes, and price-table fetches; with a cold network or several vendors this can take up to about 20 seconds, so clicking a disclosure appears unresponsive and gives no progress or terminal error state.",
+            "fix": "Separate the cheap round-card repaint from the periodic/explicit metadata refresh, so the toggle updates the cached session view immediately; if the full refresh is unavoidable, show an in-progress state and a failure state.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "Plan file added in todo/ with status \u0027plan only, nothing implemented yet\u0027 despite the change implementing it and the Definition of Done requiring plan promotion",
+            "why": "The project\u0027s plan lifecycle rules (referenced in CLAUDE.md: \u0027node .claude/rules/shared/tools/plan-lifecycle.mjs\u0027) and the plan\u0027s own written Definition of Done specify: \u0027- [ ] CoaiMcp.Tests.exe and npm test pass; docs, help and CHANGELOG updated; the plan promoted.\u0027 Introducing the plan as a new file in todo/ asserting \u0027\u003E Status: **plan only, nothing implemented yet.**\u0027 directly violates the promotion requirement for implemented work.",
+            "fix": "Promote the plan file to research/ with an updated IMPLEMENTED status header matching the implementation record, or remove it from todo/.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 809,
+            "title": "Inline vendor span uses class \u0022vendor\u0022, inheriting settings card border and padding styles.",
+            "why": "The stylesheet already defines \u0022.vendor\u0022 for the settings card container with a border, border-radius, and 8px of padding. Applying class=\u0022vendor\u0022 to the inline vendor span in tight reviewer rows causes the vendor name to render inside an oversized padded box that clips adjacent text and appears visually struck through.",
+            "fix": "Change class=\u0022vendor\u0022 to class=\u0022who\u0022 (or another non-colliding class name) in panelView.ts and update the corresponding assertions in tests.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a fixed sleep interval (20ms * attempt). If a file lock (e.g., from an antivirus scanner or another process) persists longer than the total retry window (approx 150ms), the code throws. However, if the lock is held by a process that never releases it (rare but possible in enterprise environments), the \u0060Thread.Sleep\u0060 loop might not be sufficient to handle transient spikes, or worse, if the logic is extended, it could spin. More critically, the \u0060MoveOverExisting\u0060 method is called inside a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060. If the file is held by a scanner that intermittently locks/unlocks, the retry might succeed. But if the lock is permanent, it throws. The real risk is that the \u0060MoveOverExisting\u0060 logic is *not* robust enough for high-concurrency scenarios where multiple writers might contend for the same destination file *after* the unique temp name collision is resolved. If the destination file (",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite wait strategy (e.g., exponential backoff with a hard cap) or a \u0060CancellationToken\u0060 to prevent the server from hanging indefinitely if the destination file is held by a long-running process (like an antivirus scanner) that never releases it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Temporary scratch files accumulate on failed moves due to cleanup timing",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060TryDelete(temp)\u0060 is called in a \u0060finally\u0060 block *after* the \u0060MoveOverExisting\u0060 loop. If \u0060MoveOverExisting\u0060 throws an exception on the final attempt (e.g., \u0060UnauthorizedAccessException\u0060 after 5 retries), the \u0060finally\u0060 block executes and deletes the temp file. However, if the loop succeeds but the \u0060File.Move\u0060 throws *during* the retry (e.g., on attempt 3), the \u0060finally\u0060 block runs, deleting the temp file, but the exception propagates. The critical issue is that if \u0060MoveOverExisting\u0060 throws *before* the loop finishes (e.g., on the first try), the \u0060finally\u0060 block deletes the temp file. But if the loop completes successfully, the temp file is deleted. The real risk is if \u0060MoveOverExisting\u0060 throws *after* a successful move but before the \u0060finally\u0060 block runs (unlikely), or if the \u0060TryDelete\u0060 itself fails silently. More critically, if \u0060MoveOverExisting\u0060 throws on the *last* attempt, the \u0060finally\u0060 block runs, deleting the temp file. But if the loop *succeeds* (all",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs before the retry loop completes, so that if the move fails after the first attempt, the temporary file is cleaned up before the next retry.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 75,
+            "title": "User toggle state may not persist correctly across panel ticks",
+            "why": "When a user closes a card (e.g., \u0060afterToggle(previous, key, false)\u0060), the \u0060open\u0060 set is updated to remove the key. However, if the panel re-renders before the next tick, and the round is still running, the \u0060nextOpenRounds\u0060 logic might re-add it to \u0060open\u0060 if it\u0027s in \u0060autoOpened\u0060. The current logic removes the key from \u0060panelOpened\u0060, but if the round is still running, \u0060nextOpenRounds\u0060 will re-add it to \u0060autoOpened\u0060 and \u0060open\u0060 on the next tick, effectively ignoring the user\u0027s close action. This creates a flicker where the card closes, then re-opens immediately if the round is still running.",
+            "fix": "Ensure \u0060afterToggle\u0060 updates the \u0060open\u0060 set correctly when a user closes a card that was previously auto-opened, and that the \u0060panelOpened\u0060 set is updated to reflect the user\u0027s explicit choice.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary recomputation of open rounds state on every render tick",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 calls \u0060nextOpenRounds\u0060 on every render tick (every 5 seconds). This function performs set operations and filtering on the entire list of rounds. While the logic is simple, doing this on every tick for a large number of rounds (e.g., 100\u002B rounds) creates unnecessary CPU overhead. The state should only be recomputed when the \u0060sessions\u0060 data actually changes (e.g., a new round starts, a round finishes, or a user toggles a card).",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 and only recompute it when the underlying \u0060sessions\u0060 data changes, rather than on every render tick.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:57:34 \u001B[32mINF\u001B[0m] coai-mcp#4896 finding [Major/Ux] src_vs_code/src/openRounds.ts:75 - User toggle state may not persist correctly across panel ticks (from local) [gating] Round=1 Stage=CodeReview\r | [09:57:34 \u001B[32mINF\u001B[0m] coai-mcp#4896 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary recomputation of open rounds state on every render tick (from local) Round=1 Stage=CodeReview\r | [09:57:34 \u001B[32mINF\u001B[0m] coai-mcp#4896 settings reloaded - the panel\u0027s file changed on disk",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|split-once|1",
+    "startedUtc": "2026-09-05T09:57:34.1854628Z",
+    "finishedUtc": "2026-09-05T10:00:18.3373566Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 35.5,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 13,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 39413,
+        "tokensOut": 4389,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes is promised but no claim protocol or verification is specified",
+            "why": "If two servers read the same unclaimed record concurrently, both can pass the check and issue the split order, violating the once-only guarantee.",
+            "fix": "Specify an atomic create/transaction primitive for the claim and include a concurrent two-process check proving exactly one process issues the order.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback has no defined stable checkout identity",
+            "why": "When a caller exports no session id and changes from branch \u0060feature\u0060 to \u0060feature-epic-1\u0060, the implementation has no specified key that links those sessions; it can either split the epic again or accidentally share state with another checkout of the same repository.",
+            "fix": "Define canonical checkout identity and keying rules, including worktrees, cloned paths, and simultaneous checkouts, then verify parent and child branches share only the intended claim.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Claim lifetime and reset rules are missing, so old state can control unrelated future plans",
+            "why": "A claim persisted for a checkout or branch can remain when the user returns a year later or reuses a branch for a new root plan, causing the new caller to be treated as an already-split piece and skip the required split order.",
+            "fix": "Bind claims to an explicit plan/run identity or generation, define cleanup/reset behavior, and verify branch reuse and a later independent plan start fresh.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how the verdict from this review round is bound to the claim",
+            "why": "If a previous passing verdict is cached and the current plan review fails, the stale pass can still trigger a command; conversely, a current pass can be ignored after an intermediate state update.",
+            "fix": "Store and evaluate the current round identifier or plan hash together with the verdict, and make the eligibility check and claim use that same record atomically.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "A process killed between claiming and issuing leaves retries unable to complete the promised order",
+            "why": "With the required once-only claim, a server that claims successfully and is terminated before spawning the command leaves the next attempt believing the order was already issued, so a passing caller receives no split or autonomy command.",
+            "fix": "Specify a durable state transition and recovery policy, such as an atomic claim-plus-enqueue record with retryable delivery and an idempotent command, and verify termination at each boundary.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The unwritable-store fail-open behavior is asserted without defining the observable result",
+            "why": "When the feature is enabled and the data directory is read-only, callers cannot tell whether fail-open means issuing the command without a claim, continuing with an in-memory claim, or aborting; different implementations can silently disable splitting or issue duplicates.",
+            "fix": "Define the exact warning, exit/result behavior, and command policy for an unwritable store, and verify it with a read-only directory while the plan passes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Fail-open on unwritable store causes infinite recursive split loops",
+            "why": "Requirement 5 specifies that an unwritable store fails open with a warning. If the claim store cannot write the record marking that an epic split has occurred, every subsequent round checking the unwritable store will find no claim record and repeatedly order another epic split on every child epic, reintroducing the infinite recursion the feature was designed to eliminate.",
+            "fix": "Fail safe on unwritable store by assuming a claim exists and issuing the autonomy/single-unit order (or blocking the split order) when storage is unwritable.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fallback tracking across checkout branches without session IDs lacks a defined concrete keying mechanism",
+            "why": "Requirement 6 mandates following callers across branches of one checkout without requiring the AI to pass identifiers (Constraints) or relying on CLAUDE_CODE_SESSION_ID. Because git checkouts switch HEAD or worktrees have distinct paths, there is no shared caller-level lifecycle identifier defined to distinguish independent user runs from child epic reviews in the same repo checkout, causing either false-positive split suppression or missed claims.",
+            "fix": "Specify the exact fallback identity boundary (e.g. tie fallback claims to a parent commit hash or specific worktree/repo lockfile with a TTL) to define when the claim expires.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Retries and user-driven re-plans under the same caller session are permanently blocked from splitting",
+            "why": "Requirement 1 enforces that a caller is ordered to split exactly once. If a user rejects a generated split, changes top-level requirements, and requests a fresh plan review within the same active CLAUDE_CODE_SESSION_ID, the plan review gate will see the existing claim and refuse to issue a split order, forcing the entire modified scope to be built as a single monolithic unit.",
+            "fix": "Define a re-plan / reset mechanism (e.g., scoping the split claim to root plan hash/revision or supporting an explicit force/reset flag).",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "Unsanitized caller ID strings in file-based storage risk path traversal and filename invalidity",
+            "why": "Caller IDs (e.g. CLAUDE_CODE_SESSION_ID or fallback strings) are external input used directly in file paths. If the ID contains path separators, slashes, or OS-reserved filename characters (like colons on Windows), filesystem operations will either escape the intended directory or fail with invalid path errors.",
+            "fix": "Hash or strictly alphanumeric-sanitize the caller ID (e.g. SHA-256 digest) before using it as a filename or path component.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 128.5,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 10,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 265567,
+        "tokensOut": 15311,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 586,
+            "title": "The split-order predicate is evaluated more than once instead of being asked once.",
+            "why": "The written rule says: \u201CThe condition that issues the order and the condition that claims it are ONE question asked once.\u201D \u0060OrdersSplit(provisional)\u0060 is evaluated for claiming, then \u0060OrdersSplit(context)\u0060 is evaluated again for logging and the command path evaluates the predicate through \u0060For\u0060; this can make claiming and issuance observe different conditions.",
+            "fix": "Evaluate the predicate once, store the result, use that result to claim and construct the context, and use the stored result for logging/issuance.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 92,
+            "title": "Expired-claim deletion is not atomic with claim creation",
+            "why": "Two servers can both observe an expired claim; after one creates a fresh file, the other can delete that fresh file and create its own claim. Both return true and issue the split order, violating the once-only guarantee.",
+            "fix": "Serialize expiry replacement with a per-caller lock, then re-read the stamp while locked before deleting and creating the replacement.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 100,
+            "title": "A corrupt or temporarily locked claim fails closed without warning",
+            "why": "If the process is killed after creating the stamp but before writing its contents, the next request cannot parse it, attempts CreateNew, and the IOException is treated as another process\u0027s claim because the file exists. The caller is then denied the order indefinitely. The same happens when an expired file is temporarily locked.",
+            "fix": "Distinguish an existing live claim from claim-store errors, and atomically repair malformed or expired stamps under the same per-caller lock; warn and return true when the store cannot be modified.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 110,
+            "title": "Unexpired claim file is deleted during race between expiration check and file creation",
+            "why": "When an existing claim file expires and two concurrent processes call TryClaimSplitOrder, or when one process finds an expired file while another process simultaneously creates a fresh valid claim file, the first process executes \u0060if (File.Exists(file)) File.Delete(file);\u0060 without verifying that the file currently on disk is still the expired one. This deletes the valid, newly-written claim of the winner, allowing a subsequent attempt or retry to overwrite or claim again, breaking the mutual exclusion guarantee.",
+            "fix": "Avoid naked File.Delete before CreateNew; instead, use an atomic file replace/open strategy or open with appropriate file share and lock semantics so an active claim cannot be unlinked by a concurrent claimant.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 914,
+            "title": "Anonymous callers across different repos with identical relative/empty paths collide on the same claim",
+            "why": "When session.State.RepoPath is not an absolute canonical path or contains characters sanitized identically in FileFor, anonymous callers across different working trees or checkouts will map to the exact same claim file \u0060repo:\u003Cpath\u003E\u0060, causing an unrelated checkout to falsely be treated as an existing piece of a split plan.",
+            "fix": "Ensure \u0060session.State.RepoPath\u0060 is resolved to a fully-qualified canonical path (e.g., \u0060Path.GetFullPath(session.State.RepoPath)\u0060) before constructing the caller identity string.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "Nullable callback parameter risks NullReferenceException",
+            "why": "The method signature \u0060Action\u003Cstring\u003E? warn = null\u0060 allows the caller to omit the argument. If the code path reaches \u0060warn?.Invoke\u0060 (line 117) and the caller passed \u0060null\u0060 explicitly or the default was not handled correctly in a specific call site, the warning logic could fail silently or throw if the null check is bypassed in a future refactor. More critically, the test \u0060AnUnwritableStore_GivesTheOrderRatherThanSwallowingIt\u0060 passes a lambda, but \u0060PanelService\u0060 (line 583) passes a lambda. However, the method signature change from \u0060RecordSplitOrder\u0060 to \u0060TryClaimSplitOrder\u0060 introduces a new optional parameter that was not present in the original API contract, potentially breaking callers that rely on positional arguments or implicit defaults if not careful.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 or ensure the caller passes a non-null delegate. The current implementation invokes \u0060warn?.Invoke\u0060 without guaranteeing the caller provides one, risking a \u0060NullReferenceException\u0060 if called without the argument.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Inconsistent handling of optional warning callback",
+            "why": "The method \u0060TryClaimSplitOrder\u0060 accepts an optional \u0060warn\u0060 callback. While the code uses \u0060warn?.Invoke\u0060, the logic inside the \u0060catch (Exception e)\u0060 block assumes the callback might be null. If a caller passes \u0060null\u0060 explicitly, the warning is swallowed. The rule requires \u0027a warning rather than silently disabling\u0027, but if the callback is null, the warning is silent.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked with a consistent message format or handle the case where \u0060warn\u0060 is null more explicitly if the design requires it to be optional.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Inconsistent state propagation for FirstPlanRound",
+            "why": "The code sets \u0060FirstPlanRound: true\u0060 on \u0060provisional\u0060. Then it checks \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060. If true, it creates a new \u0060context\u0060 with \u0060FirstPlanRound\u0060 set to the result of \u0060TryClaimSplitOrder\u0060. If false, it uses \u0060provisional\u0060 as \u0060context\u0060. This means if the order is not split, \u0060FirstPlanRound\u0060 remains true. If the order is split, \u0060FirstPlanRound\u0060 becomes the boolean result of the claim. This logic is complex and potentially confusing, but more importantly, it deviates from the rule that \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The code asks \u0060OrdersSplit\u0060 twice (once for \u0060provisional\u0060, once for \u0060context\u0060 implicitly via the \u0060if\u0060 block) or relies on the state of \u0060provisional\u0060 being consistent.",
+            "fix": "The variable \u0060provisional\u0060 is created but then immediately used to create \u0060context\u0060. The logic \u0060FirstPlanRound: true\u0060 is set on \u0060provisional\u0060, but then \u0060context\u0060 is created from \u0060provisional\u0060 only if \u0060OrdersSplit\u0060 returns true. This creates a potential inconsistency where \u0060FirstPlanRound\u0060 might be true in \u0060provisional\u0060 but false in \u0060context\u0060 if the condition fails, or vice versa depending on the flow.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Violation of \u0027ONE question asked once\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to decide whether to claim, but then calls \u0060Core.Commands.GateCommands.OrdersSplit(context)\u0060 again in the \u0060if\u0060 block to log. This is two questions. The logging should be based on the result of the claim, not a re-evaluation of the condition.",
+            "fix": "Align the logic to ensure the \u0027one question\u0027 rule is strictly followed. The \u0060OrdersSplit\u0060 check should be the sole determinant for both issuing and claiming.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Redundant or confusing exception handling",
+            "why": "The code has \u0060catch (IOException)\u0060 for the race condition and \u0060catch (Exception e) when (e is IOException or UnauthorizedAccessException)\u0060 for the \u0027fail open\u0027 case. The second catch block is technically redundant because \u0060IOException\u0060 is already caught by the first block. The logic flow suggests the first catch is for the race (file exists), and the second is for other IO errors. However, the \u0060when\u0060 clause in the second catch makes it specific to \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060, which might overlap with the first catch if the order of evaluation is not clear.",
+            "fix": "The \u0060catch (Exception e)\u0060 block catches \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060 specifically, but the outer \u0060catch (IOException)\u0060 handles the race condition. The inner catch for \u0060Exception\u0060 might be redundant or confusing.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Warning message clarity",
+            "why": "The warning message \u0027the split-order memory at {Dir} could not be written ({e.Message}) \u2014 the order is being given, and may be given again\u0027 is clear, but the rule requires \u0027a warning rather than silently disabling\u0027. If \u0060warn\u0060 is null, the warning is silent. The rule implies a warning *must* be issued, so the \u0060warn\u0060 parameter should perhaps be required or a default logger used.",
+            "fix": "Ensure the \u0060warn\u0060 callback is invoked with a message that clearly indicates the \u0027fail open\u0027 nature.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 913,
+            "title": "Change in fallback logic for anonymous clients",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The previous implementation used \u0060session.State.SessionId\u0060 (which is repo\u002Bbranch), causing every epic to be treated as a new caller. The new implementation uses \u0060session.State.RepoPath\u0060, which correctly follows the caller across branches. This is a compliance fix, but it changes the behavior significantly.",
+            "fix": "The \u0060CallerFor\u0060 method now uses \u0060session.State.RepoPath\u0060 instead of \u0060session.State.SessionId\u0060. This is a change in the fallback logic.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "API contract change from void to bool",
+            "why": "The method signature changed from \u0060void RecordSplitOrder\u0060 to \u0060bool TryClaimSplitOrder\u0060. This is a breaking change for any caller that relied on the void return. However, the rule requires \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The new return value allows the caller to know if the claim succeeded, which is necessary for the \u0027fail open\u0027 logic.",
+            "fix": "The \u0060TryClaimSplitOrder\u0060 method now returns a \u0060bool\u0060 indicating success, whereas \u0060RecordSplitOrder\u0060 was \u0060void\u0060. This is a change in the API contract.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Atomic claim race window created by pre-delete of expired file",
+            "why": "The code deletes an existing file (\u0060File.Delete(file)\u0060) before attempting \u0060FileMode.CreateNew\u0060. If a second server process checks \u0060StillRemembered\u0060 (returns false), then deletes the file, then attempts \u0060CreateNew\u0060 while the first process is still deleting, the second process\u0027s \u0060CreateNew\u0060 will succeed. This allows two servers to both believe they claimed the order, violating the atomicity guarantee required to prevent \u0027epics of epics\u0027 loops.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call to a separate \u0060if\u0060 block before the \u0060try\u0060 block, or wrap the delete in its own try-catch to ensure the atomic \u0060CreateNew\u0060 is not shadowed by a delete failure.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 92,
+            "title": "Path traversal vulnerability in caller identity file naming",
+            "why": "The \u0060caller\u0060 string is used directly to construct a file path via \u0060FileFor(caller)\u0060. If a malicious or misbehaving client passes a \u0060caller\u0060 value like \u0060../../etc/passwd\u0060 or \u0060..\\..\\windows\\system32\u0060, the code could write to or overwrite arbitrary files on the server\u0027s filesystem, potentially overwriting configuration or log files, or creating a symlink to a sensitive file.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., remove or replace \u0060..\u0060, \u0060/\u0060, \u0060\\\u0060, and control characters) before using it in \u0060FileFor(caller)\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Potential deadlock or hang if file delete is blocked",
+            "why": "If the file to be deleted is locked by another process (e.g., an antivirus scanner or a previous crashed instance), \u0060File.Delete\u0060 will block or throw an exception. If it throws, the \u0060CreateNew\u0060 might not execute, or if it hangs, the server thread blocks. The current catch block only handles \u0060IOException\u0060 from \u0060CreateNew\u0060, not from the delete.",
+            "fix": "Add a timeout to the \u0060File.Delete\u0060 operation or ensure the \u0060try\u0060 block covers the delete operation as well, or use a more robust locking mechanism (e.g., \u0060FileLock\u0060 or \u0060Mutex\u0060) instead of relying solely on \u0060CreateNew\u0060 after a delete.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Silent failure of split order claim obscures state",
+            "why": "When \u0060TryClaimSplitOrder\u0060 returns \u0060false\u0060 (e.g., due to a race or unwritable store), the code proceeds to use the \u0060provisional\u0060 context without explicitly logging or signaling that the claim failed. A user or downstream process might expect the split order to be active, but it was silently skipped, leading to confusion about why the split didn\u0027t occur.",
+            "fix": "Add a specific log entry or return value indicating that the split order was claimed, and ensure the UI or downstream process reflects this state change immediately.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file existence check before atomic create",
+            "why": "The code checks \u0060File.Exists(file)\u0060 before attempting \u0060FileMode.CreateNew\u0060. While this is intended to handle expired claims, it adds an extra disk I/O operation. In high-frequency scenarios (e.g., many concurrent splits), this check could become a bottleneck, especially if the file system is slow or the directory is large.",
+            "fix": "Cache the \u0060File.Exists(file)\u0060 check result or use a more efficient file system operation to avoid redundant disk I/O in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[10:00:18 \u001B[32mINF\u001B[0m] coai-mcp#43800 finding [Minor/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - Potential deadlock or hang if file delete is blocked (from local) Round=1 Stage=CodeReview\r | [10:00:18 \u001B[32mINF\u001B[0m] coai-mcp#43800 finding [Minor/Ux] src_mcp/src/Server/PanelService.cs:578 - Silent failure of split order claim obscures state (from local) Round=1 Stage=CodeReview\r | [10:00:18 \u001B[32mINF\u001B[0m] coai-mcp#43800 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file existence check before atomic create (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 1,
+    "key": "codex,gemini,local|split-once|2",
+    "startedUtc": "2026-09-05T10:00:18.4421052Z",
+    "finishedUtc": "2026-09-05T10:05:05.7597008Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 43.6,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 39411,
+        "tokensOut": 4886,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The unwritable-store fail-open requirement contradicts the atomic single-claim guarantee",
+            "why": "With a read-only or full shared data directory, two servers can both find the caller eligible, fail to persist the claim, and\u2014under fail-open semantics\u2014both issue the split order. The claimed cross-process guarantee is therefore false exactly when persistence is unavailable.",
+            "fix": "Define the degraded-mode contract explicitly and use a coordination mechanism that can atomically claim; if at-most-once delivery is mandatory, refuse to issue the order on claim failure and surface the warning.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define crash recovery between claiming and issuing the command",
+            "why": "If a process records the claim and is killed before emitting the command, the caller is permanently told to build one unit; if it emits the command and dies before recording the claim, a retry emits it twice. Asking the condition once does not make these two side effects atomic.",
+            "fix": "Specify an idempotent command or durable reservation/outbox state machine, including which outcome is guaranteed after a crash and how retries resolve pending claims.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The caller identity and claim lifecycle are underspecified, allowing collisions and permanent suppression",
+            "why": "A filename-safe transformation can map distinct caller IDs such as \u0060a/b\u0060 and \u0060a\\b\u0060 to the same key, causing one caller\u0027s claim to suppress the other. Conversely, a once-claimed session or checkout can later start an unrelated plan and incorrectly skip splitting because no plan/round boundary or reset rule is defined.",
+            "fix": "Use a reversible encoding or fixed-length hash with collision handling, define the exact fallback checkout identity, and bind claims to a plan/round identity with explicit retry, completion, and cleanup semantics.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "\u201CMeasured from the plan THIS round\u201D has no specified source or invalidation rule",
+            "why": "A plan that passes in round 1 can be edited into a failing plan and retried in the same session; if the implementation reuses the stored round-1 verdict, it still issues the split order despite the current plan failing. The inverse can also suppress a newly passing plan.",
+            "fix": "Define a round identifier or content digest produced by the gate, require the caller decision to use that exact verdict, and invalidate or recompute it whenever the reviewed plan changes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "",
+            "line": 0,
+            "title": "The plan provides no acceptance checks for its externally visible guarantees",
+            "why": "An implementation can invoke storage or emit a command when the switch is off, emit after a failed verdict, or issue twice under two concurrent servers, and nothing in the plan requires an observable check to catch those regressions before users encounter them.",
+            "fix": "Add concrete acceptance cases covering off, failed verdict, same caller across branches, missing session ID, revised plans, concurrent processes, unwritable storage, and kill/retry at each claim-command boundary.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store failing open creates an infinite epic splitting recursion loop",
+            "why": "Requirement 5 dictates that an unwritable claim store fails OPEN. When the store is read-only or unwritable (e.g. permission issues or disk full), claiming the split order will fail and fall back to allowing the split verdict. Consequently, every child epic that returns on its own branch will also fail to persist a claim and be repeatedly ordered to split, directly reproducing the infinite \u0027epics of epics\u0027 loop that this plan was intended to prevent.",
+            "fix": "Fail CLOSED on store write errors for split orders (treat an unwritable store as already claimed / fallback to the autonomy order) or fail the review step with an explicit error rather than issuing split commands.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Fallback tracking for clients without session IDs is unspecified and conflicts with cross-branch session isolation",
+            "why": "Requirement 6 mandates tracking callers across branches when no session ID exists, while the problem statement notes sessions are keyed by repo\u002Bbranch. The plan provides no mechanism (e.g., lockfile, git state, checkout-level identifier) for identifying the same checkout across branches without a caller session ID, meaning child branches will either be treated as new sessions (causing repeated splitting) or share global state that collides across parallel runs.",
+            "fix": "Specify the exact checkout-level identifier (such as a hash of the repository root path or git common dir) used as the fallback claim key when CLAUDE_CODE_SESSION_ID is unset.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "Missing sanitization specification for caller ID file-path traversal",
+            "why": "The constraints state that caller ID is external and reaches a filename without escaping, but neither specifies nor verifies sanitization/encoding. If a malicious or malformed session ID containing directory traversal characters (e.g. \u0060../../\u0060 or Windows path separators) is supplied, it could read or write claims outside the designated storage directory.",
+            "fix": "Hash the session ID (e.g. SHA-256) or strictly whitelist alphanumeric characters before using it as a filename in the claim store.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Long-lived caller session IDs will suppress legitimate split orders across unrelated future plans",
+            "why": "A caller session ID in an interactive CLI or persistent IDE session remains constant across multiple independent tasks. If a split claim is keyed solely on caller ID without scoping to the initial root plan or goal, subsequent independent tasks in the same session that legitimately need splitting will be permanently blocked from receiving split orders.",
+            "fix": "Scope the claim key to a combination of the caller session ID and the root plan\u0027s hash or initial task ID.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 243.6,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 269357,
+        "tokensOut": 25708,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 92,
+            "title": "Expired-claim replacement is not atomic across processes.",
+            "why": "This breaks the written rule: \u201CThe claim is atomic across processes: two servers sharing a data directory cannot both give it.\u201D Deleting the expired file before \u0060CreateNew\u0060 lets one process delete a newly recreated claim belonging to another, allowing both \u0060CreateNew\u0060 calls to succeed.",
+            "fix": "Replace the delete-then-create sequence with an atomic cross-process claim/renewal operation so expiry replacement cannot remove another process\u0027s claim.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 99,
+            "title": "Expired-claim replacement is not atomic and can issue duplicate orders",
+            "why": "Two servers can both see an expired claim, delete the file, and race to create replacements; one can delete the other\u0027s newly created claim before creating its own. A concurrent plan round after expiry can therefore receive two split orders despite the claimed cross-process guarantee.",
+            "fix": "Make expiry replacement atomic, such as claiming via an exclusive lock/rename that verifies the old stamp, instead of delete-then-CreateNew.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 109,
+            "title": "An existing expired file causes write failures to fail closed without the required warning",
+            "why": "When an expired claim exists and \u0060File.Delete\u0060 or \u0060CreateNew\u0060 fails because the directory is unwritable, the disk is full, or access is denied, \u0060File.Exists(file)\u0060 is true and the first catch returns false. The caller gets no order and no warning, contrary to the fail-open requirement; a persistent stale file can silently disable splitting for that caller.",
+            "fix": "Only treat an IOException as a competing claim when an active claim was successfully observed or the file was created by another process; otherwise warn and return true for all storage failures.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 110,
+            "title": "Unconditional File.Delete before FileMode.CreateNew breaks cross-process claim atomicity",
+            "why": "When two server processes race to claim an unrecorded or expired caller, Process 1 and Process 2 both pass StillRemembered. Process 1 creates and writes the claim file. Process 2 then reaches File.Exists(file) and immediately calls File.Delete(file), removing Process 1\u0027s fresh claim file and successfully acquiring its own FileMode.CreateNew stream. Both processes return true from TryClaimSplitOrder, resulting in duplicate split orders being issued.",
+            "fix": "Do not unconditionally delete existing files before FileMode.CreateNew; handle existing files by inspecting their timestamp under file locking or attempting atomic creation/replacement only when verified expired.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 88,
+            "title": "Atomic claim introduces side-effect dependency via callback parameter",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 By passing an \u0060Action\u003Cstring\u003E? warn\u0060 into the atomic claim method, the method\u0027s return value (the claim result) becomes coupled with a side-effect (logging) that is not part of the atomic state transition. This breaks the purity of the \u0027one question\u0027 contract, as the caller must now manage the logging context for the claim to be complete.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 and the \u0060warn?.Invoke\u0060 call inside the catch block. The rule requires the caller to be ordered ONCE, and the claim logic to be atomic. The current implementation introduces a side-effect (logging a warning) that depends on an external callback, which violates the principle that the condition that issues the order and the condition that claims it are ONE question asked once. The warning is a side effect of the failure mode, not part of the atomic claim itself.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Atomic claim logic separated into check-then-delete-then-create, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current implementation performs a \u0060File.Exists\u0060 check, deletes the file if present, and then attempts \u0060CreateNew\u0060. This sequence is not atomic. If another process deletes the file between the check and the \u0060CreateNew\u0060, or if the \u0060CreateNew\u0060 fails because the file was created by another process in that window, the logic returns \u0060false\u0060 (claim lost) or \u0060true\u0060 (claim won) inconsistently. The rule requires a single atomic operation to determine the outcome, not a sequence of operations that can be interrupted.",
+            "fix": "Change the catch block for \u0060IOException\u0060 to not return \u0060false\u0060 when \u0060File.Exists(file)\u0060 is true. The current logic returns \u0060false\u0060 if the file exists (implying a race where someone else claimed it), but the rule requires that \u0027A caller that already holds a claim is a caller already inside a split, and is told so.\u0027 The current implementation returns \u0060false\u0060 for an existing file, which is correct, but the logic \u0060if (File.Exists(file)) { File.Delete(file); }\u0060 followed by \u0060CreateNew\u0060 creates a race window where the file could be deleted by another process between the check and the write, leading to a silent failure or duplicate claim if not handled strictly. The rule \u0027The condition that issues the order and the condition that claims it are ONE question asked once\u0027 implies the check and the claim must be inseparable. The current code separates the existence check (delete) from the atomic creation.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "FirstPlanRound flag set before atomic claim, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code sets \u0060FirstPlanRound: true\u0060 in the \u0060provisional\u0060 context before calling \u0060TryClaimSplitOrder\u0060. This means the flag is set regardless of whether the claim succeeds. If the claim fails (e.g., due to an unwritable store), the flag remains \u0060true\u0060, but the caller is not actually ordered to split (because the claim failed). This creates a state where the flag says \u0027first round\u0027 but the order was not given, violating the atomicity of the \u0027one question\u0027 contract.",
+            "fix": "Remove the \u0060FirstPlanRound: true\u0060 assignment in the \u0060provisional\u0060 context. The rule states: \u0027A caller is ordered to split ONCE. A plan that is already a piece is told so instead.\u0027 The current code sets \u0060FirstPlanRound\u0060 to \u0060true\u0060 unconditionally, then checks \u0060OrdersSplit\u0060 and claims the order. This means the \u0060FirstPlanRound\u0060 flag is set before the claim is verified, potentially allowing a caller that has already claimed an order to be treated as a first-round caller if the claim fails (e.g., due to an unwritable store). The rule requires that the \u0027claim\u0027 and the \u0027order\u0027 are one question. The current code separates the flag setting from the claim verification.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 907,
+            "title": "Comment misrepresents fallback logic: \u0027Our session\u0027 vs \u0027checkout\u0027",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The comment in \u0060CallerFor\u0060 says: \u0027Our session is repo\u002Bbranch, and an epic arrives on its own branch: a session-keyed fallback would call every epic a fresh caller...\u0027 This implies the fallback is the session, but the code actually falls back to \u0060session.State.RepoPath\u0060 (the checkout). The comment is misleading because it suggests the fallback is the session, when it is actually the checkout. This is a minor deviation because the code is correct, but the comment could confuse a reader about the actual fallback mechanism.",
+            "fix": "Change the fallback from \u0060CallerIdentity.Current()\u0060 to \u0060session.State.RepoPath\u0060 to be consistent with the rule \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The current code uses \u0060CallerIdentity.Current()\u0060 which returns the session ID, but the rule requires that a client with no session ID falls back to the checkout (repo path), not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the fallback is the checkout, not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the backup",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "Race condition allows duplicate split orders under concurrent load",
+            "why": "The method checks \u0060StillRemembered\u0060 (read) before attempting \u0060FileMode.CreateNew\u0060 (write). If two servers run in parallel: Server A reads \u0027unclaimed\u0027, Server B reads \u0027unclaimed\u0027, Server A writes and succeeds, Server B writes and succeeds. The test \u0060TheClaimIsATOMIC\u0060 passes because it uses \u0060Parallel.For\u0060 on the same instance, but the logic relies on the OS \u0060CreateNew\u0060 to serialize. However, the pre-check \u0060if (StillRemembered(...))\u0060 is outside the \u0060try\u0060 block. If a file exists but is stale (expired), it is deleted. If two servers race to delete and create, or if the check happens between the delete and create, both might succeed if the check logic isn\u0027t perfectly atomic with the write. More critically, the \u0060catch (IOException) when (File.Exists(file))\u0060 block returns \u0060false\u0060 (claim failed), but if the file was created by a rival just before the exception, the caller thinks they failed, yet the rival succeeded. Wait, the real issue is: if \u0060StillRemembered\u0060 returns false (file expired or no",
+            "fix": "Move the \u0060StillRemembered\u0060 check inside the \u0060try\u0060 block, immediately after \u0060Directory.CreateDirectory\u0060, so the check happens on the same file handle state as the \u0060CreateNew\u0060 attempt.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "Path traversal vulnerability in caller identity file name",
+            "why": "The \u0060caller\u0060 string is used directly in \u0060FileFor(caller)\u0060 to create a file path. If a caller passes a value like \u0060../../etc/passwd\u0060 or \u0060C:\\Windows\\System32\\config\u0060, the code writes to an arbitrary location on the filesystem. An attacker controlling the caller ID (e.g., via a malicious MCP client or environment variable) could overwrite critical system files or log files, or create a symlink to a sensitive file, leading to data leakage or privilege escalation.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., remove or replace \u0060/\u0060, \u0060\\\u0060, \u0060:\u0060, \u0060*\u0060, \u0060?\u0060, \u0060",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 90,
+            "title": "Potential deadlock or hang on slow/unresponsive storage",
+            "why": "The code performs \u0060File.Exists\u0060 followed by \u0060File.Delete\u0060 and then \u0060FileMode.CreateNew\u0060. If the underlying storage is slow, network-mounted, or the file handle is locked by another process, these operations can block indefinitely. In a high-concurrency scenario with many callers, this could lead to thread pool exhaustion or a complete stall of the server\u0027s ability to process new requests.",
+            "fix": "Add a timeout to the \u0060File.Exists\u0060 and \u0060File.Delete\u0060 operations, or use a more robust locking mechanism (e.g., \u0060Mutex\u0060) to prevent indefinite hangs on slow storage.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 575,
+            "title": "Inconsistent state propagation for FirstPlanRound flag",
+            "why": "The code creates a \u0060provisional\u0060 context with \u0060FirstPlanRound: true\u0060, then conditionally updates it based on \u0060TryClaimSplitOrder\u0060. However, if \u0060GateCommands.OrdersSplit(provisional)\u0060 returns false, the \u0060context\u0060 variable is assigned the \u0060provisional\u0060 object, but the logic for \u0060FirstPlanRound\u0060 might not be correctly reflected in the final \u0060commands\u0060 generated by \u0060GateCommands.For(context)\u0060. If the \u0060FirstPlanRound\u0060 flag is used elsewhere in the system to determine behavior, this inconsistency could lead to unexpected splitting behavior or missed split orders.",
+            "fix": "Ensure the \u0060provisional\u0060 context is passed correctly to \u0060GateCommands.For\u0060 and that the \u0060FirstPlanRound\u0060 flag is consistently applied across all code paths, not just the split order path.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 85,
+            "title": "Missing null/empty check for caller identity",
+            "why": "If \u0060caller\u0060 is an empty string or null, \u0060FileFor(caller)\u0060 might create a file with a weird name (e.g., \u0060.\u0060 or \u0060null\u0060) or throw an exception. This could lead to silent failures where the split order is recorded but not retrievable, or the file system becomes cluttered with invalid entries.",
+            "fix": "Add a check to ensure the \u0060caller\u0060 string is not empty or null before using it in \u0060FileFor\u0060.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Race condition in atomic claim due to pre-check delete",
+            "why": "The code checks if a file exists and deletes it (line 97) before attempting \u0060FileMode.CreateNew\u0060. If two servers run in parallel: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false), Server A deletes the file, Server B deletes the file (no-op), Server A creates the file and returns true, Server B attempts to create the file and throws \u0060IOException\u0060. The current catch block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060 to determine if it was a race. However, if Server B deletes the file *after* Server A creates it but *before* Server B\u0027s \u0060CreateNew\u0060 executes, the \u0060File.Exists\u0060 check in the catch block will be true (because Server A created it), causing Server B to return \u0060false\u0060 (claim failed) instead of \u0060true\u0060 (claim succeeded). This creates a scenario where two servers can both believe they failed to claim, or worse, if the delete happens between the check and the create, the logic for \u0027someone else claimed it\u0027 becomes ambiguous. More critically, if the",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or wrap it in its own try-catch before the \u0060CreateNew\u0060 attempt.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Split order claimed on rounds that may not issue a command",
+            "why": "The code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to determine if a split should be ordered. If this returns true, it then calls \u0060TryClaimSplitOrder\u0060. However, the \u0060provisional\u0060 context used for the claim includes \u0060FirstPlanRound: true\u0060 (line 573), which is hardcoded. The original logic used \u0060!_callers.SplitAlreadyOrdered(caller, DateTime.UtcNow)\u0060 to determine if it was the first round. By hardcoding \u0060FirstPlanRound: true\u0060 and then checking \u0060OrdersSplit\u0060 *after* the claim, the code risks claiming a split order for a round that might not actually be the \u0027first\u0027 round in the sequence if the logic for determining \u0027first\u0027 is decoupled from the claim. Specifically, if \u0060OrdersSplit\u0060 returns true based on \u0060provisional\u0060, but the claim fails (e.g., due to race), the system might proceed with a split order that was already claimed by another process, or fail to claim it when it should have. The logic flow is: 1. Create provisional with \u0060FirstPlanRound: true\u0060. 2. Check if \u0060pro\u0060",
+            "fix": "Pass the \u0060provisional\u0060 context to \u0060OrdersSplit\u0060 *after* the claim attempt, or ensure the claim is only attempted if \u0060OrdersSplit\u0060 returns true, to avoid claiming a split order on a round that doesn\u0027t actually issue a split command.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file system checks in atomic claim logic",
+            "why": "The code performs \u0060File.Exists(file)\u0060 (line 95) and then \u0060File.Delete(file)\u0060 (line 97), followed by \u0060new FileStream(file, ...)\u0060 (line 100). In a high-concurrency environment where multiple servers are checking the same caller, this results in multiple file system calls per claim attempt. While \u0060File.Exists\u0060 is a check, the subsequent \u0060Delete\u0060 and \u0060CreateNew\u0060 operations are expensive. If the file exists and is not expired, the code deletes it and then tries to create a new one. This sequence of operations (check, delete, create) can be optimized by using a single atomic operation or by caching the existence check. In a scenario with 100 concurrent servers checking the same caller, this could lead to 300 file system calls per second, potentially causing I/O contention.",
+            "fix": "Cache the \u0060File.Exists\u0060 result or use a single \u0060File.TryOpen\u0060 pattern to avoid redundant file system calls in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[10:05:05 \u001B[32mINF\u001B[0m] coai-mcp#43792 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:97 - Race condition in atomic claim due to pre-check delete (from local) [gating] Round=1 Stage=CodeReview\r | [10:05:05 \u001B[32mINF\u001B[0m] coai-mcp#43792 finding [Major/Ux] src_mcp/src/Server/PanelService.cs:578 - Split order claimed on rounds that may not issue a command (from local) [gating] Round=1 Stage=CodeReview\r | [10:05:05 \u001B[32mINF\u001B[0m] coai-mcp#43792 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file system checks in atomic claim logic (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  }
+]

--- a/research/data/bench-2026-09-05/epic1b-v0.17.3/tables.md
+++ b/research/data/bench-2026-09-05/epic1b-v0.17.3/tables.md
@@ -1,0 +1,21 @@
+# Bench
+
+## Per arm
+
+| arm | stage | runs | verdicts | median time | median findings | gating | useful | tokens in / out | cost |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | code | 4 | proceed×3, good_enough×1 | 214.2s | 16 | 37 | — | 1.4M / 79.1k | not reported |
+| `codex,gemini,local` | plan-1 | 4 | good_enough | 48.5s | 15 | 46 | — | 158.4k / 21.7k | not reported |
+
+## Per run
+
+| arm | case | # | lane | stage | verdict | time | findings | gating | tokens in / out |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | plan-1 | good_enough | 48.5s | 15 | 11 | 39k / 7.3k |
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | code | proceed | 107.6s | 11 | 7 | 445.2k / 13.7k |
+| `codex,gemini,local` | rounds-collapse | 2 | 1 | plan-1 | good_enough | 50.3s | 14 | 10 | 40.6k / 5.1k |
+| `codex,gemini,local` | rounds-collapse | 2 | 1 | code | proceed | 214.2s | 11 | 8 | 404.8k / 24.3k |
+| `codex,gemini,local` | split-once | 1 | 1 | plan-1 | good_enough | 35.5s | 15 | 13 | 39.4k / 4.4k |
+| `codex,gemini,local` | split-once | 1 | 1 | code | proceed | 128.5s | 18 | 10 | 265.6k / 15.3k |
+| `codex,gemini,local` | split-once | 2 | 1 | plan-1 | good_enough | 43.6s | 14 | 12 | 39.4k / 4.9k |
+| `codex,gemini,local` | split-once | 2 | 1 | code | good_enough | 243.6s | 16 | 12 | 269.4k / 25.7k |

--- a/research/data/bench-2026-09-05/epic2-v0.17.2/runs.json
+++ b/research/data/bench-2026-09-05/epic2-v0.17.2/runs.json
@@ -1,0 +1,2734 @@
+[
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T09:10:10.4200852Z",
+    "finishedUtc": "2026-09-05T09:14:43.2859182Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 82.7,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 10,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 39291,
+        "tokensOut": 7466,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build step 5 still prescribes the conflicting \u0060vendor\u0060 CSS class",
+            "why": "A team following the build order emits \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060; the plan itself says \u0060.vendor\u0060 is already the settings-card class and that it rendered vendor names with unwanted border, radius, padding, and a line through the text. The stated implementation therefore reintroduces the shipped defect despite the deviation note saying the class is \u0060who\u0060.",
+            "fix": "Change the build step to require the collision-free class, such as \u0060who\u0060, and test that vendor-name spans do not use the settings-card class.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping guarantee is not verified for all session-derived fields or render paths",
+            "why": "The only named escaping test injects \u0060\u003C\u0060 into a vendor name in a reviewer row. A session containing markup in a round title, reviewer-detail field, error text, live-section vendor, or spending-row field can still corrupt or execute in the page while all listed tests pass.",
+            "fix": "Enumerate every session-derived HTML text and attribute insertion, require context-appropriate escaping, and add malicious-input tests for each render path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ownership state has no defined recovery when the extension host is interrupted",
+            "why": "If the host is killed after auto-opening a running round but before reconciliation, the in-memory ownership set is lost; when the round later appears finished, it can remain expanded forever, violating the automatic-collapse promise. The plan also does not define identity handling for stale or reused round keys.",
+            "fix": "Specify persistence or deterministic restart reconciliation for ownership, define the round identity, and test activation after a round finishes while the panel is unavailable.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The panel behavior for status polling failures is unspecified",
+            "why": "If status polling times out while an auto-opened round is actually still running, treating missing status as finished collapses it prematurely, while treating it as finished-but-unknown leaves it expanded; either behavior can violate the user\u2019s view expectations.",
+            "fix": "Treat unknown or errored status as non-terminal, retain ownership, and reconcile after the next successful status read; test timeout, malformed status, and process-termination cases.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true 2 / Build order 3 (panelProvider): Missing handling for crashed or timed-out rounds leaves cards stuck open or reporting unbounded durations",
+            "why": "If a reviewer process crashes, times out, or is killed without writing a completion timestamp, the panel cannot observe a standard \u0027finished\u0027 event; calculating duration from start time or waiting for a finished flag causes the card to report elapsed time indefinitely and never trigger auto-collapse.",
+            "fix": "Add explicit timeout and process liveness checks in panelProvider so orphaned rounds are marked terminated and auto-closed after the configured timeout threshold.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order 5 (panelView): Wrapping vendor names in class \u0027vendor\u0027 collides with existing settings card CSS styles",
+            "why": "The class \u0027.vendor\u0027 is already defined in the stylesheet with card rules (border, border-radius, and 8px padding); applying it to an inline \u003Cspan\u003E inside a tight reviewer row applies box padding and borders that visually strike through the vendor text.",
+            "fix": "Use a distinct class name (such as \u0027who\u0027 or \u0027vendor-name\u0027) for inline vendor spans instead of reusing \u0027.vendor\u0027.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Build order 3 (panelProvider): Toggling card disclosure triggers full panel data refresh instead of local UI state change",
+            "why": "When an operator clicks a card to expand or collapse it, rebuilding the full card body triggers backend discovery steps (binary stat-ing, vendor CLI probing, remote price lookups), blocking UI responsiveness for up to several seconds.",
+            "fix": "Isolate card expansion/collapse state in the view layer to toggle DOM visibility without re-executing backend discovery and external probes.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Build order 4 (rounds.ts): Placing vendorColour in session parser module couples view concerns to data parsing",
+            "why": "rounds.ts is responsible for parsing session files; placing VS Code chart palette mapping (--vscode-charts-*) in rounds.ts forces non-session consumers (like spending rows) to import from the session parser and introduces theme/DOM concerns into backend parsing logic.",
+            "fix": "Move vendorColour into a dedicated view-utility module (e.g., vendorColour.ts) shared by panelView and spending rows.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 189.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 9,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 432524,
+        "tokensOut": 10882,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The change leaves a stale unpromoted copy of the implemented plan",
+            "why": "The plan\u2019s Definition of Done says: \u201Cdocs, help and CHANGELOG updated; the plan promoted.\u201D This diff adds a duplicate whose status still says \u201Cplan only, nothing implemented yet,\u201D contradicting the implemented plan in \u0060research/\u0060 and leaving project documentation inconsistent.",
+            "fix": "Remove the stale \u0060todo/PLAN_rounds_collapse_and_vendor_colour.md\u0060, or promote and update it to describe the shipped implementation.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 154,
+            "title": "Concurrent saves can overwrite newer session state with an older snapshot",
+            "why": "Two server processes can serialize the same session at different times; the older snapshot may reach MoveOverExisting after the newer snapshot and replace it. For example, one reviewer transition saves round 3, then a delayed writer saves round 2, losing the later status/findings even though both saves succeeded.",
+            "fix": "Serialize saves per session across processes or add generation/compare-and-swap protection so stale snapshots cannot replace newer state.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 150,
+            "title": "Unique scratch files are leaked when the process is terminated during a save",
+            "why": "A process killed after File.WriteAllText and before the finally block leaves its unique .tmp file behind. Repeated interrupted saves accumulate indefinitely; after disk space is exhausted, subsequent session saves fail and can abort round progress.",
+            "fix": "Remove orphaned session scratch files during startup, retaining only files belonging to an active save if such coordination exists.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 140,
+            "title": "Toggling a round still waits for the full expensive panel refresh",
+            "why": "When a person opens or closes a card, this immediately calls \u0060render()\u0060, which performs the existing configuration, CLI, GitHub, and price-table work. On a machine with those probes taking about 20 seconds, the click appears unresponsive and the changed card does not appear until the refresh completes, with no progress or terminal feedback.",
+            "fix": "Render the updated round state from cached data immediately, then schedule the expensive environment refresh separately; alternatively add a lightweight render path for round toggles.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Vendor name span inside reviewer row reuses \u0027.vendor\u0027 CSS class causing broken/struck-through styling",
+            "why": "In src_vs_code/src/panelView.ts line 810, the vendor name is wrapped in \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:...\u0022\u003E\u0060. In the extension stylesheet, \u0060.vendor\u0060 targets settings cards with border, border-radius, and padding. When applied to an inline word within a tight reviewer row, this renders as a box/strikethrough-like artifact over the vendor name.",
+            "fix": "Change \u0060\u003Cspan class=\u0022vendor\u0022 ...\u003E\u0060 to \u0060\u003Cspan class=\u0022who\u0022 ...\u003E\u0060 (or update stylesheet/class name) so that existing card styling for \u0060.vendor\u0060 is not applied to the inline vendor label.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 151,
+            "title": "Atomic session file replacement uses separate ProcessId scratch file and synchronous Thread.Sleep retry in request path",
+            "why": "In \u0060SessionStore.cs\u0060 line 176, \u0060Thread.Sleep(20 * attempt)\u0060 blocks the calling thread during concurrent session persistence, and if the file move succeeds partially or if destination locking persists beyond 300ms total backoff, the caller gets an exception during background round persistence.",
+            "fix": "Catch \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060 in \u0060MoveOverExisting\u0060, or retry during atomic replacement, and avoid deleting the file unconditionally in \u0060finally\u0060 if \u0060File.Move\u0060 already consumed the scratch file or if handling partial failure.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "SessionStore concurrency fix lacks explicit retry logic for destination lock",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 states: \u0027The instruction also travels in the snippet the extension hands to target repos... so an AI that never reads this file still gets it.\u0027 The plan explicitly states: \u0027The move is retried briefly for the case a unique name cannot fix (a reader or a scanner holding the destination)\u0027. The implementation in \u0060SessionStore.cs\u0060 adds a retry loop, but the comment in \u0060module_server.md\u0060 (which is part of the plan) says \u0027the move is retried briefly for the case a unique name cannot fix\u0027. The code implements this, but the rule in \u0060review-gate.md\u0060 requires that the *instruction* travels. The instruction here is the *convention* of retrying. The code implements it, but the *reasoning* in the comment is slightly different from the rule\u0027s requirement. Wait, the rule is about the *scope* and *diff*. The rule in \u0060review-gate.md\u0060 is about the *review process*. The rule in \u0060vendor-routing.md\u0060 is about CLI routing. The rule in \u0060CLAUDE.md\u0060 is about \u0060CL",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method retries the \u0060File.Move\u0060 call for the specific exception types mentioned in the comment (IOException, UnauthorizedAccessException) and that the retry logic is bounded.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Retry loop in MoveOverExisting may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a sleep of \u006020 * attempt\u0060 milliseconds. If a file lock (e.g., from an antivirus scanner or a slow indexer) persists longer than the total retry window (approx 150ms), the method throws. However, if the lock is transient but the system is under heavy load, the retry logic might not be sufficient, or worse, if the \u0060Thread.Sleep\u0060 is interrupted or the process is killed during the sleep, the temporary file might be left behind if the \u0060finally\u0060 block logic is not robust. More critically, if the \u0060File.Move\u0060 throws a different exception (e.g., \u0060PathTooLongException\u0060) that isn\u0027t caught by the \u0060catch\u0060 block, the loop exits early, potentially leaving the temp file orphaned if the \u0060TryDelete\u0060 isn\u0027t called. The specific risk is a race condition where the file is held by a scanner; the retry might succeed, but if it fails after 5 attempts, the exception is thrown, but the \u0060finally\u0060 block ensures cleanup. The real risk is if the \u0060MoveOverExisting\u0060 \u0060",
+            "fix": "Ensure the retry loop in MoveOverExisting uses a bounded, non-exponential backoff or a maximum total duration to prevent indefinite hanging during transient file system locks, and verify that the final exception is logged with full context before re-throwing.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Potential CSS injection via vendor name in style attribute",
+            "why": "The code constructs a style attribute: \u0060style=\u0022color:${vendorColour(row.provider)}\u0022\u0060. While \u0060vendorColour\u0060 returns a CSS variable (e.g., \u0060var(--vscode-charts-blue)\u0060), the \u0060row.provider\u0060 is used to determine the color. If \u0060row.provider\u0060 contains a string that, when passed to \u0060vendorColour\u0060, results in a value that isn\u0027t strictly a CSS variable (e.g., if the hash logic changes or a fallback is used), or if \u0060vendorColour\u0060 is modified to return a hex value, an attacker could inject CSS properties. More critically, if \u0060row.provider\u0060 itself is not escaped *before* being used in the \u0060vendorColour\u0060 lookup (though it is trimmed/lowercased), and if \u0060vendorColour\u0060 were to return a raw string that isn\u0027t a variable, it could be dangerous. However, the primary risk here is that \u0060row.provider\u0060 comes from a session file (JSON). If the session file is corrupted or maliciously crafted to contain a vendor name like \u0060\u0027; background: red; /*\u0060, and if \u0060vendorColour\u0060 were to return a raw value (e.g., if the \u0060",
+            "fix": "Ensure \u0060vendorColour\u0060 is called with a sanitized string or that the \u0060escapeHtml\u0060 function is applied to the vendor name *before* it is passed to the style attribute, or verify that the style attribute itself is safe from injection if the vendor name contains special characters (though unlikely in CSS variables).",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Potential duplicate keys in openRounds state if cards array contains duplicates",
+            "why": "The \u0060nextOpenRounds\u0060 function iterates over \u0060cards\u0060 and adds keys to \u0060Set\u0060s. If the \u0060cards\u0060 array passed to this function contains duplicate entries for the same round (e.g., due to a bug in \u0060sessions.flatMap\u0060 or a race condition in the caller), the \u0060Set\u0060 will deduplicate them, but the logic for \u0060autoOpened\u0060 and \u0060panelOpened\u0060 might behave unexpectedly if the same key is processed multiple times in a way that assumes unique iteration. Specifically, if a round is added to \u0060autoOpened\u0060 twice, it doesn\u0027t matter for a Set, but if the logic relied on the count of additions, it would be wrong. The current logic uses \u0060Set.has\u0060 checks, so duplicates are handled, but the \u0060filter\u0060 at the end relies on \u0060alive.has(key)\u0060. If \u0060cards\u0060 has duplicates, \u0060alive\u0060 (derived from \u0060cards.map\u0060) will also have duplicates, but \u0060Set\u0060 handles that. The real risk is if \u0060roundKey\u0060 is not stable or if the \u0060cards\u0060 array is mutated during iteration (unlikely in this functional style). The finding is minor because Sets *",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all cards before adding to the \u0060Set\u0060 to prevent duplicate keys if the same round appears multiple times in the \u0060cards\u0060 array.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Race condition in scratch file cleanup leaves orphaned temp files under high concurrency",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060finally\u0060 block calls \u0060TryDelete(temp)\u0060 unconditionally. If \u0060MoveOverExisting\u0060 succeeds (the file is moved to the destination), the \u0060finally\u0060 block attempts to delete the now-moved temp file. However, if a second concurrent writer (with a different PID/GUID) has already claimed that specific temp path (unlikely but possible if GUID collision occurs or if the path logic is flawed) or if the file handle is still held by the OS immediately after move, the \u0060TryDelete\u0060 might fail silently. More critically, if \u0060MoveOverExisting\u0060 throws on the last attempt (line 168), the \u0060finally\u0060 block runs. If the temp file was successfully moved but the \u0060MoveOverExisting\u0060 logic failed to update state or if the \u0060File.Move\u0060 threw an exception that was caught, the \u0060finally\u0060 block tries to delete. The real issue is that \u0060TryDelete\u0060 swallows exceptions. If the move succeeds but the delete fails (e.g., file locked by another process), the temp file remains. In a high-concurrency loop",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs after the retry loop completes, rather than in a \u0060finally\u0060 block that executes even if the move succeeds but the delete throws.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Vendor colour inconsistency due to case/space sensitivity in session data",
+            "why": "The \u0060vendorColour\u0060 function in \u0060vendorColour.ts\u0060 (line 45) trims and lowercases the input. However, if the session file contains a vendor name with leading/trailing spaces or mixed case that differs from the canonical name used in the \u0060ANCHORED\u0060 map (e.g., \u0027 Codex \u0027 vs \u0027codex\u0027), the function will correctly map to the anchored color. But if the session data is inconsistent (e.g., \u0027Codex\u0027 vs \u0027codex\u0027 in different parts of the system), the \u0060ANCHORED\u0060 lookup might fail for one variant, falling back to a hash. This causes the same vendor to appear in different colors within the same session or across restarts if the data source changes. The test \u0060test(\u0027case and stray space are the same vendor\u0027)\u0060 confirms this is handled, but if the session data is not normalized *before* being passed to \u0060vendorColour\u0060, or if the \u0060ANCHORED\u0060 map keys are not strictly lowercase, a mismatch occurs. Specifically, if a session file has \u0027Codex\u0027 (capital C) and the \u0060ANCHORED\u0060 map has \u0027codex\u0027, the \u0060vendorColour\u0060 will",
+            "fix": "Ensure \u0060vendorColour\u0060 is called with the exact string from the session file, trimming whitespace and lowercasing before lookup, or ensure the session data is normalized before rendering.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary re-calculation of open rounds state on every panel refresh",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 (line 165) calls \u0060nextOpenRounds\u0060 on every tick (every 5 seconds). This function iterates over all cards, filters, and creates new Sets. While the logic is O(N) and N is small (number of rounds), doing this on every tick without checking if the underlying session data has changed is wasteful. If the session data hasn\u0027t changed, the \u0060nextOpenRounds\u0060 result will be identical, but the code still performs the full calculation and creates new array/set objects. This could lead to unnecessary re-renders if the UI component depends on object identity or if the calculation is heavy (though it\u0027s likely fast). A better approach would be to compare the previous session data with the new one and only recalculate if there\u0027s a change.",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 or avoid recalculating it on every tick if the session data hasn\u0027t changed.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:14:43 \u001B[32mINF\u001B[0m] coai-mcp#22780 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Race condition in scratch file cleanup leaves orphaned temp files under high concurrency (from local) [gating] Round=1 Stage=CodeReview\r | [09:14:43 \u001B[32mINF\u001B[0m] coai-mcp#22780 finding [Major/Ux] src_vs_code/src/panelView.ts:702 - Vendor colour inconsistency due to case/space sensitivity in session data (from local) [gating] Round=1 Stage=CodeReview\r | [09:14:43 \u001B[32mINF\u001B[0m] coai-mcp#22780 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary re-calculation of open rounds state on every panel refresh (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 2,
+    "key": "codex,gemini,local|rounds-collapse|2",
+    "startedUtc": "2026-09-05T09:10:10.4229526Z",
+    "finishedUtc": "2026-09-05T09:11:50.3017861Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 99.6,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 38961,
+        "tokensOut": 7490,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build step 5 instructs the implementation to use the \u0060.vendor\u0060 class even though the documented fix requires \u0060.who\u0060",
+            "why": "Following the stated build order makes vendor spans inherit the existing settings-card \u0060.vendor\u0060 styles, reproducing the shipped border, radius, padding, and struck-through-looking vendor names.",
+            "fix": "Change the build step and acceptance wording to require the non-conflicting class (\u0060who\u0060), or explicitly rename/remove the existing \u0060.vendor\u0060 selector before using it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Panel-open provenance is only described as a second set, with no persistence or recovery behavior",
+            "why": "If the extension host is killed after this panel auto-opens a running round but before it finishes, the in-memory set is lost while the webview can retain the expanded card; after restart the finished round has no provenance and remains expanded, violating the auto-close guarantee.",
+            "fix": "Specify and test persistence/reconciliation of panel-opened state across host/webview restart, or explicitly reset/recompute expanded state when provenance is unavailable.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping guarantee covers only the reviewer vendor field, not every session-file value rendered by the panel",
+            "why": "A session file containing a title, plan name, or other interpolated value such as \u0060\u003Cimg src=x onerror=...\u003E\u0060 can still execute if any existing panel template inserts that field as HTML; the single test for a reviewer vendor containing \u0060\u003C\u0060 cannot detect this.",
+            "fix": "Audit every session-derived interpolation in the panel, route all of them through the shared escaping renderer, and add named tests for each rendered field or a representative malicious value per template.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The test plan does not verify the stable colour contract in the live section and spending rows",
+            "why": "The listed tests exercise \u0060vendorColour\u0060 and a reviewer row, but a wiring error in the live or spending-row renderer can leave those vendor names grey or use a different mapping while all listed tests pass.",
+            "fix": "Add integration assertions that the same vendor produces the same CSS variable in a round card, live row, and spending row, including after a restart/order change.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Build order (Step 3 \u0026 5): Card expansion repaints the panel and triggers expensive background probing",
+            "why": "When a user toggles an accordion triangle to expand or collapse a card, the panel re-renders by executing the full provider update cycle (reading configurations, stat-ing the server binary, probing CLI vendor binaries, and fetching external network resources). This causes UI latency of up to twenty seconds for a local disclosure toggle.",
+            "fix": "Decouple local UI card expansion state from data acquisition, or handle card collapse/expand purely within client-side DOM disclosure logic without triggering full panel refresh pipelines.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Constraints \u0026 Build order (Step 5): Injecting HTML spans into the shared reviewer row renderer breaks plain-text test assertions",
+            "why": "The constraints mandate \u0027One renderer for a reviewer row, not a text one and an HTML one that drift. The text version is what the tests read today.\u0027 However, Step 5 changes the renderer to emit \u0027\u003Cspan class=\u0022vendor\u0022 style=\u0022color:\u2026\u0022\u003E\u0027. Any existing tests and non-HTML consumers reading the output will receive raw HTML tags instead of plain text, breaking the test suite.",
+            "fix": "Separate the structured row representation from rendering, or supply a plain-text formatting mode/tag stripper for test and non-HTML contexts.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order (Step 3): Dead or timed-out rounds without completion markers stay open indefinitely and report inflated durations",
+            "why": "If a reviewer process crashes, times out, or terminates abruptly without writing a finished timestamp to disk, the session file never records completion. The panel evaluates the round as perpetually running, measures elapsed duration from start time up to current time (e.g. hundreds of minutes), and fails to trigger auto-close.",
+            "fix": "Add a liveness or timeout threshold check when inspecting round state so abandoned or dead rounds without completion records are treated as finished/failed and collapsed.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order (Step 5): Class name \u0027.vendor\u0027 conflicts with existing container styles in stylesheet",
+            "why": "Step 5 specifies wrapping inline vendor names in \u0027\u003Cspan class=\u0022vendor\u0022\u003E\u0027. If \u0027.vendor\u0027 is already defined in the panel stylesheet for settings cards (with padding, border, and border-radius), applying it to an inline word applies container styles that visually render as lines through or boxes around the text.",
+            "fix": "Use a distinct, non-conflicting class name such as \u0027.who\u0027 or \u0027.vendor-badge\u0027 for the inline vendor label.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 0,
+        "verdict": "",
+        "error": "git worktree add: Preparing worktree (detached HEAD 267e07a)\r\nfatal: \u0027C:/Users/strug/AppData/Local/coai-mcp/worktrees/coai-wt-a0fc7e7d-r1\u0027 already exists",
+        "gatingCount": 0,
+        "reviewers": "",
+        "tokensIn": 0,
+        "tokensOut": 0,
+        "costUsd": null,
+        "findings": [],
+        "commands": [],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:11:50 \u001B[32mINF\u001B[0m] coai-mcp#37996 finding [Major/Reliability] Dead rounds report incorrect duration due to missing completion state (from local) [gating] Round=1 Stage=PlanReview\r | [09:11:50 \u001B[32mINF\u001B[0m] coai-mcp#37996 finding [Major/Ux] Visual regression causes vendor names to appear struck-through (from local) [gating] Round=1 Stage=PlanReview\r | [09:11:50 \u001B[32mINF\u001B[0m] coai-mcp#37996 finding [Minor/Reliability] Legacy rounds render as empty placeholders with misleading interaction cues (from local) Round=1 Stage=PlanReview",
+    "onDisk": {
+      "rounds": 1,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 3,
+    "lane": 3,
+    "key": "codex,gemini,local|rounds-collapse|3",
+    "startedUtc": "2026-09-05T09:10:10.4179803Z",
+    "finishedUtc": "2026-09-05T09:13:36.5146718Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 49,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 9,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 38033,
+        "tokensOut": 6359,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The open-state design cannot preserve a person\u0027s manual open choice",
+            "why": "The plan only adds a set of rounds opened by the panel and says a person\u0027s toggle removes the key from that set. If a running round was opened by the person (or the person reopens an auto-opened round), there is no positive manual-open record to distinguish it from a round that should be collapsed; when the status changes to finished, cleanup can close it despite the promise that the person\u0027s choice survives.",
+            "fix": "Track explicit user-opened/user-closed intent separately from panel-owned auto-open state, and define precedence and transitions for auto-open, user open, and user close before implementing cleanup.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping guarantee is broader than the verification and rendering steps",
+            "why": "The only specified security test covers a vendor name in a reviewer row, while session-file data also reaches spending rows and potentially other displayed labels or attributes. A session value such as \u0060\u003Cimg src=x onerror=...\u003E\u0060 in an untested rendering path can still become executable HTML although the definition of done claims that nothing from the session file is unescaped.",
+            "fix": "Enumerate every session-derived text and attribute rendered by panelView, apply context-appropriate escaping to all of them, and add injection tests for reviewer, round/live, and spending-row paths.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The palette test permits chart-variable names that the editor does not actually define",
+            "why": "Testing only the \u0060--vscode-charts-*\u0060 prefix allows a value such as \u0060--vscode-charts-unknown\u0060; the style technically passes the test but renders with no color in both themes, violating the visible color guarantee.",
+            "fix": "Specify the supported VS Code chart variables explicitly and test that every returned value belongs to that allowlist, ideally with a rendered integration assertion.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Build order / panelProvider: Card disclosure toggle triggers full server, CLI, and network reload",
+            "why": "When a user clicks to expand or collapse a round card, the panel repaints the entire view by executing the full provider refresh cycle (re-reading configuration, stat-ing the server binary, probing vendor CLIs, and making remote GitHub and pricing API requests), freezing the UI for up to 20 seconds for a client-side visibility toggle.",
+            "fix": "Separate local UI expansion/disclosure state management and DOM toggling from the asynchronous provider data-fetching and CLI probing pipeline.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order / panelProvider: Missing terminal state handling for crashed or timed-out rounds prevents auto-close",
+            "why": "When a reviewer process crashes, times out, or terminates ungracefully without writing completion timestamps, the round remains perpetually in a non-finished state; the panel cannot detect that it is no longer running, preventing the card from auto-closing and causing incorrect elapsed-time measurements.",
+            "fix": "Introduce explicit timeout and dead-process checks so abandoned or orphaned rounds resolve to a terminal state and trigger auto-close.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order / panelView: CSS class collision on \u0027.vendor\u0027 breaks inline text rendering",
+            "why": "Wrapping the vendor name in \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060 collides with the existing \u0060.vendor\u0060 CSS rule used for settings cards (which includes border, border-radius, and 8px padding), rendering inline vendor labels with card borders that appear as strikethrough text across compact rows.",
+            "fix": "Use a dedicated inline class name (such as \u0027who\u0027 or \u0027vendor-name\u0027) that does not conflict with existing component stylesheets.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order / panelView: Historical rounds without reviewer details render empty interactive disclosures",
+            "why": "When parsing older session files generated before per-reviewer telemetry existed, the view generates disclosure controls with pointer cursors that expand into empty content containers.",
+            "fix": "Conditionally render disclosure controls only when reviewer detail data is present, rendering legacy entries as static flat rows.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 156.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 398987,
+        "tokensOut": 17098,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 150,
+            "title": "Unique scratch files do not prevent stale writers from overwriting each other\u0027s session updates",
+            "why": "Two MCP servers can load the same session, append different rounds, and save concurrently: the later File.Move replaces the first writer\u0027s complete JSON, silently losing that writer\u0027s round trail or status despite both saves succeeding.",
+            "fix": "Serialize the full load-modify-save operation with a cross-process lock, or add version checking and reload/retry on conflict before replacing the session file.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 180,
+            "title": "Failed scratch-file cleanup is swallowed and can accumulate files indefinitely",
+            "why": "If a scanner or another process keeps a uniquely named temporary file locked, TryDelete silently leaves it behind; repeated failed saves can accumulate one scratch file per attempt until the sessions directory consumes significant disk space.",
+            "fix": "Report cleanup failures and add bounded startup/maintenance cleanup for stale scratch files, or use a cleanup strategy that cannot silently leak them.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The shipped change leaves a contradictory \u201Cplan only\u201D copy in the todo directory",
+            "why": "After this commit, the repository contains an implemented feature while its new plan says \u201Cnothing implemented yet\u201D and leaves the Definition of Done unchecked; running the mandated plan-lifecycle check or a future contributor following todo plans can treat this work as unimplemented and repeat it.",
+            "fix": "Promote or remove this plan copy, and update its status and checklist to match the shipped implementation.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 174,
+            "title": "Save retries block the calling thread with synchronous sleeps",
+            "why": "When the destination is briefly held during a busy nine-reviewer round, each save can sleep for 20\u002B40\u002B60\u002B80 ms before succeeding; because \u0060Save\u0060 is called on reviewer progress paths, concurrent rounds tie up their worker threads for up to 200 ms per blocked write instead of yielding asynchronously.",
+            "fix": "Use an asynchronous retry path with \u0060Task.Delay\u0060 and await it from persistence callers, or move the retrying file operation off the async worker thread.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 57,
+            "title": "Auto-collapsing a completed round snatches content away while the user is actively reading it",
+            "why": "When a running round is auto-opened by the panel and then finishes, \u0060nextOpenRounds\u0060 removes it from \u0060open\u0060 on the next refresh tick. If a user is actively reading the reviewer outputs or findings of that running round when the background round completes, the card collapses out from under them mid-read without any user interaction or notice, because \u0060panelOpened\u0060 still contains the round unless the user explicitly clicked/toggled the disclosure.",
+            "fix": "Only auto-close rounds if they were never interacted with, or keep finished rounds open until explicitly dismissed or when user navigates away, or defer collapse until blur/next user action.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Nit",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 180,
+            "title": "Synchronous Thread.Sleep in retry loop blocks worker thread during file contention",
+            "why": "\u0060MoveOverExisting\u0060 uses synchronous \u0060Thread.Sleep\u0060 inside retry loop. In an asynchronous server execution path or concurrent request handling, sleeping threads synchronously blocks threadpool worker threads during file contention, causing latency spikes across all concurrent MCP operations.",
+            "fix": "Use \u0060await Task.Delay(...)\u0060 or non-blocking async retry pattern for session persistence.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "SessionStore concurrency fix lacks explicit retry logic for destination lock",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 states: \u0027The instruction also travels in the snippet the extension hands to target repos... so an AI that never reads this file still gets it.\u0027 The plan explicitly states: \u0027The move is retried briefly for the case a unique name cannot fix (a reader or a scanner holding the destination)\u0027. The implementation in \u0060SessionStore.cs\u0060 adds a retry loop, but the comment in \u0060module_server.md\u0060 (which is part of the plan) says \u0027the move is retried briefly for the case a unique name cannot fix\u0027. The code implements this, but the rule in \u0060review-gate.md\u0060 requires that the *instruction* travels. The instruction here is the *convention* of retrying. The code implements it, but the *reasoning* in the comment is slightly different from the rule\u0027s requirement. Wait, the rule is about the *scope* and *diff*. The rule in \u0060review-gate.md\u0060 is about the *review process*. The rule in \u0060vendor-routing.md\u0060 is about CLI routing. The rule in \u0060CLAUDE.md\u0060 is about \u0060CL",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method retries the \u0060File.Move\u0060 call for the specific exception types mentioned in the comment (IOException, UnauthorizedAccessException) and that the retry logic is bounded.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Retry loop in MoveOverExisting may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a sleep of \u006020 * attempt\u0060 milliseconds. If a file lock (e.g., from an antivirus scanner or a slow indexer) persists longer than the total retry window (approx 150ms), the method throws. However, if the lock is transient but the system is under heavy load, the retry logic might not be sufficient, or worse, if the \u0060Thread.Sleep\u0060 is interrupted or the process is killed during the sleep, the temporary file might be left behind if the \u0060finally\u0060 block logic is not robust. More critically, if the \u0060File.Move\u0060 throws a different exception (e.g., \u0060PathTooLongException\u0060) that isn\u0027t caught by the \u0060catch\u0060 block, the loop exits early, potentially leaving the temp file orphaned if the \u0060TryDelete\u0060 isn\u0027t called. The specific risk is a race condition where the file is held by a scanner; the retry might succeed, but if it fails after 5 attempts, the exception is thrown, but the \u0060finally\u0060 block ensures cleanup. The real risk is if the \u0060MoveOverExisting\u0060 \u0060",
+            "fix": "Ensure the retry loop in MoveOverExisting uses a bounded, non-exponential backoff or a maximum total duration to prevent indefinite hanging during transient file system locks, and verify that the final exception is logged with full context before re-throwing.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Potential CSS injection via vendor name in style attribute",
+            "why": "The code constructs a style attribute: \u0060style=\u0022color:${vendorColour(row.provider)}\u0022\u0060. While \u0060vendorColour\u0060 returns a CSS variable (e.g., \u0060var(--vscode-charts-blue)\u0060), the \u0060row.provider\u0060 is used to determine the color. If \u0060row.provider\u0060 contains a string that, when passed to \u0060vendorColour\u0060, results in a value that isn\u0027t strictly a CSS variable (e.g., if the hash logic changes or a fallback is used), or if \u0060vendorColour\u0060 is modified to return a hex value, an attacker could inject CSS properties. More critically, if \u0060row.provider\u0060 itself is not escaped *before* being used in the \u0060vendorColour\u0060 lookup (though it is trimmed/lowercased), and if \u0060vendorColour\u0060 were to return a raw string that isn\u0027t a variable, it could be dangerous. However, the primary risk here is that \u0060row.provider\u0060 comes from a session file (JSON). If the session file is corrupted or maliciously crafted to contain a vendor name like \u0060\u0027; background: red; /*\u0060, and if \u0060vendorColour\u0060 were to return a raw value (e.g., if the \u0060",
+            "fix": "Ensure \u0060vendorColour\u0060 is called with a sanitized string or that the \u0060escapeHtml\u0060 function is applied to the vendor name *before* it is passed to the style attribute, or verify that the style attribute itself is safe from injection if the vendor name contains special characters (though unlikely in CSS variables).",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Potential duplicate keys in openRounds state if cards array contains duplicates",
+            "why": "The \u0060nextOpenRounds\u0060 function iterates over \u0060cards\u0060 and adds keys to \u0060Set\u0060s. If the \u0060cards\u0060 array passed to this function contains duplicate entries for the same round (e.g., due to a bug in \u0060sessions.flatMap\u0060 or a race condition in the caller), the \u0060Set\u0060 will deduplicate them, but the logic for \u0060autoOpened\u0060 and \u0060panelOpened\u0060 might behave unexpectedly if the same key is processed multiple times in a way that assumes unique iteration. Specifically, if a round is added to \u0060autoOpened\u0060 twice, it doesn\u0027t matter for a Set, but if the logic relied on the count of additions, it would be wrong. The current logic uses \u0060Set.has\u0060 checks, so duplicates are handled, but the \u0060filter\u0060 at the end relies on \u0060alive.has(key)\u0060. If \u0060cards\u0060 has duplicates, \u0060alive\u0060 (derived from \u0060cards.map\u0060) will also have duplicates, but \u0060Set\u0060 handles that. The real risk is if \u0060roundKey\u0060 is not stable or if the \u0060cards\u0060 array is mutated during iteration (unlikely in this functional style). The finding is minor because Sets *",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all cards before adding to the \u0060Set\u0060 to prevent duplicate keys if the same round appears multiple times in the \u0060cards\u0060 array.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Race condition in scratch file cleanup leaves orphaned temp files under high concurrency",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060finally\u0060 block calls \u0060TryDelete(temp)\u0060 unconditionally. If \u0060MoveOverExisting\u0060 succeeds (the file is moved to the destination), the \u0060finally\u0060 block attempts to delete the now-moved temp file. However, if a second concurrent writer (with a different PID/GUID) has already claimed that specific temp path (unlikely but possible if GUID collision occurs or if the path logic is flawed) or if the file handle is still held by the OS immediately after move, the \u0060TryDelete\u0060 might fail silently. More critically, if \u0060MoveOverExisting\u0060 throws on the last attempt (line 168), the \u0060finally\u0060 block runs. If the temp file was successfully moved but the \u0060MoveOverExisting\u0060 logic failed to update state or if the \u0060File.Move\u0060 threw an exception that was caught, the \u0060finally\u0060 block tries to delete. The real issue is that \u0060TryDelete\u0060 swallows exceptions. If the move succeeds but the delete fails (e.g., file locked by another process), the temp file remains. In a high-concurrency loop",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs after the retry loop completes, rather than in a \u0060finally\u0060 block that executes even if the move succeeds but the delete throws.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Vendor colour inconsistency due to case/space sensitivity in session data",
+            "why": "The \u0060vendorColour\u0060 function in \u0060vendorColour.ts\u0060 (line 45) trims and lowercases the input. However, if the session file contains a vendor name with leading/trailing spaces or mixed case that differs from the canonical name used in the \u0060ANCHORED\u0060 map (e.g., \u0027 Codex \u0027 vs \u0027codex\u0027), the function will correctly map to the anchored color. But if the session data is inconsistent (e.g., \u0027Codex\u0027 vs \u0027codex\u0027 in different parts of the system), the \u0060ANCHORED\u0060 lookup might fail for one variant, falling back to a hash. This causes the same vendor to appear in different colors within the same session or across restarts if the data source changes. The test \u0060test(\u0027case and stray space are the same vendor\u0027)\u0060 confirms this is handled, but if the session data is not normalized *before* being passed to \u0060vendorColour\u0060, or if the \u0060ANCHORED\u0060 map keys are not strictly lowercase, a mismatch occurs. Specifically, if a session file has \u0027Codex\u0027 (capital C) and the \u0060ANCHORED\u0060 map has \u0027codex\u0027, the \u0060vendorColour\u0060 will",
+            "fix": "Ensure \u0060vendorColour\u0060 is called with the exact string from the session file, trimming whitespace and lowercasing before lookup, or ensure the session data is normalized before rendering.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary re-calculation of open rounds state on every panel refresh",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 (line 165) calls \u0060nextOpenRounds\u0060 on every tick (every 5 seconds). This function iterates over all cards, filters, and creates new Sets. While the logic is O(N) and N is small (number of rounds), doing this on every tick without checking if the underlying session data has changed is wasteful. If the session data hasn\u0027t changed, the \u0060nextOpenRounds\u0060 result will be identical, but the code still performs the full calculation and creates new array/set objects. This could lead to unnecessary re-renders if the UI component depends on object identity or if the calculation is heavy (though it\u0027s likely fast). A better approach would be to compare the previous session data with the new one and only recalculate if there\u0027s a change.",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 or avoid recalculating it on every tick if the session data hasn\u0027t changed.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:13:36 \u001B[32mINF\u001B[0m] coai-mcp#5888 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Race condition in scratch file cleanup leaves orphaned temp files under high concurrency (from local) [gating] Round=1 Stage=CodeReview\r | [09:13:36 \u001B[32mINF\u001B[0m] coai-mcp#5888 finding [Major/Ux] src_vs_code/src/panelView.ts:702 - Vendor colour inconsistency due to case/space sensitivity in session data (from local) [gating] Round=1 Stage=CodeReview\r | [09:13:36 \u001B[32mINF\u001B[0m] coai-mcp#5888 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary re-calculation of open rounds state on every panel refresh (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 5,
+    "key": "codex,gemini,local|split-once|1",
+    "startedUtc": "2026-09-05T09:10:10.4257222Z",
+    "finishedUtc": "2026-09-05T09:11:16.5291209Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 65.8,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 47677,
+        "tokensOut": 4313,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claiming is incompatible with the required fail-open behavior when the store is unwritable",
+            "why": "If two servers share a read-only or unavailable data directory, neither can atomically record a claim; with \u201Cfails OPEN\u201D they can both continue and issue the split order, violating the explicit at-most-once guarantee.",
+            "fix": "Define the precedence and behavior for claim-store failure: either fail closed for order issuance, or replace the guarantee with a scoped best-effort guarantee and specify the warning/command behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan has no crash-safe protocol for a claim made before or after command emission",
+            "why": "If a process records the claim and is killed before emitting the command, a retry suppresses the only command; if it emits first and is killed before recording the claim, a retry emits a duplicate. Atomicity between two processes does not make these separate operations crash-safe.",
+            "fix": "Specify a durable state machine or idempotency protocol covering claim, command creation, and acknowledgement, including recovery of an in-progress claim after timeout or process death.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback does not define a stable checkout identity across branches",
+            "why": "With no exported session id, a run on branch A and a later run on branch B need to resolve to the same caller, but the stated existing repo\u002Bbranch key deliberately produces different keys. Separate branch paths or Git worktrees can therefore either re-split or accidentally share unrelated callers.",
+            "fix": "Define and test the canonical checkout key and its lifecycle for clones, linked worktrees, branch changes, renames, and concurrent checkouts; persist it without requiring the AI to pass an id.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not specify how stale verdicts are excluded from the current-round decision",
+            "why": "A caller with a cached passing verdict can edit the plan so the current review fails; if the prior verdict or claim state is reused, it still emits the split command despite the current round failing.",
+            "fix": "Bind verdict and claim eligibility to an explicit current review/run identifier or content digest, and invalidate it when the plan, thresholds, or review round changes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The caller-id-to-file mapping is underspecified and can cause traversal or identity collisions",
+            "why": "An id such as \u0060../../other\u0060, \u0060a/b\u0060, or \u0060a\\b\u0060 can escape or address unintended files if path handling is incomplete; sanitizing distinct ids to the same filename can make one caller consume another caller\u2019s once-only claim.",
+            "fix": "Use an injective, non-path-derived encoding such as a cryptographic digest of the raw id, with a fixed directory and atomic create/lock semantics, and define handling for malformed or oversized ids.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true] Requirement 5 (fail open on unwritable store) directly causes recursive split loops",
+            "why": "If the persistence store is unwritable (e.g. permission error, read-only disk, or quota exceeded), failing open allows the claim to be treated as unclaimed. When the subsequent child review sessions run with the same unwritable store, each review fails to persist its claim and issues a new split order again, re-triggering the infinite \u0027epics of epics\u0027 loop that this feature was created to stop.",
+            "fix": "Specify fail-closed behavior for split orders when the persistence store is unwritable (i.e. default to issuing the autonomy order / single-unit review if storage cannot be checked or written, logging a warning).",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true] Requirement 6 gives no mechanism to track non-Claude callers across branches without violating the identifier constraint",
+            "why": "Requirement 6 mandates following a client with no session ID across different branch checkouts, but the Constraints state \u0027Nothing may be added that requires the calling AI to remember and pass an identifier\u0027 and the design notes that sessions are keyed repo\u002Bbranch. A different branch creates a new session, leaving zero shared ambient state to correlate the child branch review back to the parent checkout without passing an identifier or having a defined parent workspace/PID lineage.",
+            "fix": "Define the concrete shared fallback key for clients without session IDs (e.g. parent process ID tree or repo root origin checkout metadata) or explicitly limit branch tracking to environments providing ambient caller identifiers.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "[Constraints] Path traversal sanitization is mandated for caller ID without specifying collision resistance or invalid character handling",
+            "why": "Sanitizing arbitrary strings into file names without defining a collision-safe encoding (such as SHA-256 hashing) allows different caller IDs containing special characters or slashes (e.g. \u0027foo/bar\u0027 vs \u0027foo_bar\u0027) to collide on the same state file, causing one caller\u0027s review to incorrectly inherit or consume another caller\u0027s split claim.",
+            "fix": "Specify a deterministic, safe filename mapping such as hashing the raw caller ID (e.g. \u0060sha256(caller_id)\u0060) rather than sanitizing characters in-place.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 0,
+        "verdict": "",
+        "error": "git worktree add: Preparing worktree (detached HEAD 7133c2f)\r\nfatal: \u0027C:/Users/strug/AppData/Local/coai-mcp/worktrees/coai-wt-daab3961-r1\u0027 already exists",
+        "gatingCount": 0,
+        "reviewers": "",
+        "tokensIn": 0,
+        "tokensOut": 0,
+        "costUsd": null,
+        "findings": [],
+        "commands": [],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:11:16 \u001B[32mINF\u001B[0m] coai-mcp#35388 finding [Major/Reliability] Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split. (from local) [gating] Round=1 Stage=PlanReview\r | [09:11:16 \u001B[32mINF\u001B[0m] coai-mcp#35388 finding [Major/Ux] Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting. (from local) [gating] Round=1 Stage=PlanReview\r | [09:11:16 \u001B[32mINF\u001B[0m] coai-mcp#35388 finding [Minor/Reliability] Unwritable store fails OPEN with a warning rather than failing the entire operation. (from local) Round=1 Stage=PlanReview",
+    "onDisk": {
+      "rounds": 1,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 4,
+    "key": "codex,gemini,local|split-once|2",
+    "startedUtc": "2026-09-05T09:10:10.4179726Z",
+    "finishedUtc": "2026-09-05T09:12:52.3695947Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 46.9,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 42024,
+        "tokensOut": 6918,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define an atomic claim mechanism for the shared store",
+            "why": "Two processes can both observe that a passing caller has not claimed the split order and both issue it unless the implementation uses a documented lock or atomic create/compare-and-swap. That violates the stated case of two servers sharing one data directory and can produce duplicate split commands.",
+            "fix": "Specify the on-disk transaction and locking primitive, including stale-lock and crash recovery, and verify concurrently that exactly one process emits the order.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback cannot be implemented unambiguously across branch changes",
+            "why": "A client without CLAUDE_CODE_SESSION_ID that reviews a passing plan on branch A and then reviews its piece on branch B has no stated stable identity or parent-to-piece mapping. A branch-only key either repeats the split or suppresses an order from an unrelated caller using the same checkout.",
+            "fix": "Define the fallback identity and lifetime, and specify how branch transitions map the parent claim to the piece without requiring the AI to pass an identifier.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan has no round identity to ensure the verdict belongs to the plan reviewed this round",
+            "why": "If a prior passing verdict is persisted and the plan changes before a retry or new review, a lookup keyed only by repository, branch, or caller can issue a split command based on the old plan, violating the current-round requirement.",
+            "fix": "Persist a plan-content hash or review-round nonce with the verdict and require an exact match before claiming or issuing the command; invalidate it when the plan changes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Crash and partial-write behavior is unspecified for the claim record",
+            "why": "If a process is killed after recording a claim but before issuing the command, the next invocation may permanently suppress the required order; if it is killed before the claim becomes durable, a retry may issue it twice.",
+            "fix": "Define a crash-safe state machine and write protocol, including when a claim is consumed, recovery of in-progress records, and termination checks at each boundary.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open behavior can turn an unwritable store into repeated split orders",
+            "why": "With a read-only or full data directory, the first passing review cannot persist its claim. If fail-open continues issuing the command, every retry or process can issue it again, creating duplicate work; withholding it would contradict the stated fail-open guarantee.",
+            "fix": "Define fail-open precisely and specify an idempotency or bounded process-local safeguard, plus the exact warning and retry behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The caller-id filesystem boundary requirement lacks collision-safe encoding",
+            "why": "An identifier containing separators, traversal text, excessive length, or two distinct values that normalize to the same filename can escape the directory or cause callers to share a claim unexpectedly.",
+            "fix": "Store a fixed-length cryptographic encoding or validated opaque key instead of the raw caller string, with explicit length and collision handling.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true #5] Failing open on an unwritable store causes infinite recursive plan splitting",
+            "why": "If the persistence store is read-only or unwritable (e.g., permission restrictions, full disk), failing open allows the split order to be issued while preventing the claim from ever being recorded. When the spawned child epics return for review on their respective branches, their checks also fail open and issue further split orders, directly reproducing the unbounded \u0027epics of epics\u0027 recursion the feature is intended to stop.",
+            "fix": "Fail closed when the store is unwritable by falling back to the autonomy/single-unit order (suppressing split orders) and emitting a warning.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "[Constraints \u0026 What must be true #3, #7] Atomic check-and-claim consumes the single split allowance on failing plans or evaluation crashes",
+            "why": "If checking eligibility and claiming the token are performed as a single atomic operation (\u0027ONE question asked once\u0027) when the gate runs, a plan that fails review or encounters an unhandled crash during evaluation will consume the session claim. When the user or caller fixes the plan and resubmits it within the same caller session, the claim is already marked used, improperly forcing the now-passing plan into the autonomy order without ever splitting.",
+            "fix": "Only commit the split claim state when a plan has passed review and the split order is successfully emitted, or release/roll back the claim if the verdict does not pass or the process crashes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true #6] Sessionless checkout-level fallback causes collisions between independent tasks in the same working tree",
+            "why": "For callers that do not export CLAUDE_CODE_SESSION_ID, tracking across branches without session IDs forces the store to key purely on checkout path. If a developer runs two independent tasks or sequential workflows in the same local checkout, the second task will match the earlier claim key and incorrectly suppress plan splitting.",
+            "fix": "Define an explicit fallback identity strategy (e.g., parent process group / PPID) or scope sessionless claims to the specific root git commit / merge-base ref rather than checkout directory alone.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 114.8,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 278381,
+        "tokensOut": 18324,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "The split-order predicate is evaluated twice instead of once",
+            "why": "The written constraint says: \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 The code evaluates \u0060OrdersSplit(provisional)\u0060 to decide whether to claim, then evaluates \u0060OrdersSplit(context)\u0060 again to decide whether to log the order. This duplicates the governing question and allows the issuance condition to drift from the claim condition.",
+            "fix": "Evaluate \u0060OrdersSplit(provisional)\u0060 once, store the result, and use that single result together with the claim result to build the final context and decide whether the order was issued.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 108,
+            "title": "A disk-full write is mistaken for another process\u0027s claim and suppresses the split order",
+            "why": "\u0060FileMode.CreateNew\u0060 creates the file before \u0060StreamWriter\u0060 flushes it. If the subsequent write or disposal throws \u0060IOException\u0060 because the disk fills, \u0060File.Exists(file)\u0060 is true, so the first catch returns false as though another server won. \u0060PanelService\u0060 then changes \u0060FirstPlanRound\u0060 to false and emits no split command, violating the required fail-open behavior.",
+            "fix": "Scope the collision catch only around \u0060FileMode.CreateNew\u0060; treat write/flush failures as store failures, remove the partial file best-effort, warn, and return true.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 99,
+            "title": "Replacing an expired claim leaves an unprotected deletion gap",
+            "why": "Two servers seeing an expired claim both delete the old file before either creates its replacement. If the process that deleted it is killed, or the competing create fails afterward, the durable claim is lost; a later request can then receive another split order even though the previous order was still the same caller\u0027s remembered claim.",
+            "fix": "Use an atomic stale-claim replacement protocol, such as creating a uniquely named replacement and atomically renaming/promoting it, or hold an interprocess lock while removing the expired claim and creating the new one.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Expired claims are deleted non-atomically, so concurrent servers can both claim the same order",
+            "why": "When an existing claim is expired, two servers can both observe it, delete it, and race to create the replacement; if server A creates the file before server B\u0027s delete, B can delete A\u0027s new claim and then also return true. With two MCP servers handling the same first plan round, both emit the split instruction.",
+            "fix": "Serialize replacement per caller (for example with a separate atomic per-caller lock file), recheck the timestamp while holding that lock, then delete and recreate the expired claim.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 108,
+            "title": "Non-atomic delete before CreateNew enables concurrent processes to delete each other\u0027s fresh claims and duplicate split orders",
+            "why": "When an expired claim file exists and two server processes invoke TryClaimSplitOrder concurrently, both evaluate StillRemembered as false. Process A deletes the expired file and successfully creates a new claim file via FileMode.CreateNew. Process B then executes File.Delete(file), deleting Process A\u0027s newly written unexpired claim, and successfully executes FileMode.CreateNew for itself. Both processes return true, violating the requirement that exactly one server claims the order. Additionally, on Windows, if Process B executes File.Delete while Process A holds the FileStream open, File.Delete throws UnauthorizedAccessException or IOException, which is caught by the second catch block (lines 120-126) and treated as an unwritable store, causing Process B to fail open and also return true.",
+            "fix": "Avoid non-atomic File.Delete before FileMode.CreateNew. For replacing expired claims atomically, write to a unique temporary file in Dir and replace the target via File.Move(temp, file, overwrite: true) under synchronization or using an open FileStream lock with FileShare.None, ensuring locked/contended files return false rather than failing open.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 87,
+            "title": "Method name \u0060TryClaimSplitOrder\u0060 implies a boolean return indicating success, but the method returns \u0060true\u0060 even on failure (fail-open) when a warning is issued.",
+            "why": "The method name \u0060Try...\u0060 conventionally implies that \u0060false\u0060 means the operation failed. However, the implementation returns \u0060true\u0060 when the store is unwritable (fail-open), meaning the caller got the order despite the write failing. This contradicts the standard semantic of \u0060Try\u0060 methods where \u0060false\u0060 indicates failure.",
+            "fix": "Rename \u0060TryClaimSplitOrder\u0060 to \u0060RecordSplitOrder\u0060 or ensure the method name reflects the atomic claim nature in the public API if the name is intended to be descriptive of the action rather than the return value.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 108,
+            "title": "The \u0060warn\u0060 action is only invoked in the \u0060catch (Exception e)\u0060 block, but not in the \u0060catch (IOException) when (File.Exists(file))\u0060 block.",
+            "why": "The \u0060catch (IOException) when (File.Exists(file))\u0060 block returns \u0060false\u0060 (someone else claimed it), but does not invoke the \u0060warn\u0060 action. This creates an inconsistency where a race condition (someone else claiming) is silent, while a store failure (unwritable) is warned. The rule states \u0027a warning rather than silently disabling\u0027, implying warnings should be consistent for failures.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked consistently for all failure cases or document that it is only invoked for specific exceptions.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Nit",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "Variable name \u0060provisional\u0060 is used for a \u0060CommandContext\u0060 that is immediately used to create another \u0060context\u0060 variable, which may cause confusion.",
+            "why": "The code creates a \u0060provisional\u0060 context, then immediately creates a \u0060context\u0060 variable based on it. The naming convention in the project (e.g., \u0060CallerSessions\u0060, \u0060PanelService\u0060) suggests clear, descriptive names. Using \u0060provisional\u0060 for a temporary state that is immediately used to create the final state is less clear than using a more descriptive name or reusing the variable.",
+            "fix": "Rename \u0060provisional\u0060 to \u0060context\u0060 or \u0060commandContext\u0060 to avoid confusion with the final \u0060context\u0060 variable.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Race condition in atomic claim allows duplicate orders on concurrent access",
+            "why": "The code checks \u0060StillRemembered\u0060, then deletes an expired file, then attempts \u0060FileMode.CreateNew\u0060. If two servers run in parallel: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false). Server A deletes the file. Server B deletes the file (no-op). Server A creates the file. Server B creates the file (fails with IOException). However, the catch block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060. If Server B\u0027s \u0060CreateNew\u0060 fails because Server A created it, \u0060File.Exists\u0060 is true, so it returns \u0060false\u0060. But if Server A\u0027s \u0060CreateNew\u0060 fails (e.g., due to a transient lock), and Server B succeeds, both might think they succeeded if the logic isn\u0027t perfectly atomic. More critically, the \u0060File.Delete\u0060 happens *before* the \u0060CreateNew\u0060 attempt. If the file exists but is stale, it is deleted. If two threads enter simultaneously, they both see it exists, both delete it, then both try to create. The OS \u0060CreateNew\u0060 ensures only one succeeds, but the logic assumes the \u0060",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or ensure the \u0060File.Exists\u0060 check covers the deletion path before \u0060CreateNew\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 905,
+            "title": "Unsanitized caller ID allows path traversal into data directory",
+            "why": "The \u0060CallerFor\u0060 method constructs a caller ID from \u0060session.State.RepoPath\u0060 (e.g., \u0060repo:/path/to/repo\u0060). If an attacker controls the repo path or can influence the session state, they could inject \u0060../\u0060 sequences. The \u0060FileFor\u0060 method uses this string directly as a filename. An attacker could craft a session where \u0060RepoPath\u0060 is \u0060../../etc/passwd\u0060, causing the server to write the split-order claim to \u0060/etc/passwd\u0060 (or a sibling directory), potentially overwriting critical configuration or creating a symlink to a sensitive file. This is especially dangerous because the \u0060CallerIdentity\u0060 logic falls back to this path, and the file is created with \u0060FileMode.CreateNew\u0060 which might succeed if the path resolves to an existing file in a writable location.",
+            "fix": "Sanitize the \u0060caller\u0060 string (specifically the repo path) before using it in \u0060FileFor(caller)\u0060 to ensure it doesn\u0027t contain path traversal characters like \u0060..\u0060 or null bytes.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Stale file deletion may fail silently under high contention",
+            "why": "The code attempts to delete an existing file before creating a new one. If the file is locked by another process (e.g., an antivirus scanner or a previous crashed instance), \u0060File.Delete\u0060 might throw an \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060. The current catch block only handles exceptions *after* the \u0060CreateNew\u0060 attempt. If the delete fails, the subsequent \u0060CreateNew\u0060 might fail with a different error, or the code might proceed with a stale file if the exception is swallowed. This could lead to a situation where the split order is not recorded correctly, or the file is left in an inconsistent state.",
+            "fix": "Add a timeout or retry logic to the \u0060File.Delete\u0060 operation, or handle the case where the file is locked by another process more gracefully.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Nit",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 582,
+            "title": "Warning message lacks sufficient context for debugging",
+            "why": "The warning message \u0060the split-order memory at {Dir} could not be written\u0060 is generic. If the feature fails silently (fails open), the operator needs to know *which* caller was affected and *when* the failure occurred to correlate it with other logs. Without this, debugging a split-order failure becomes a guessing game.",
+            "fix": "Ensure the \u0060warn\u0060 action is logged with sufficient context (e.g., caller ID, timestamp) to aid debugging.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 580,
+            "title": "Ambiguous feedback on split order claim success vs. failure",
+            "why": "The \u0060TryClaimSplitOrder\u0060 method returns a boolean, but the calling code in \u0060PanelService\u0060 only logs \u0027split ordered\u0027 if \u0060OrdersSplit\u0060 is true. If the claim fails (returns false), the user sees no indication that the split order was *attempted* but *denied* (e.g., another server already claimed it). The user might think the feature is off or the condition wasn\u0027t met, when in fact it was a race condition. The warning message \u0060the split-order memory at {Dir} could not be written\u0060 is only shown on exception, not on a successful claim that returns false.",
+            "fix": "Add a specific log entry or return value indicating that the split order was claimed vs. just given, or ensure the warning message in \u0060CallerSessions\u0060 is more descriptive about the \u0027open\u0027 failure state.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Redundant file system calls in atomic claim logic",
+            "why": "The code performs \u0060File.Exists(file)\u0060 twice: once before \u0060CreateNew\u0060 (to delete) and once in the \u0060catch\u0060 block for \u0060IOException\u0060. On high-concurrency systems (8\u002B servers), this results in 2-3 file system calls per claim attempt. While not blocking, it adds latency and I/O overhead. A single \u0060FileStream\u0060 with \u0060FileShare.None\u0060 and \u0060Lock\u0060 would be more efficient.",
+            "fix": "Cache the \u0060File.Exists\u0060 check result or use a more atomic file locking mechanism (e.g., \u0060FileStream\u0060 with \u0060FileShare.None\u0060 and \u0060Lock\u0060 on the file handle) to avoid multiple file system calls.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:12:52 \u001B[32mINF\u001B[0m] coai-mcp#40660 finding [Nit/Ux] src_mcp/src/Server/PanelService.cs:582 - Warning message lacks sufficient context for debugging (from local) Round=1 Stage=CodeReview\r | [09:12:52 \u001B[32mINF\u001B[0m] coai-mcp#40660 finding [Minor/Ux] src_mcp/src/Server/PanelService.cs:580 - Ambiguous feedback on split order claim success vs. failure (from local) Round=1 Stage=CodeReview\r | [09:12:52 \u001B[32mINF\u001B[0m] coai-mcp#40660 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:97 - Redundant file system calls in atomic claim logic (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 3,
+    "lane": 5,
+    "key": "codex,gemini,local|split-once|3",
+    "startedUtc": "2026-09-05T09:11:16.6086103Z",
+    "finishedUtc": "2026-09-05T09:14:10.5271429Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 49.6,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 33682,
+        "tokensOut": 6252,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The fallback identity for clients without CLAUDE_CODE_SESSION_ID is unspecified and can merge independent checkouts.",
+            "why": "Two worktrees of the same repository share the data directory, and both callers omit the session variable. Without a defined stable checkout key, one can consume the other\u0027s split claim, so one checkout receives no command or an autonomy order intended for the other.",
+            "fix": "Define and persist a canonical checkout identity (including worktree path) and specify how it is derived consistently from any working directory; key claims by that identity plus the current plan round.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "A process crash after claiming but before returning the command can permanently lose the command.",
+            "why": "Server A atomically claims a passing split verdict and is killed before its response is delivered. Server B retries the same review and sees the claim, so neither process emits the required order.",
+            "fix": "Specify a recoverable claim protocol, such as pending claims with an owner and lease/retry semantics, or mark completion only after the command handoff is durably acknowledged.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how \u201Cthis round\u201D is distinguished from prior reviews.",
+            "why": "A caller revises its plan and runs another passing review in the same checkout after the earlier split command was claimed. If the store is keyed only by checkout/session, the new round is treated as already handled; if it is keyed only by verdict, an old pass can trigger a command for the new plan.",
+            "fix": "Define a round key derived from the exact reviewed plan (for example a normalized-content hash plus review context), and require the verdict and claim to use that key.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The filename-safety requirement lacks a collision-resistant encoding for arbitrary caller IDs.",
+            "why": "Distinct caller strings such as \u0060a/b\u0060, \u0060a\\\\b\u0060, and \u0060a:b\u0060 can collide under common sanitization, causing one caller to suppress or inherit another caller\u2019s claim; naive path joining can also let \u0060..\u0060 escape the store.",
+            "fix": "Specify an allowlist-independent encoding such as a cryptographic hash of the caller ID, stored beneath a fixed directory, and test traversal and collision cases.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027What must be true\u0027 (item 5): Failing open on an unwritable store reproduces the infinite recursive splitting loop",
+            "why": "If the persistence store is unwritable (e.g., read-only filesystem, permission denial, or full disk), failing open by continuing to issue the split order prevents any claim from being recorded. Every resulting child epic will then also encounter an unwritable store, fail open, and be ordered to split into sub-epics indefinitely.",
+            "fix": "Change the unwritable store behavior to fail closed by emitting a warning and defaulting to the single-unit autonomy order instead of issuing a split order.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027What must be true\u0027 (item 6): Checkout-level tracking without a session ID permanently blocks future root plans from splitting",
+            "why": "When a client does not export CLAUDE_CODE_SESSION_ID, falling back to tracking across the checkout means the first plan that splits consumes the claim for that checkout; subsequent unrelated root plans created later in the same checkout will be permanently misclassified as sub-pieces and prevented from splitting.",
+            "fix": "Define a scoped identity fallback (such as parent process tree ID or checkout plus root plan creation timestamp/hash) instead of a permanent checkout-wide claim flag.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027SCOPE\u0027 \u0026 \u0027What must be true\u0027 (item 1): Reusing CLAUDE_CODE_SESSION_ID across multiple tasks in one CLI session disables splitting on subsequent plans",
+            "why": "CLAUDE_CODE_SESSION_ID persists for the lifetime of an interactive Claude Code session across multiple user requests. Once a user splits an initial plan, the session ID is claimed; any subsequent independent large feature planned in the same interactive session will see the existing claim and refuse to split.",
+            "fix": "Key the split claim on both the CLAUDE_CODE_SESSION_ID and a fingerprint/hash of the root plan content.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 124,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 288890,
+        "tokensOut": 18717,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "The split-order predicate is evaluated twice instead of once",
+            "why": "The written constraint says: \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 The code calls \u0060GateCommands.OrdersSplit\u0060 once before claiming and again after claiming.",
+            "fix": "Store the predicate result in a local and reuse that single boolean for claiming, command generation, and logging.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 100,
+            "title": "Replacing an expired claim by deleting it first breaks atomicity",
+            "why": "Two servers can both observe the expired file: each checks \u0060File.Exists\u0060, one creates a replacement, and the other then deletes that new file before creating its own marker, so both return true and issue the split order. A process killed between \u0060Delete\u0060 and \u0060CreateNew\u0060 also leaves no claim and permits another order.",
+            "fix": "Replace the expired marker atomically, such as by writing a uniquely named temporary file and atomically replacing the old marker, or serialize expiry replacement with an OS-level lock.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 581,
+            "title": "The claim is consumed before the split instruction is successfully delivered",
+            "why": "After a valid plan passes, \u0060TryClaimSplitOrder\u0060 writes the marker before \u0060For\u0060 completes and before the response is returned. If the server crashes, the client disconnects, or response persistence fails at that point, retrying the same plan sees the caller as already claimed and receives the piece/autonomy path instead of the required split order; the split instruction is lost.",
+            "fix": "Make claiming and successful command delivery recoverable together, or defer/record the claim only after command construction and response persistence succeeds, with crash recovery for an in-flight claim.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 109,
+            "title": "A failed replacement is mistaken for a competing claim",
+            "why": "When an expired marker exists but deletion or creation fails for an unrelated reason, such as a read-only directory or a full disk, \u0060catch (IOException) when (File.Exists(file))\u0060 returns false without warning. The caller is then told it is already inside a split even though no new claim was made, violating the documented fail-open behavior and potentially suppressing every later split until the stale file is removed.",
+            "fix": "Only return false after positively establishing that another process created a valid current marker; route deletion, creation, and write failures through the warning/fail-open path.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 115,
+            "title": "Unconditional deletion of existing claim file breaks atomicity when concurrent servers race to claim a new caller",
+            "why": "When two server instances concurrently attempt to claim a split order for a new caller, both pass the initial StillRemembered check when the file does not yet exist. Server A creates the file with FileMode.CreateNew. Server B then executes File.Delete(file), deleting Server A\u0027s newly created claim file, and successfully creates its own file via FileMode.CreateNew. Both servers return true and issue duplicate split orders, defeating the cross-process single-claim guarantee.",
+            "fix": "Avoid deleting the file prior to FileMode.CreateNew unless it was confirmed to exist with an expired timestamp, or handle expired claim renewal without unconditionally deleting files created by concurrent races.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 87,
+            "title": "Method name \u0060TryClaimSplitOrder\u0060 implies a boolean return indicating success, but the method returns \u0060true\u0060 even on failure (fail-open) when a warning is issued.",
+            "why": "The method name \u0060Try...\u0060 conventionally implies that \u0060false\u0060 means the operation failed. However, the implementation returns \u0060true\u0060 when the store is unwritable (fail-open), meaning the caller got the order despite the write failing. This contradicts the standard semantic of \u0060Try\u0060 methods where \u0060false\u0060 indicates failure.",
+            "fix": "Rename \u0060TryClaimSplitOrder\u0060 to \u0060RecordSplitOrder\u0060 or ensure the method name reflects the atomic claim nature in the public API if the name is intended to be descriptive of the action rather than the return value.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 108,
+            "title": "The \u0060warn\u0060 action is only invoked in the \u0060catch (Exception e)\u0060 block, but not in the \u0060catch (IOException) when (File.Exists(file))\u0060 block.",
+            "why": "The \u0060catch (IOException) when (File.Exists(file))\u0060 block returns \u0060false\u0060 (someone else claimed it), but does not invoke the \u0060warn\u0060 action. This creates an inconsistency where a race condition (someone else claiming) is silent, while a store failure (unwritable) is warned. The rule states \u0027a warning rather than silently disabling\u0027, implying warnings should be consistent for failures.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked consistently for all failure cases or document that it is only invoked for specific exceptions.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Nit",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "Variable name \u0060provisional\u0060 is used for a \u0060CommandContext\u0060 that is immediately used to create another \u0060context\u0060 variable, which may cause confusion.",
+            "why": "The code creates a \u0060provisional\u0060 context, then immediately creates a \u0060context\u0060 variable based on it. The naming convention in the project (e.g., \u0060CallerSessions\u0060, \u0060PanelService\u0060) suggests clear, descriptive names. Using \u0060provisional\u0060 for a temporary state that is immediately used to create the final state is less clear than using a more descriptive name or reusing the variable.",
+            "fix": "Rename \u0060provisional\u0060 to \u0060context\u0060 or \u0060commandContext\u0060 to avoid confusion with the final \u0060context\u0060 variable.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Race condition in atomic claim allows duplicate orders on concurrent access",
+            "why": "The code checks \u0060StillRemembered\u0060, then deletes an expired file, then attempts \u0060FileMode.CreateNew\u0060. If two servers run in parallel: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false). Server A deletes the file. Server B deletes the file (no-op). Server A creates the file. Server B creates the file (fails with IOException). However, the catch block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060. If Server B\u0027s \u0060CreateNew\u0060 fails because Server A created it, \u0060File.Exists\u0060 is true, so it returns \u0060false\u0060. But if Server A\u0027s \u0060CreateNew\u0060 fails (e.g., due to a transient lock), and Server B succeeds, both might think they succeeded if the logic isn\u0027t perfectly atomic. More critically, the \u0060File.Delete\u0060 happens *before* the \u0060CreateNew\u0060 attempt. If the file exists but is stale, it is deleted. If two threads enter simultaneously, they both see it exists, both delete it, then both try to create. The OS \u0060CreateNew\u0060 ensures only one succeeds, but the logic assumes the \u0060",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or ensure the \u0060File.Exists\u0060 check covers the deletion path before \u0060CreateNew\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 905,
+            "title": "Unsanitized caller ID allows path traversal into data directory",
+            "why": "The \u0060CallerFor\u0060 method constructs a caller ID from \u0060session.State.RepoPath\u0060 (e.g., \u0060repo:/path/to/repo\u0060). If an attacker controls the repo path or can influence the session state, they could inject \u0060../\u0060 sequences. The \u0060FileFor\u0060 method uses this string directly as a filename. An attacker could craft a session where \u0060RepoPath\u0060 is \u0060../../etc/passwd\u0060, causing the server to write the split-order claim to \u0060/etc/passwd\u0060 (or a sibling directory), potentially overwriting critical configuration or creating a symlink to a sensitive file. This is especially dangerous because the \u0060CallerIdentity\u0060 logic falls back to this path, and the file is created with \u0060FileMode.CreateNew\u0060 which might succeed if the path resolves to an existing file in a writable location.",
+            "fix": "Sanitize the \u0060caller\u0060 string (specifically the repo path) before using it in \u0060FileFor(caller)\u0060 to ensure it doesn\u0027t contain path traversal characters like \u0060..\u0060 or null bytes.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Stale file deletion may fail silently under high contention",
+            "why": "The code attempts to delete an existing file before creating a new one. If the file is locked by another process (e.g., an antivirus scanner or a previous crashed instance), \u0060File.Delete\u0060 might throw an \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060. The current catch block only handles exceptions *after* the \u0060CreateNew\u0060 attempt. If the delete fails, the subsequent \u0060CreateNew\u0060 might fail with a different error, or the code might proceed with a stale file if the exception is swallowed. This could lead to a situation where the split order is not recorded correctly, or the file is left in an inconsistent state.",
+            "fix": "Add a timeout or retry logic to the \u0060File.Delete\u0060 operation, or handle the case where the file is locked by another process more gracefully.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Nit",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 582,
+            "title": "Warning message lacks sufficient context for debugging",
+            "why": "The warning message \u0060the split-order memory at {Dir} could not be written\u0060 is generic. If the feature fails silently (fails open), the operator needs to know *which* caller was affected and *when* the failure occurred to correlate it with other logs. Without this, debugging a split-order failure becomes a guessing game.",
+            "fix": "Ensure the \u0060warn\u0060 action is logged with sufficient context (e.g., caller ID, timestamp) to aid debugging.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 580,
+            "title": "Ambiguous feedback on split order claim success vs. failure",
+            "why": "The \u0060TryClaimSplitOrder\u0060 method returns a boolean, but the calling code in \u0060PanelService\u0060 only logs \u0027split ordered\u0027 if \u0060OrdersSplit\u0060 is true. If the claim fails (returns false), the user sees no indication that the split order was *attempted* but *denied* (e.g., another server already claimed it). The user might think the feature is off or the condition wasn\u0027t met, when in fact it was a race condition. The warning message \u0060the split-order memory at {Dir} could not be written\u0060 is only shown on exception, not on a successful claim that returns false.",
+            "fix": "Add a specific log entry or return value indicating that the split order was claimed vs. just given, or ensure the warning message in \u0060CallerSessions\u0060 is more descriptive about the \u0027open\u0027 failure state.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Redundant file system calls in atomic claim logic",
+            "why": "The code performs \u0060File.Exists(file)\u0060 twice: once before \u0060CreateNew\u0060 (to delete) and once in the \u0060catch\u0060 block for \u0060IOException\u0060. On high-concurrency systems (8\u002B servers), this results in 2-3 file system calls per claim attempt. While not blocking, it adds latency and I/O overhead. A single \u0060FileStream\u0060 with \u0060FileShare.None\u0060 and \u0060Lock\u0060 would be more efficient.",
+            "fix": "Cache the \u0060File.Exists\u0060 check result or use a more atomic file locking mechanism (e.g., \u0060FileStream\u0060 with \u0060FileShare.None\u0060 and \u0060Lock\u0060 on the file handle) to avoid multiple file system calls.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:14:10 \u001B[32mINF\u001B[0m] coai-mcp#35560 finding [Nit/Ux] src_mcp/src/Server/PanelService.cs:582 - Warning message lacks sufficient context for debugging (from local) Round=1 Stage=CodeReview\r | [09:14:10 \u001B[32mINF\u001B[0m] coai-mcp#35560 finding [Minor/Ux] src_mcp/src/Server/PanelService.cs:580 - Ambiguous feedback on split order claim success vs. failure (from local) Round=1 Stage=CodeReview\r | [09:14:10 \u001B[32mINF\u001B[0m] coai-mcp#35560 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:97 - Redundant file system calls in atomic claim logic (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  }
+]

--- a/research/data/bench-2026-09-05/epic2-v0.17.2/tables.md
+++ b/research/data/bench-2026-09-05/epic2-v0.17.2/tables.md
@@ -1,0 +1,25 @@
+# Bench
+
+## Per arm
+
+| arm | stage | runs | verdicts | median time | median findings | gating | useful | tokens in / out | cost |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | code | 6 | proceed×3, FAILED×2, good_enough×1 | 124s | 13 | 31 | — | 1.4M / 65k | not reported |
+| `codex,gemini,local` | plan-1 | 6 | good_enough | 65.8s | 14 | 65 | — | 239.7k / 38.8k | not reported |
+
+## Per run
+
+| arm | case | # | lane | stage | verdict | time | findings | gating | tokens in / out |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | plan-1 | good_enough | 82.7s | 14 | 10 | 39.3k / 7.5k |
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | code | proceed | 189.9s | 13 | 9 | 432.5k / 10.9k |
+| `codex,gemini,local` | rounds-collapse | 2 | 2 | plan-1 | good_enough | 99.6s | 14 | 11 | 39k / 7.5k |
+| `codex,gemini,local` | rounds-collapse | 2 | 2 | code | **FAILED** | 0s | 0 | 0 | 0 / 0 |
+| `codex,gemini,local` | rounds-collapse | 3 | 3 | plan-1 | good_enough | 49s | 13 | 9 | 38k / 6.4k |
+| `codex,gemini,local` | rounds-collapse | 3 | 3 | code | proceed | 156.9s | 13 | 8 | 399k / 17.1k |
+| `codex,gemini,local` | split-once | 1 | 5 | plan-1 | good_enough | 65.8s | 13 | 12 | 47.7k / 4.3k |
+| `codex,gemini,local` | split-once | 1 | 5 | code | **FAILED** | 0s | 0 | 0 | 0 / 0 |
+| `codex,gemini,local` | split-once | 2 | 4 | plan-1 | good_enough | 46.9s | 14 | 12 | 42k / 6.9k |
+| `codex,gemini,local` | split-once | 2 | 4 | code | proceed | 114.8s | 14 | 7 | 278.4k / 18.3k |
+| `codex,gemini,local` | split-once | 3 | 5 | plan-1 | good_enough | 49.6s | 12 | 11 | 33.7k / 6.3k |
+| `codex,gemini,local` | split-once | 3 | 5 | code | good_enough | 124s | 14 | 7 | 288.9k / 18.7k |

--- a/research/data/bench-2026-09-05/epic2b-v0.17.2/runs.json
+++ b/research/data/bench-2026-09-05/epic2b-v0.17.2/runs.json
@@ -1,0 +1,3140 @@
+[
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T09:28:06.0381814Z",
+    "finishedUtc": "2026-09-05T09:40:43.5375214Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 77.7,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 38673,
+        "tokensOut": 5920,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping guarantee is unverified for spending rows",
+            "why": "A session file containing a vendor such as \u0060\u003C/span\u003E\u003Cimg src=x onerror=...\u003E\u0060 is rendered in spending rows, but the only named escaping test covers a reviewer row. The reviewer path can be safe while spending rows still inject markup.",
+            "fix": "Use one escaped vendor-rendering helper for every vendor-bearing view, and test the hostile vendor in round cards, the live section, and spending rows.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete XSS risk \u0393\u00C7\u00F6 the same escaper-applied-at-some-sites class this repository\u0027s own security rule records as its recurring defect \u0393\u00C7\u00F6 and the fix (one shared escaping helper plus a hostile-vendor test per rendering site) is proportionate and directly actionable."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Panel ownership is lost when the extension host or panel provider is recreated",
+            "why": "If the host reloads while a panel-opened round is running, the proposed in-memory set is empty. When the round finishes, it remains expanded, violating the auto-close promise for a normal restart sequence.",
+            "fix": "Define the ownership lifetime and either persist panel-opened IDs with cleanup or explicitly limit and test the behavior to one provider lifetime.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real, undefined lifetime for the in-memory ownership set that this family\u0027s own durable-status rule says cannot survive a reload, and its fix accepts the cheap option of documenting and testing a one-lifetime scope, so it is proportionate to the risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The ownership transition has no failure behavior",
+            "why": "If the refresh or render that records a user\u0027s toggle fails or the panel is disposed mid-transition, the UI and ownership set can disagree. A later finish may leave a user-opened card expanded or close a card the user never successfully opened.",
+            "fix": "Define an atomic toggle/ownership transition with failure handling, and test refresh failure and panel disposal during the transition.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It asks for atomic-transition machinery and disposal tests around an in-memory expand/collapse toggle whose worst outcome is a card showing the wrong open state, names no concrete failing path, and after a panel is disposed there is no UI left to disagree with the set."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Reopening an auto-closed finished round is not fully specified",
+            "why": "The plan says reopening makes the round the person\u0027s choice, but only specifies removing an ownership key. A later refresh can therefore overwrite the reopened state because no explicit user-opened state is recorded.",
+            "fix": "Specify the toggle state machine for finished rounds and test auto-close \u2192 finish \u2192 reopen \u2192 refresh.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, testable gap in the state machine: if \u0027no ownership key\u0027 is indistinguishable from \u0027never auto-closed\u0027, a refresh can re-collapse a round the person deliberately reopened, which is exactly the durable-status defect this family\u0027s rules warn about, and the proposed test sequence is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027Constraints\u0027 \u0026 \u0027Build order\u0027: Unified row renderer emitting HTML markup breaks plain-text test consumers",
+            "why": "The plan enforces a single unified renderer for reviewer rows (to prevent drift with text versions that existing tests read), while Step 5 injects HTML markup (\u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:...\u0022\u003E\u0060) into that same renderer. Any test or consumer asserting on plain-text row representation receives raw HTML markup, breaking existing test assertions.",
+            "fix": "Separate the data formatting/text representation from HTML decoration, or update the test contract to parse structured reviewer row models rather than string assertions on renderer output.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real contradiction inside the plan itself: a renderer mandated to stay unified with the plain-text rows existing tests assert on cannot also start emitting HTML spans without breaking those assertions, so the plan must separate text formatting from HTML decoration before implementation, and the proposed fix is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027Build order\u0027: Defining UI theme palette helper \u0060vendorColour\u0060 inside session parser \u0060rounds.ts\u0060 couples data parsing to editor presentation",
+            "why": "Step 4 places \u0060vendorColour(name)\u0060 inside \u0060rounds.ts\u0060 to return \u0060--vscode-charts-*\u0060 CSS variables. Because \u0060rounds.ts\u0060 is responsible for parsing session files, importing theme/CSS variable generation into the parser couples data parsing logic to VS Code UI presentation and creates cyclic or unnecessary dependencies for non-UI consumers (such as spending summaries or headless tasks).",
+            "fix": "Move \u0060vendorColour\u0060 into a dedicated view-layer utility module (e.g. \u0060vendorColour.ts\u0060) and import it only in view/rendering components.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "A helper that maps a vendor name to a CSS-variable string is a pure function with no VS Code import, so the coupling and cyclic-dependency claims are speculative; this is a taste-level file-placement nit rated Major, and the repository\u0027s own style rule (organise by feature, not by type) argues for keeping it beside the rounds code."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027Build order\u0027: In-memory panel-opened set fails to auto-collapse rounds across extension host reloads or dead round states",
+            "why": "Step 3 stores the \u0027panel-opened\u0027 state exclusively in an in-memory set on \u0060panelProvider\u0060. If the extension host reloads, crashes, or a round terminates unexpectedly without a clean finished event while running, the in-memory tracking is lost; upon subsequent load, the round can no longer be identified as panel-opened and will remain open indefinitely.",
+            "fix": "Persist panel-opened round IDs in extension workspace state or reconcile expansion against round lifecycle timestamps.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "Losing an in-memory \u0027panel-opened\u0027 set across an extension-host reload only means one card fails to auto-collapse once and the user clicks it shut, an ephemeral UI convenience that does not warrant a Major reliability finding, and the dead-round half of the argument is unrelated to where the set lives since a round that never emits finished would not collapse under any persistence scheme."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete durability gap a careful engineer would want addressed: tracking \u0027opened by the panel\u0027 in a transient in-memory set silently loses that provenance on extension-host restart, so the auto-close decision flips the wrong way, and the remedy (persist the origin with the round\u0027s own identity) is proportionate even if \u0027data loss\u0027 and Blocking overstate the consequence."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Its premise that Fable cannot be a configured reviewer contradicts this repository\u0027s own vendor-routing rule, which makes Claude models reviewer rows on the claude CLI, so \u0027returns false on every real machine\u0027 is asserted rather than shown, and the proposed fix names constructs (a Fable model instance in a CommandContext) that do not exist here."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It builds a Major-severity freeze scenario from one phrase in the plan, inventing the mechanism (synchronous blocking in an extension host where I/O is async and the webview never blocks on it), the number (20 seconds) and the consequence, so it reports a guess as a measurement rather than something the plan actually says."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It restates a caveat the plan already admits, and its fix (write completion on logical finish) cannot apply to the very case it describes, since a round that died writes nothing; the real remedy would be a heartbeat with a staleness cutoff or a sweep, which the finding never names."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It speculates a bordered, padded inline span renders as a strikethrough, which is not how a border box looks (it reads as a badge/chip), hedges on which class it even means, and rates an unverified perceptual guess Major."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The plan already gives legacy rounds the fallback the fix asks for (a disclosure that opens into an explanatory apology), so the finding restates the design and adds only speculation that this looks like a failed load."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 679.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "8 of 9 reviewers answered; failed: local/Architecture: exit 69: ine at http://127.0.0.1:11434/v1 did not finish in time - it was still working after 590s of the 590s this reviewer was given. The engine is up; it is slower th\u2026",
+        "tokensIn": 350737,
+        "tokensOut": 16790,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 157,
+            "title": "Concurrent saves can still overwrite newer session state with stale snapshots",
+            "why": "Two MCP servers can successfully write unique scratch files for the same repo/branch, but the last move wins without checking whether its snapshot is stale. If server A saves reviewer 2\u0027s result and server B later moves an older snapshot containing only reviewer 1, a restart loads a regressed round and loses reviewer 2\u0027s progress.",
+            "fix": "Serialize saves per session key across processes or use locking/compare-and-swap to reject stale snapshots before replacement; test an older save completing after a newer save.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The code\u0027s own comment proves two servers do save the same repo\u002Bbranch key concurrently, and after the unique-scratch fix that collision no longer crashes but silently lets the last mover replace the file with a stale snapshot, which is exactly the persisted source of truth a restart re-orients from under the durable-status rule; the proposed CAS is heavier than needed (a session lease at open or a stated residual would do), but the race is real and unstated in the store\u0027s header."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 135,
+            "title": "Opening a round still waits for the full expensive panel refresh before showing its body",
+            "why": "Clicking a round immediately calls \u0060this.refresh()\u0060, which rebuilds the whole panel instead of using the already-loaded card data. On a slow setup with multiple vendor probes, GitHub checks, and price-table fetches, the reviewer rows can remain absent for many seconds with no interaction-level progress or error state.",
+            "fix": "Render the toggled card from the existing state immediately, and run unrelated metadata/vendor/price refreshes separately in the background.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Vendor span uses stylesheet class \u0027vendor\u0027 which applies card borders and padding to inline text",
+            "why": "The CSS class \u0027.vendor\u0027 is already defined in the extension stylesheet for settings cards with a border, border-radius, and 8px padding. Using it on an inline \u003Cspan\u003E around the vendor name in reviewer rows renders the vendor word with card box styling inside a compact line, visually appearing as a struck-through border line across the text.",
+            "fix": "Change \u003Cspan class=\u0022vendor\u0022 ...\u003E to \u003Cspan class=\u0022who\u0022 ...\u003E in roundCard.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Concurrent save race condition leaves orphaned scratch files and silent failures",
+            "why": "In \u0060SessionStore.Save\u0060, the code generates a unique scratch filename using \u0060Environment.ProcessId\u0060 and a GUID. However, if two processes (or threads in a multi-threaded scenario) happen to generate the same GUID or if the process ID is reused rapidly, they could collide. More critically, the \u0060MoveOverExisting\u0060 method retries 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms). If the destination file is held by a virus scanner or another process for longer than ~250ms, the move fails. The code then enters the \u0060finally\u0060 block and calls \u0060TryDelete(temp)\u0060. If the move failed, \u0060temp\u0060 still exists. If the \u0060TryDelete\u0060 fails (e.g., file locked), it swallows the exception. The result is a session file that never updated (stale data) and a temporary file left behind, potentially filling the disk or causing future collisions if the temp name generation isn\u0027t perfectly unique. The comment admits \u0027a save that never lands is a real problem\u0027 but the \u0060finally\u0060 block\u0027s \u0060TryDelete\u0060 might *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite backoff and that the final exception is re-thrown or logged with context, rather than silently swallowed if the file is held by a scanner.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding misreads the code: the retry is already bounded, the final attempt\u0027s exception propagates by design (the \u0060when attempt \u003C attempts\u0060 filter excludes it from the catch), the scratch file is our own and is removed in \u0060finally\u0060, and a PID-plus-GUID collision is not a real risk, so nothing it asks for is missing."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 806,
+            "title": "Potential HTML injection in vendor name rendering if escaping order is flawed",
+            "why": "In \u0060roundCard\u0060, the code constructs the reviewer row as: \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:${vendorColour(row.provider)}\u0022\u003E\u0060 \u002B \u0060${escapeHtml(row.provider)}\u0060 \u002B \u0060\u003C/span\u003E${escapeHtml(row.rest)}\u0060. If \u0060row.provider\u0060 contains a string like \u0060\u003Cscript\u003E\u0060, \u0060escapeHtml\u0060 converts it to \u0060\u0026lt;script\u0026gt;\u0060. However, if the \u0060vendorColour\u0060 function (or the caller) relies on the raw provider name for the style, and the style attribute is interpolated directly into the HTML string without escaping, an attacker could inject a style attribute. Wait, the style is \u0060color:var(...)\u0060, so it\u0027s safe. The real risk is if \u0060row.provider\u0060 is used in a context where it\u0027s not escaped *before* being placed inside the span, or if \u0060row.rest\u0060 contains unescaped HTML. The code escapes \u0060row.provider\u0060 and \u0060row.rest\u0060 separately. The risk is if \u0060row.provider\u0060 is *not* escaped before being used in the \u0060style\u0060 attribute (e.g., if \u0060vendorColour\u0060 returned a hex value that wasn\u0027t quoted, but it returns a CSS variable). The actual flaw",
+            "fix": "Ensure \u0060vendorColour\u0060 is called *after* \u0060escapeHtml\u0060 or that the HTML structure wraps the escaped text correctly, preventing a scenario where a vendor name like \u0060\u003Cscript\u003E\u0060 renders as an active tag if the escaping logic is applied to the wrong part of the string.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding argues itself out of its own claim mid-sentence: both \u0060row.provider\u0060 and \u0060row.rest\u0060 are escaped, the style value comes from \u0060vendorColour\u0060 rather than raw input, and the proposed fix (reordering an escape that already covers the text) changes nothing."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Race condition in round state management could lead to duplicate keys or lost state",
+            "why": "The \u0060nextOpenRounds\u0060 function builds a \u0060Set\u0060 of keys from \u0060cards\u0060. If two rounds have the same \u0060roundKey\u0060 (e.g., same repo, branch, stage, number), the second one will overwrite the first in the Set. This means if a user has two rounds with identical metadata (perhaps from different branches or a bug in ID generation), only one will be tracked in the \u0060open\u0060 state. If the user interacts with the \u0027wrong\u0027 one (the one that was processed last), the state update might not reflect the actual round they clicked. This is a subtle data loss scenario where the UI state diverges from the actual session data.",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all rounds before adding to the \u0060open\u0060 set, or handle collisions explicitly.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Not a race condition and not this file\u0027s defect: roundKey is by construction unique per round, a Set already collapses duplicates harmlessly, and a collision would be an upstream key-generation bug the proposed uniqueness check here could neither cause nor cure."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:40:43 \u001B[32mINF\u001B[0m] coai-mcp#23396 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Concurrent save race condition leaves orphaned scratch files and silent failures (from local) [gating] Round=1 Stage=CodeReview\r | [09:40:43 \u001B[32mINF\u001B[0m] coai-mcp#23396 finding [Major/Security] src_vs_code/src/panelView.ts:806 - Potential HTML injection in vendor name rendering if escaping order is flawed (from local) [gating] Round=1 Stage=CodeReview\r | [09:40:43 \u001B[32mINF\u001B[0m] coai-mcp#23396 finding [Minor/Reliability] src_vs_code/src/openRounds.ts:45 - Race condition in round state management could lead to duplicate keys or lost state (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 4,
+    "key": "codex,gemini,local|rounds-collapse|2",
+    "startedUtc": "2026-09-05T09:28:06.0317619Z",
+    "finishedUtc": "2026-09-05T09:41:41.9626589Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 66.2,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 9,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 48384,
+        "tokensOut": 2817,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The universal session-file escaping guarantee is not implemented or verified beyond one reviewer-row case",
+            "why": "A malicious session value such as \u0060\u0022\u003E\u003Cimg src=x onerror=...\u003E\u0060 in a spending row, live section, round title, or another interpolated field can still become executable HTML because the plan only specifies escaping the reviewer vendor word and tests only that path.",
+            "fix": "Define a single escaping boundary for every session-derived interpolation, or render session values through DOM text APIs, and add concrete coverage for each page rendering path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real gap that matches this family\u0027s own recorded defect class (an escaper applied at one site, not all): reviewer output is untrusted vendor text rendered into a webview, so asking for one escaping boundary plus coverage per rendering path is proportionate and actionable."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The colour requirement is unverified for the live section and spending rows",
+            "why": "A vendor can render correctly in a round reviewer row while the live section or spending rows omit the colour or call a different formatter; the only colour tests cover the function itself, so the promised cross-page consistency can reach users broken.",
+            "fix": "Add rendering assertions for the live section and spending rows, including the same vendor appearing in all three locations and receiving the same CSS variable.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete test gap at the layer users see: the scope promises one colour per vendor across three render sites, only the formatter is tested, and a site that skips the formatter is exactly the decision-applied-at-some-sites defect this repository\u0027s rules single out, so a rendering assertion per site is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The auto-open set can incorrectly claim a card that the person already opened",
+            "why": "If a person opens a running round while it is closed and a refresh then processes that round as running, an implementation that adds every running card to the panel-opened set will close it when it finishes, violating the stated user-owned behavior.",
+            "fix": "Specify and test that the set is updated only on an actual panel-initiated closed-to-open transition; a card already open from a person action must never be added.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Colour identity is based on the raw display name without a canonical vendor identity rule",
+            "why": "If one path reports \u0060codex\u0060 and another reports \u0060Codex\u0060 or adds surrounding whitespace, hashing the raw strings assigns different colours to the same vendor, breaking the stable-colour promise across sections or after data-format changes.",
+            "fix": "Canonicalize vendor names (at least trim and case-fold, with any known aliases) before hashing, while retaining the original name for display.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Class name collision with \u0060.vendor\u0060 in stylesheet breaks rendering of vendor labels",
+            "why": "In \u0027Build order\u0027 step 5, the plan specifies \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060. However, \u0060.vendor\u0060 is already defined in the stylesheet for the settings card with border, border-radius, and padding, causing the text to render with an unintended strike-through appearance.",
+            "fix": "Wrap the vendor name in a dedicated class (e.g., .who) and add CSS rule tests checking computed styles against existing classes to avoid class name collisions in the webview stylesheet.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Architectural layering violation placing view styling helper inside rounds session parser",
+            "why": "In \u0027Build order\u0027 step 4, vendorColour(name) is placed in rounds.ts. rounds.ts handles parsing session files, while vendorColour is a UI view concern needed by both round cards and spending rows. Placing UI rendering helpers in parser modules forces views like spending rows to depend on session parser code.",
+            "fix": "Place vendorColour in a standalone view utility module (e.g. vendorColour.ts) that both spending rows and round cards import without depending on session parser modules.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 749.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "8 of 9 reviewers answered; failed: local/Architecture: unparseable: the answer was not the schema\u0027s JSON after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\local-Architecture-20260905-094056-051.txt)",
+        "tokensIn": 430586,
+        "tokensOut": 26376,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_vs_code/src/vendorColour.ts",
+            "line": 47,
+            "title": "Blank vendor names return a non-chart editor variable",
+            "why": "This violates the written requirements: \u0022The colours come from the editor\u0027s own chart palette, so they hold in a light theme as well as a dark one.\u0022 The test plan also requires that \u0022every colour it can return is a \u0060--vscode-charts-*\u0060 variable.\u0022 \u0060vendorColour(\u0027\u0027)\u0060 and whitespace return \u0060var(--vscode-foreground)\u0060, which is outside the chart palette.",
+            "fix": "Return one of the declared \u0060--vscode-charts-*\u0060 palette entries for blank names, or ensure blank values never pass through the vendor-colour function.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The added plan is left marked as unimplemented after the change shipped",
+            "why": "The repository\u0027s written completion requirement says: \u0022[ ] ... docs, help and CHANGELOG updated; the plan promoted.\u0022 The change simultaneously documents the work as \u0022Status: IMPLEMENTED\u0022 in its supplied plan, but adds a duplicate plan whose status says \u0022plan only, nothing implemented yet,\u0022 leaving the plan artifact inconsistent with the shipped implementation.",
+            "fix": "Remove the stale duplicate plan, or update it to the implemented/promoted status and check off its Definition of Done.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 160,
+            "title": "Concurrent saves can silently overwrite each other\u0027s session history",
+            "why": "Two MCP servers can load the same session, each append a different reviewer transition, and then call Save with complete but stale snapshots; unique scratch names prevent the move exception, but the last File.Move replaces the first writer\u0027s JSON, silently dropping rounds, findings, or status.",
+            "fix": "Serialize saves per session and merge/reload the current destination before writing, or use an inter-process lock/compare-and-swap so a stale writer cannot replace newer session state.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 179,
+            "title": "Persistence retries block the server thread with synchronous sleeps",
+            "why": "If the session destination is briefly locked, each save can sleep for 20, 40, 60, and 80 ms before its final attempt. A round saving after 10 reviewer transitions can therefore block the calling thread for up to 2 seconds, delaying progress/status handling while the person waits with no update.",
+            "fix": "Use asynchronous persistence/retry with cancellable Task.Delay, or move the save off the request/progress path while retaining a bounded retry.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Vendor span uses \u0060.vendor\u0060 class colliding with settings card styles",
+            "why": "In \u0060roundCard\u0060, reviewer rows wrap vendor names in \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022...\u0022\u003E\u0060. In the webview stylesheet, \u0060.vendor\u0060 styles top-level vendor configuration cards with border, border-radius, and 8px padding. Applying \u0060.vendor\u0060 to an inline span inside a compact reviewer line applies those card box styles around a single word, visually corrupting the text and rendering it like struck-out text.",
+            "fix": "Change the class on the vendor span in \u0060panelView.ts\u0060 from \u0060vendor\u0060 to \u0060who\u0060 (or another class not shared with the settings card container).",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a fixed sleep interval (20ms * attempt). If a file lock (e.g., from an antivirus scanner or another process) persists longer than the total retry window (approx 150ms), the code throws. However, if the lock is held by a process that never releases it (rare but possible in enterprise environments), the \u0060Thread.Sleep\u0060 loop might not be sufficient to handle transient spikes, or worse, if the logic is extended, it could spin. More critically, the \u0060MoveOverExisting\u0060 method is called inside a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060. If the file is held by a scanner that intermittently locks/unlocks, the retry might succeed. But if the lock is permanent, it throws. The real risk is that the \u0060MoveOverExisting\u0060 logic is *not* robust enough for high-concurrency scenarios where multiple writers might contend for the same destination file *after* the unique temp name collision is resolved. If the destination file (",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite wait strategy (e.g., exponential backoff with a hard cap) or a \u0060CancellationToken\u0060 to prevent the server from hanging indefinitely if the destination file is held by a long-running process (like an antivirus scanner) that never releases it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Temporary scratch files accumulate on failed moves due to cleanup timing",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060TryDelete(temp)\u0060 is called in a \u0060finally\u0060 block *after* the \u0060MoveOverExisting\u0060 loop. If \u0060MoveOverExisting\u0060 throws an exception on the final attempt (e.g., \u0060UnauthorizedAccessException\u0060 after 5 retries), the \u0060finally\u0060 block executes and deletes the temp file. However, if the loop succeeds but the \u0060File.Move\u0060 throws *during* the retry (e.g., on attempt 3), the \u0060finally\u0060 block runs, deleting the temp file, but the exception propagates. The critical issue is that if \u0060MoveOverExisting\u0060 throws *before* the loop finishes (e.g., on the first try), the \u0060finally\u0060 block deletes the temp file. But if the loop completes successfully, the temp file is deleted. The real risk is if \u0060MoveOverExisting\u0060 throws *after* a successful move but before the \u0060finally\u0060 block runs (unlikely), or if the \u0060TryDelete\u0060 itself fails silently. More critically, if \u0060MoveOverExisting\u0060 throws on the *last* attempt, the \u0060finally\u0060 block runs, deleting the temp file. But if the loop *succeeds* (all",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs before the retry loop completes, so that if the move fails after the first attempt, the temporary file is cleaned up before the next retry.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 75,
+            "title": "User toggle state may not persist correctly across panel ticks",
+            "why": "When a user closes a card (e.g., \u0060afterToggle(previous, key, false)\u0060), the \u0060open\u0060 set is updated to remove the key. However, if the panel re-renders before the next tick, and the round is still running, the \u0060nextOpenRounds\u0060 logic might re-add it to \u0060open\u0060 if it\u0027s in \u0060autoOpened\u0060. The current logic removes the key from \u0060panelOpened\u0060, but if the round is still running, \u0060nextOpenRounds\u0060 will re-add it to \u0060autoOpened\u0060 and \u0060open\u0060 on the next tick, effectively ignoring the user\u0027s close action. This creates a flicker where the card closes, then re-opens immediately if the round is still running.",
+            "fix": "Ensure \u0060afterToggle\u0060 updates the \u0060open\u0060 set correctly when a user closes a card that was previously auto-opened, and that the \u0060panelOpened\u0060 set is updated to reflect the user\u0027s explicit choice.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary recomputation of open rounds state on every render tick",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 calls \u0060nextOpenRounds\u0060 on every render tick (every 5 seconds). This function performs set operations and filtering on the entire list of rounds. While the logic is simple, doing this on every tick for a large number of rounds (e.g., 100\u002B rounds) creates unnecessary CPU overhead. The state should only be recomputed when the \u0060sessions\u0060 data actually changes (e.g., a new round starts, a round finishes, or a user toggles a card).",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 and only recompute it when the underlying \u0060sessions\u0060 data changes, rather than on every render tick.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:41:41 \u001B[32mINF\u001B[0m] coai-mcp#32568 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Temporary scratch files accumulate on failed moves due to cleanup timing (from local) [gating] Round=1 Stage=CodeReview\r | [09:41:41 \u001B[32mINF\u001B[0m] coai-mcp#32568 finding [Major/Ux] src_vs_code/src/openRounds.ts:75 - User toggle state may not persist correctly across panel ticks (from local) [gating] Round=1 Stage=CodeReview\r | [09:41:41 \u001B[32mINF\u001B[0m] coai-mcp#32568 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary recomputation of open rounds state on every render tick (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 3,
+    "lane": 2,
+    "key": "codex,gemini,local|rounds-collapse|3",
+    "startedUtc": "2026-09-05T09:28:06.0346532Z",
+    "finishedUtc": "2026-09-05T09:37:14.5006453Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 95.4,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 39112,
+        "tokensOut": 6641,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Auto-close ownership is lost when the panel or extension host is recreated",
+            "why": "The proposed ownership set lives in \u0060panelProvider\u0060, so if the panel is disposed, VS Code reloads, or the extension host restarts after this panel auto-opens a running round but before it finishes, the finished round is no longer in the set and remains expanded forever, violating the promised lifecycle behavior.",
+            "fix": "Persist the panel-opened round IDs, or define and implement a recovery mechanism that reconstructs ownership from panel state; add a test covering host/panel recreation during a running round.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping requirement is broader than the single reviewer-vendor test and implementation step",
+            "why": "A session file containing HTML such as \u0060\u003Cimg src=x onerror=...\u003E\u0060 in a round title, reviewer output, live-section field, or spending-row vendor can still reach the webview if those other render paths are not audited, while the plan only specifies escaping the reviewer vendor span and tests one vendor name.",
+            "fix": "Enumerate every session-derived value rendered by \u0060panelView\u0060, apply context-appropriate escaping to every HTML/text/attribute sink, and add malicious fixtures for each sink (including attributes and reviewer text), not just one vendor name.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how completion is detected or recovered after polling and command failures",
+            "why": "If the server stops, a status read times out, or the extension host is killed between detecting completion and updating \u0060expanded\u0060, the panel can leave an auto-opened finished card expanded indefinitely; the test plan only covers a successful running-to-finished transition and gives no retry or reconciliation behavior.",
+            "fix": "Specify the authoritative completion signal and idempotent reconciliation on every refresh/reconnect, including timeout/error handling, and test failures and restart during the transition.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The colour contract does not guarantee distinct colours for the vendors it displays",
+            "why": "A fixed palette indexed by a hash can map two displayed vendors to the same chart variable; the stated test checks only two selected common names, so a real session with a colliding pair still renders indistinguishable vendor names despite the symptom requiring vendor identity to be communicated by colour.",
+            "fix": "Either explicitly allow collisions and remove the implied distinctness requirement, or define a collision-aware assignment policy with stable persisted identity mapping and test representative collisions.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order #5: Reusing class \u0027vendor\u0027 on inline spans collides with existing card container styles",
+            "why": "Step 5 specifies wrapping the vendor word in \u0027\u003Cspan class=\u0022vendor\u0022 style=\u0022color:\u2026\u0022\u003E\u0027, but \u0027.vendor\u0027 is already defined in the stylesheet for settings cards with borders, border-radius, and 8px padding. Applying this class to an inline word inside a tight reviewer row renders card container styling across the word, creating visual distortion and appearing as struck-out text.",
+            "fix": "Use a distinct, dedicated class name such as \u0027who\u0027 or \u0027vendor-name\u0027 for the inline span in panelView.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Constraints: Single reviewer row renderer constraint conflicts with HTML span generation for tests",
+            "why": "The plan requires \u0027One renderer for a reviewer row, not a text one and an HTML one that drift\u0027 because \u0027The text version is what the tests read today\u0027, while Step 5 mandates wrapping vendor names in \u0027\u003Cspan ...\u003E\u0027. If a single function outputs HTML, existing tests expecting plain text receive raw HTML markup and fail; if it outputs plain text, HTML vendor styling cannot be rendered.",
+            "fix": "Separate the structured data formatter from the HTML view renderer, or explicitly define the renderer return type as structured tokens/HTML and update test assertions to match.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section 2 \u0026 Build order #3: Auto-close lifecycle assumes clean completion and fails on dead or timed-out rounds",
+            "why": "The state transition relies on a round explicitly completing to trigger auto-close and stop duration measurement. When a reviewer process crashes, times out, or terminates abruptly without writing a completion record to the session file, the round remains in the running set indefinitely, leaving the card expanded and calculating duration against current time rather than its timeout point.",
+            "fix": "Add timeout validation against the configured reviewer timeout to mark dead rounds as completed/failed during state evaluation.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 452.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 491273,
+        "tokensOut": 23669,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 2,
+            "title": "The added plan is still marked as unimplemented after the change shipped",
+            "why": "This contradicts the written Definition of Done: \u0022Docs, help and CHANGELOG updated; the plan promoted.\u0022 The file says \u0022Status: plan only, nothing implemented yet\u0022 even though this diff implements the plan and adds the updated research documentation. This leaves a stale unpromoted plan in the repository.",
+            "fix": "Remove this obsolete todo plan or promote it by marking it implemented and updating its status to match the shipped change.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 166,
+            "title": "Concurrent saves can silently discard newer session state",
+            "why": "Two MCP servers can save the same repository/branch concurrently: each serializes its own snapshot, then the last \u0060File.Move(..., overwrite: true)\u0060 replaces the destination. A stale writer can therefore overwrite newer reviewer progress, causing data loss after restart and potentially rerunning work.",
+            "fix": "Serialize saves per session across processes, or add version checking and merge/retry logic so stale snapshots cannot replace newer state.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 137,
+            "title": "Toggling a round still triggers the full expensive repaint synchronously",
+            "why": "Opening or closing one card immediately enters the full repaint path, which rebuilds configuration, CLI/server status, GitHub/version data, and price tables. A normal toggle can therefore take the reported ~20 seconds before the changed card appears, with no progress or terminal feedback.",
+            "fix": "Update the round disclosure locally, or defer the full refresh to the existing background tick.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 180,
+            "title": "Synchronous thread sleep in file move retry loop blocks worker threads",
+            "why": "In MoveOverExisting, Thread.Sleep(20 * attempt) synchronously blocks the calling thread up to 200ms across 5 attempts on I/O collisions. Under high concurrency across multiple MCP sessions, this ties up thread pool threads performing session persistence.",
+            "fix": "Use Thread.Sleep with 0 or Task.Delay with yield, or reduce backoff steps/avoid blocking all calling threads synchronously in hot paths.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Nit",
+            "category": "Performance",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 38,
+            "title": "Redundant mapping and set allocation across cards in open round reconciliation",
+            "why": "nextOpenRounds filters and maps cards multiple times (cards.filter(isRunning).map(roundKey), cards.map(roundKey)) producing multiple intermediate arrays and Sets on every 5-second tick and toggle event.",
+            "fix": "Construct cards.map(roundKey) once and derive running/alive sets from that single traversal.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 193,
+            "title": "Missing newline before closing brace in \u0060Save\u0060 method",
+            "why": "The \u0060Save\u0060 method in \u0060SessionStore.cs\u0060 ends with a closing brace immediately following the \u0060try\u0060 block\u0027s closing brace without a separating newline, deviating from the project\u0027s implicit formatting convention of separating logical blocks.",
+            "fix": "Add a newline before the closing brace of the \u0060Save\u0060 method.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 217,
+            "title": "Missing newline before closing brace in \u0060MoveOverExisting\u0060 method",
+            "why": "The \u0060MoveOverExisting\u0060 method ends with a closing brace immediately following the \u0060for\u0060 loop\u0027s closing brace without a separating newline, deviating from the project\u0027s implicit formatting convention of separating logical blocks.",
+            "fix": "Add a newline before the closing brace of the \u0060MoveOverExisting\u0060 method.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 225,
+            "title": "Missing newline before closing brace in \u0060TryDelete\u0060 method",
+            "why": "The \u0060TryDelete\u0060 method ends with a closing brace immediately following the \u0060try\u0060 block\u0027s closing brace without a separating newline, deviating from the project\u0027s implicit formatting convention of separating logical blocks.",
+            "fix": "Add a newline before the closing brace of the \u0060TryDelete\u0060 method.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 815,
+            "title": "Missing newline before closing brace in \u0060roundCard\u0060 function",
+            "why": "The \u0060roundCard\u0060 function ends with a closing brace immediately following the \u0060reviewers\u0060 variable assignment without a separating newline, deviating from the project\u0027s implicit formatting convention of separating logical blocks.",
+            "fix": "Add a newline before the closing brace of the \u0060roundCard\u0060 function.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_vs_code/src/rounds.ts",
+            "line": 153,
+            "title": "Missing newline before closing brace in \u0060reviewerRows\u0060 function",
+            "why": "The \u0060reviewerRows\u0060 function ends with a closing brace immediately following the \u0060map\u0060 call without a separating newline, deviating from the project\u0027s implicit formatting convention of separating logical blocks.",
+            "fix": "Add a newline before the closing brace of the \u0060reviewerRows\u0060 function.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_vs_code/src/vendorColour.ts",
+            "line": 61,
+            "title": "Missing newline before closing brace in \u0060vendorColour\u0060 function",
+            "why": "The \u0060vendorColour\u0060 function ends with a closing brace immediately following the \u0060return\u0060 statement without a separating newline, deviating from the project\u0027s implicit formatting convention of separating logical blocks.",
+            "fix": "Add a newline before the closing brace of the \u0060vendorColour\u0060 function.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 806,
+            "title": "Vendor name colour injection via unescaped style attribute",
+            "why": "The code constructs \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:${vendorColour(row.provider)}\u0022\u003E\u0060 using string interpolation. While \u0060vendorColour\u0060 returns a CSS variable (e.g., \u0060var(--vscode-charts-blue)\u0060), the \u0060row.provider\u0060 value is escaped *inside* the span text but the \u0060style\u0060 attribute itself is not escaped. If a vendor name contains a quote or semicolon (e.g., \u0060codex\u0022;alert(1)//\u0060), the resulting HTML becomes \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:var(--vscode-charts-blue)\u0022\u003Ecodex\u0022;alert(1)//\u003C/span\u003E\u0060. While the colour function is deterministic, the \u0060style\u0060 attribute value is derived from the vendor name. If \u0060vendorColour\u0060 were to return a raw hex value or if the vendor name itself were to be interpolated directly into the style (which is not the case here, but the pattern is risky), an attacker could inject CSS properties. More critically, if \u0060vendorColour\u0060 returns a value containing a semicolon or closing brace, it could break the style declaration. The specific risk here is that \u0060vendorColour\u0060",
+            "fix": "Ensure \u0060vendorColour\u0060 returns a CSS variable string and that the \u0060style\u0060 attribute is constructed via a template literal that escapes the value, or use a dedicated DOM property setter instead of raw string interpolation.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 145,
+            "title": "Race condition in session persistence causes silent data loss on concurrent writes",
+            "why": "The code generates a unique temp filename per write (\u0060${file}.{ProcessId}-{Guid}.tmp\u0060) to avoid collisions. However, if two processes write to the same session file simultaneously, they might generate the *same* temp filename if the \u0060Guid\u0060 generation is not perfectly unique across processes (e.g., if the seed is time-based and the processes start within the same millisecond). If Process A writes to \u0060session.tmp\u0060, then Process B writes to \u0060session.tmp\u0060 (overwriting A\u0027s temp file), and then both try to move their respective temp files to \u0060session.json\u0060, Process A\u0027s move might succeed (if it still has the file handle) or fail. If Process B\u0027s move succeeds and deletes the file, Process A\u0027s \u0060TryDelete\u0060 might fail or succeed. The critical failure mode is if Process A\u0027s \u0060MoveOverExisting\u0060 throws an exception (e.g., \u0060UnauthorizedAccessException\u0060 because Process B already moved the file), and the exception is caught and retried. If the retry loop exhausts, the exception is thrown. However, if \u0060",
+            "fix": "Add a check to ensure the \u0060temp\u0060 file exists before attempting \u0060File.Move\u0060, or wrap the \u0060MoveOverExisting\u0060 call in a try-catch that handles \u0060FileNotFoundException\u0060 specifically for the temp file.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "src_mcp/core/Commands/GateCommands.cs",
+            "line": 73,
+            "title": "Loss of explicit Fable availability check creates implicit dependency on caller state",
+            "why": "The change removes the \u0060FableAvailable\u0060 field from \u0060CommandContext\u0060 and relies solely on the \u0060SplitWithFable\u0060 boolean. The comment explains that Fable is the calling AI, not a reviewer. However, if an external caller (e.g., a future version of the extension or a different client) sets \u0060SplitWithFable\u0060 to \u0060true\u0060 but the underlying AI model (Fable) is actually unavailable or misconfigured, the system will attempt to issue the Fable command without verifying its existence. This could lead to a runtime error or a silent failure where the split command is issued but the model fails to execute, leaving the round in an inconsistent state. The previous check \u0060context.FableAvailable\u0060 acted as a guard against this specific scenario.",
+            "fix": "Add a comment or a constant to document that \u0060SplitWithFable\u0060 is now the sole condition, and consider adding a deprecation warning or a migration path for any external callers that might still pass \u0060FableAvailable\u0060.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 163,
+            "title": "Scratch file cleanup races with failed moves, potentially deleting the target file",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060finally\u0060 block at line 163 calls \u0060TryDelete(temp)\u0060. If \u0060MoveOverExisting\u0060 (line 153) throws an exception after the last retry (e.g., due to a persistent lock), the \u0060finally\u0060 block executes. If the destination file (\u0060file\u0060) was already moved or if the temp file was somehow replaced by another process during the retry loop, deleting \u0060temp\u0060 might not be the issue, but more critically, if \u0060MoveOverExisting\u0060 fails and throws, the \u0060finally\u0060 block runs. However, the real issue is that \u0060TryDelete\u0060 is called on \u0060temp\u0060 which is correct, but if the \u0060Move\u0060 succeeds, \u0060temp\u0060 is gone. If the \u0060Move\u0060 fails, \u0060temp\u0060 remains. The specific risk is if \u0060MoveOverExisting\u0060 throws *after* a successful move in a previous iteration (unlikely) or if the logic assumes \u0060temp\u0060 exists. Wait, the logic is: \u0060File.Move(temp, file)\u0060. If it succeeds, \u0060temp\u0060 is gone. If it fails, \u0060temp\u0060 remains. The \u0060finally\u0060 block deletes \u0060temp\u0060. If the move succeeds, \u0060File.Delete(temp)\u0060 throws because the file",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of the \u0060Save\u0060 method, or ensure it runs after the \u0060MoveOverExisting\u0060 logic completes successfully, rather than in a \u0060finally\u0060 block that executes even if the move fails.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 805,
+            "title": "Potential inconsistency in reviewer row rendering between text and HTML views",
+            "why": "The change introduces \u0060reviewerRows\u0060 in \u0060rounds.ts\u0060 to split the provider name for coloring. In \u0060panelView.ts\u0060, the code uses \u0060reviewerRows\u0060 to generate HTML (line 805). However, if any other part of the codebase (e.g., a text export or a different view component) still relies on \u0060reviewerLines\u0060 or a direct string concatenation of the provider name without using the new \u0060reviewerRows\u0060 structure, the vendor name might not be colored or escaped correctly in those specific contexts. The diff shows \u0060reviewerLines\u0060 is still defined and used in \u0060roundCard\u0060 for the \u0060open\u0060 check, but the actual rendering uses \u0060reviewerRows\u0060. If a future change reverts to using \u0060reviewerLines\u0060 for a specific view, the color logic is lost.",
+            "fix": "Ensure the \u0060vendorColour\u0060 function is imported and used consistently in all places where reviewer rows are rendered, specifically checking if \u0060reviewerRows\u0060 is used everywhere \u0060reviewerLines\u0060 was previously used.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 55,
+            "title": "Inefficient set construction in \u0060nextOpenRounds\u0060 causes unnecessary allocations",
+            "why": "The function \u0060nextOpenRounds\u0060 creates new \u0060Set\u0060 objects from existing arrays (\u0060previous.autoOpened\u0060, etc.) and then filters them. Specifically, lines 55-57 create new Sets from the previous state, then iterate to add/remove items, and finally convert back to arrays for the return value. This involves multiple passes over the data. For a list of rounds that could grow large (e.g., hundreds of rounds over a long session), this creates unnecessary garbage and CPU cycles on every 5-second tick. A more efficient approach would be to mutate the existing Sets or build new ones in a single pass without intermediate array conversions.",
+            "fix": "Replace the \u0060filter\u0060 and \u0060Set\u0060 conversions in \u0060nextOpenRounds\u0060 with a single pass that builds the new sets directly, avoiding multiple array allocations and iterations.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:37:14 \u001B[32mINF\u001B[0m] coai-mcp#29956 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:163 - Scratch file cleanup races with failed moves, potentially deleting the target file (from local) [gating] Round=1 Stage=CodeReview\r | [09:37:14 \u001B[32mINF\u001B[0m] coai-mcp#29956 finding [Minor/Ux] src_vs_code/src/panelView.ts:805 - Potential inconsistency in reviewer row rendering between text and HTML views (from local) Round=1 Stage=CodeReview\r | [09:37:14 \u001B[32mINF\u001B[0m] coai-mcp#29956 finding [Minor/Performance] src_vs_code/src/openRounds.ts:55 - Inefficient set construction in \u0060nextOpenRounds\u0060 causes unnecessary allocations (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 3,
+    "key": "codex,gemini,local|split-once|1",
+    "startedUtc": "2026-09-05T09:28:06.0281427Z",
+    "finishedUtc": "2026-09-05T09:30:51.6891389Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 41.5,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 49832,
+        "tokensOut": 6119,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The claim cannot be made atomic with issuing the external command",
+            "why": "If the process claims the split before enqueueing the command and is killed in between, the caller is permanently marked as handled but receives no command; if it enqueues first and dies before claiming, a retry can issue the command twice.",
+            "fix": "Define a durable outbox or idempotency protocol with explicit recovery semantics for the claim/command boundary, and verify both kill windows.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open behavior for an unwritable store contradicts the exactly-once guarantee",
+            "why": "When the store is read-only, the caller cannot record its claim; retrying the same passing plan can therefore issue another split command, while suppressing the command would violate the stated fail-open behavior. The plan does not define which outcome is intended.",
+            "fix": "Specify the exact command behavior on read/write failure and either provide a durable fallback claim location or explicitly downgrade the once-only guarantee with an observable error.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback has no lifecycle or collision rule",
+            "why": "After one split in a checkout, a later unrelated plan started in the same checkout with no session ID can inherit the stale marker and be treated as an already-split piece; concurrent plans in the same checkout likewise cannot be distinguished and one can consume the other\u0027s claim.",
+            "fix": "Define a checkout identity plus a bounded, lineage-linked record (for example a plan fingerprint and branch transition), and specify cleanup, expiry, and concurrent-plan behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define safe encoding for the caller-controlled store key",
+            "why": "A caller ID such as \u0060..\\..\\other\u0060 or \u0060C:\\temp\\x\u0060 reaches filename construction; using it directly can write or claim outside the data directory, and platform-specific separators and reserved names create additional collisions.",
+            "fix": "Specify an injective filesystem-safe encoding (or store IDs as data keys rather than path components), enforce directory containment after resolution, and test Windows path and reserved-name cases.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The split verdict is not bound to the plan content that triggers the command",
+            "why": "If a plan passes, then is edited or replaced before command issuance, a stored boolean or prior-round verdict can still cause the new plan to receive the split order even though this round did not review that content.",
+            "fix": "Persist and compare a plan-content fingerprint or review token with the claim, and invalidate the command whenever the reviewed plan changes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027What must be true\u0027 (Item 5): Failing open on unwritable storage re-enables the infinite split recursion loop",
+            "why": "When the backing store is read-only or permissions fail, failing open prevents recording that a split was issued. Every subsequent child epic review running on a new branch will see an unrecorded claim and issue another split order, reproducing the unbounded recursive split loop.",
+            "fix": "Fail closed on storage write failures by falling back to the single-unit autonomy order (or surfacing a fatal error) instead of issuing split orders when the state cannot be recorded.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027What must be true\u0027 (Item 6): Checkout-level fallback tracking permanently suppresses split orders for future tasks",
+            "why": "When CLAUDE_CODE_SESSION_ID is missing, tracking across branches by repo checkout causes a single split claim to persist for the workspace. When a developer later starts an entirely new, unrelated large plan on a new branch in that checkout, it is misidentified as a child piece and prevented from splitting.",
+            "fix": "Bind the fallback tracking key to the root plan\u0027s git commit hash or base branch lineage rather than a mutable checkout-wide flag, and clear or expire state when a new root branch is created.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027Constraints\u0027: Combining split check and claim into a single atomic step breaks plan retry",
+            "why": "If checking and claiming are executed in a single atomic step during verdict evaluation, a crash, network failure, or retry during the initial plan review leaves the caller id already marked as split. Retrying the root plan review will cause it to be misclassified as an epic piece and forced to execute as a single unit.",
+            "fix": "Ensure the claim is tied to the successful dispatch and acknowledgment of the split command, or make re-evaluation for the exact same session and branch idempotent.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 124,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 10,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 242725,
+        "tokensOut": 15411,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 581,
+            "title": "The split-order predicate is evaluated more than once instead of asking the issue/claim question once",
+            "why": "The scope constraint says \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 This code calls \u0060OrdersSplit(provisional)\u0060 to decide whether to claim and calls \u0060OrdersSplit(context)\u0060 again after \u0060For\u0060; the two evaluations can drift if command logic changes or state is observed differently, so the claim and emitted-order conditions are not the same single predicate evaluation.",
+            "fix": "Store the initial \u0060OrdersSplit(provisional)\u0060 result in a local and use that result both to decide whether to claim and to determine/report the split order, or refactor the command flow so the predicate is evaluated exactly once.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 109,
+            "title": "Expired-claim replacement can delete a concurrent live claim",
+            "why": "After the 24-hour window, two processes can both observe the expired file; one can delete the file after the other has created the replacement, allowing both requests to receive the split order and leaving the claim state nondeterministic.",
+            "fix": "Protect expiry checking, deletion, and CreateNew with an inter-process lock, or use an atomic replacement protocol that cannot remove a newly created claim.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 114,
+            "title": "A process crash after CreateNew permanently suppresses the split order",
+            "why": "If the server is killed after creating the claim file but before writing and flushing its timestamp, the empty file remains. A later request sees File.Exists and returns false from the IOException filter, so no order is issued for the entire retention period even though the store is writable.",
+            "fix": "Write a complete claim to a temporary file and atomically publish it, or validate the existing claim contents and treat an empty/invalid file as an unavailable claim only while it is actively locked.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 111,
+            "title": "Unconditional File.Delete before FileMode.CreateNew causes race conditions and sharing violations between concurrent servers",
+            "why": "When two server instances concurrently claim a split order for the same caller, if Process 1 successfully creates the claim file while Process 2 has already passed the StillRemembered check, Process 2 will unconditionally execute File.Delete(file). This either deletes Process 1\u0027s new claim allowing Process 2 to also succeed via FileMode.CreateNew (granting duplicate split orders), or on Windows throws UnauthorizedAccessException/sharing violation while Process 1 holds the FileStream open, causing Process 2 to enter the generic catch block and return true (failing open incorrectly and issuing duplicate split orders).",
+            "fix": "Do not delete the file before FileMode.CreateNew; instead, rely on atomic file creation or atomic replacement via unique temporary files, and treat file sharing/locking contention as an active claim (returning false) rather than a persistent directory failure.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "Nullable callback parameter risks NullReferenceException",
+            "why": "The method signature \u0060Action\u003Cstring\u003E? warn = null\u0060 allows the caller to omit the argument. If the code path reaches \u0060warn?.Invoke\u0060 (line 117) and the caller passed \u0060null\u0060 explicitly or the default was not handled correctly in a specific call site, the warning logic could fail silently or throw if the null check is bypassed in a future refactor. More critically, the test \u0060AnUnwritableStore_GivesTheOrderRatherThanSwallowingIt\u0060 passes a lambda, but \u0060PanelService\u0060 (line 583) passes a lambda. However, the method signature change from \u0060RecordSplitOrder\u0060 to \u0060TryClaimSplitOrder\u0060 introduces a new optional parameter that was not present in the original API contract, potentially breaking callers that rely on positional arguments or implicit defaults if not careful.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 or ensure the caller passes a non-null delegate. The current implementation invokes \u0060warn?.Invoke\u0060 without guaranteeing the caller provides one, risking a \u0060NullReferenceException\u0060 if called without the argument.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Inconsistent handling of optional warning callback",
+            "why": "The method \u0060TryClaimSplitOrder\u0060 accepts an optional \u0060warn\u0060 callback. While the code uses \u0060warn?.Invoke\u0060, the logic inside the \u0060catch (Exception e)\u0060 block assumes the callback might be null. If a caller passes \u0060null\u0060 explicitly, the warning is swallowed. The rule requires \u0027a warning rather than silently disabling\u0027, but if the callback is null, the warning is silent.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked with a consistent message format or handle the case where \u0060warn\u0060 is null more explicitly if the design requires it to be optional.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Inconsistent state propagation for FirstPlanRound",
+            "why": "The code sets \u0060FirstPlanRound: true\u0060 on \u0060provisional\u0060. Then it checks \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060. If true, it creates a new \u0060context\u0060 with \u0060FirstPlanRound\u0060 set to the result of \u0060TryClaimSplitOrder\u0060. If false, it uses \u0060provisional\u0060 as \u0060context\u0060. This means if the order is not split, \u0060FirstPlanRound\u0060 remains true. If the order is split, \u0060FirstPlanRound\u0060 becomes the boolean result of the claim. This logic is complex and potentially confusing, but more importantly, it deviates from the rule that \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The code asks \u0060OrdersSplit\u0060 twice (once for \u0060provisional\u0060, once for \u0060context\u0060 implicitly via the \u0060if\u0060 block) or relies on the state of \u0060provisional\u0060 being consistent.",
+            "fix": "The variable \u0060provisional\u0060 is created but then immediately used to create \u0060context\u0060. The logic \u0060FirstPlanRound: true\u0060 is set on \u0060provisional\u0060, but then \u0060context\u0060 is created from \u0060provisional\u0060 only if \u0060OrdersSplit\u0060 returns true. This creates a potential inconsistency where \u0060FirstPlanRound\u0060 might be true in \u0060provisional\u0060 but false in \u0060context\u0060 if the condition fails, or vice versa depending on the flow.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Violation of \u0027ONE question asked once\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to decide whether to claim, but then calls \u0060Core.Commands.GateCommands.OrdersSplit(context)\u0060 again in the \u0060if\u0060 block to log. This is two questions. The logging should be based on the result of the claim, not a re-evaluation of the condition.",
+            "fix": "Align the logic to ensure the \u0027one question\u0027 rule is strictly followed. The \u0060OrdersSplit\u0060 check should be the sole determinant for both issuing and claiming.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Redundant or confusing exception handling",
+            "why": "The code has \u0060catch (IOException)\u0060 for the race condition and \u0060catch (Exception e) when (e is IOException or UnauthorizedAccessException)\u0060 for the \u0027fail open\u0027 case. The second catch block is technically redundant because \u0060IOException\u0060 is already caught by the first block. The logic flow suggests the first catch is for the race (file exists), and the second is for other IO errors. However, the \u0060when\u0060 clause in the second catch makes it specific to \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060, which might overlap with the first catch if the order of evaluation is not clear.",
+            "fix": "The \u0060catch (Exception e)\u0060 block catches \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060 specifically, but the outer \u0060catch (IOException)\u0060 handles the race condition. The inner catch for \u0060Exception\u0060 might be redundant or confusing.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Warning message clarity",
+            "why": "The warning message \u0027the split-order memory at {Dir} could not be written ({e.Message}) \u2014 the order is being given, and may be given again\u0027 is clear, but the rule requires \u0027a warning rather than silently disabling\u0027. If \u0060warn\u0060 is null, the warning is silent. The rule implies a warning *must* be issued, so the \u0060warn\u0060 parameter should perhaps be required or a default logger used.",
+            "fix": "Ensure the \u0060warn\u0060 callback is invoked with a message that clearly indicates the \u0027fail open\u0027 nature.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 913,
+            "title": "Change in fallback logic for anonymous clients",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The previous implementation used \u0060session.State.SessionId\u0060 (which is repo\u002Bbranch), causing every epic to be treated as a new caller. The new implementation uses \u0060session.State.RepoPath\u0060, which correctly follows the caller across branches. This is a compliance fix, but it changes the behavior significantly.",
+            "fix": "The \u0060CallerFor\u0060 method now uses \u0060session.State.RepoPath\u0060 instead of \u0060session.State.SessionId\u0060. This is a change in the fallback logic.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "API contract change from void to bool",
+            "why": "The method signature changed from \u0060void RecordSplitOrder\u0060 to \u0060bool TryClaimSplitOrder\u0060. This is a breaking change for any caller that relied on the void return. However, the rule requires \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The new return value allows the caller to know if the claim succeeded, which is necessary for the \u0027fail open\u0027 logic.",
+            "fix": "The \u0060TryClaimSplitOrder\u0060 method now returns a \u0060bool\u0060 indicating success, whereas \u0060RecordSplitOrder\u0060 was \u0060void\u0060. This is a change in the API contract.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Atomic claim race window created by pre-delete of expired file",
+            "why": "The code deletes an existing file (\u0060File.Delete(file)\u0060) before attempting \u0060FileMode.CreateNew\u0060. If a second server process checks \u0060StillRemembered\u0060 (returns false), then deletes the file, then attempts \u0060CreateNew\u0060 while the first process is still deleting, the second process\u0027s \u0060CreateNew\u0060 will succeed. This allows two servers to both believe they claimed the order, violating the atomicity guarantee required to prevent \u0027epics of epics\u0027 loops.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call to a separate \u0060if\u0060 block before the \u0060try\u0060 block, or wrap the delete in its own try-catch to ensure the atomic \u0060CreateNew\u0060 is not shadowed by a delete failure.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 92,
+            "title": "Path traversal vulnerability in caller identity file naming",
+            "why": "The \u0060caller\u0060 string is used directly to construct a file path via \u0060FileFor(caller)\u0060. If a malicious or misbehaving client passes a \u0060caller\u0060 value like \u0060../../etc/passwd\u0060 or \u0060..\\..\\windows\\system32\u0060, the code could write to or overwrite arbitrary files on the server\u0027s filesystem, potentially overwriting configuration or log files, or creating a symlink to a sensitive file.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., remove or replace \u0060..\u0060, \u0060/\u0060, \u0060\\\u0060, and control characters) before using it in \u0060FileFor(caller)\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Potential deadlock or hang if file delete is blocked",
+            "why": "If the file to be deleted is locked by another process (e.g., an antivirus scanner or a previous crashed instance), \u0060File.Delete\u0060 will block or throw an exception. If it throws, the \u0060CreateNew\u0060 might not execute, or if it hangs, the server thread blocks. The current catch block only handles \u0060IOException\u0060 from \u0060CreateNew\u0060, not from the delete.",
+            "fix": "Add a timeout to the \u0060File.Delete\u0060 operation or ensure the \u0060try\u0060 block covers the delete operation as well, or use a more robust locking mechanism (e.g., \u0060FileLock\u0060 or \u0060Mutex\u0060) instead of relying solely on \u0060CreateNew\u0060 after a delete.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Silent failure of split order claim obscures state",
+            "why": "When \u0060TryClaimSplitOrder\u0060 returns \u0060false\u0060 (e.g., due to a race or unwritable store), the code proceeds to use the \u0060provisional\u0060 context without explicitly logging or signaling that the claim failed. A user or downstream process might expect the split order to be active, but it was silently skipped, leading to confusion about why the split didn\u0027t occur.",
+            "fix": "Add a specific log entry or return value indicating that the split order was claimed, and ensure the UI or downstream process reflects this state change immediately.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file existence check before atomic create",
+            "why": "The code checks \u0060File.Exists(file)\u0060 before attempting \u0060FileMode.CreateNew\u0060. While this is intended to handle expired claims, it adds an extra disk I/O operation. In high-frequency scenarios (e.g., many concurrent splits), this check could become a bottleneck, especially if the file system is slow or the directory is large.",
+            "fix": "Cache the \u0060File.Exists(file)\u0060 check result or use a more efficient file system operation to avoid redundant disk I/O in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:30:51 \u001B[32mINF\u001B[0m] coai-mcp#16340 finding [Minor/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - Potential deadlock or hang if file delete is blocked (from local) Round=1 Stage=CodeReview\r | [09:30:51 \u001B[32mINF\u001B[0m] coai-mcp#16340 finding [Minor/Ux] src_mcp/src/Server/PanelService.cs:578 - Silent failure of split order claim obscures state (from local) Round=1 Stage=CodeReview\r | [09:30:51 \u001B[32mINF\u001B[0m] coai-mcp#16340 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file existence check before atomic create (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 5,
+    "key": "codex,gemini,local|split-once|2",
+    "startedUtc": "2026-09-05T09:28:06.0280487Z",
+    "finishedUtc": "2026-09-05T09:36:46.8419164Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 60.3,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 49190,
+        "tokensOut": 5908,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how a claim remains unique when two processes race",
+            "why": "Two servers start with the same eligible caller and shared data directory; if both perform a read followed by a write without an explicitly atomic primitive, both observe \u201Cunclaimed\u201D and both issue the split order, violating the stated exactly-once guarantee.",
+            "fix": "Specify the storage primitive and protocol (for example, an atomic create or transactional compare-and-set), including the behavior for contention, stale locks, crashes, and a test that launches concurrent claimers and asserts exactly one command.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan leaves the no-session-id checkout identity undefined and permits cross-checkout or cross-run claims",
+            "why": "A client without \u0060CLAUDE_CODE_SESSION_ID\u0060 makes two branches in the same checkout, but the plan names no stable identity or canonicalization algorithm; conversely, a reused checkout or two worktrees can cause an old claim to suppress splitting for a later unrelated plan or allow branches to share the wrong claim.",
+            "fix": "Define the exact checkout key, including worktree/common-git-dir semantics, its lifecycle and reset rules, and tests for branch switching, reused checkouts, multiple worktrees, and concurrent unrelated plans.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Store-open failures have no specified command outcome and undermine the exactly-once requirement",
+            "why": "When the data directory is read-only, the plan requires a warning but does not say whether the caller continues and issues the command; if it continues, retries can issue it repeatedly because no claim can be persisted, while refusing to issue it may block an otherwise valid plan.",
+            "fix": "Choose and document the failure policy, define the user-visible error, exit status, and retry behavior, and add a read-only-store test covering the command list and warning.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan has no handling or verification for malformed, missing, timed-out, or interrupted verdicts",
+            "why": "If the reviewer times out, is killed after producing a partial verdict, or returns an unparseable result, \u201Cplan did not pass\u201D does not determine whether a split claim is attempted; a retry can either lose the split permanently or emit duplicate orders.",
+            "fix": "Specify verdict parsing and state transitions for every non-success path, persist claim state only after eligibility is established, and test timeout, malformed output, termination between claim and command emission, and retry.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The filename-safety requirement lacks a concrete encoding and collision rule",
+            "why": "Caller ids such as \u0060../../other\u0060, \u0060C:\\temp\\x\u0060, or two distinct ids that normalize to the same path can escape the store or cause unrelated callers to share a claim; the plan only says the id must not escape the directory.",
+            "fix": "Require an opaque encoding or hash for the filename, define collision handling and permissions, and test platform-specific separators, Unicode, and very long ids.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "",
+            "line": 0,
+            "title": "The plan promises unchanged behavior but specifies no compatibility or migration verification for existing claim data",
+            "why": "An earlier release may already have a data directory or an empty command list; after upgrade, a changed schema or keying rule can reinterpret old state, suppress a first eligible split, or cause old invocations to emit commands despite the feature being off.",
+            "fix": "Define the on-disk schema/version and migration or invalidation policy, and verify upgrade, unknown-data, feature-off, and empty-command-list cases.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Failing open on store write errors causes infinite recursive splitting",
+            "why": "If the claim store is read-only or unwritable (e.g., full disk or permission errors), failing open allows the split order to be issued without persisting the claim state. When child epics return on their new branches for review, the unwritable store fails open again, issuing split orders indefinitely and recreating the exact \u0027epics of epics\u0027 infinite loop the feature exists to prevent.",
+            "fix": "Fail closed when the claim store is unwritable by suppressing the split order and falling back to single-unit execution with a logged warning.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fallback checkout-level tracking collides with future unrelated plan reviews",
+            "why": "When a client does not export CLAUDE_CODE_SESSION_ID, keying claims by checkout/repository means the first split permanently consumes the claim for that working copy. Any future, unrelated feature plan reviewed in the same checkout will be misidentified as a child piece and denied the split order.",
+            "fix": "Scope fallback tracking to an ephemeral process/parent PID or require explicit caller identity rather than a static checkout path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic one-step claim consumes the split allowance before review verdict passes",
+            "why": "If claiming the split order and evaluating the conditions occur in a single atomic step, a plan review that is rejected or encounters a gate error will have already recorded the claim. When the user revises the plan and resubmits it in the same session, it will be treated as an already-split piece and never receive the split order.",
+            "fix": "Condition the atomic claim acquisition strictly on a passing plan review verdict, or record the claim conditionally in a two-phase transaction that commits only on pass.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 460.3,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 13,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 305557,
+        "tokensOut": 28034,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "The split-order predicate is evaluated twice instead of once",
+            "why": "The written constraint says: \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 This code asks \u0060GateCommands.OrdersSplit\u0060 once for claiming and again after constructing the context for logging, allowing the claim condition and issuance condition to drift. Compute the decision once and reuse it for both claim/issuance handling.",
+            "fix": "Store the result of the applicable \u0060OrdersSplit\u0060 decision in one local and reuse that value for the claim and subsequent order/logging path.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 106,
+            "title": "Expired-claim deletion is not synchronized with concurrent replacement",
+            "why": "Two servers can both read the same expired claim, then each delete and recreate the file. The second server can delete the first server\u0027s newly-created claim and successfully create its own, so both return true and issue the split order.",
+            "fix": "Synchronize expiry replacement across processes, or use an atomic replacement protocol that never deletes a newly-created claim observed by another process.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 114,
+            "title": "A write failure is mistaken for another process winning the claim",
+            "why": "When the process creates the file but writing the timestamp fails, such as on a full disk, the IOException filter sees the file and returns false. The order is withheld without the required warning, even though no valid claim was recorded.",
+            "fix": "Track whether this invocation created the file and only treat an existing file as a competing claim when it was not created by this invocation; otherwise warn and fail open, cleaning up the partial file where possible.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 111,
+            "title": "TOCTOU race in TryClaimSplitOrder deletes active claims and allows concurrent processes to both grant split orders",
+            "why": "When an expired claim file exists (or when two processes evaluate StillRemembered concurrently), executing File.Delete immediately before FileMode.CreateNew allows Process B to delete the fresh claim file just written by Process A. Process B then successfully creates its own file, resulting in both processes returning true and issuing duplicate split orders across servers.",
+            "fix": "Do not delete existing files before FileMode.CreateNew; coordinate expired claim replacement using file locking or an atomic file rename/replace mechanism.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 111,
+            "title": "Synchronous, blocking file I/O executed on async request path in TryClaimSplitOrder",
+            "why": "PanelService calls TryClaimSplitOrder synchronously inside the async request handling flow (PanelService.cs:581). TryClaimSplitOrder performs Directory.CreateDirectory, File.Exists, File.Delete, and synchronous FileStream/StreamWriter operations against local disk (or potentially network-mounted shares). Under high concurrency or slow disk I/O, synchronous file operations block the ThreadPool worker thread handling the MCP tool call.",
+            "fix": "Make TryClaimSplitOrderAsync asynchronous with non-blocking I/O (FileStream with useAsync: true / writer.WriteAsync) and await it from PanelService, or offload file I/O appropriately.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 914,
+            "title": "Anonymous caller fallback string includes full RepoPath, creating sensitive/messy identifiers and noisy log output",
+            "why": "When CallerIdentity.Current() is empty, CallerFor falls back to $\u0022repo:{session.State.RepoPath}\u0022. FileFor(caller) hashes or sanitizes this for file naming, but CallerFor is logged in plaintext (_log.Information(\u0022split ordered to caller {Caller}\u0022, caller) at line 587) and stored inside claim files. On machines with deeply nested or user-identifying repository paths (e.g. containing usernames/spaces/tokens), log entries become cluttered and noisy.",
+            "fix": "Normalize or hash RepoPath (e.g., repo:{Sha256(RepoPath)[..12]}) or format it consistently when logging/identifying anonymous repo callers.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 88,
+            "title": "Atomic claim introduces side-effect dependency via callback parameter",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 By passing an \u0060Action\u003Cstring\u003E? warn\u0060 into the atomic claim method, the method\u0027s return value (the claim result) becomes coupled with a side-effect (logging) that is not part of the atomic state transition. This breaks the purity of the \u0027one question\u0027 contract, as the caller must now manage the logging context for the claim to be complete.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 and the \u0060warn?.Invoke\u0060 call inside the catch block. The rule requires the caller to be ordered ONCE, and the claim logic to be atomic. The current implementation introduces a side-effect (logging a warning) that depends on an external callback, which violates the principle that the condition that issues the order and the condition that claims it are ONE question asked once. The warning is a side effect of the failure mode, not part of the atomic claim itself.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Atomic claim logic separated into check-then-delete-then-create, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current implementation performs a \u0060File.Exists\u0060 check, deletes the file if present, and then attempts \u0060CreateNew\u0060. This sequence is not atomic. If another process deletes the file between the check and the \u0060CreateNew\u0060, or if the \u0060CreateNew\u0060 fails because the file was created by another process in that window, the logic returns \u0060false\u0060 (claim lost) or \u0060true\u0060 (claim won) inconsistently. The rule requires a single atomic operation to determine the outcome, not a sequence of operations that can be interrupted.",
+            "fix": "Change the catch block for \u0060IOException\u0060 to not return \u0060false\u0060 when \u0060File.Exists(file)\u0060 is true. The current logic returns \u0060false\u0060 if the file exists (implying a race where someone else claimed it), but the rule requires that \u0027A caller that already holds a claim is a caller already inside a split, and is told so.\u0027 The current implementation returns \u0060false\u0060 for an existing file, which is correct, but the logic \u0060if (File.Exists(file)) { File.Delete(file); }\u0060 followed by \u0060CreateNew\u0060 creates a race window where the file could be deleted by another process between the check and the write, leading to a silent failure or duplicate claim if not handled strictly. The rule \u0027The condition that issues the order and the condition that claims it are ONE question asked once\u0027 implies the check and the claim must be inseparable. The current code separates the existence check (delete) from the atomic creation.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "FirstPlanRound flag set before atomic claim, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code sets \u0060FirstPlanRound: true\u0060 in the \u0060provisional\u0060 context before calling \u0060TryClaimSplitOrder\u0060. This means the flag is set regardless of whether the claim succeeds. If the claim fails (e.g., due to an unwritable store), the flag remains \u0060true\u0060, but the caller is not actually ordered to split (because the claim failed). This creates a state where the flag says \u0027first round\u0027 but the order was not given, violating the atomicity of the \u0027one question\u0027 contract.",
+            "fix": "Remove the \u0060FirstPlanRound: true\u0060 assignment in the \u0060provisional\u0060 context. The rule states: \u0027A caller is ordered to split ONCE. A plan that is already a piece is told so instead.\u0027 The current code sets \u0060FirstPlanRound\u0060 to \u0060true\u0060 unconditionally, then checks \u0060OrdersSplit\u0060 and claims the order. This means the \u0060FirstPlanRound\u0060 flag is set before the claim is verified, potentially allowing a caller that has already claimed an order to be treated as a first-round caller if the claim fails (e.g., due to an unwritable store). The rule requires that the \u0027claim\u0027 and the \u0027order\u0027 are one question. The current code separates the flag setting from the claim verification.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 907,
+            "title": "Comment misrepresents fallback logic: \u0027Our session\u0027 vs \u0027checkout\u0027",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The comment in \u0060CallerFor\u0060 says: \u0027Our session is repo\u002Bbranch, and an epic arrives on its own branch: a session-keyed fallback would call every epic a fresh caller...\u0027 This implies the fallback is the session, but the code actually falls back to \u0060session.State.RepoPath\u0060 (the checkout). The comment is misleading because it suggests the fallback is the session, when it is actually the checkout. This is a minor deviation because the code is correct, but the comment could confuse a reader about the actual fallback mechanism.",
+            "fix": "Change the fallback from \u0060CallerIdentity.Current()\u0060 to \u0060session.State.RepoPath\u0060 to be consistent with the rule \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The current code uses \u0060CallerIdentity.Current()\u0060 which returns the session ID, but the rule requires that a client with no session ID falls back to the checkout (repo path), not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the fallback is the checkout, not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the backup",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "Race condition allows duplicate split orders under concurrent load",
+            "why": "The method checks \u0060StillRemembered\u0060 (read) before attempting \u0060FileMode.CreateNew\u0060 (write). If two servers run in parallel: Server A reads \u0027unclaimed\u0027, Server B reads \u0027unclaimed\u0027, Server A writes and succeeds, Server B writes and succeeds. The test \u0060TheClaimIsATOMIC\u0060 passes because it uses \u0060Parallel.For\u0060 on the same instance, but the logic relies on the OS \u0060CreateNew\u0060 to serialize. However, the pre-check \u0060if (StillRemembered(...))\u0060 is outside the \u0060try\u0060 block. If a file exists but is stale (expired), it is deleted. If two servers race to delete and create, or if the check happens between the delete and create, both might succeed if the check logic isn\u0027t perfectly atomic with the write. More critically, the \u0060catch (IOException) when (File.Exists(file))\u0060 block returns \u0060false\u0060 (claim failed), but if the file was created by a rival just before the exception, the caller thinks they failed, yet the rival succeeded. Wait, the real issue is: if \u0060StillRemembered\u0060 returns false (file expired or no",
+            "fix": "Move the \u0060StillRemembered\u0060 check inside the \u0060try\u0060 block, immediately after \u0060Directory.CreateDirectory\u0060, so the check happens on the same file handle state as the \u0060CreateNew\u0060 attempt.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "Path traversal vulnerability in caller identity file name",
+            "why": "The \u0060caller\u0060 string is used directly in \u0060FileFor(caller)\u0060 to create a file path. If a caller passes a value like \u0060../../etc/passwd\u0060 or \u0060C:\\Windows\\System32\\config\u0060, the code writes to an arbitrary location on the filesystem. An attacker controlling the caller ID (e.g., via a malicious MCP client or environment variable) could overwrite critical system files or log files, or create a symlink to a sensitive file, leading to data leakage or privilege escalation.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., remove or replace \u0060/\u0060, \u0060\\\u0060, \u0060:\u0060, \u0060*\u0060, \u0060?\u0060, \u0060",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 90,
+            "title": "Potential deadlock or hang on slow/unresponsive storage",
+            "why": "The code performs \u0060File.Exists\u0060 followed by \u0060File.Delete\u0060 and then \u0060FileMode.CreateNew\u0060. If the underlying storage is slow, network-mounted, or the file handle is locked by another process, these operations can block indefinitely. In a high-concurrency scenario with many callers, this could lead to thread pool exhaustion or a complete stall of the server\u0027s ability to process new requests.",
+            "fix": "Add a timeout to the \u0060File.Exists\u0060 and \u0060File.Delete\u0060 operations, or use a more robust locking mechanism (e.g., \u0060Mutex\u0060) to prevent indefinite hangs on slow storage.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 575,
+            "title": "Inconsistent state propagation for FirstPlanRound flag",
+            "why": "The code creates a \u0060provisional\u0060 context with \u0060FirstPlanRound: true\u0060, then conditionally updates it based on \u0060TryClaimSplitOrder\u0060. However, if \u0060GateCommands.OrdersSplit(provisional)\u0060 returns false, the \u0060context\u0060 variable is assigned the \u0060provisional\u0060 object, but the logic for \u0060FirstPlanRound\u0060 might not be correctly reflected in the final \u0060commands\u0060 generated by \u0060GateCommands.For(context)\u0060. If the \u0060FirstPlanRound\u0060 flag is used elsewhere in the system to determine behavior, this inconsistency could lead to unexpected splitting behavior or missed split orders.",
+            "fix": "Ensure the \u0060provisional\u0060 context is passed correctly to \u0060GateCommands.For\u0060 and that the \u0060FirstPlanRound\u0060 flag is consistently applied across all code paths, not just the split order path.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 85,
+            "title": "Missing null/empty check for caller identity",
+            "why": "If \u0060caller\u0060 is an empty string or null, \u0060FileFor(caller)\u0060 might create a file with a weird name (e.g., \u0060.\u0060 or \u0060null\u0060) or throw an exception. This could lead to silent failures where the split order is recorded but not retrievable, or the file system becomes cluttered with invalid entries.",
+            "fix": "Add a check to ensure the \u0060caller\u0060 string is not empty or null before using it in \u0060FileFor\u0060.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Race condition in atomic claim due to pre-check delete",
+            "why": "The code checks if a file exists and deletes it (line 97) before attempting \u0060FileMode.CreateNew\u0060. If two servers run in parallel: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false), Server A deletes the file, Server B deletes the file (no-op), Server A creates the file and returns true, Server B attempts to create the file and throws \u0060IOException\u0060. The current catch block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060 to determine if it was a race. However, if Server B deletes the file *after* Server A creates it but *before* Server B\u0027s \u0060CreateNew\u0060 executes, the \u0060File.Exists\u0060 check in the catch block will be true (because Server A created it), causing Server B to return \u0060false\u0060 (claim failed) instead of \u0060true\u0060 (claim succeeded). This creates a scenario where two servers can both believe they failed to claim, or worse, if the delete happens between the check and the create, the logic for \u0027someone else claimed it\u0027 becomes ambiguous. More critically, if the",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or wrap it in its own try-catch before the \u0060CreateNew\u0060 attempt.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Split order claimed on rounds that may not issue a command",
+            "why": "The code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to determine if a split should be ordered. If this returns true, it then calls \u0060TryClaimSplitOrder\u0060. However, the \u0060provisional\u0060 context used for the claim includes \u0060FirstPlanRound: true\u0060 (line 573), which is hardcoded. The original logic used \u0060!_callers.SplitAlreadyOrdered(caller, DateTime.UtcNow)\u0060 to determine if it was the first round. By hardcoding \u0060FirstPlanRound: true\u0060 and then checking \u0060OrdersSplit\u0060 *after* the claim, the code risks claiming a split order for a round that might not actually be the \u0027first\u0027 round in the sequence if the logic for determining \u0027first\u0027 is decoupled from the claim. Specifically, if \u0060OrdersSplit\u0060 returns true based on \u0060provisional\u0060, but the claim fails (e.g., due to race), the system might proceed with a split order that was already claimed by another process, or fail to claim it when it should have. The logic flow is: 1. Create provisional with \u0060FirstPlanRound: true\u0060. 2. Check if \u0060pro\u0060",
+            "fix": "Pass the \u0060provisional\u0060 context to \u0060OrdersSplit\u0060 *after* the claim attempt, or ensure the claim is only attempted if \u0060OrdersSplit\u0060 returns true, to avoid claiming a split order on a round that doesn\u0027t actually issue a split command.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file system checks in atomic claim logic",
+            "why": "The code performs \u0060File.Exists(file)\u0060 (line 95) and then \u0060File.Delete(file)\u0060 (line 97), followed by \u0060new FileStream(file, ...)\u0060 (line 100). In a high-concurrency environment where multiple servers are checking the same caller, this results in multiple file system calls per claim attempt. While \u0060File.Exists\u0060 is a check, the subsequent \u0060Delete\u0060 and \u0060CreateNew\u0060 operations are expensive. If the file exists and is not expired, the code deletes it and then tries to create a new one. This sequence of operations (check, delete, create) can be optimized by using a single atomic operation or by caching the existence check. In a scenario with 100 concurrent servers checking the same caller, this could lead to 300 file system calls per second, potentially causing I/O contention.",
+            "fix": "Cache the \u0060File.Exists\u0060 result or use a single \u0060File.TryOpen\u0060 pattern to avoid redundant file system calls in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:36:46 \u001B[32mINF\u001B[0m] coai-mcp#13088 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:97 - Race condition in atomic claim due to pre-check delete (from local) [gating] Round=1 Stage=CodeReview\r | [09:36:46 \u001B[32mINF\u001B[0m] coai-mcp#13088 finding [Major/Ux] src_mcp/src/Server/PanelService.cs:578 - Split order claimed on rounds that may not issue a command (from local) [gating] Round=1 Stage=CodeReview\r | [09:36:46 \u001B[32mINF\u001B[0m] coai-mcp#13088 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file system checks in atomic claim logic (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 3,
+    "lane": 3,
+    "key": "codex,gemini,local|split-once|3",
+    "startedUtc": "2026-09-05T09:30:51.8647606Z",
+    "finishedUtc": "2026-09-05T09:42:39.8496638Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 535.4,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 10,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 49534,
+        "tokensOut": 5668,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define an atomic claim mechanism for the shared store",
+            "why": "Two servers can both observe a passing plan and an unclaimed key, then both write their claims and emit the split order; the stated single-order guarantee is therefore violated under the exact multi-process scenario the plan targets.",
+            "fix": "Specify a transactional or atomic-create claim operation, including lock scope, durable winner semantics, and crash recovery, and verify it with concurrent claimers sharing one data directory.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-ID fallback has no defined stable checkout identity",
+            "why": "If two child processes omit CLAUDE_CODE_SESSION_ID, a branch-based key fails to follow a parent across branches, while a repository-path key can make unrelated invocations in the same checkout share a claim and suppress a legitimate split order.",
+            "fix": "Define and persist a stable per-checkout identity, its creation and locking rules, and how it behaves across branch changes, restarts, copied checkouts, and worktrees.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The plan requires caller-ID path safety without specifying a safe encoding",
+            "why": "An identifier such as \u0060..\\..\\other\u0060, a path separator-containing value, or an excessively long Unicode string can escape the store directory, fail unpredictably, or collide if it is only partially sanitized.",
+            "fix": "Never use the caller string as a path component; encode it with a fixed-length collision-resistant digest under a fixed namespace, and define collision and length handling.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan has no verification for its cross-round and gating guarantees",
+            "why": "A stale persisted passing verdict, an edited plan, the switch being off, or a failed review could still produce a command if the implementation consults stored state without binding it to the current review round; the plan provides no acceptance check that these cases yield an empty command list or exactly one parent split.",
+            "fix": "Add explicit end-to-end acceptance cases for off, failed, passed-parent, already-piece, edited-current-plan, repeated, and concurrent invocations, asserting the emitted command list and claim count.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "SCOPE: Failing open on an unwritable claim store triggers the unbounded recursive split loop the feature is meant to eliminate.",
+            "why": "When the persistence store is unwritable (e.g., read-only filesystem, permission denial, or disk full), Item 5 specifies failing open. Every child epic returning on a new branch will fail to record or detect previous claims, causing the gate to continuously issue split orders at every round and reintroducing the infinite \u0027epics of epics\u0027 recursion.",
+            "fix": "Fail closed on store write failures by treating the plan as a piece (issuing the autonomy order) and logging a warning instead of issuing a new split command.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "SCOPE: Checkout-level fallback for callers without session IDs permanently blocks splitting for all subsequent projects in that repository.",
+            "why": "Item 6 requires tracking clients without a session ID across branches in a single checkout, but the plan specifies no expiration, reset condition, or task lifecycle boundary. Once the first split claim is written for a repository checkout, all future unrelated plans reviewed in that checkout will match the fallback claim and be permanently treated as already-split pieces.",
+            "fix": "Key checkout-level fallback claims by root task ID/commit lineage or attach a TTL/invalidation mechanism rather than relying on a permanent checkout-wide flag.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 172,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 13,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 263340,
+        "tokensOut": 17827,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 580,
+            "title": "The split-order predicate is evaluated twice instead of once",
+            "why": "The written rule says: \u201CThe condition that issues the order and the condition that claims it are ONE question asked once.\u201D This change calls \u0060GateCommands.OrdersSplit(provisional)\u0060 to decide whether to claim, then calls \u0060GateCommands.OrdersSplit(context)\u0060 again to decide whether to log the order. The compliant version computes the predicate once and reuses that result.",
+            "fix": "Store the single \u0060OrdersSplit\u0060 result, use it for the claim decision, command generation, and logging, and avoid the second predicate call.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 96,
+            "title": "Expired-claim replacement is vulnerable to a delete/create race",
+            "why": "When a remembered claim expires, two server processes can both observe it, delete it, and then each successfully run CreateNew; both return true and issue the split order. A fresh claim can also be deleted by a process that observed the old expired stamp.",
+            "fix": "Use an exclusive lock on a stable per-caller lock file, re-read the stamp while holding it, and only then replace the expired claim.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "A write failure after claim-file creation fails closed without warning",
+            "why": "If CreateNew succeeds but StreamWriter.Write fails, such as when the disk fills, File.Exists(file) is true, so the first IOException catch returns false as if another process claimed it. The split order is suppressed and no warning is logged, contrary to the required fail-open behavior; a partial claim file is also left behind.",
+            "fix": "Track whether this process created the file and treat subsequent write/flush failures as fail-open: warn and return true, then remove the partial file when safe.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 91,
+            "title": "Expired-claim replacement can let two concurrent servers both claim the order",
+            "why": "If two servers see the same caller\u0027s expired stamp, both pass the initial check. One can create the new file, after which the other deletes that fresh claim and creates its own file, causing both calls to return true and issue duplicate split instructions.",
+            "fix": "Use an atomic replacement/locking protocol that never deletes a claim created by another process; do not implement expiry as an unconditional delete followed by CreateNew.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 114,
+            "title": "Unconditional deletion of existing claim file creates a race condition that breaks atomic claim deduplication",
+            "why": "When two processes attempt to claim a split order concurrently, Process B can execute File.Delete(file) immediately after Process A has successfully created the claim file via FileMode.CreateNew. This deletes Process A\u0027s newly established claim and allows Process B\u0027s subsequent FileMode.CreateNew to succeed, causing both servers to return true and issue duplicate split orders to the caller.",
+            "fix": "Do not unconditionally delete the file before FileMode.CreateNew; only delete or replace the claim file if its existing timestamp is verified to be expired, allowing FileMode.CreateNew to act as the sole atomic mutual exclusion check for unexpired claims.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "Violation of logging convention: warning passed as callback instead of using the service logger",
+            "why": "The rule in \u0060CLAUDE.md\u0060 states: \u0027The server\u0027s console logging goes to stderr; one stray stdout line is a protocol corruption... The sanctioned stdout writes are \u0060--help\u0060 and \u0060--version\u0060\u0027. The current implementation passes a callback \u0060warn\u0060 to the method, which is then invoked inside the method. This couples the storage logic to a specific logging mechanism (the callback) rather than using the service\u0027s dedicated logger (\u0060_log\u0060) as defined in the project\u0027s logging convention. The \u0060PanelService\u0060 already has access to \u0060_log\u0060 and passes it as a callback, but the rule implies a standard logging path. More critically, the rule \u0027No secret ever reaches argv or a log line\u0027 is respected, but the architectural convention of \u0027Logging per \u0060.claude/rules/shared/common/logging-serilog.md\u0060\u0027 suggests a unified logging interface. The current design forces the caller to provide the logging action, which is a deviation from the standard pattern where the service handles its own logging.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 and the \u0060warn?.Invoke\u0060 call inside the catch block. The rule requires the warning to be logged via \u0060_log.Warning\u0060 in the caller (\u0060PanelService\u0060), not passed as a callback.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 107,
+            "title": "Inconsistent exception handling pattern in \u0060TryClaimSplitOrder\u0060",
+            "why": "The code has a specific \u0060catch (IOException) when (File.Exists(file))\u0060 block, followed by a \u0060catch (Exception e) when (e is IOException or UnauthorizedAccessException)\u0060. The second catch block is redundant because \u0060IOException\u0060 is already caught by the first block. This creates a potential logic gap where an \u0060IOException\u0060 that does not satisfy \u0060File.Exists(file)\u0060 (e.g., a race condition where the file is deleted between the check and the write) falls through to the second block, which then treats it as a generic exception. The rule \u0027No secret ever reaches argv or a log line\u0027 is not violated, but the architectural convention of \u0027clean exception handling\u0027 is slightly compromised by the redundant catch block.",
+            "fix": "Change the catch block to \u0060catch (Exception e) when (e is IOException or UnauthorizedAccessException)\u0060 to \u0060catch (IOException)\u0060 and \u0060catch (UnauthorizedAccessException)\u0060 separately, or ensure the \u0060Exception\u0060 catch block only handles the specific cases. The current code catches \u0060Exception\u0060 with a filter, which is acceptable, but the logic inside the \u0060catch (Exception e)\u0060 block assumes \u0060e\u0060 is one of the two types. A more explicit handling is preferred.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 575,
+            "title": "Violation of atomicity rule: split order condition and claim are not a single question",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code first checks \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to decide if an order should be issued, and *then* calls \u0060TryClaimSplitOrder\u0060 to claim it. This is two separate questions: \u0027Should we issue an order?\u0027 and \u0027Did we claim it?\u0027. The rule requires that the claim be part of the same logical step as the decision to issue the order. The fix is to combine these into a single operation or ensure the claim is made before the decision is finalized.",
+            "fix": "Remove the \u0060provisional\u0060 variable and use \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 directly in the condition, or rename \u0060provisional\u0060 to \u0060context\u0060 to avoid confusion. The current code creates a \u0060provisional\u0060 context, then checks if it orders a split, and if so, creates a new context with the claimed order. This is a deviation from the rule \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Inconsistency between \u0060FirstPlanRound\u0060 flag and split order claim",
+            "why": "The rule states: \u0027A caller that already holds a claim is a caller already inside a split, and is told so.\u0027 The current code sets \u0060FirstPlanRound: true\u0060 unconditionally, then checks if the caller has already ordered a split. If the caller has already ordered a split, \u0060FirstPlanRound\u0060 should be \u0060false\u0060. The current implementation sets \u0060FirstPlanRound\u0060 to \u0060true\u0060 regardless of whether the caller has already ordered a split, which contradicts the rule that a caller with an existing claim is not a first plan round.",
+            "fix": "Change \u0060FirstPlanRound: true\u0060 to \u0060FirstPlanRound: !_callers.SplitAlreadyOrdered(caller, DateTime.UtcNow)\u0060 to ensure the \u0060FirstPlanRound\u0060 flag is consistent with the claim logic.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "Path traversal via unvalidated caller ID in file creation",
+            "why": "The \u0060caller\u0060 string is derived from \u0060CallerIdentity.Current()\u0060 or a session ID, which may contain path separators (e.g., \u0060repo:../etc/passwd\u0060 or \u0060session:a/b/c\u0060). The code uses this string directly in \u0060FileFor(caller)\u0060 to create a file under the data directory. An attacker controlling the caller ID (or a client passing a malicious ID) can write to arbitrary files outside the intended data directory, potentially overwriting configuration or log files.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., \u0060Path.GetFileName\u0060 or regex validation) before using it in \u0060FileFor(caller)\u0060 to ensure it contains only valid filename characters and does not escape the data directory.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 96,
+            "title": "Race condition in expired claim cleanup causes spurious failures",
+            "why": "The code checks \u0060if (File.Exists(file))\u0060 and then deletes it before attempting \u0060FileMode.CreateNew\u0060. If another process (or a concurrent thread) deletes the file between the check and the delete, or if the file is locked, the subsequent \u0060CreateNew\u0060 might fail unexpectedly or the delete might throw. More critically, if the file is deleted by a concurrent process *after* the check but *before* \u0060CreateNew\u0060, \u0060CreateNew\u0060 will succeed (as intended), but if the file exists and is locked, \u0060CreateNew\u0060 throws. The current logic assumes the file state is stable between check and write, which is not true in a multi-process environment.",
+            "fix": "Wrap the \u0060File.Delete(file)\u0060 call in a try-catch block to handle cases where the file is deleted by another process between the existence check and the delete operation, or where the file is locked.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 107,
+            "title": "Silent failure on non-IO exceptions during claim attempt",
+            "why": "The catch block for \u0060Exception\u0060 only triggers for \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060. If a different exception occurs (e.g., \u0060DirectoryNotFoundException\u0060 if the parent directory is missing, or a \u0060PathTooLongException\u0060), the method returns \u0060false\u0060 without logging a warning. This hides the root cause of the failure, making it appear as if the claim was simply taken by another process, when in fact the store might be broken.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked with a consistent message format and that the warning is logged even if the \u0060Exception\u0060 is not an \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060 but still prevents the write.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Potential null reference in caller ID fallback",
+            "why": "The \u0060CallerFor\u0060 method returns a string based on \u0060CallerIdentity.Current()\u0060 or a session ID. If both are empty or null (though unlikely given the logic), the resulting string might be empty or unexpected. While the code uses \u0060CallerIdentity.Current() is { Length: \u003E 0 }\u0060, if \u0060session.State.RepoPath\u0060 is null, the fallback string \u0060repo:\u0060 \u002B null could result in \u0060repo:\u0060 or \u0060repo:null\u0060, which might not be a valid caller ID for the file system logic.",
+            "fix": "Add a check to ensure \u0060CallerFor\u0060 returns a non-empty, non-null string before using it in \u0060TryClaimSplitOrder\u0060 to prevent potential null reference exceptions or unexpected behavior.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "Race condition in atomic claim allows duplicate split orders under high concurrency",
+            "why": "The code checks \u0060StillRemembered\u0060 (read) at line 93, then deletes the file (line 97), then attempts \u0060CreateNew\u0060 (line 99). If two servers run in parallel: Server A reads \u0027unclaimed\u0027, Server B reads \u0027unclaimed\u0027, Server A deletes and claims, Server B deletes (overwriting A\u0027s file) and claims. Both return \u0060true\u0060, causing the split order to be issued twice. This happens specifically when two MCP clients spawn simultaneously on the same machine.",
+            "fix": "Move the \u0060StillRemembered\u0060 check to the end of the \u0060try\u0060 block, after the \u0060CreateNew\u0060 succeeds, or wrap the entire read-check-write sequence in a single \u0060lock\u0060 object to ensure atomicity of the \u0027check-then-act\u0027 logic.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "Silent failure on unwritable store masks feature degradation",
+            "why": "When the data directory is a file (e.g., \u0060File.WriteAllText(file, \u0022not a directory\u0022)\u0060), \u0060Directory.CreateDirectory\u0060 succeeds (no-op), but \u0060CreateNew\u0060 fails. The catch block at line 105 catches the exception, logs a warning, and returns \u0060true\u0060. The caller believes it successfully claimed the order and issued the split command, but the state was never persisted. If the server restarts, it forgets the claim and issues the split again, creating an infinite loop of split orders.",
+            "fix": "Change the fallback logic to check if the file exists and is readable before attempting \u0060CreateNew\u0060, or return \u0060false\u0060 immediately if the directory is a file (as tested in \u0060AnUnwritableStore\u0060), rather than swallowing the exception and returning \u0060true\u0060.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Redundant file system stat call in hot path",
+            "why": "The code calls \u0060File.Exists(file)\u0060 at line 97 to check for an expired claim, then immediately opens the file again at line 99. This results in two separate file system calls (stat \u002B open) for every split order check. In a high-frequency review loop, this doubles the I/O overhead for the claim check.",
+            "fix": "Replace \u0060File.Exists(file)\u0060 with a check on the \u0060FileStream\u0060 creation result or use \u0060FileMode.OpenOrCreate\u0060 with a lock to avoid the extra file system stat call.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[09:42:39 \u001B[32mINF\u001B[0m] coai-mcp#15952 finding [Blocking/Reliability] src_mcp/src/Server/CallerSessions.cs:93 - Race condition in atomic claim allows duplicate split orders under high concurrency (from local) [gating] Round=1 Stage=CodeReview\r | [09:42:39 \u001B[32mINF\u001B[0m] coai-mcp#15952 finding [Major/Ux] src_mcp/src/Server/CallerSessions.cs:105 - Silent failure on unwritable store masks feature degradation (from local) [gating] Round=1 Stage=CodeReview\r | [09:42:39 \u001B[32mINF\u001B[0m] coai-mcp#15952 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:97 - Redundant file system stat call in hot path (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    }
+  }
+]

--- a/research/data/bench-2026-09-05/epic2b-v0.17.2/tables.md
+++ b/research/data/bench-2026-09-05/epic2b-v0.17.2/tables.md
@@ -1,0 +1,25 @@
+# Bench
+
+## Per arm
+
+| arm | stage | runs | verdicts | median time | median findings | gating | useful | tokens in / out | cost |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | code | 6 | proceed×4, good_enough×2 | 460.3s | 17 | 53 | 1/4 | 2.1M / 128.1k | not reported |
+| `codex,gemini,local` | plan-1 | 6 | good_enough | 77.7s | 13 | 64 | 7/15 | 274.7k / 33.1k | not reported |
+
+## Per run
+
+| arm | case | # | lane | stage | verdict | time | findings | gating | tokens in / out |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | plan-1 | good_enough | 77.7s | 13 | 11 | 38.7k / 5.9k |
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | code | proceed | 679.6s | 6 | 5 | 350.7k / 16.8k |
+| `codex,gemini,local` | rounds-collapse | 2 | 4 | plan-1 | good_enough | 66.2s | 12 | 9 | 48.4k / 2.8k |
+| `codex,gemini,local` | rounds-collapse | 2 | 4 | code | proceed | 749.6s | 9 | 6 | 430.6k / 26.4k |
+| `codex,gemini,local` | rounds-collapse | 3 | 2 | plan-1 | good_enough | 95.4s | 13 | 11 | 39.1k / 6.6k |
+| `codex,gemini,local` | rounds-collapse | 3 | 2 | code | proceed | 452.9s | 17 | 6 | 491.3k / 23.7k |
+| `codex,gemini,local` | split-once | 1 | 3 | plan-1 | good_enough | 41.5s | 13 | 12 | 49.8k / 6.1k |
+| `codex,gemini,local` | split-once | 1 | 3 | code | proceed | 124s | 17 | 10 | 242.7k / 15.4k |
+| `codex,gemini,local` | split-once | 2 | 5 | plan-1 | good_enough | 60.3s | 14 | 11 | 49.2k / 5.9k |
+| `codex,gemini,local` | split-once | 2 | 5 | code | good_enough | 460.3s | 18 | 13 | 305.6k / 28k |
+| `codex,gemini,local` | split-once | 3 | 3 | plan-1 | good_enough | 535.4s | 11 | 10 | 49.5k / 5.7k |
+| `codex,gemini,local` | split-once | 3 | 3 | code | good_enough | 172s | 16 | 13 | 263.3k / 17.8k |

--- a/research/data/bench-2026-09-05/matrix-v0.17.4/runs.json
+++ b/research/data/bench-2026-09-05/matrix-v0.17.4/runs.json
@@ -1,0 +1,8605 @@
+[
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex|rounds-collapse|1",
+    "startedUtc": "2026-09-05T14:28:18.6537942Z",
+    "finishedUtc": "2026-09-05T14:30:16.3272342Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 38.8,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 15274,
+        "tokensOut": 1834,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The auto-open state model reopens a running round after the person closes it",
+            "why": "The plan says a person\u0027s toggle removes the round from the panel-opened set, but the next refresh sees that same round still running and the auto-open rule can add it again. A person who closes a running round therefore sees it reopen, violating the stated behavior.",
+            "fix": "Track an explicit user-closed/suppressed state, make auto-open skip suppressed rounds, and clear suppression only when the person explicitly reopens the card.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible state-machine gap \u0393\u00C7\u00F6 a set-membership model with no persisted user-closed flag will re-add a still-running round on the next refresh, producing a card that reopens after the person dismisses it \u0393\u00C7\u00F6 and proposes the right fix, so it is worth acting on even though no file is cited."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The build step still prescribes the conflicting vendor CSS class despite documenting that it is broken",
+            "why": "Following step 5 literally creates \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060, while the plan itself says \u0060.vendor\u0060 is already the settings-card class that adds padding, borders, and radius, producing the reported struck-through-looking vendor names.",
+            "fix": "Change the build instruction and acceptance criteria to use the shipped non-conflicting class, such as \u0060who\u0060, or explicitly rename and isolate the existing stylesheet selector.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete self-contradiction in the plan \u0393\u00C7\u00F6 a build step that prescribes the very class name the same document identifies as colliding with an existing settings-card selector \u0393\u00C7\u00F6 which would reproduce the reported visual defect if followed literally, and it points at a specific fix."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping guarantee covers only the vendor field, leaving other session-file values unspecified",
+            "why": "A session containing an HTML payload in another rendered value such as a reviewer name, round title, or spending label can still reach the webview unescaped if only the vendor span is escaped. The single \u0060\u003C\u0060 vendor test cannot establish the promised guarantee for all session-derived output.",
+            "fix": "Define one escaping boundary for every session-derived text node and attribute in the shared renderer, and add tests for each rendered field and attribute context.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names the exact defect class this codebase has repeatedly paid for \u0393\u00C7\u00F6 a protective measure applied at only the site someone thought of \u0393\u00C7\u00F6 and its fix (one escaping boundary in the shared renderer rather than per-field escaping) is the proportionate remedy, even though it cites no specific unescaped site."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Killed or restarted panels have no specified reconciliation for auto-open ownership",
+            "why": "If the host or panel is killed after a panel auto-opens a running round but before it observes that the round finished, the in-memory ownership set may be lost while the expanded card remains, so the finished card can stay expanded indefinitely after recovery.",
+            "fix": "Specify initialization reconciliation for expanded cards and ownership, and test a restart between the running and finished states.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Without any code shown, this is a speculative durability concern about a transient UI expansion state whose worst outcome is a card left expanded \u0393\u00C7\u00F6 a cosmetic residue that a user fixes by collapsing it \u0393\u00C7\u00F6 and the demanded reconciliation spec plus restart test is machinery well out of proportion to that risk."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 78.7,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 1,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 224557,
+        "tokensOut": 5973,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/core/Server/SessionStore.cs",
+            "line": 164,
+            "title": "Concurrent saves can silently overwrite newer session state",
+            "why": "Two servers can load the same session, then save different round trails using unique scratch files. If writer A moves a newer file and writer B subsequently moves its stale snapshot, B\u0027s overwrite wins and A\u0027s completed round or pending findings disappear without an error.",
+            "fix": "Serialize saves per session or reload and merge under a lock before replacing the destination; ensure stale writers cannot overwrite a newer session version.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "I could not open src_mcp/core/Server/SessionStore.cs at the reviewed commit, so this is judged on its words alone: it names a concrete last-writer-wins hazard in the store that holds round trails and resolve decisions \u0393\u00C7\u00F6 state whose silent loss would break the gate\u0027s own guarantees \u0393\u00C7\u00F6 and that is something an engineer would want to know even if the right answer turns out to be a version check or a documented single-writer assumption rather than the locking the fix proposes."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 178,
+            "title": "The retry loop blocks a worker thread while saving a session",
+            "why": "When another server or scanner holds the destination, each failed save sleeps for 20\u002B40\u002B60\u002B80 ms synchronously; a nine-reviewer round with repeated contention can tie up the MCP worker for roughly 200 ms per save and delay progress handling.",
+            "fix": "Use an asynchronous delay in an async save path, or isolate the retry from request-handling threads with a bounded async persistence queue.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The retry path only runs on rare contention and its worst case is ~200 ms of sleep on a save that already involves disk I/O, so demanding an async persistence queue is machinery out of proportion to the risk \u0393\u00C7\u00F6 and the code deliberately keeps the bound short for exactly this reason."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:30:16 \u001B[32mINF\u001B[0m] coai-mcp#10660 round 1 CodeReview proceed: 1 gating finding(s); all 3 reviewers answered; 224557 in / 5973 out tokens (no cost reported) over 77.6s\r | [14:30:16 \u001B[32mINF\u001B[0m] coai-mcp#10660 finding [Blocking/Reliability] src_mcp/core/Server/SessionStore.cs:164 - Concurrent saves can silently overwrite newer session state (from codex) [gating] Round=1 Stage=CodeReview\r | [14:30:16 \u001B[32mINF\u001B[0m] coai-mcp#10660 finding [Minor/Performance] src_mcp/src/Server/SessionStore.cs:178 - The retry loop blocks a worker thread while saving a session (from codex) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex",
+    "repeat": 2,
+    "lane": 2,
+    "key": "codex|rounds-collapse|2",
+    "startedUtc": "2026-09-05T14:28:18.6474067Z",
+    "finishedUtc": "2026-09-05T14:29:46.3066968Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 42.8,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 15276,
+        "tokensOut": 2043,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The \u0060panelView\u0060 step still specifies the conflicting \u0060.vendor\u0060 class and can recreate the shipped styling defect",
+            "why": "A builder following step 5 emits \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060; the plan itself says \u0060.vendor\u0060 already styles the settings card, so a vendor name such as \u0060codex\u0060 receives that card\u0027s border, radius, and padding and renders as a struck-through-looking word instead of an inline label.",
+            "fix": "Replace the build step with the resolved class name (\u0060who\u0060) and explicitly update or verify the corresponding selector; remove the contradictory \u0060.vendor\u0060 instruction.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It catches an internal contradiction in the plan \u0393\u00C7\u00F6 a build step that instructs emitting a class the plan itself says is already taken by a different component \u0393\u00C7\u00F6 which would reintroduce the very styling defect the change exists to fix, and the fix (name the resolved class and its selector) is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The auto-open state design does not explicitly record a person\u0027s re-open choice",
+            "why": "The plan introduces only the set of rounds opened by the panel and says a person\u0027s toggle removes the key. If the panel auto-opens a running round, the person closes it, then reopens it before completion, the key remains absent; a later finish transition has no recorded distinction between a deliberate re-open and an unrelated state, so the promised \u0022re-opening ... makes it theirs again\u0022 behavior is not specified or directly tested.",
+            "fix": "Define the state transition table and add an explicit manual-open/ownership set (or equivalent) for auto-opened rounds, including close, re-open, finish, restart, and disappearance transitions.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It demands a full state-transition table and an extra ownership set for a UI panel\u0027s auto-open convenience, where the stated behavior (a round the person reopened is simply open, and open rounds stay open) already covers the scenario \u0393\u00C7\u00F6 machinery out of proportion to the risk, and \u0027Major/Reliability\u0027 overstates a cosmetic panel affordance."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping guarantee is not verified for all session-file output contexts",
+            "why": "The only named test uses a vendor containing \u0060\u003C\u0060, but session data is rendered into HTML text, attributes, and an inline \u0060style\u0060 value across reviewer rows, round metadata, and spending rows. A quote or \u0060\u003C/span\u003E\u003Cscript\u003E\u0060 in another field can therefore still break the page or inject markup while the definition of done claims that nothing from a session file reaches the page unescaped.",
+            "fix": "Inventory every session-derived interpolation and test representative \u0060\u0026\u0060, quotes, apostrophes, \u0060\u003C\u0060, \u0060\u003E\u0060, and \u0060\u003C/script\u003E\u0060 payloads in each output context; use context-appropriate escaping or DOM text/style APIs rather than relying on one text-node case.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real gap \u0393\u00C7\u00F6 a single text-node test does not establish the claimed \u0027nothing unescaped\u0027 guarantee when session values are also interpolated into attributes and an inline style, where a text escaper is the wrong tool \u0393\u00C7\u00F6 and the fix (enumerate the sites, escape per context) is proportionate to that risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan promises that no reviewer lookup occurs, but no test observes or blocks that lookup",
+            "why": "Deleting \u0060FableIsUsable\u0060 and setting the command condition is a structural intention, not behavioral proof. A future or remaining call can still query configured providers before issuing the command; the listed test only proves the command eventually fires with fixtures and cannot detect an unwanted provider/configuration or network lookup.",
+            "fix": "Instrument the provider/configuration lookup and assert it is never called for \u0060SplitWithFable\u0060, while separately asserting checked and unchecked behavior and the exact command payload.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It demands negative-observation instrumentation (asserting a provider lookup is never called) for code whose lookup was deleted outright, which is machinery out of proportion to the risk and unanchored to any actual file or call site."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The finish transition is underspecified for crashes, timeouts, and incomplete rounds",
+            "why": "The plan keys auto-collapse to a round being \u0022no longer running,\u0022 but a killed server or a stale session record can move a round to an error/incomplete/unknown state. That can either leave an auto-open card expanded forever or collapse a round that never completed, with no defined behavior or test for the operator\u0027s stated dead-round scenario.",
+            "fix": "Define the terminal-state predicate and recovery behavior for timeout, process death, malformed/stale session files, and host restart, then test each state against the auto-open set.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A card whose auto-collapse hinges on \u0027no longer running\u0027 genuinely leaves the dead-round case undefined \u0393\u00C7\u00F6 a crashed or stale session never reports finished and the card stays expanded forever, which is the operator\u0027s own stated scenario and exactly what the durable-status rule (\u0027never get stuck\u0027, sweep orphaned rows) exists to prevent, so the plan owes one sentence naming the terminal-state predicate even if the full per-state test matrix is more than the risk warrants."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 44.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 287210,
+        "tokensOut": 4383,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 1,
+            "title": "The implemented plan remains in todo status and contradicts the shipped implementation",
+            "why": "The plan\u0027s Definition of Done requires: \u0022docs, help and CHANGELOG updated; the plan promoted.\u0022 This diff adds a plan whose status still says \u0022plan only, nothing implemented yet\u0022 even though the implementation is shipped and the research copy says implemented, leaving contradictory lifecycle state for tooling and future contributors.",
+            "fix": "Promote this plan to the implemented plan location/status, or remove the stale todo copy so only one authoritative plan state remains.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding faults the plan for saying \u0022nothing implemented yet\u0022 while asserting the work is shipped and a research copy exists, but the reviewed file is a newly added todo plan with no evidence of a shipped implementation or duplicate research copy \u0393\u00C7\u00F6 the status line is exactly what planning-docs.md requires of a new plan in todo/."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 160,
+            "title": "Concurrent saves can overwrite newer session state with an older snapshot",
+            "why": "Two MCP processes saving the same repo and branch can serialize different snapshots concurrently. If the newer snapshot moves first and the older snapshot moves afterward, the final session file regresses, silently losing reviewer progress or status already persisted.",
+            "fix": "Serialize saves per session across processes, or add version/timestamp checks so an older snapshot cannot replace a newer one.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The file itself documents that several servers share this data directory and write the same session files, so the unique-scratch-name fix closes only the temp-file collision and leaves a genuine lost-update race \u0393\u00C7\u00F6 including the startup sweep\u0027s whole-session rewrite racing a live round\u0027s Persist \u0393\u00C7\u00F6 which is exactly the durable-status guarantee this store exists to provide."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 140,
+            "title": "Clicking a round still triggers the full expensive refresh without progress feedback",
+            "why": "When a person opens or closes one card, the handler immediately calls \u0060refresh()\u0060, which re-reads configuration, probes CLIs, checks published versions, and fetches pricing; for the documented worst case this takes up to 20 seconds, leaving the click with no visible completion or busy state.",
+            "fix": "Update only the affected card\u0027s open state from cached data, or defer the full refresh; if a refresh is required, expose an in-progress state and a terminal error state.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It misnames the call (\u0060render()\u0060, not \u0060refresh()\u0060) and invents a 20-second cost that the caching timestamps (\u0060cliCheckedAt\u0060, \u0060pricesCheckedAt\u0060, \u0060localCheckedAt\u0060) and the fact that the same render already runs on every five-second watcher tick contradict \u0393\u00C7\u00F6 and the immediate repaint it objects to is required, as the comment explains, because a card\u0027s body is only built when open."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:29:46 \u001B[32mINF\u001B[0m] coai-mcp#31472 finding [Major/Convention] todo/PLAN_rounds_collapse_and_vendor_colour.md:1 - The implemented plan remains in todo status and contradicts the shipped implementation (from codex) [gating] Round=1 Stage=CodeReview\r | [14:29:46 \u001B[32mINF\u001B[0m] coai-mcp#31472 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:160 - Concurrent saves can overwrite newer session state with an older snapshot (from codex) [gating] Round=1 Stage=CodeReview\r | [14:29:46 \u001B[32mINF\u001B[0m] coai-mcp#31472 finding [Major/Ux] src_vs_code/src/panelProvider.ts:140 - Clicking a round still triggers the full expensive refresh without progress feedback (from codex) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "gemini",
+    "repeat": 1,
+    "lane": 3,
+    "key": "gemini|rounds-collapse|1",
+    "startedUtc": "2026-09-05T14:28:18.6454488Z",
+    "finishedUtc": "2026-09-05T14:28:55.9324641Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 13.5,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 2,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 14599,
+        "tokensOut": 1287,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order and constraints in section \u00273. panelProvider\u0027 fail to handle race conditions where a completed round is pruned before it can be closed",
+            "why": "When pruning logic eagerly removes keys from the tracking set for non-living rounds while a round finishes between poll/event cycles, a card opened by the panel that transitions to finished and gets pruned simultaneously will lose its tracking key before the UI receives the close command, leaving the finished card stuck in an expanded state.",
+            "fix": "Ensure the state transition evaluation (finished check and closure trigger) executes before or atomically with pruning inactive round keys from the tracking set.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding is a speculative race-condition narrative built from a plan section heading with no code, file, or line to anchor it \u0393\u00C7\u00F6 it invents pruning/tracking-set mechanics whose existence it never establishes, so no one could act on it."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "",
+            "line": 0,
+            "title": "Section \u00275. panelView\u0027 introduces an unbudgeted CSS class collision with existing \u0060.vendor\u0060 card styles",
+            "why": "Specifying \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:\u2026\u0022\u003E\u0060 directly collides with existing \u0060.vendor\u0060 CSS rules that apply border, border-radius, and padding, causing vendor names inside single-line labels to render with border/padding boxes across the extension UI.",
+            "fix": "Change the target span class in the view spec from \u0060.vendor\u0060 to a dedicated inline styling class such as \u0060.who\u0060 or \u0060.vendor-tag\u0060.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding asserts a concrete CSS collision (existing \u0060.vendor\u0060 rules with border/radius/padding rendering boxes around inline vendor names) without any file or evidence, and a plan-level class-name choice inside a view spec is a trivial, easily-adjusted detail rather than a Major convention breach \u0393\u00C7\u00F6 as stated it is unverifiable and disproportionate."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order 4 in section \u0027rounds.ts\u0027 places view-only palette mapping inside the session parser module",
+            "why": "Importing or defining CSS theme palette variables (\u0060--vscode-charts-*\u0060) in \u0060rounds.ts\u0060 couples the session log parsing layer with UI rendering concerns and prevents spending rows from accessing vendor colors without importing the session parser.",
+            "fix": "Place \u0060vendorColour\u0060 in a dedicated UI/view utility module (e.g., \u0060vendorColour.ts\u0060) that both \u0060panelView\u0060 and spending row components can import independently.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It objects to a plan step placing a small \u0060vendorColour\u0060 helper in \u0060rounds.ts\u0060 on purely speculative coupling grounds \u0393\u00C7\u00F6 no defect, no rule broken, and a one-function move is cheaper to make when a second consumer actually appears."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Test plan omits verification for multi-round state tracking when user manually closes an auto-opened round and later re-opens it",
+            "why": "The tracking logic specifies that user interaction drops the key from the panel-opened set, but tests only cover the linear running-\u003Efinished transition; if an operator closes a running card and reopens it while still running, lack of edge-case test coverage risks re-adding it to the auto-close set and collapsing it unexpectedly on finish.",
+            "fix": "Add an explicit test case verifying that a card re-opened manually by the user while running is not re-enrolled into the auto-close set.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It asks for a test of a scenario the described tracking logic already handles by construction \u0393\u00C7\u00F6 a user-opened card is by definition dropped from the panel-opened set \u0393\u00C7\u00F6 so this is speculative test-coverage machinery out of proportion to a hypothetical UI collapse, with no evidence the code actually re-enrolls it."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 23.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 1,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 127054,
+        "tokensOut": 6747,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Vendor span in reviewer rows reuses the \u0027.vendor\u0027 settings card class",
+            "why": "In the webview stylesheet, \u0027.vendor\u0027 styles vendor configuration cards with a border, border-radius, and 8px padding. Applying class=\u0022vendor\u0022 to the inline vendor \u003Cspan\u003E inside a tight reviewer row causes card border and padding styles to wrap the single word, rendering in the webview as a visual box/line through the reviewer text.",
+            "fix": "Change class=\u0022vendor\u0022 to class=\u0022who\u0022 on the vendor \u003Cspan\u003E in panelView.ts line 810 (and update the corresponding test assertion in panelView.test.ts).",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:28:55 \u001B[32mINF\u001B[0m] coai-mcp#44700 reviewer gemini/UxDxPerformance answered in 22.2s: 1 finding(s), 47098 in / 5500 out tokens Round=1 Stage=CodeReview\r | [14:28:55 \u001B[32mINF\u001B[0m] coai-mcp#44700 round 1 CodeReview proceed: 1 gating finding(s); all 3 reviewers answered; 127054 in / 6747 out tokens (no cost reported) over 22.3s\r | [14:28:55 \u001B[32mINF\u001B[0m] coai-mcp#44700 finding [Major/Ux] src_vs_code/src/panelView.ts:810 - Vendor span in reviewer rows reuses the \u0027.vendor\u0027 settings card class (from gemini) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "gemini",
+    "repeat": 2,
+    "lane": 4,
+    "key": "gemini|rounds-collapse|2",
+    "startedUtc": "2026-09-05T14:28:18.6600084Z",
+    "finishedUtc": "2026-09-05T14:28:18.86291Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 0,
+        "verdict": "",
+        "error": "the round failed: The process cannot access the file \u0027C:\\Users\\strug\\AppData\\Local\\coai-mcp\\finding-schema.json\u0027 because it is being used by another process. (see the coai-mcp log for the stack)",
+        "gatingCount": 0,
+        "reviewers": "",
+        "tokensIn": 0,
+        "tokensOut": 0,
+        "costUsd": null,
+        "findings": [],
+        "commands": [],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "at CoaiMcp.Server.PanelService.\u003CRunStageAsync\u003Ed__34.MoveNext() \u002B 0x8a2\r | --- End of stack trace from previous location ---\r |    at CoaiMcp.Server.PanelService.\u003CRunStageAsync\u003Ed__34.MoveNext() \u002B 0x1279",
+    "onDisk": {
+      "rounds": 0,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "local",
+    "repeat": 1,
+    "lane": 7,
+    "key": "local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T14:28:18.6454595Z",
+    "finishedUtc": "2026-09-05T14:30:08.7470329Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 47.5,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 2761,
+        "tokensOut": 1340,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, checkable gap \u0393\u00C7\u00F6 panel-opened ownership held in state that a host restart wipes, leaving a round stuck open or wrongly closed \u0393\u00C7\u00F6 which is exactly the durable-status/sweep concern a plan should settle before implementation, even though its title overstates it as data loss and its suggested remedy (an id the round almost certainly already has) misses that the real fix is persisting the marker."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, checkable failure mode \u0393\u00C7\u00F6 a user-facing toggle gated on a condition that never holds because the calling AI is not a configured reviewer, producing a silent no-op rather than an error \u0393\u00C7\u00F6 and proposes a specific alternative gate, which is exactly the kind of claim worth verifying before the feature ships."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real design risk \u0393\u00C7\u00F6 a repaint path that stat-s a binary, probes CLIs and fetches remote price tables \u0393\u00C7\u00F6 and proposes a proportionate fix (cache and refresh on config change or interval), which a careful engineer would want to settle before building the card, even though the specific 20-second figure is asserted rather than measured."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real gap the plan itself concedes \u0393\u00C7\u00F6 an interrupted round has no terminal timestamp, so its duration is computed from start and grows without bound, making a dead round read as still running, which is exactly the durable-status failure this codebase\u0027s rules require a terminal state and sweep for; the described trigger (\u0027the process doesn\u0027t die\u0027) is muddled, but the defect and the proposed fix are sound."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a specific visual artifact (a border/padding-induced strikethrough through vendor names) that no CSS actually produces \u0393\u00C7\u00F6 borders and padding on an inline element do not draw a line through text \u0393\u00C7\u00F6 so the finding is a fabricated symptom with a fix for a problem that does not exist."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a UI failure mode from a plan sentence it misreads \u0393\u00C7\u00F6 the plan already describes legacy rounds rendering an explanatory apology, which is precisely the fallback state being demanded, and no file or code is named to support the claimed hand-cursor/empty-content defect."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 62.3,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 69072,
+        "tokensOut": 2884,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may silently swallow a final failure",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 states: \u0027The server refuses one without it\u0027 (referring to scope) and implies strict adherence to protocol. More critically, the \u0060vendor-routing.md\u0060 rule states \u0027breaking it is invisible in the output\u0027. The \u0060MoveOverExisting\u0060 method retries 5 times. If the 5th attempt fails, the \u0060catch\u0060 block inside the loop (line 183) catches the exception but the loop exits. The method then returns. The caller (\u0060Save\u0060) has a \u0060try...finally\u0060 block. If \u0060MoveOverExisting\u0060 throws, it propagates. If it succeeds, it returns. However, the logic \u0060catch (Exception e) when (...) \u0026\u0026 attempt \u003C attempts\u0060 means on the 5th attempt, if it fails, the loop exits *without* re-throwing or handling the exception explicitly in a way that guarantees visibility. Wait, looking closer: \u0060catch\u0060 block has \u0060Thread.Sleep\u0060. If \u0060attempt\u0060 reaches 5, the loop condition \u0060attempt \u003C= attempts\u0060 is true. Inside, if it throws, it hits the catch. \u0060attempt \u003C attempts\u0060 (5 \u003C 5) is false. So it *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method\u0027s retry loop uses a bounded number of attempts and that the final attempt throws if it fails, rather than silently swallowing the error.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about the code \u0393\u00C7\u00F6 the \u0060when (\u0393\u00C7\u00AA \u0026\u0026 attempt \u003C attempts)\u0060 filter means the fifth attempt\u0027s exception is not caught and propagates, exactly as the method\u0027s own remarks state, so the suggested fix asks for behaviour that already exists (and the reasoning even trails off mid-sentence while citing unrelated rules)."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Concurrent save race condition leaves orphaned scratch files and silent failures",
+            "why": "In \u0060SessionStore.Save\u0060, the code generates a unique scratch filename using \u0060Environment.ProcessId\u0060 and a GUID. However, if two processes (or threads in a multi-threaded scenario) happen to generate the same GUID or if the process ID is reused rapidly, they could collide. More critically, the \u0060MoveOverExisting\u0060 method retries 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms). If the destination file is held by a virus scanner or another process for longer than ~250ms, the move fails. The code then enters the \u0060finally\u0060 block and calls \u0060TryDelete(temp)\u0060. If the move failed, \u0060temp\u0060 still exists. If the \u0060TryDelete\u0060 fails (e.g., file locked), it swallows the exception. The result is a session file that never updated (stale data) and a temporary file left behind, potentially filling the disk or causing future collisions if the temp name generation isn\u0027t perfectly unique. The comment admits \u0027a save that never lands is a real problem\u0027 but the \u0060finally\u0060 block\u0027s \u0060TryDelete\u0060 might *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite backoff and that the final exception is re-thrown or logged with context, rather than silently swallowed if the file is held by a scanner.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Its central ask \u0393\u00C7\u00F6 that the final move failure be surfaced rather than silently swallowed \u0393\u00C7\u00F6 is already what the code does (the \u0060when (\u0393\u00C7\u00AA \u0026\u0026 attempt \u003C attempts)\u0060 guard lets the last attempt throw, and \u0060TryDelete\u0060 in the \u0060finally\u0060 only swallows cleanup of the writer\u0027s own uniquely-named scratch file), while the GUID/PID-collision and disk-filling concerns are speculative and out of proportion to a few hundred bytes of JSON."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 806,
+            "title": "Potential HTML injection in vendor name rendering if escaping order is flawed",
+            "why": "In \u0060roundCard\u0060, the code constructs the reviewer row as: \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:${vendorColour(row.provider)}\u0022\u003E\u0060 \u002B \u0060${escapeHtml(row.provider)}\u0060 \u002B \u0060\u003C/span\u003E${escapeHtml(row.rest)}\u0060. If \u0060row.provider\u0060 contains a string like \u0060\u003Cscript\u003E\u0060, \u0060escapeHtml\u0060 converts it to \u0060\u0026lt;script\u0026gt;\u0060. However, if the \u0060vendorColour\u0060 function (or the caller) relies on the raw provider name for the style, and the style attribute is interpolated directly into the HTML string without escaping, an attacker could inject a style attribute. Wait, the style is \u0060color:var(...)\u0060, so it\u0027s safe. The real risk is if \u0060row.provider\u0060 is used in a context where it\u0027s not escaped *before* being placed inside the span, or if \u0060row.rest\u0060 contains unescaped HTML. The code escapes \u0060row.provider\u0060 and \u0060row.rest\u0060 separately. The risk is if \u0060row.provider\u0060 is *not* escaped before being used in the \u0060style\u0060 attribute (e.g., if \u0060vendorColour\u0060 returned a hex value that wasn\u0027t quoted, but it returns a CSS variable). The actual flaw",
+            "fix": "Ensure \u0060vendorColour\u0060 is called *after* \u0060escapeHtml\u0060 or that the HTML structure wraps the escaped text correctly, preventing a scenario where a vendor name like \u0060\u003Cscript\u003E\u0060 renders as an active tag if the escaping logic is applied to the wrong part of the string.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding visibly reasons itself out of its own claim mid-sentence \u0393\u00C7\u00F6 the style attribute holds \u0060vendorColour\u0060\u0027s output, not the provider name, and both \u0060row.provider\u0060 and \u0060row.rest\u0060 are already escaped \u0393\u00C7\u00F6 so it names no real defect and gives a fix that would break correct code."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Race condition in round state management could lead to duplicate keys or lost state",
+            "why": "The \u0060nextOpenRounds\u0060 function builds a \u0060Set\u0060 of keys from \u0060cards\u0060. If two rounds have the same \u0060roundKey\u0060 (e.g., same repo, branch, stage, number), the second one will overwrite the first in the Set. This means if a user has two rounds with identical metadata (perhaps from different branches or a bug in ID generation), only one will be tracked in the \u0060open\u0060 state. If the user interacts with the \u0027wrong\u0027 one (the one that was processed last), the state update might not reflect the actual round they clicked. This is a subtle data loss scenario where the UI state diverges from the actual session data.",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all rounds before adding to the \u0060open\u0060 set, or handle collisions explicitly.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It calls a pure, synchronous function a \u0027race condition\u0027 and invents a duplicate-key premise that would be a defect in roundKey generation elsewhere, not here \u0393\u00C7\u00F6 keying state by roundKey is the deliberate design, and the proposed uniqueness check is machinery for a hypothetical."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:30:08 \u001B[32mINF\u001B[0m] coai-mcp#47112 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Concurrent save race condition leaves orphaned scratch files and silent failures (from local) [gating] Round=1 Stage=CodeReview\r | [14:30:08 \u001B[32mINF\u001B[0m] coai-mcp#47112 finding [Major/Security] src_vs_code/src/panelView.ts:806 - Potential HTML injection in vendor name rendering if escaping order is flawed (from local) [gating] Round=1 Stage=CodeReview\r | [14:30:08 \u001B[32mINF\u001B[0m] coai-mcp#47112 finding [Minor/Reliability] src_vs_code/src/openRounds.ts:45 - Race condition in round state management could lead to duplicate keys or lost state (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "local",
+    "repeat": 2,
+    "lane": 5,
+    "key": "local|rounds-collapse|2",
+    "startedUtc": "2026-09-05T14:28:18.6566066Z",
+    "finishedUtc": "2026-09-05T14:35:59.087002Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 385.3,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 2761,
+        "tokensOut": 1340,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about persistence and identity mechanics of a plan it does not quote and names no file or code, inventing a restart-rehydration failure mode from assumptions rather than from anything shown to exist."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding asserts a specific mechanism (\u0060PanelService.FableIsUsable()\u0060 querying a reviewer provider list) and its failure mode without any file or line to anchor it, and nothing in the given material supports that the check is implemented that way \u0393\u00C7\u00F6 it reads as a confident guess about code the reviewer did not open, so acting on it would mean rewriting gating logic on an unverified premise."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible failure \u0393\u00C7\u00F6 expensive blocking I/O (config read, binary stat, CLI probes, network price fetches) on a UI repaint path \u0393\u00C7\u00F6 with a user-visible symptom and a proportionate fix (cache and refresh on change or interval), which is exactly what a plan reviewer should catch before it ships."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It draws a real consequence out of an acknowledged gap \u0393\u00C7\u00F6 a round with no completion time renders as an ever-growing \u0027running\u0027 duration, so a dead round is indistinguishable from a live one and the card reports a runtime that is wall-clock since start rather than actual, exactly the stuck in-flight state the durable-status rule forbids."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a specific visual symptom (text appearing struck-through) that a border/padding/radius on an inline span would not actually produce, and it names no file or line, so it is speculative styling fiction rather than an observed defect."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The plan already specifies exactly the fallback the finding demands \u0393\u00C7\u00F6 a disclosure that opens into an apology explaining detail predates the feature \u0393\u00C7\u00F6 so the finding restates the design as a defect and its own \u0027indistinguishable from a failed load\u0027 claim contradicts the apology text it quotes, leaving only a hand-cursor nit."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 74.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 69072,
+        "tokensOut": 3546,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 142,
+            "title": "Session persistence uses a fixed scratch name instead of a per-write unique name",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 (inherited from \u0060vendor-routing.md\u0060 logic regarding visibility of errors) and the specific plan deviation states: \u0027A session is saved under its own scratch name, and the move is retried\u0027. The diff shows the scratch file name is now unique (\u0060${file}.{Environment.ProcessId}-{Guid.NewGuid()}.tmp\u0060), but the rule explicitly requires the move to be retried for cases a unique name cannot fix (e.g., a scanner holding the destination). The current implementation retries, but the rule text in \u0060module_server.md\u0060 says \u0027the move is retried briefly for the case a unique name cannot fix\u0027. The implementation does retry. However, the rule in \u0060review-gate.md\u0060 states \u0027The server refuses one without it\u0027 regarding scope. Wait, the rule is about the scratch name. The rule in \u0060module_server.md\u0060 says: \u0027each write goes to a scratch file of its OWN name\u0027. The diff does this. But the rule in \u0060review-gate.md\u0060 says \u0027Never hand a reviewer a bare diff\u0027. This is a new",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method retries the move operation for the case where a reader or scanner holds the destination file, as explicitly required by the rule.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent and self-refuting \u0393\u00C7\u00F6 it repeatedly concedes mid-text that the code already does what it demands (\u0027The implementation does retry\u0027, the scratch name \u0027is now unique\u0027), cites rules that have nothing to do with file persistence, and ends mid-sentence, so it names no actual defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a fixed sleep interval (20ms * attempt). If a file lock (e.g., from an antivirus scanner or another process) persists longer than the total retry window (approx 150ms), the code throws. However, if the lock is held by a process that never releases it (rare but possible in enterprise environments), the \u0060Thread.Sleep\u0060 loop might not be sufficient to handle transient spikes, or worse, if the logic is extended, it could spin. More critically, the \u0060MoveOverExisting\u0060 method is called inside a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060. If the file is held by a scanner that intermittently locks/unlocks, the retry might succeed. But if the lock is permanent, it throws. The real risk is that the \u0060MoveOverExisting\u0060 logic is *not* robust enough for high-concurrency scenarios where multiple writers might contend for the same destination file *after* the unique temp name collision is resolved. If the destination file (",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite wait strategy (e.g., exponential backoff with a hard cap) or a \u0060CancellationToken\u0060 to prevent the server from hanging indefinitely if the destination file is held by a long-running process (like an antivirus scanner) that never releases it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is self-contradictory and factually wrong about the code: the loop is already bounded at 5 attempts (~300ms max) with the last attempt allowed to throw, so it cannot hang or spin, and the \u0027fix\u0027 asks for exactly what the code already does."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Temporary scratch files accumulate on failed moves due to cleanup timing",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060TryDelete(temp)\u0060 is called in a \u0060finally\u0060 block *after* the \u0060MoveOverExisting\u0060 loop. If \u0060MoveOverExisting\u0060 throws an exception on the final attempt (e.g., \u0060UnauthorizedAccessException\u0060 after 5 retries), the \u0060finally\u0060 block executes and deletes the temp file. However, if the loop succeeds but the \u0060File.Move\u0060 throws *during* the retry (e.g., on attempt 3), the \u0060finally\u0060 block runs, deleting the temp file, but the exception propagates. The critical issue is that if \u0060MoveOverExisting\u0060 throws *before* the loop finishes (e.g., on the first try), the \u0060finally\u0060 block deletes the temp file. But if the loop completes successfully, the temp file is deleted. The real risk is if \u0060MoveOverExisting\u0060 throws *after* a successful move but before the \u0060finally\u0060 block runs (unlikely), or if the \u0060TryDelete\u0060 itself fails silently. More critically, if \u0060MoveOverExisting\u0060 throws on the *last* attempt, the \u0060finally\u0060 block runs, deleting the temp file. But if the loop *succeeds* (all",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs before the retry loop completes, so that if the move fails after the first attempt, the temporary file is cleaned up before the next retry.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent and wrong about the code \u0393\u00C7\u00F6 it repeatedly contradicts itself, never identifies an actual leak (the \u0060finally\u0060 deletes the temp file on every path, and its proposed fix of deleting the temp inside the retry loop would destroy the very file the next attempt needs to move)."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 75,
+            "title": "User toggle state may not persist correctly across panel ticks",
+            "why": "When a user closes a card (e.g., \u0060afterToggle(previous, key, false)\u0060), the \u0060open\u0060 set is updated to remove the key. However, if the panel re-renders before the next tick, and the round is still running, the \u0060nextOpenRounds\u0060 logic might re-add it to \u0060open\u0060 if it\u0027s in \u0060autoOpened\u0060. The current logic removes the key from \u0060panelOpened\u0060, but if the round is still running, \u0060nextOpenRounds\u0060 will re-add it to \u0060autoOpened\u0060 and \u0060open\u0060 on the next tick, effectively ignoring the user\u0027s close action. This creates a flicker where the card closes, then re-opens immediately if the round is still running.",
+            "fix": "Ensure \u0060afterToggle\u0060 updates the \u0060open\u0060 set correctly when a user closes a card that was previously auto-opened, and that the \u0060panelOpened\u0060 set is updated to reflect the user\u0027s explicit choice.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is factually wrong about this code: \u0060afterToggle\u0060 deliberately keeps the key in \u0060autoOpened\u0060, and \u0060nextOpenRounds\u0060 only re-opens when \u0060!autoOpened.has(key)\u0060, so a user-closed running round is never re-opened \u0393\u00C7\u00F6 the very case the code comments on lines 44-45 and 82-84 already address."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary recomputation of open rounds state on every render tick",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 calls \u0060nextOpenRounds\u0060 on every render tick (every 5 seconds). This function performs set operations and filtering on the entire list of rounds. While the logic is simple, doing this on every tick for a large number of rounds (e.g., 100\u002B rounds) creates unnecessary CPU overhead. The state should only be recomputed when the \u0060sessions\u0060 data actually changes (e.g., a new round starts, a round finishes, or a user toggles a card).",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 and only recompute it when the underlying \u0060sessions\u0060 data changes, rather than on every render tick.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "A per-tick set operation over a handful of round cards in a VS Code webview is negligible CPU, and the proposed cache would add invalidation complexity to a state machine whose whole point is that it recomputes from the current round list \u0393\u00C7\u00F6 a micro-optimization out of proportion to any real risk."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:35:59 \u001B[32mINF\u001B[0m] coai-mcp#30616 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Temporary scratch files accumulate on failed moves due to cleanup timing (from local) [gating] Round=1 Stage=CodeReview\r | [14:35:59 \u001B[32mINF\u001B[0m] coai-mcp#30616 finding [Major/Ux] src_vs_code/src/openRounds.ts:75 - User toggle state may not persist correctly across panel ticks (from local) [gating] Round=1 Stage=CodeReview\r | [14:35:59 \u001B[32mINF\u001B[0m] coai-mcp#30616 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary recomputation of open rounds state on every render tick (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini",
+    "repeat": 1,
+    "lane": 6,
+    "key": "codex,gemini|rounds-collapse|1",
+    "startedUtc": "2026-09-05T14:28:18.6507628Z",
+    "finishedUtc": "2026-09-05T14:28:57.8578857Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 39,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 50484,
+        "tokensOut": 3490,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The \u0060panelView\u0060 build step contradicts the documented \u0060who\u0060 class deviation and can reapply the settings-card styling to vendor names.",
+            "why": "A developer following step 5 emits \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060; in the stated stylesheet \u0060.vendor\u0060 has border, radius, and padding, so names render with a border and spacing instead of only a colour.",
+            "fix": "Change the build step and acceptance criteria to require the shipped \u0060who\u0060 class, or explicitly rename/remove the conflicting stylesheet selector before using \u0060vendor\u0060.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It catches a concrete internal contradiction \u0393\u00C7\u00F6 a build step instructing a class name whose stylesheet rule would render vendor names with a border and padding, contrary to the plan\u0027s own stated deviation \u0393\u00C7\u00F6 which is exactly the kind of spec inconsistency that would ship as a visible UI defect if not resolved before implementation."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping guarantee is verified only for reviewer rows, leaving other session-file-derived render paths unprotected.",
+            "why": "A session containing a vendor name such as \u0060\u003C/span\u003E\u003Cscript\u003E...\u003C/script\u003E\u0060 could still execute if the live section or spending-row renderer interpolates it directly; the only specified escaping test covers a reviewer row.",
+            "fix": "Define one escaped rendering path for every vendor occurrence and add concrete tests for malicious vendor names in the live section and spending rows, including attribute-breaking input.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real and specific injection risk \u0393\u00C7\u00F6 untrusted vendor names from session files reaching other render paths where escaping was never verified \u0393\u00C7\u00F6 and asks for the proportionate fix of one escaped rendering path plus tests, which is exactly the \u0027measure applied at only some of its sites\u0027 class this codebase keeps paying for."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The ownership logic has no defined recovery when the server is killed before a round writes a terminal state.",
+            "why": "If a panel-opened round\u0027s process is terminated after its session file says \u0060running\u0060, the panel has no completion transition to observe, so it remains auto-open indefinitely and violates the promised finished/closed behavior.",
+            "fix": "Specify and test stale-running detection or an explicit interrupted terminal state, including the timeout and cleanup behavior after the server or extension host is killed.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A round left stuck in \u0060running\u0060 after the server is killed is exactly the durable-status/crash-sweep failure this family\u0027s rules mandate against, and the finding names both the observable symptom (a panel that never closes) and the two legitimate remedies (stale-running detection or an explicit interrupted terminal state), which is actionable even without a file reference."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The test plan does not verify that colouring is applied in the live section and spending rows or remains legible in a light theme.",
+            "why": "\u0060vendorColour\u0060 can pass all listed tests while a render call site omits the style, and checking that a CSS variable name exists does not prove its light-theme value is readable; users can still see grey vendor names or unreadable text.",
+            "fix": "Add render-level assertions for every vendor display location and fixture tests using representative light and dark chart-palette values.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real gap that this family\u0027s own testing rule already forbids \u0393\u00C7\u00F6 asserting that a colour variable exists proves nothing about whether the render call sites apply it or whether the value is legible, so the plan\u0027s tests could pass over grey vendor names."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 5 / CSS class collision: Reusing class .vendor overrides card-level styling and strikes through text",
+            "why": "Build order step 5 specifies wrapping the vendor name in \u0027\u003Cspan class=\u0022vendor\u0022 style=\u0022color:\u2026\u0022\u003E\u0027. In this stylesheet, \u0027.vendor\u0027 already styles the vendor settings card (with borders, border-radius, and padding). Applying \u0027.vendor\u0027 inline inside tight text rows causes the vendor name to render with border/padding boxes that visually appear as struck-through text.",
+            "fix": "Specify a distinct, dedicated CSS class name (e.g. \u0027who\u0027 or \u0027vendor-tag\u0027) in the markup and stylesheet instead of reusing \u0027.vendor\u0027.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The claimed mechanism is wrong \u0393\u00C7\u00F6 borders and padding cannot make text render as struck through \u0393\u00C7\u00F6 so the finding dresses a speculative class-name overlap in an invented symptom, and even the real concern (pick a different class name) is a trivial markup choice, not a Major UX defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 3 / Repaint overhead: Toggle interaction triggers a full provider refresh with slow I/O and network calls",
+            "why": "Build order step 3 ties card expansion state toggling to the panel refresh flow without isolating UI expansion state from data fetching. Toggling a card triggers full provider repainting (reading config, stat-ing binaries, probing vendor CLIs, making GitHub requests, and price table fetching), delaying a simple collapse/expand triangle toggle by up to 20 seconds.",
+            "fix": "Decouple webview card expand/collapse UI state toggling and DOM visibility from full background data-fetching/provider refresh cycles.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "Tying a purely cosmetic expand/collapse toggle to a full provider refresh \u0393\u00C7\u00F6 config reads, binary stats, CLI probes, network calls \u0393\u00C7\u00F6 is a real, actionable design defect with a concrete user-visible cost, and the fix (isolate UI state from data fetching) is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 3 / Dead round detection: Abandoned rounds remain in auto-opened set and report misleading runtimes indefinitely",
+            "why": "A round that crashes or is terminated without writing a completion time is never marked as finished in session files. Because Build order step 3 only closes rounds that transition out of running status, dead rounds remain in the auto-opened set indefinitely and compute duration against current time, reporting durations like \u0027361m 40s\u0027 on machines with short timeouts.",
+            "fix": "Incorporate a timeout or stale-heartbeat check so that rounds exceeding the maximum reviewer timeout are marked dead and automatically closed.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete stuck-state defect \u0393\u00C7\u00F6 a round that dies without writing a completion time never leaves the auto-opened set and keeps accruing elapsed time against the current clock, producing absurd durations like \u0027361m 40s\u0027 \u0393\u00C7\u00F6 which is exactly the interrupted/non-terminal-state sweep the project\u0027s own reliability and durable-status rules require, and the fix (a timeout or stale-heartbeat check bounded by the reviewer timeout) is proportionate."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 4 / Layering violation: Placing vendorColour in rounds.ts forces non-parsing views to import the parser",
+            "why": "Build order step 4 places \u0027vendorColour(name)\u0027 in \u0027rounds.ts\u0027. \u0027rounds.ts\u0027 handles session file parsing, whereas palette indexing is a pure UI/view concern. View components like spending rows need vendor color mapping without taking on dependencies on session parsing logic.",
+            "fix": "Place \u0027vendorColour\u0027 in a dedicated presentation/view utility module (e.g. \u0027vendorColour.ts\u0027) that both round cards and spending rows can import independently.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "Placing one small pure helper in a module a build-order step already touches is a trivial organizational preference, not a real layering problem \u0393\u00C7\u00F6 importing a named export costs nothing at runtime and the split can be done freely later if a second consumer appears."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Symptom 2 \u0026 Build order step 3 / Empty disclosure affordance: Legacy rounds without reviewer detail render expandable disclosure widgets with empty bodies",
+            "why": "Rounds recorded before per-reviewer details existed do not contain reviewer breakdowns. Automatically rendering them as collapsible/expandable cards with cursor pointers promises expandable details but opens into an empty body.",
+            "fix": "Conditionally render expandable disclosure controls only when per-reviewer detail is present; render legacy rounds as flat non-expandable rows.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "An expandable control that opens onto nothing is a real UX defect for legacy rounds lacking per-reviewer data, and gating the disclosure on the presence of detail is a proportionate, concrete fix."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 0.1,
+        "verdict": "",
+        "error": "git worktree add: Preparing worktree (detached HEAD 267e07a)\r\nfatal: \u0027C:/Users/strug/AppData/Local/coai-mcp/worktrees/coai-wt-17d2a77b-r1\u0027 already exists",
+        "gatingCount": 0,
+        "reviewers": "",
+        "tokensIn": 0,
+        "tokensOut": 0,
+        "costUsd": null,
+        "findings": [],
+        "commands": [],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:28:57 \u001B[32mINF\u001B[0m] coai-mcp#43012 finding [Major/Reliability] Build order step 3 / Dead round detection: Abandoned rounds remain in auto-opened set and report misleading runtimes indefinitely (from gemini) [gating] Round=1 Stage=PlanReview\r | [14:28:57 \u001B[32mINF\u001B[0m] coai-mcp#43012 finding [Minor/Architecture] Build order step 4 / Layering violation: Placing vendorColour in rounds.ts forces non-parsing views to import the parser (from gemini) Round=1 Stage=PlanReview\r | [14:28:57 \u001B[32mINF\u001B[0m] coai-mcp#43012 finding [Minor/Ux] Symptom 2 \u0026 Build order step 3 / Empty disclosure affordance: Legacy rounds without reviewer detail render expandable disclosure widgets with empty bodies (from gemini) Round=1 Stage=PlanReview",
+    "onDisk": {
+      "rounds": 1,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini",
+    "repeat": 2,
+    "lane": 4,
+    "key": "codex,gemini|rounds-collapse|2",
+    "startedUtc": "2026-09-05T14:28:18.9623386Z",
+    "finishedUtc": "2026-09-05T14:30:04.3985225Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 41.7,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 75654,
+        "tokensOut": 6320,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The Fable test does not verify that provider discovery is removed from the command path",
+            "why": "With a provider-discovery call still present, the test can pass when discovery happens to return codex/gemini/local, but a timeout or failed vendor probe on a real machine will block or suppress the checkbox command even though Fable should require no provider lookup.",
+            "fix": "Mock provider discovery to hang or fail and assert that checking SplitWithFable still issues the Fable order without invoking that discovery path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and self-contradictory \u0393\u00C7\u00F6 it asserts a provider-discovery call is \u0027still present\u0027 in a command path without naming any file, function, or code, and demands an elaborate hang/fail mock for a test whose subject it never identifies."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The build step still prescribes the known-broken \u0060vendor\u0060 CSS class despite the stated shipped deviation",
+            "why": "The plan\u0027s implementation instructions wrap the name in \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060, but its own deviation says \u0060.vendor\u0060 is an existing settings-card class with border, radius, and padding; following the build order therefore recreates the reported struck-through and padded vendor-name rendering.",
+            "fix": "Update the implementation step and acceptance criteria to use the chosen neutral class, such as \u0060who\u0060, and add a rendering assertion that the vendor span has no settings-card styles.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It catches a direct self-contradiction in the plan \u0393\u00C7\u00F6 the build step still tells the implementer to apply the very class the deviation section identifies as the cause of the broken rendering \u0393\u00C7\u00F6 so anyone following the steps in order would reproduce the defect the change exists to fix."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The auto-close state machine is underspecified for panel refreshes and user toggles between open and finish events",
+            "why": "If the panel auto-opens a running round, the person closes and reopens it before the completion refresh, an implementation that only adds/removes the ID during the final close pass can misclassify the card and collapse a card the person now owns (or leave an auto-opened card expanded). The listed tests do not cover this sequence, including the promised re-opening behavior.",
+            "fix": "Define the toggle transition rules explicitly\u2014manual open must clear panel ownership, manual close must clear it, and only a still-owned ID may be auto-collapsed\u2014and test the close/reopen-before-finish sequence.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible race in a UI state machine \u0393\u00C7\u00F6 auto-open ownership not cleared by a manual toggle before the completion refresh \u0393\u00C7\u00F6 and states the transition rules and the missing test sequence, which is exactly what someone implementing the auto-close behaviour would need to get right."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order: Reusing existing \u0060.vendor\u0060 CSS class in panelView causes style conflicts on inline vendor names",
+            "why": "Build order step 5 plans to wrap vendor names in \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060. If \u0060.vendor\u0060 is already defined in the stylesheet with card-level styles (e.g. border, border-radius, padding), applying it to inline text causes the text to look struck through or broken across lines.",
+            "fix": "Use a distinct class name such as \u0060who\u0060 or \u0060vendor-tag\u0060 in \u0060panelView\u0060 that is scoped specifically for inline text styling without card borders or box padding.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about a CSS collision it never verified \u0393\u00C7\u00F6 no stylesheet was checked and no \u0060.vendor\u0060 card-level rule was shown to exist \u0393\u00C7\u00F6 and dresses a hypothetical naming preference as a Major UX defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "panelProvider: Toggling or repainting round cards triggers full expensive provider discovery and remote price fetches",
+            "why": "When round state changes (running to finished) or when a card is toggled, if \u0060panelProvider\u0060 rebuilds the view by re-running full configuration checks, CLI probing, and network fetches, collapsing/expanding a card blocks UI responsiveness for up to twenty seconds.",
+            "fix": "Decouple round card state/expansion rendering from system configuration probing and remote price fetching by caching provider status and rendering cards from local session state.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding is explicitly conditional (\u0027if \u0060panelProvider\u0060 rebuilds the view by re-running full configuration checks...\u0027) and names no file, line, or observed code path \u0393\u00C7\u00F6 it is a speculative performance hypothesis rather than a defect the author verified, so an engineer receiving it has nothing to act on but a guess."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order: Placing vendorColour in rounds.ts mixes view concerns with session file parsing",
+            "why": "\u0060rounds.ts\u0060 handles parsing session files. Importing it or coupling it with UI palette logic forces non-view layers (or components like spending rows that only need the palette) to depend on session parser modules.",
+            "fix": "Extract \u0060vendorColour\u0060 into a dedicated view-utility module (e.g., \u0060vendorColour.ts\u0060) so UI components can consume it independently of \u0060rounds.ts\u0060.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It is a speculative module-organization preference about a single small colour helper, with no named file and no demonstrated coupling problem \u0393\u00C7\u00F6 the kind of churn that costs a rename and buys nothing."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "panelView: Elapsed time calculation on dead/uncompleted rounds lacks timeout capping",
+            "why": "When a reviewer round crashes or is killed without writing a completion timestamp, calculating duration as \u0060now - startTime\u0060 reports absurd durations (e.g. hundreds of minutes) even when reviewer timeout has expired.",
+            "fix": "Cap the calculated runtime of incomplete rounds at the configured reviewer timeout or mark them explicitly as timed out/interrupted if no completion timestamp is recorded.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about a UI elapsed-time display with no file, line, or code shown, and the suggested remedy (cap at the reviewer timeout) would hide rather than reveal a stuck round \u0393\u00C7\u00F6 the honest fix, marking interrupted rounds, is a display nicety that no evidence here shows is broken."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 63.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 361027,
+        "tokensOut": 15350,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The checked-in plan still declares the implemented change as unimplemented",
+            "why": "The repository\u0027s own Definition of Done says the plan is to be promoted, but this newly added copy says \u0022Status: plan only, nothing implemented yet\u0022 while the same change updates the research documentation to \u0022Status: IMPLEMENTED\u0022 and ships the implementation. This leaves two contradictory project plans and violates the documented plan-lifecycle convention.",
+            "fix": "Remove this stale todo copy or replace it with the promoted/implemented plan state so there is one authoritative status.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The repository\u0027s plan-lifecycle rule is explicit that an implemented plan left in \u0060todo/\u0060 with a \u0027nothing implemented yet\u0027 status is a violation, and a commit that ships the implementation plus an IMPLEMENTED copy in \u0060research/\u0060 while adding this contradictory one is exactly the drift the check exists to catch \u0393\u00C7\u00F6 a real, actionable convention breach the author would want fixed before merge."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 164,
+            "title": "Concurrent saves can still silently lose session history",
+            "why": "If two MCP servers load the same session, append different round records, and call Save concurrently, the unique scratch files prevent collisions but \u0060MoveOverExisting\u0060 still replaces the destination wholesale. The second move wins, so the first server\u0027s newly recorded round or state disappears; a restart then loads an incomplete session and may repeat work or lose the round trail.",
+            "fix": "Serialize saves per session (for example with an interprocess lock) and/or reload-and-merge the latest destination before replacing it, while retaining the unique scratch names for crash-safe writes.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The file\u0027s own comment documents concurrent servers saving the same session key, so the unique-scratch fix removed the crash but left a genuine last-writer-wins lost-update on the round trail \u0393\u00C7\u00F6 exactly the durable-status guarantee this class claims, and a follow-up the author would want to know about."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 807,
+            "title": "Reviewer vendor names use the existing settings-card \u0060vendor\u0060 class",
+            "why": "Every rendered reviewer name receives \u0060class=\u0022vendor\u0022\u0060, but this stylesheet class already denotes a settings card. In a round with reviewer rows, the vendor word therefore inherits the card border, radius, and padding instead of only the intended colour, making the row appear malformed.",
+            "fix": "Use the dedicated reviewer-name class (for example \u0060who\u0060) and style that class with only the vendor colour behavior.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 178,
+            "title": "File-save retries synchronously sleep on the round progress path",
+            "why": "When two MCP servers or a scanner briefly hold the session destination, each save blocks its executing thread for 20\u002B40\u002B60\u002B80 ms before retrying. A nine-reviewer round can hit this on many transitions, leaving status updates stale for seconds and consuming worker threads during concurrent rounds.",
+            "fix": "Use an awaited delay in an async persistence path, or serialize per-session writes so the retry does not block the round\u0027s progress thread.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The retry sleeps total at most 200 ms and only fire when a move actually fails \u0393\u00C7\u00F6 a rare contention case the comment documents \u0393\u00C7\u00F6 so calling it a performance defect and demanding an async/serialized rewrite is machinery out of proportion to the risk in a synchronous stdio server."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Vendor span uses class \u0022vendor\u0022 which collides with settings card stylesheet rules",
+            "why": "The class \u0022.vendor\u0022 is already assigned in the stylesheet to vendor settings cards, attaching a border, border-radius, and 8px padding. Using \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060 around the single vendor word inside a tight reviewer row applies full card box styling around inline text, rendering as a box/strike-through in the line.",
+            "fix": "Change \u0060\u003Cspan class=\u0022vendor\u0022\u0060 to \u0060\u003Cspan class=\u0022who\u0022\u0060 so the inline vendor name does not inherit the card container styling.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:30:04 \u001B[32mINF\u001B[0m] coai-mcp#20320 finding [Major/Ux] src_vs_code/src/panelView.ts:807 - Reviewer vendor names use the existing settings-card \u0060vendor\u0060 class (from codex) [gating] Round=1 Stage=CodeReview\r | [14:30:04 \u001B[32mINF\u001B[0m] coai-mcp#20320 finding [Minor/Performance] src_mcp/src/Server/SessionStore.cs:178 - File-save retries synchronously sleep on the round progress path (from codex) Round=1 Stage=CodeReview\r | [14:30:04 \u001B[32mINF\u001B[0m] coai-mcp#20320 finding [Major/Ux] src_vs_code/src/panelView.ts:810 - Vendor span uses class \u0022vendor\u0022 which collides with settings card stylesheet rules (from gemini) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,local",
+    "repeat": 1,
+    "lane": 3,
+    "key": "codex,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T14:28:56.0556526Z",
+    "finishedUtc": "2026-09-05T14:36:05.8738334Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 39.3,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 17845,
+        "tokensOut": 3326,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping requirement is only verified for one reviewer-row field",
+            "why": "A session file containing a vendor such as \u0060\u0022\u003E\u003Cimg src=x onerror=alert(1)\u003E\u0060 in a spending row or another card-rendered field can still reach the page unescaped while the specified reviewer-row test passes, leaving an XSS path.",
+            "fix": "Define and test escaping at every session-file-to-HTML boundary, including spending rows, live rows, titles, and reviewer details; use controlled CSS variables rather than interpolating session data into attributes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It flags a real \u0027measure applied at some of its sites\u0027 gap \u0393\u00C7\u00F6 one escaping test on one field leaves the other session-file-to-HTML interpolations (spending rows, titles, attribute values) unverified, which is exactly the class of defect a careful engineer would want enumerated rather than assumed."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The Fable test does not prove that reviewer discovery is removed",
+            "why": "A test can observe the Fable order being issued while the implementation still enumerates configured reviewer providers first; if one provider CLI hangs or fails, ticking the checkbox can still time out even though Fable is unconditional.",
+            "fix": "Mock provider discovery to throw or block and assert it is never called when \u0060SplitWithFable\u0060 is enabled, in addition to asserting that the order is issued.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Without any file, code, or concrete evidence that discovery still runs, this is a speculative demand for mock-based machinery about a hypothetical implementation detail rather than an identified defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The colour requirement is not verified in every rendering location",
+            "why": "If the reviewer-row renderer applies \u0060vendorColour\u0060 but the live section or spending-row renderer omits the span, uses a different escaping path, or passes a differently formatted name, the tests can pass while the same vendor appears uncoloured or inconsistently coloured across the panel.",
+            "fix": "Add location-specific assertions for reviewer, live, and spending output, including the exact rendered CSS variable and escaped text for a hostile vendor name.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It names no site and no actual gap \u0393\u00C7\u00F6 it is a conditional \u0027if some renderer omitted the span\u0027 worry that asks for per-location assertions and hostile-name escaping checks without any evidence that a rendering location is uncovered, so the reader has nothing to act on but speculative test machinery."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "",
+            "line": 0,
+            "title": "The build step contradicts the documented class-name deviation",
+            "why": "Following step 5 literally creates \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060; the plan itself says \u0060.vendor\u0060 is already a styled settings-card class, so the vendor name can inherit its border, radius, and padding and render with the known struck-through appearance.",
+            "fix": "Change the build step and acceptance criteria to require the non-conflicting \u0060who\u0060 class, or explicitly require a scoped selector that cannot collide with the existing \u0060.vendor\u0060 rule.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It catches a real internal contradiction \u0393\u00C7\u00F6 the build step\u0027s literal instruction reuses a class name the plan itself flags as already styled, so following it would ship a visibly wrong render, and the fix (rename or scope the selector) is concrete and proportionate."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is a speculative narrative built on assumed implementation details (\u0027a specific set\u0027, \u0027object identity or timestamp proximity\u0027) that it never establishes exist, and it names no file or code to check, so it reads as an invented failure mode rather than a defect anyone can act on."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, checkable failure mode \u0393\u00C7\u00F6 gating a user-visible toggle on a reviewer registry that by construction cannot contain the calling AI, yielding a silently inert checkbox \u0393\u00C7\u00F6 which is exactly the kind of blocking, verify-before-shipping question an engineer would want raised even if the eventual answer is that the check resolves some other way."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible UX failure \u0393\u00C7\u00F6 a synchronous chain of config reads, binary stats, CLI probes and network price-table fetches on a UI repaint path freezing the panel for seconds \u0393\u00C7\u00F6 and proposes the proportionate fix (cache and re-evaluate on change or interval), which is exactly what someone implementing that toggle would want flagged before shipping."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real user-facing defect \u0393\u00C7\u00F6 an interrupted round rendering an ever-growing \u0027elapsed\u0027 time that reads as still-running \u0393\u00C7\u00F6 and proposes a proportionate fix (persist a terminal timestamp/flag), which is exactly the stuck in-flight state a durable status is supposed to prevent."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative CSS fabrication \u0393\u00C7\u00F6 it invents a rendering artifact (a border/padding somehow drawing a strikethrough through text) that borders and padding cannot produce, names no file or line, and proposes a fix for a symptom nobody observed."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It fabricates a UI failure mode from a phrase in the plan \u0393\u00C7\u00F6 no file, no line, no evidence that legacy rounds render a hand cursor over an empty panel \u0393\u00C7\u00F6 and prescribes a distinct \u0027legacy\u0027 visual treatment for a case the plan already says it handles with an explanatory message."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 390.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 275762,
+        "tokensOut": 6922,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The committed plan falsely remains marked as unimplemented",
+            "why": "The plan\u0027s written completion rule says: \u0022[ ] ... docs, help and CHANGELOG updated; the plan promoted.\u0022 This diff ships the implementation and updates those artifacts, but adds a plan stating \u0022Status: plan only, nothing implemented yet,\u0022 leaving repository lifecycle documentation contradictory.",
+            "fix": "Promote the plan to its implemented status and record the shipped versions/deviations, or remove the stale plan-only file.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "If the same diff ships the implementation, docs and CHANGELOG, a plan landing with \u0027nothing implemented yet\u0027 is exactly the lifecycle drift this repo\u0027s MANDATORY planning rule exists to prevent \u0393\u00C7\u00F6 and one the status-line-based CI check cannot detect, so a human has to catch it; the fix (promote with deviations) is one cheap step in the same task."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 142,
+            "title": "Concurrent saves can still lose the newest session state",
+            "why": "With two MCP servers sharing one data directory, writer A can save a session containing round 2, then writer B can move a stale snapshot containing only round 1 after it; the per-write scratch names prevent the exception but the last move still silently rolls the durable session trail back, so a later restart forgets completed rounds or pending findings.",
+            "fix": "Serialize saves per session or perform a read/merge/compare-and-swap under a lock before replacing the destination, so an older snapshot cannot overwrite a newer one.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The code\u0027s own comment establishes that two servers really do write the same session file concurrently, so it correctly points out that the unique-scratch-name fix removed the crash but left the lost-update race, where an older snapshot silently overwrites a newer round trail \u0393\u00C7\u00F6 exactly the durable-status guarantee this store exists to provide."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 139,
+            "title": "Toggling a round synchronously triggers the full expensive panel refresh",
+            "why": "When a person opens or closes a card, this handler immediately repaints; the refresh path reads configuration, probes CLIs, checks GitHub, and fetches price tables. On a machine where those calls take around 20 seconds, the toggle appears frozen and the person waits before the disclosure state is reflected.",
+            "fix": "Update the local open-round state and patch only the affected round markup immediately; run the unrelated status, update, and pricing refreshes separately without blocking the toggle.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The premise is wrong for this code: \u0060render()\u0060 is fire-and-forget (\u0060void\u0060), its expensive reads are all timestamp-cached (\u0060latestCheckedAt\u0060, \u0060cliCheckedAt\u0060, \u0060pricesCheckedAt\u0060, \u0060localCheckedAt\u0060) and it already runs on the watcher\u0027s five-second tick, so a toggle adds no new cost \u0393\u00C7\u00F6 and the comment right at the cited line explains that the immediate repaint exists because a card\u0027s body is only built when open, which the suggested fix would break."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may silently swallow a final failure",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 states: \u0027The server refuses one without it\u0027 (referring to scope) and implies strict adherence to protocol. More critically, the \u0060vendor-routing.md\u0060 rule states \u0027breaking it is invisible in the output\u0027. The \u0060MoveOverExisting\u0060 method retries 5 times. If the 5th attempt fails, the \u0060catch\u0060 block inside the loop (line 183) catches the exception but the loop exits. The method then returns. The caller (\u0060Save\u0060) has a \u0060try...finally\u0060 block. If \u0060MoveOverExisting\u0060 throws, it propagates. If it succeeds, it returns. However, the logic \u0060catch (Exception e) when (...) \u0026\u0026 attempt \u003C attempts\u0060 means on the 5th attempt, if it fails, the loop exits *without* re-throwing or handling the exception explicitly in a way that guarantees visibility. Wait, looking closer: \u0060catch\u0060 block has \u0060Thread.Sleep\u0060. If \u0060attempt\u0060 reaches 5, the loop condition \u0060attempt \u003C= attempts\u0060 is true. Inside, if it throws, it hits the catch. \u0060attempt \u003C attempts\u0060 (5 \u003C 5) is false. So it *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method\u0027s retry loop uses a bounded number of attempts and that the final attempt throws if it fails, rather than silently swallowing the error.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about the code and contradicts itself mid-text: the exception filter \u0060attempt \u003C attempts\u0060 deliberately lets the fifth attempt throw and propagate out of \u0060Save\u0060, which is exactly the behaviour the finding asks for as its fix and which the method\u0027s own remarks already document."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Concurrent save race condition leaves orphaned scratch files and silent failures",
+            "why": "In \u0060SessionStore.Save\u0060, the code generates a unique scratch filename using \u0060Environment.ProcessId\u0060 and a GUID. However, if two processes (or threads in a multi-threaded scenario) happen to generate the same GUID or if the process ID is reused rapidly, they could collide. More critically, the \u0060MoveOverExisting\u0060 method retries 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms). If the destination file is held by a virus scanner or another process for longer than ~250ms, the move fails. The code then enters the \u0060finally\u0060 block and calls \u0060TryDelete(temp)\u0060. If the move failed, \u0060temp\u0060 still exists. If the \u0060TryDelete\u0060 fails (e.g., file locked), it swallows the exception. The result is a session file that never updated (stale data) and a temporary file left behind, potentially filling the disk or causing future collisions if the temp name generation isn\u0027t perfectly unique. The comment admits \u0027a save that never lands is a real problem\u0027 but the \u0060finally\u0060 block\u0027s \u0060TryDelete\u0060 might *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite backoff and that the final exception is re-thrown or logged with context, rather than silently swallowed if the file is held by a scanner.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Its central claim is false \u0393\u00C7\u00F6 the last attempt is deliberately outside the \u0060when (\u0393\u00C7\u00AA \u0026\u0026 attempt \u003C attempts)\u0060 filter so a failed move does throw, and \u0060TryDelete\u0060 in the \u0060finally\u0060 swallows only its own delete failure, not the move\u0027s exception; the remaining points (GUID collision, a stray unique-named temp file) are speculative and negligible, and the suggested fix is already what the code does."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 806,
+            "title": "Potential HTML injection in vendor name rendering if escaping order is flawed",
+            "why": "In \u0060roundCard\u0060, the code constructs the reviewer row as: \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:${vendorColour(row.provider)}\u0022\u003E\u0060 \u002B \u0060${escapeHtml(row.provider)}\u0060 \u002B \u0060\u003C/span\u003E${escapeHtml(row.rest)}\u0060. If \u0060row.provider\u0060 contains a string like \u0060\u003Cscript\u003E\u0060, \u0060escapeHtml\u0060 converts it to \u0060\u0026lt;script\u0026gt;\u0060. However, if the \u0060vendorColour\u0060 function (or the caller) relies on the raw provider name for the style, and the style attribute is interpolated directly into the HTML string without escaping, an attacker could inject a style attribute. Wait, the style is \u0060color:var(...)\u0060, so it\u0027s safe. The real risk is if \u0060row.provider\u0060 is used in a context where it\u0027s not escaped *before* being placed inside the span, or if \u0060row.rest\u0060 contains unescaped HTML. The code escapes \u0060row.provider\u0060 and \u0060row.rest\u0060 separately. The risk is if \u0060row.provider\u0060 is *not* escaped before being used in the \u0060style\u0060 attribute (e.g., if \u0060vendorColour\u0060 returned a hex value that wasn\u0027t quoted, but it returns a CSS variable). The actual flaw",
+            "fix": "Ensure \u0060vendorColour\u0060 is called *after* \u0060escapeHtml\u0060 or that the HTML structure wraps the escaped text correctly, preventing a scenario where a vendor name like \u0060\u003Cscript\u003E\u0060 renders as an active tag if the escaping logic is applied to the wrong part of the string.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent \u0393\u00C7\u00F6 it visibly reasons its way out of its own premise mid-sentence (\u0027Wait, the style is color:var(...), so it\u0027s safe\u0027), never identifies an actual flaw, and the code it points at already escapes both \u0060row.provider\u0060 and \u0060row.rest\u0060 before interpolation."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Race condition in round state management could lead to duplicate keys or lost state",
+            "why": "The \u0060nextOpenRounds\u0060 function builds a \u0060Set\u0060 of keys from \u0060cards\u0060. If two rounds have the same \u0060roundKey\u0060 (e.g., same repo, branch, stage, number), the second one will overwrite the first in the Set. This means if a user has two rounds with identical metadata (perhaps from different branches or a bug in ID generation), only one will be tracked in the \u0060open\u0060 state. If the user interacts with the \u0027wrong\u0027 one (the one that was processed last), the state update might not reflect the actual round they clicked. This is a subtle data loss scenario where the UI state diverges from the actual session data.",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all rounds before adding to the \u0060open\u0060 set, or handle collisions explicitly.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The keys are derived deterministically from round identity and are only ever used as set membership for expand/collapse UI state, so a hypothetical collision would collapse two identical cards\u0027 open state at worst \u0393\u00C7\u00F6 the finding invents an ID-generation bug it never demonstrates and asks for uniqueness machinery out of all proportion to a cosmetic risk."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:36:05 \u001B[32mINF\u001B[0m] coai-mcp#45812 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Concurrent save race condition leaves orphaned scratch files and silent failures (from local) [gating] Round=1 Stage=CodeReview\r | [14:36:05 \u001B[32mINF\u001B[0m] coai-mcp#45812 finding [Major/Security] src_vs_code/src/panelView.ts:806 - Potential HTML injection in vendor name rendering if escaping order is flawed (from local) [gating] Round=1 Stage=CodeReview\r | [14:36:05 \u001B[32mINF\u001B[0m] coai-mcp#45812 finding [Minor/Reliability] src_vs_code/src/openRounds.ts:45 - Race condition in round state management could lead to duplicate keys or lost state (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,local",
+    "repeat": 2,
+    "lane": 6,
+    "key": "codex,local|rounds-collapse|2",
+    "startedUtc": "2026-09-05T14:28:57.9735797Z",
+    "finishedUtc": "2026-09-05T14:33:30.8868698Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 87.3,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 17847,
+        "tokensOut": 2737,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The stated session-file escaping guarantee is not verified for all dynamic fields rendered by the panel",
+            "why": "A session containing markup in a round name, prompt, reviewer output, or spending description can still reach an HTML template through a field other than the reviewer vendor; the only named test covers a vendor containing \u0060\u003C\u0060, so the claimed guarantee can ship with an XSS hole.",
+            "fix": "Inventory every session-derived value used by panelView, escape each at the rendering boundary (including attribute/style contexts), and add malicious-value tests for every rendered field or route all fields through one safe renderer.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "With no file, line, or concrete unescaped field named \u0393\u00C7\u00F6 and no code shown to check the claim against \u0393\u00C7\u00F6 this is a speculative demand to audit and test every rendered value on the strength of one test\u0027s narrow name, which is machinery out of proportion to any risk it actually demonstrates."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The auto-collapse design does not define or test restart and interrupted-round behavior",
+            "why": "If the extension host reloads while a round is running, the new in-memory \u201Crounds THIS panel opened\u201D set is empty, so that round will not be auto-opened and later will not be auto-collapsed; if the process is killed or times out without a completion timestamp, the plan gives no defined distinction between a finished round and a dead round.",
+            "fix": "Persist panel ownership or explicitly define restart semantics, and specify/test completed, failed, timed-out, killed, and missing-completion-time transitions, including expansion and duration behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible failure \u0393\u00C7\u00F6 an extension-host reload leaves the in-memory ownership set empty so a live round is never auto-expanded or collapsed \u0393\u00C7\u00F6 and the undefined terminal-state semantics for killed/timed-out rounds is exactly the durable-status gap this codebase\u0027s rules call out, so the designer would want to answer it before building."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The plan leaves the user-toggle versus programmatic-collapse race unspecified",
+            "why": "When a round is auto-opened and the user closes it near the refresh in which it stops running, an update can process stale auto-open ownership after the toggle and close or reopen the card contrary to the user\u0027s last action; a user reopening during the transition may likewise be mistaken for an automatic state change.",
+            "fix": "Define event ordering for concurrent refreshes, make user actions authoritative with state/version handling, and test close/reopen actions racing with the running-to-finished update.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It demands event-ordering specs and version/state machinery for a hypothetical race in a UI card\u0027s auto-expand behaviour, where the worst outcome is a panel briefly in the wrong open/closed state that one click fixes \u0393\u00C7\u00F6 machinery out of proportion to the risk."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a failure mode from an assumed implementation \u0393\u00C7\u00F6 object identity or timestamp proximity for tracking \u0027opened by the panel\u0027 \u0393\u00C7\u00F6 without any code or plan text shown to support it, and asks for an ID field that a round almost certainly already has, so it is speculation dressed as a Blocking defect."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is built on an invented premise \u0393\u00C7\u00F6 it asserts what \u0060PanelService.FableIsUsable()\u0060 checks and that Fable cannot be in the provider list without naming any file or line, and its confident \u0027returns false on every real machine\u0027 conclusion is speculation about code it never opened."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a concrete 20-second UI freeze and a chain of blocking calls that the quoted plan phrase (\u0027repaint to build a card\u0027s body\u0027) does not establish, so the fix it prescribes \u0393\u00C7\u00F6 caching config reads, binary stats, CLI probes and GitHub price fetches \u0393\u00C7\u00F6 is machinery proposed against a fabricated symptom rather than a demonstrated one."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete user-visible defect \u0393\u00C7\u00F6 a round with no completion timestamp renders an ever-growing elapsed time, so a dead round reads as still running \u0393\u00C7\u00F6 and the fix (write a terminal state/timestamp rather than inferring liveness from absence) is proportionate and matches the durable-status rule this family already holds."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a visual artifact \u0393\u00C7\u00F6 a border plus padding on an inline span does not render as a strikethrough through the text \u0393\u00C7\u00F6 so the finding is speculative CSS fiction about an unnamed file rather than a defect anyone could act on."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a UI defect from a plan\u0027s own acknowledgement that pre-existing rounds lack per-reviewer data \u0393\u00C7\u00F6 the plan already says such rounds show an explanatory message, which is exactly the fallback state the finding demands, and it cites no file or code to show the hand-cursor/flat-line problem actually exists."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 185.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 346292,
+        "tokensOut": 9093,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The committed plan incorrectly remains a plan-only document after implementation shipped",
+            "why": "The project plan explicitly requires: \u0022[ ] ... the plan promoted.\u0022 The repository\u0027s implementation plan is marked implemented, but this new copy says \u0022Status: plan only, nothing implemented yet\u0022 and leaves its Definition of Done unchecked, creating contradictory lifecycle metadata.",
+            "fix": "Remove the stale todo copy or promote it with implemented status and completed Definition of Done checkboxes.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "A newly written plan sitting in \u0060todo/\u0060 with a \u0060plan only, nothing implemented yet\u0060 status is exactly what planning-docs.md prescribes, and the finding\u0027s premise \u0393\u00C7\u00F6 that this is a stale duplicate of an already-implemented plan \u0393\u00C7\u00F6 is asserted without evidence, so acting on its fix would delete a legitimately open plan."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 153,
+            "title": "Concurrent saves can still overwrite one another and lose session history",
+            "why": "Two MCP servers can load the same session, then save different full snapshots: server A adds round 1, server B adds round 2, and whichever \u0060File.Move(..., overwrite: true)\u0060 runs last replaces the file with its stale snapshot, silently deleting the other round or findings.",
+            "fix": "Serialize saves per session across processes with an exclusive lock, or reload and merge the current destination under a lock before atomically replacing it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The unique-scratch-name fix only removed the temp-file collision; the last-writer-wins whole-file overwrite of a shared session file by concurrent MCP servers \u0393\u00C7\u00F6 the very concurrency the code\u0027s own comment documents \u0393\u00C7\u00F6 genuinely loses round history, so it is a real defect a careful engineer would want to know about."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Reviewer vendor names use the existing card-level \u0060vendor\u0060 class",
+            "why": "Every colored reviewer row renders its provider as \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060; the stylesheet already assigns \u0060.vendor\u0060 to settings cards, so these inline names inherit card borders, radius, and padding and visibly disrupt the reviewer sentence instead of only changing its color.",
+            "fix": "Use the dedicated \u0060who\u0060 class for reviewer-name spans and update the corresponding markup assertions.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The newly added plan incorrectly says the implemented change has not been implemented",
+            "why": "A future contributor or plan-lifecycle check sees \u0060Status: plan only, nothing implemented yet\u0060 despite the shipped implementation, so the repository presents this work as outstanding and may prompt duplicate implementation or block plan promotion.",
+            "fix": "Mark the plan implemented/promoted, or remove this stale todo copy.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "If the same change shipped the implementation, a plan left in \u0060todo/\u0060 still claiming \u0022nothing implemented yet\u0022 is exactly the state \u0060planning-docs.md\u0060 forbids by name and \u0060plan-lifecycle.mjs\u0060 fails CI on, so it is a concrete, actionable defect rather than a nitpick."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 142,
+            "title": "Session persistence uses a fixed scratch name instead of a per-write unique name",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 (inherited from \u0060vendor-routing.md\u0060 logic regarding visibility of errors) and the specific plan deviation states: \u0027A session is saved under its own scratch name, and the move is retried\u0027. The diff shows the scratch file name is now unique (\u0060${file}.{Environment.ProcessId}-{Guid.NewGuid()}.tmp\u0060), but the rule explicitly requires the move to be retried for cases a unique name cannot fix (e.g., a scanner holding the destination). The current implementation retries, but the rule text in \u0060module_server.md\u0060 says \u0027the move is retried briefly for the case a unique name cannot fix\u0027. The implementation does retry. However, the rule in \u0060review-gate.md\u0060 states \u0027The server refuses one without it\u0027 regarding scope. Wait, the rule is about the scratch name. The rule in \u0060module_server.md\u0060 says: \u0027each write goes to a scratch file of its OWN name\u0027. The diff does this. But the rule in \u0060review-gate.md\u0060 says \u0027Never hand a reviewer a bare diff\u0027. This is a new",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method retries the move operation for the case where a reader or scanner holds the destination file, as explicitly required by the rule.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent and self-refuting \u0393\u00C7\u00F6 it repeatedly concedes the code already does what it demands (\u0027The implementation does retry\u0027), wanders into unrelated rules about review scope, and is cut off mid-sentence, so it names no actual defect in code that already uses a per-write unique scratch name and a bounded retry."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a fixed sleep interval (20ms * attempt). If a file lock (e.g., from an antivirus scanner or another process) persists longer than the total retry window (approx 150ms), the code throws. However, if the lock is held by a process that never releases it (rare but possible in enterprise environments), the \u0060Thread.Sleep\u0060 loop might not be sufficient to handle transient spikes, or worse, if the logic is extended, it could spin. More critically, the \u0060MoveOverExisting\u0060 method is called inside a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060. If the file is held by a scanner that intermittently locks/unlocks, the retry might succeed. But if the lock is permanent, it throws. The real risk is that the \u0060MoveOverExisting\u0060 logic is *not* robust enough for high-concurrency scenarios where multiple writers might contend for the same destination file *after* the unique temp name collision is resolved. If the destination file (",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite wait strategy (e.g., exponential backoff with a hard cap) or a \u0060CancellationToken\u0060 to prevent the server from hanging indefinitely if the destination file is held by a long-running process (like an antivirus scanner) that never releases it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is self-contradictory and wrong about the code it reviews: the loop is already bounded at 5 attempts with the last attempt allowed to throw \u0393\u00C7\u00F6 exactly the \u0027bounded, non-infinite wait strategy\u0027 it asks for \u0393\u00C7\u00F6 and it speculates about hypothetical future extensions rather than naming a real defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Temporary scratch files accumulate on failed moves due to cleanup timing",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060TryDelete(temp)\u0060 is called in a \u0060finally\u0060 block *after* the \u0060MoveOverExisting\u0060 loop. If \u0060MoveOverExisting\u0060 throws an exception on the final attempt (e.g., \u0060UnauthorizedAccessException\u0060 after 5 retries), the \u0060finally\u0060 block executes and deletes the temp file. However, if the loop succeeds but the \u0060File.Move\u0060 throws *during* the retry (e.g., on attempt 3), the \u0060finally\u0060 block runs, deleting the temp file, but the exception propagates. The critical issue is that if \u0060MoveOverExisting\u0060 throws *before* the loop finishes (e.g., on the first try), the \u0060finally\u0060 block deletes the temp file. But if the loop completes successfully, the temp file is deleted. The real risk is if \u0060MoveOverExisting\u0060 throws *after* a successful move but before the \u0060finally\u0060 block runs (unlikely), or if the \u0060TryDelete\u0060 itself fails silently. More critically, if \u0060MoveOverExisting\u0060 throws on the *last* attempt, the \u0060finally\u0060 block runs, deleting the temp file. But if the loop *succeeds* (all",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs before the retry loop completes, so that if the move fails after the first attempt, the temporary file is cleaned up before the next retry.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent and wrong about the code \u0393\u00C7\u00F6 it contradicts itself repeatedly, never lands on an actual defect, and the existing \u0060finally { TryDelete(temp) }\u0060 already cleans up the scratch file on every path including a failed move; the proposed \u0027fix\u0027 would delete the temp file mid-retry and break the retry loop."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 75,
+            "title": "User toggle state may not persist correctly across panel ticks",
+            "why": "When a user closes a card (e.g., \u0060afterToggle(previous, key, false)\u0060), the \u0060open\u0060 set is updated to remove the key. However, if the panel re-renders before the next tick, and the round is still running, the \u0060nextOpenRounds\u0060 logic might re-add it to \u0060open\u0060 if it\u0027s in \u0060autoOpened\u0060. The current logic removes the key from \u0060panelOpened\u0060, but if the round is still running, \u0060nextOpenRounds\u0060 will re-add it to \u0060autoOpened\u0060 and \u0060open\u0060 on the next tick, effectively ignoring the user\u0027s close action. This creates a flicker where the card closes, then re-opens immediately if the round is still running.",
+            "fix": "Ensure \u0060afterToggle\u0060 updates the \u0060open\u0060 set correctly when a user closes a card that was previously auto-opened, and that the \u0060panelOpened\u0060 set is updated to reflect the user\u0027s explicit choice.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is wrong about this code: \u0060afterToggle\u0060 deliberately keeps the key in \u0060autoOpened\u0060, and \u0060nextOpenRounds\u0060 only opens a running round when \u0060!autoOpened.has(key)\u0060, so the described re-open/flicker cannot happen \u0393\u00C7\u00F6 the comments on lines 44-45 and 82-83 state exactly this guard."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary recomputation of open rounds state on every render tick",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 calls \u0060nextOpenRounds\u0060 on every render tick (every 5 seconds). This function performs set operations and filtering on the entire list of rounds. While the logic is simple, doing this on every tick for a large number of rounds (e.g., 100\u002B rounds) creates unnecessary CPU overhead. The state should only be recomputed when the \u0060sessions\u0060 data actually changes (e.g., a new round starts, a round finishes, or a user toggles a card).",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 and only recompute it when the underlying \u0060sessions\u0060 data changes, rather than on every render tick.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "A pure set/filter pass over at most a few dozen round cards every five seconds is negligible next to the file reads, config reads and full HTML repaint that surround it, and the proposed cache would reintroduce exactly the staleness the current design exists to avoid."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:33:30 \u001B[32mINF\u001B[0m] coai-mcp#47000 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Temporary scratch files accumulate on failed moves due to cleanup timing (from local) [gating] Round=1 Stage=CodeReview\r | [14:33:30 \u001B[32mINF\u001B[0m] coai-mcp#47000 finding [Major/Ux] src_vs_code/src/openRounds.ts:75 - User toggle state may not persist correctly across panel ticks (from local) [gating] Round=1 Stage=CodeReview\r | [14:33:30 \u001B[32mINF\u001B[0m] coai-mcp#47000 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary recomputation of open rounds state on every render tick (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "gemini,local",
+    "repeat": 1,
+    "lane": 2,
+    "key": "gemini,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T14:29:46.4126131Z",
+    "finishedUtc": "2026-09-05T14:40:31.2348367Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 395.8,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 24732,
+        "tokensOut": 5682,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order 3 (panelProvider): Closing a running round will cause it to auto-reopen on the next background refresh",
+            "why": "Step 3 specifies that toggling a card merely removes its key from the panel-opened set. While a round is still actively running, removing the key leaves no record of the user\u0027s explicit close action; on the next polling or state refresh tick, the provider detects a running round not currently in the panel-opened set and re-expands it.",
+            "fix": "Track an explicit set of user-collapsed rounds so auto-open logic skips active rounds that the operator deliberately closed.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete state-machine bug \u0393\u00C7\u00F6 an auto-open rule driven by \u0027is running AND not in the opened set\u0027 will re-expand a round the operator deliberately collapsed on the next refresh tick \u0393\u00C7\u00F6 and proposes the standard fix of recording the explicit collapse, which is exactly the kind of thing a careful engineer would want caught before the UI ships."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Constraints (panelProvider): Pruning open/closed sets to living rounds forces finished cards to collapse when inspected",
+            "why": "The constraints require open/closed sets to be pruned strictly to living rounds. If an operator manually expands a finished round to inspect historical output or reviewer logs, the next prune cycle will identify the round as non-living and delete its ID from the open set, snapping the card shut on re-render.",
+            "fix": "Prune only the panel\u0027s auto-opened tracking set to living rounds, while bounding user-expanded state by an LRU size limit rather than by round liveness.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It rests on reading \u0022living rounds\u0022 as \u0022still-running rounds\u0022 when pruning to the rounds that still exist is the ordinary meaning \u0393\u00C7\u00F6 a finished round still on the panel stays in that set \u0393\u00C7\u00F6 so the collapse it predicts is speculative, and the LRU-bounded expansion state it asks for is machinery far out of proportion to a card that might close."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Constraints \u0026 Build order 5 (panelView): Injecting HTML span tags into the single reviewer row renderer breaks plain-text test assertions",
+            "why": "The constraint mandates using a single renderer for reviewer rows to avoid drift with existing tests that read text. Step 5 injects HTML span tags directly into this shared renderer, which causes existing test assertions expecting plain strings (like \u0027codex/PlanCritique \u2014 running\u0027) to receive HTML markup and fail.",
+            "fix": "Separate the underlying reviewer row representation from its HTML view decoration, or provide a clean plain-text projection for unit tests and non-DOM consumers.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible break \u0393\u00C7\u00F6 putting HTML markup inside the shared reviewer-row renderer that existing plain-text assertions read \u0393\u00C7\u00F6 and proposes the right separation of model from view, which is something the implementer would want to know before writing step 5."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a mechanism it never verified \u0393\u00C7\u00F6 no file, no line, and a chain of speculation about an \u0027opened by panel\u0027 set and object-identity matching that it never establishes exists in this code \u0393\u00C7\u00F6 so it reads as a plausible-sounding hypothetical rather than a defect anyone can act on."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, checkable failure \u0393\u00C7\u00F6 gating a user-facing toggle on a provider-list lookup for a model that is the caller rather than a configured reviewer, so the check is always false and the checkbox silently does nothing \u0393\u00C7\u00F6 and points at the specific condition to replace, which is exactly the kind of thing an engineer would want settled before shipping."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a 20-second synchronous UI freeze from a plan sentence about repainting a card body, with no code cited and no evidence that config reads, a stat, CLI probes, and network price fetches are actually chained synchronously on the toggle path \u0393\u00C7\u00F6 a speculative performance claim asking for a caching layer against a cost nobody measured."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It faults a plan for a gap that plan explicitly states and reasons about, and its own scenario is incoherent \u0393\u00C7\u00F6 a round with no completion time is by definition one the system cannot distinguish from still-running, so \u0027elapsed since start\u0027 is the honest reading, not a miscalculation, and the proposed \u0027write a completion flag on logical finish\u0027 is exactly what a dead round cannot do."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a specific visual artifact (a border/padding producing what reads as a strikethrough through a vendor name) that CSS does not plausibly produce and that is nowhere anchored in a file or line, so it is a speculative UX claim rather than a defect anyone can act on."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The plan already specifies the fallback the finding asks for \u0393\u00C7\u00F6 an explanatory apology in the disclosure \u0393\u00C7\u00F6 so this is a cosmetic restatement of documented behaviour rather than a defect worth acting on."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 248.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 207864,
+        "tokensOut": 16784,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Nit",
+            "category": "Reliability",
+            "file": "src_vs_code/src/vendorColour.ts",
+            "line": 46,
+            "title": "Object prototype properties collide with ANCHORED dictionary lookups",
+            "why": "When vendor name matches an Object prototype property (such as \u0027constructor\u0027), ANCHORED[name] evaluates to the prototype property (e.g. Object constructor function) instead of undefined, causing vendorColour to return a Function object rather than a CSS color string.",
+            "fix": "Use Object.hasOwn(ANCHORED, name) before indexing or define ANCHORED using Object.create(null).",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "Technically true, but vendor names are a small closed set of product identifiers (\u0027codex\u0027, \u0027gemini\u0027, \u0027local\u0027, operator-named rows) that will never be \u0027constructor\u0027 or \u0027toString\u0027, and the worst outcome is one label rendering an invalid CSS colour \u0393\u00C7\u00F6 a theoretical lint pattern rather than a defect anyone will meet."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Vendor name span uses class \u0027vendor\u0027 which inherits card box styling in reviewer rows",
+            "why": "The stylesheet already defines \u0027.vendor\u0027 for vendor settings cards with borders, border-radius, and 8px of padding. Applying class=\u0027vendor\u0027 to an inline \u003Cspan\u003E inside reviewer rows causes the vendor name to render with full card styling inside a tight row, creating a visual line through the text and breaking row layout.",
+            "fix": "Replace class=\u0022vendor\u0022 with class=\u0022who\u0022 in reviewer row rendering and update test assertions accordingly.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may silently swallow a final failure",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 states: \u0027The server refuses one without it\u0027 (referring to scope) and implies strict adherence to protocol. More critically, the \u0060vendor-routing.md\u0060 rule states \u0027breaking it is invisible in the output\u0027. The \u0060MoveOverExisting\u0060 method retries 5 times. If the 5th attempt fails, the \u0060catch\u0060 block inside the loop (line 183) catches the exception but the loop exits. The method then returns. The caller (\u0060Save\u0060) has a \u0060try...finally\u0060 block. If \u0060MoveOverExisting\u0060 throws, it propagates. If it succeeds, it returns. However, the logic \u0060catch (Exception e) when (...) \u0026\u0026 attempt \u003C attempts\u0060 means on the 5th attempt, if it fails, the loop exits *without* re-throwing or handling the exception explicitly in a way that guarantees visibility. Wait, looking closer: \u0060catch\u0060 block has \u0060Thread.Sleep\u0060. If \u0060attempt\u0060 reaches 5, the loop condition \u0060attempt \u003C= attempts\u0060 is true. Inside, if it throws, it hits the catch. \u0060attempt \u003C attempts\u0060 (5 \u003C 5) is false. So it *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method\u0027s retry loop uses a bounded number of attempts and that the final attempt throws if it fails, rather than silently swallowing the error.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is factually wrong \u0393\u00C7\u00F6 the \u0060when (... \u0026\u0026 attempt \u003C attempts)\u0060 filter means the fifth failure is not caught and propagates, exactly the behaviour the \u0027fix\u0027 asks for and the behaviour the method\u0027s own remarks already document; the write-up even talks itself out of the claim mid-sentence and cites two unrelated rules as justification."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Concurrent save race condition leaves orphaned scratch files and silent failures",
+            "why": "In \u0060SessionStore.Save\u0060, the code generates a unique scratch filename using \u0060Environment.ProcessId\u0060 and a GUID. However, if two processes (or threads in a multi-threaded scenario) happen to generate the same GUID or if the process ID is reused rapidly, they could collide. More critically, the \u0060MoveOverExisting\u0060 method retries 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms). If the destination file is held by a virus scanner or another process for longer than ~250ms, the move fails. The code then enters the \u0060finally\u0060 block and calls \u0060TryDelete(temp)\u0060. If the move failed, \u0060temp\u0060 still exists. If the \u0060TryDelete\u0060 fails (e.g., file locked), it swallows the exception. The result is a session file that never updated (stale data) and a temporary file left behind, potentially filling the disk or causing future collisions if the temp name generation isn\u0027t perfectly unique. The comment admits \u0027a save that never lands is a real problem\u0027 but the \u0060finally\u0060 block\u0027s \u0060TryDelete\u0060 might *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite backoff and that the final exception is re-thrown or logged with context, rather than silently swallowed if the file is held by a scanner.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is wrong about the code \u0393\u00C7\u00F6 the retry loop\u0027s \u0060attempt \u003C attempts\u0060 guard already lets the final failure throw (as the comment states) and the unique-name \u0060TryDelete\u0060 only ever removes the writer\u0027s own scratch file, so the \u0027silently swallowed\u0027 failure it asks to fix is exactly what the code already does, and the GUID-collision and disk-filling concerns are negligible."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 806,
+            "title": "Potential HTML injection in vendor name rendering if escaping order is flawed",
+            "why": "In \u0060roundCard\u0060, the code constructs the reviewer row as: \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:${vendorColour(row.provider)}\u0022\u003E\u0060 \u002B \u0060${escapeHtml(row.provider)}\u0060 \u002B \u0060\u003C/span\u003E${escapeHtml(row.rest)}\u0060. If \u0060row.provider\u0060 contains a string like \u0060\u003Cscript\u003E\u0060, \u0060escapeHtml\u0060 converts it to \u0060\u0026lt;script\u0026gt;\u0060. However, if the \u0060vendorColour\u0060 function (or the caller) relies on the raw provider name for the style, and the style attribute is interpolated directly into the HTML string without escaping, an attacker could inject a style attribute. Wait, the style is \u0060color:var(...)\u0060, so it\u0027s safe. The real risk is if \u0060row.provider\u0060 is used in a context where it\u0027s not escaped *before* being placed inside the span, or if \u0060row.rest\u0060 contains unescaped HTML. The code escapes \u0060row.provider\u0060 and \u0060row.rest\u0060 separately. The risk is if \u0060row.provider\u0060 is *not* escaped before being used in the \u0060style\u0060 attribute (e.g., if \u0060vendorColour\u0060 returned a hex value that wasn\u0027t quoted, but it returns a CSS variable). The actual flaw",
+            "fix": "Ensure \u0060vendorColour\u0060 is called *after* \u0060escapeHtml\u0060 or that the HTML structure wraps the escaped text correctly, preventing a scenario where a vendor name like \u0060\u003Cscript\u003E\u0060 renders as an active tag if the escaping logic is applied to the wrong part of the string.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent \u0393\u00C7\u00F6 it visibly reasons itself out of its own premise mid-sentence (\u0027Wait, the style is color:var(...), so it\u0027s safe\u0027), truncates unfinished, and the code it describes already escapes both \u0060row.provider\u0060 and \u0060row.rest\u0060; there is no defect here to act on."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Race condition in round state management could lead to duplicate keys or lost state",
+            "why": "The \u0060nextOpenRounds\u0060 function builds a \u0060Set\u0060 of keys from \u0060cards\u0060. If two rounds have the same \u0060roundKey\u0060 (e.g., same repo, branch, stage, number), the second one will overwrite the first in the Set. This means if a user has two rounds with identical metadata (perhaps from different branches or a bug in ID generation), only one will be tracked in the \u0060open\u0060 state. If the user interacts with the \u0027wrong\u0027 one (the one that was processed last), the state update might not reflect the actual round they clicked. This is a subtle data loss scenario where the UI state diverges from the actual session data.",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all rounds before adding to the \u0060open\u0060 set, or handle collisions explicitly.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a collision scenario that cannot occur \u0393\u00C7\u00F6 roundKey is derived from identifying metadata, so two cards with the same key are the same round, and the function is pure set bookkeeping over card keys with no click-routing involved; the proposed uniqueness check would add machinery for a hypothetical bug elsewhere."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:40:31 \u001B[32mINF\u001B[0m] coai-mcp#48140 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Concurrent save race condition leaves orphaned scratch files and silent failures (from local) [gating] Round=1 Stage=CodeReview\r | [14:40:31 \u001B[32mINF\u001B[0m] coai-mcp#48140 finding [Major/Security] src_vs_code/src/panelView.ts:806 - Potential HTML injection in vendor name rendering if escaping order is flawed (from local) [gating] Round=1 Stage=CodeReview\r | [14:40:31 \u001B[32mINF\u001B[0m] coai-mcp#48140 finding [Minor/Reliability] src_vs_code/src/openRounds.ts:45 - Race condition in round state management could lead to duplicate keys or lost state (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "gemini,local",
+    "repeat": 2,
+    "lane": 4,
+    "key": "gemini,local|rounds-collapse|2",
+    "startedUtc": "2026-09-05T14:30:04.4713012Z",
+    "finishedUtc": "2026-09-05T14:37:11.5010401Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 37.5,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 27958,
+        "tokensOut": 3457,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 5: CSS class name collision with \u0060.vendor\u0060 breaks rendering of inline vendor labels",
+            "why": "The plan specifies wrapping vendor names in \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060. However, \u0060.vendor\u0060 already styles vendor settings cards (applying borders, border-radius, and 8px padding), causing inline vendor text in reviewer rows to render with card box styles that look like struck-out text.",
+            "fix": "Use a distinct class name such as \u0060who\u0060 or \u0060vendor-name\u0060 in the markup specification, or scope the CSS rule to reviewer rows.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, checkable collision \u0393\u00C7\u00F6 reusing an existing card-styling class for inline text \u0393\u00C7\u00F6 that would produce visibly wrong rendering, and offers a cheap fix, which is exactly the kind of thing a plan reviewer should catch before the markup is written."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 3 \u0026 panelProvider: Card expand/collapse toggle triggers heavy synchronous side-effects and probe delays",
+            "why": "When a round status change triggers a card repaint or toggle in \u0060panelProvider\u0060, card body construction executes configuration reads, binary stat checks, vendor CLI probes, and remote network calls (GitHub release check, price tables), causing up to 20-second UI freezes for a simple collapse/expand transition.",
+            "fix": "Decouple card expand/collapse state updates and list rendering from heavy backend CLI probing and remote price/version fetching.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding asserts a specific 20-second UI freeze on card expand/collapse in a \u0060panelProvider\u0060 without naming a file, line, or call chain, and no such code is presented here to judge against \u0393\u00C7\u00F6 it reads as a speculative performance story rather than an identified defect anyone could act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "rounds.ts / panelView: Dead or timed-out rounds without completion timestamps report inflated elapsed runtimes",
+            "why": "When a reviewer or round crashes or times out without writing a completion time, duration calculation falls back to measuring between start time and current wall-clock time (\u0060Date.now()\u0060), displaying false runtimes in the hundreds of minutes on dead rounds.",
+            "fix": "Cap the calculated runtime at the configured reviewer timeout or calculate against the last recorded event timestamp when completion time is missing.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "A round that dies without a completion timestamp rendering an ever-growing elapsed time is a real UI defect that misleads an operator about whether work is still running, and the finding names both the mechanism and a proportionate fix."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 4: Placing \u0060vendorColour\u0060 in \u0060rounds.ts\u0060 couples UI theme logic to session file parsing",
+            "why": "\u0060rounds.ts\u0060 is responsible for parsing session files. Putting \u0060vendorColour\u0060 (which resolves \u0060--vscode-charts-*\u0060 palette tokens) into \u0060rounds.ts\u0060 forces consumers like spending rows to import parser modules solely for view formatting.",
+            "fix": "Place \u0060vendorColour\u0060 in a dedicated view-utility module (e.g. \u0060vendorColour.ts\u0060) separate from \u0060rounds.ts\u0060.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It is a speculative file-placement preference about a single small helper in a plan\u0027s build order, with no defect or rule violation behind it \u0393\u00C7\u00F6 moving one colour function to its own module is churn out of proportion to the coupling it describes."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "panelView: Legacy rounds without reviewer details render misleading expandable disclosure cards",
+            "why": "Rounds recorded before per-reviewer detail existed are rendered as interactive disclosure elements with pointer hand cursors, leading users to expand them only to find empty/apologetic placeholder content.",
+            "fix": "Render legacy rounds lacking per-reviewer details as non-expandable flat rows.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "A speculative cosmetic nit about legacy rounds rendering as expandable cards with placeholder text \u0393\u00C7\u00F6 it names no file or code, describes no defect a user is actually harmed by, and asks for a branching render path out of proportion to a one-time hand-cursor annoyance."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about an ownership/identity mechanism (\u0027opened by panel\u0027 sets, object identity, timestamp proximity) that it never anchors to any file or line, and the data-loss scenario it describes is invented from that assumption rather than observed in the code."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding asserts a specific failure mechanism \u0393\u00C7\u00F6 that \u0060FableIsUsable()\u0060 consults the reviewer provider list and therefore always returns false \u0393\u00C7\u00F6 without any file or line to anchor it, and no such symbol or plan text is given here to support the claim, so it reads as an invented architecture defect rather than a checkable one."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real design risk \u0393\u00C7\u00F6 CLI probes and a network price-table fetch sitting on a UI repaint path \u0393\u00C7\u00F6 and proposes a proportionate fix (cache and refresh on config change or interval), which is exactly the kind of thing the implementer would want settled before writing the toggle, even though the specific 20-second figure is asserted rather than measured."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real, user-visible defect the plan itself concedes \u0393\u00C7\u00F6 a round that died is stamped with no completion time, so its card\u0027s duration keeps growing from the start time and an interrupted round is indistinguishable from a running one, which is exactly what the durable-status rule (\u0027never stick on the in-flight state\u0027, sweep orphaned rows) forbids; the proposed fix is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative CSS fabrication \u0393\u00C7\u00F6 it invents a \u0027strikethrough\u0027 rendering artifact that borders and padding do not produce, cites no file or actual stylesheet, and proposes a fix for a symptom nobody has observed."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about UI affordances for legacy rounds from a phrase in the plan, without pointing at any code or evidence that a hand cursor or empty panel actually ships \u0393\u00C7\u00F6 a graceful-degradation note dressed up as a reliability defect."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 389.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 199157,
+        "tokensOut": 17195,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Vendor name span uses \u0022.vendor\u0022 class colliding with vendor settings card styling, causing broken inline borders and padding",
+            "why": "In the webview stylesheet, \u0022.vendor\u0022 styles full vendor configuration cards with a border, border-radius, and 8px of padding. Applying class=\u0022vendor\u0022 to an inline \u003Cspan\u003E inside a tight reviewer row applies those card styles to a single word, causing the border and padding to collide with the line box and render as a horizontal line through the vendor text.",
+            "fix": "Replace class=\u0022vendor\u0022 with class=\u0022who\u0022 on the vendor name \u003Cspan\u003E in roundCard.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 142,
+            "title": "Session persistence uses a fixed scratch name instead of a per-write unique name",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 (inherited from \u0060vendor-routing.md\u0060 logic regarding visibility of errors) and the specific plan deviation states: \u0027A session is saved under its own scratch name, and the move is retried\u0027. The diff shows the scratch file name is now unique (\u0060${file}.{Environment.ProcessId}-{Guid.NewGuid()}.tmp\u0060), but the rule explicitly requires the move to be retried for cases a unique name cannot fix (e.g., a scanner holding the destination). The current implementation retries, but the rule text in \u0060module_server.md\u0060 says \u0027the move is retried briefly for the case a unique name cannot fix\u0027. The implementation does retry. However, the rule in \u0060review-gate.md\u0060 states \u0027The server refuses one without it\u0027 regarding scope. Wait, the rule is about the scratch name. The rule in \u0060module_server.md\u0060 says: \u0027each write goes to a scratch file of its OWN name\u0027. The diff does this. But the rule in \u0060review-gate.md\u0060 says \u0027Never hand a reviewer a bare diff\u0027. This is a new",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method retries the move operation for the case where a reader or scanner holds the destination file, as explicitly required by the rule.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent and self-refuting \u0393\u00C7\u00F6 it repeatedly concedes the code already does what it demands (\u0027The implementation does retry\u0027), wanders into unrelated rules about review scope, and asks for a change that is already present at lines 148 and 169-184."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a fixed sleep interval (20ms * attempt). If a file lock (e.g., from an antivirus scanner or another process) persists longer than the total retry window (approx 150ms), the code throws. However, if the lock is held by a process that never releases it (rare but possible in enterprise environments), the \u0060Thread.Sleep\u0060 loop might not be sufficient to handle transient spikes, or worse, if the logic is extended, it could spin. More critically, the \u0060MoveOverExisting\u0060 method is called inside a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060. If the file is held by a scanner that intermittently locks/unlocks, the retry might succeed. But if the lock is permanent, it throws. The real risk is that the \u0060MoveOverExisting\u0060 logic is *not* robust enough for high-concurrency scenarios where multiple writers might contend for the same destination file *after* the unique temp name collision is resolved. If the destination file (",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite wait strategy (e.g., exponential backoff with a hard cap) or a \u0060CancellationToken\u0060 to prevent the server from hanging indefinitely if the destination file is held by a long-running process (like an antivirus scanner) that never releases it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The loop is already bounded at five attempts and deliberately lets the last one throw \u0393\u00C7\u00F6 the finding contradicts itself mid-argument, trails off unfinished, and its proposed fix (a bounded, non-infinite wait that surfaces failure) is precisely what the code and its comment already do."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Temporary scratch files accumulate on failed moves due to cleanup timing",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060TryDelete(temp)\u0060 is called in a \u0060finally\u0060 block *after* the \u0060MoveOverExisting\u0060 loop. If \u0060MoveOverExisting\u0060 throws an exception on the final attempt (e.g., \u0060UnauthorizedAccessException\u0060 after 5 retries), the \u0060finally\u0060 block executes and deletes the temp file. However, if the loop succeeds but the \u0060File.Move\u0060 throws *during* the retry (e.g., on attempt 3), the \u0060finally\u0060 block runs, deleting the temp file, but the exception propagates. The critical issue is that if \u0060MoveOverExisting\u0060 throws *before* the loop finishes (e.g., on the first try), the \u0060finally\u0060 block deletes the temp file. But if the loop completes successfully, the temp file is deleted. The real risk is if \u0060MoveOverExisting\u0060 throws *after* a successful move but before the \u0060finally\u0060 block runs (unlikely), or if the \u0060TryDelete\u0060 itself fails silently. More critically, if \u0060MoveOverExisting\u0060 throws on the *last* attempt, the \u0060finally\u0060 block runs, deleting the temp file. But if the loop *succeeds* (all",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs before the retry loop completes, so that if the move fails after the first attempt, the temporary file is cleaned up before the next retry.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The \u0060finally\u0060 block already deletes the scratch file on every path \u0393\u00C7\u00F6 success, retry-exhaustion throw, or otherwise \u0393\u00C7\u00F6 so the claimed accumulation cannot happen; the finding contradicts itself mid-sentence, is truncated, and its suggested fix (deleting the temp inside the move loop) would break the retry it claims to protect."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 75,
+            "title": "User toggle state may not persist correctly across panel ticks",
+            "why": "When a user closes a card (e.g., \u0060afterToggle(previous, key, false)\u0060), the \u0060open\u0060 set is updated to remove the key. However, if the panel re-renders before the next tick, and the round is still running, the \u0060nextOpenRounds\u0060 logic might re-add it to \u0060open\u0060 if it\u0027s in \u0060autoOpened\u0060. The current logic removes the key from \u0060panelOpened\u0060, but if the round is still running, \u0060nextOpenRounds\u0060 will re-add it to \u0060autoOpened\u0060 and \u0060open\u0060 on the next tick, effectively ignoring the user\u0027s close action. This creates a flicker where the card closes, then re-opens immediately if the round is still running.",
+            "fix": "Ensure \u0060afterToggle\u0060 updates the \u0060open\u0060 set correctly when a user closes a card that was previously auto-opened, and that the \u0060panelOpened\u0060 set is updated to reflect the user\u0027s explicit choice.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claimed re-open cannot happen: \u0060nextOpenRounds\u0060 only opens a running round when it is absent from \u0060autoOpened\u0060, and \u0060afterToggle\u0060 deliberately keeps the key there (as the comment on lines 82\u0393\u00C7\u00F484 states), so a user-closed running card stays closed \u0393\u00C7\u00F6 the finding\u0027s suggested fix is what the code already does."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary recomputation of open rounds state on every render tick",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 calls \u0060nextOpenRounds\u0060 on every render tick (every 5 seconds). This function performs set operations and filtering on the entire list of rounds. While the logic is simple, doing this on every tick for a large number of rounds (e.g., 100\u002B rounds) creates unnecessary CPU overhead. The state should only be recomputed when the \u0060sessions\u0060 data actually changes (e.g., a new round starts, a round finishes, or a user toggles a card).",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 and only recompute it when the underlying \u0060sessions\u0060 data changes, rather than on every render tick.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The recompute runs at most every five seconds over a handful of in-memory round objects \u0393\u00C7\u00F6 trivially cheap next to the file reads, config reads and HTML repaint in the same render \u0393\u00C7\u00F6 and the proposed cache would add invalidation complexity to state whose whole point is that it must be re-derived when rounds start or finish."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:37:11 \u001B[32mINF\u001B[0m] coai-mcp#8092 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Temporary scratch files accumulate on failed moves due to cleanup timing (from local) [gating] Round=1 Stage=CodeReview\r | [14:37:11 \u001B[32mINF\u001B[0m] coai-mcp#8092 finding [Major/Ux] src_vs_code/src/openRounds.ts:75 - User toggle state may not persist correctly across panel ticks (from local) [gating] Round=1 Stage=CodeReview\r | [14:37:11 \u001B[32mINF\u001B[0m] coai-mcp#8092 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary recomputation of open rounds state on every render tick (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 7,
+    "key": "codex,gemini,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T14:30:08.8338819Z",
+    "finishedUtc": "2026-09-05T14:34:27.3742345Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 49.7,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 40599,
+        "tokensOut": 4398,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping guarantee is not verified for spending rows or other session-derived fields",
+            "why": "A session containing a vendor name such as \u0060\u003C/span\u003E\u003Cimg src=x onerror=...\u003E\u0060 could still be inserted by the spending-row renderer if only the reviewer-row path escapes it; the plan requires all session-file output to be escaped but tests only a reviewer row.",
+            "fix": "Specify escaping at the shared renderer/output boundary and add an end-to-end test covering every session-derived vendor display, including spending rows.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names the family\u0027s own recurring defect \u0393\u00C7\u00F6 a protective measure applied at only the site somebody thought of \u0393\u00C7\u00F6 and asks for the escape to sit at the shared output boundary with a test covering every session-derived field, which is proportionate and actionable even without a file reference."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Auto-open ownership is undefined across panel reloads and extension-host restarts",
+            "why": "If the panel auto-opens a running round and the webview or extension host is recreated before it finishes, the in-memory ownership set is lost; when the round finishes, the card can remain expanded, violating the promised finished-state behavior.",
+            "fix": "Define the ownership lifetime and either persist the per-round marker or explicitly scope the guarantee to one panel instance and test panel recreation.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete failure mode \u0393\u00C7\u00F6 in-memory auto-open ownership lost on webview or extension-host recreation leaves a finished round\u0027s card expanded, contradicting the stated behavior \u0393\u00C7\u00F6 and asks for the proportionate fix of either persisting the marker or scoping the guarantee explicitly."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Killed, timed-out, and incomplete rounds have no defined finish-transition behavior",
+            "why": "A round terminated halfway or lacking a completion timestamp may be classified as merely not running; the cleanup logic could collapse it as finished, fail to prune it, or produce misleading duration/state on the next refresh.",
+            "fix": "Define predicates for finished, interrupted, and incomplete rounds, including missing or malformed session data, and test process termination, timeout, and recovery on a later poll.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It names no file, line, or concrete code path and is written entirely in hedged hypotheticals (\u0027may\u0027, \u0027could\u0027), so it is a generic reliability template \u0393\u00C7\u00F6 a demand for predicates and tests around states it never shows to be mishandled \u0393\u00C7\u00F6 rather than a defect anyone can act on."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "",
+            "line": 0,
+            "title": "The palette test allows nonexistent chart-variable names",
+            "why": "Checking only the \u0060--vscode-charts-*\u0060 prefix permits a typo such as \u0060--vscode-charts-typo\u0060; the browser then falls back to inherited grey, so the promised visible colouring fails.",
+            "fix": "List the exact finite palette and assert every returned token belongs to that list, with a rendered-style check for a representative vendor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Without any file or code shown, this is a speculative style objection about a test\u0027s prefix assertion, and the proposed fix \u0393\u00C7\u00F6 hardcoding the finite VS Code chart palette plus a rendered-style check \u0393\u00C7\u00F6 is exactly the duplicated-list machinery that testing.md warns goes stale, disproportionate to a typo risk a reviewer would catch."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order 3: A round that times out or dies uncompleted is never marked not-running, causing duration math and open/closed state tracking to stay stuck indefinitely",
+            "why": "The plan assumes rounds cleanly transition from running to finished. However, if a reviewer process hangs, crashes, or is killed halfway without writing a completion timestamp, session parsing continues treating the round as running or open. As a result, the panel either leaves the card auto-expanded or miscalculates elapsed time from start to now indefinitely rather than handling orphaned/stale round state.",
+            "fix": "Define explicit state transitions for stalled or orphaned rounds by enforcing a maximum timeout threshold when evaluating running status and pruning panel auto-open sets.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "A round whose reviewer process dies without writing a completion stamp leaving the card permanently \u0027running\u0027 with ever-growing elapsed time is a real, plausible stuck-state defect, and naming a timeout/orphan transition is exactly the kind of thing the reliability rules here demand of any non-terminal state."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order 5: Wrapping vendor spans with class \u0027vendor\u0027 overrides existing card styling in the stylesheet",
+            "why": "Build order 5 specifies \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:\u2026\u0022\u003E\u0060. In the existing stylesheet, \u0060.vendor\u0060 targets top-level settings cards (with borders, border-radius, and padding), causing inline vendor text inside reviewer rows to render with card box styling and visual artifacts.",
+            "fix": "Use a distinct inline class name such as \u0060who\u0060 or \u0060vendor-badge\u0060 instead of \u0060.vendor\u0060 in the markup and stylesheet.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "A CSS class-name collision that would visibly break the rendered reviewer rows is a real, concrete defect with a cheap fix, and it is exactly the kind of thing a plan author cannot see from the plan text alone."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Constraints \u0026 Build order 4: Placing view-tier CSS palette logic in session parser \u0060rounds.ts\u0060 violates layer separation and breaks spending row reuse",
+            "why": "Build order 4 places \u0060vendorColour(name)\u0060 in \u0060rounds.ts\u0060, which parses session disk files. Spending rows need vendor colors without depending on session parser modules, and non-view parsing logic becomes tightly coupled to VS Code CSS theme variables (\u0060--vscode-charts-*\u0060).",
+            "fix": "Move \u0060vendorColour\u0060 to a dedicated view utility module (e.g., \u0060vendorColour.ts\u0060) imported independently by both round cards and spending rows.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete layering problem in the plan \u0393\u00C7\u00F6 a view-tier CSS-theme helper parked in a disk-parsing module \u0393\u00C7\u00F6 that would force a second consumer (spending rows) to import the session parser, and the one-line fix of putting it in its own module is proportionate and actionable."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Constraints: Legacy session files lacking per-reviewer detail render empty disclosure arrows that open into blank cards",
+            "why": "When expanding rounds recorded under earlier schemas that lack detailed per-reviewer metrics, the UI renders standard clickable disclosure carets that open empty cards rather than rendering flat non-expandable rows.",
+            "fix": "Check if reviewer detail records exist before rendering disclosure carets, falling back to flat text rows for legacy rounds.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about a legacy-schema rendering case with no file, line, or evidence that such sessions or empty cards exist, so it is an unverifiable hypothetical rather than an observed defect."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is an unanchored hypothesis about a mechanism it assumes rather than shows \u0393\u00C7\u00F6 no file, no quoted design, a self-contradictory failure story (\u0027stays open forever, or conversely auto-closed\u0027), and a fix (give the round a durable id) that any round-keyed session store almost certainly already has, so nobody can act on it as written."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding asserts a specific mechanism (FableIsUsable checking a reviewer provider list that Fable cannot appear in) with no file, no line, and no code to support it \u0393\u00C7\u00F6 an unverifiable speculation dressed as a Blocking architectural defect, and its proposed fix names a \u0060CommandContext\u0060 with no evidence such a thing exists here."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a mechanism and a number the plan never states \u0393\u00C7\u00F6 \u0027repaint to build a card\u0027s body\u0027 says nothing about doing config reads, CLI probes and network price fetches synchronously on the render path, so the 20-second freeze, the double-toggling and the Major severity are all extrapolated from one phrase rather than from anything in the design."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real, concrete defect \u0393\u00C7\u00F6 a crashed round\u0027s card showing an ever-growing elapsed clock instead of its true runtime or an honest \u0027interrupted\u0027 marker \u0393\u00C7\u00F6 with a cheap, proportionate fix (stamp a terminal/last-seen time), which is exactly the durable-status and absent-is-not-zero obligation this family already holds."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a visual artifact \u0393\u00C7\u00F6 a border with padding cannot render as a strikethrough through the middle of text \u0393\u00C7\u00F6 and reasons from a speculative CSS inheritance chain with no file or line to check, so there is nothing here a careful engineer could act on."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about UI polish for legacy rounds by quoting the plan\u0027s own acknowledgement of the limitation back as a defect, names no file or code, and proposes a \u0027legacy\u0027 badge whose value is asserted rather than shown \u0393\u00C7\u00F6 cosmetic churn, not something a careful engineer needs to act on."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 208.7,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 484833,
+        "tokensOut": 18062,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The added plan is left marked as unimplemented after the change shipped",
+            "why": "The file says \u201CStatus: plan only, nothing implemented yet,\u201D while this diff implements its scope and the plan\u0027s Definition of Done requires the plan to be promoted. This leaves the repository\u0027s planning state contradictory and can cause plan-lifecycle checks or future contributors to treat shipped work as pending.",
+            "fix": "Promote this plan into the corresponding research plan/documentation and remove the stale \u0060todo/\u0060 copy, or update the todo entry to the project\u0027s completed/archive form.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real breach of this repository\u0027s mandatory planning-docs rule \u0393\u00C7\u00F6 a plan whose scope shipped in the same change must be promoted to \u0060research/\u0060 with an \u0060IMPLEMENTED\u0060 status and its deviations, and leaving it saying \u0022nothing implemented yet\u0022 is precisely the drift that rule (and its CI check) exists to prevent."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 157,
+            "title": "Concurrent saves still use last-writer-wins and can silently discard round history",
+            "why": "Two MCP servers can load the same session, then save stale snapshots concurrently: one persists a record containing reviewer 1 while the other persists its older snapshot containing reviewer 2. The unique scratch names prevent the access-denied exception, but whichever move happens last replaces the session and loses the other record. A later restart then shows incomplete history and may misreport gate progress.",
+            "fix": "Serialize saves per session or use versioned read-modify-write with conflict retry so concurrent updates are merged or rejected instead of blindly overwriting the destination.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The code\u0027s own comment proves two servers concurrently save the SAME session file, so the unique-scratch-name fix removed the access-denied crash but left an unguarded read-modify-write whose loser silently overwrites the winner\u0027s round record and Pending findings \u0393\u00C7\u00F6 a real durability and gate-state defect the comment does not claim to have fixed."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 131,
+            "title": "Toggling a round still waits for the full expensive panel refresh",
+            "why": "Clicking a round disclosure immediately repaints the whole panel, including configuration reads, CLI probes, GitHub checks, and price-table fetches. With a slow or unavailable service this can take up to 20 seconds, so a local open/close action appears stuck with no progress or terminal feedback.",
+            "fix": "Use a lightweight round-only render for \u0060round\u0060 messages, or cache the slow section data and reserve full refreshes for polling or settings changes.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The panel already re-renders through this exact path every five seconds for the rounds list, and the slow probes are all timestamp-gated (\u0060latestCheckedAt\u0060, \u0060cliCheckedAt\u0060, \u0060pricesCheckedAt\u0060, \u0060localCheckedAt\u0060), so the \u002720 seconds on a toggle\u0027 cost is asserted rather than real, and the proposed round-only render path adds a second rendering mode to fix it."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 178,
+            "title": "Thread.Sleep in synchronous retry loop blocks worker/threadpool threads during concurrent save collisions",
+            "why": "When multiple concurrent writers or scanner processes hold session files, SessionStore.Save retries synchronously with Thread.Sleep (up to 300ms total backoff across 5 attempts per write) on the calling thread. In an async/multi-client MCP server servicing frequent reviewer transition events, synchronous thread blocking under contention can cause thread-pool starvation and pipeline delays.",
+            "fix": "Make SessionStore save and retry asynchronous (Task.Delay) or keep synchronous backoff minimal (e.g., shorter spin/yield) without thread-blocking delays on request paths.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The retry path is a rare, bounded fallback (at most 200 ms across four sleeps, only when something else holds the destination) inside an already-synchronous file-I/O method in a stdio server whose concurrency is separate processes rather than a shared thread pool, so the thread-pool-starvation risk is asserted rather than real and converting just this loop to async would be churn out of proportion to it."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Unsanitized CSS style injection via vendorColour output in usageRows",
+            "why": "In usageRows, r.provider is passed to vendorColour(r.provider) and interpolated directly into style=\u0022color:${vendorColour(r.provider)}\u0022. Although vendorColour hashes unknown names and returns var(--vscode-charts-*), any unexpected return string could allow style/CSS context escape if not validated or escaped.",
+            "fix": "Ensure vendorColour return values are strictly validated against an allowed palette whitelist before embedding into style attributes.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding admits vendorColour returns a fixed \u0060var(--vscode-charts-*)\u0060 palette value, so it flags a hypothetical escape that this code does not have \u0393\u00C7\u00F6 and the actual attacker-controlled part, r.provider, is already escapeHtml\u0027d everywhere it is rendered."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may silently swallow a final failure",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 states: \u0027The server refuses one without it\u0027 (referring to scope) and implies strict adherence to protocol. More critically, the \u0060vendor-routing.md\u0060 rule states \u0027breaking it is invisible in the output\u0027. The \u0060MoveOverExisting\u0060 method retries 5 times. If the 5th attempt fails, the \u0060catch\u0060 block inside the loop (line 183) catches the exception but the loop exits. The method then returns. The caller (\u0060Save\u0060) has a \u0060try...finally\u0060 block. If \u0060MoveOverExisting\u0060 throws, it propagates. If it succeeds, it returns. However, the logic \u0060catch (Exception e) when (...) \u0026\u0026 attempt \u003C attempts\u0060 means on the 5th attempt, if it fails, the loop exits *without* re-throwing or handling the exception explicitly in a way that guarantees visibility. Wait, looking closer: \u0060catch\u0060 block has \u0060Thread.Sleep\u0060. If \u0060attempt\u0060 reaches 5, the loop condition \u0060attempt \u003C= attempts\u0060 is true. Inside, if it throws, it hits the catch. \u0060attempt \u003C attempts\u0060 (5 \u003C 5) is false. So it *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method\u0027s retry loop uses a bounded number of attempts and that the final attempt throws if it fails, rather than silently swallowing the error.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about the code: the exception filter \u0060attempt \u003C attempts\u0060 deliberately lets the fifth failure propagate \u0393\u00C7\u00F6 exactly the fix it asks for \u0393\u00C7\u00F6 and the finding\u0027s own text visibly reaches that conclusion mid-sentence before being submitted anyway."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Concurrent save race condition leaves orphaned scratch files and silent failures",
+            "why": "In \u0060SessionStore.Save\u0060, the code generates a unique scratch filename using \u0060Environment.ProcessId\u0060 and a GUID. However, if two processes (or threads in a multi-threaded scenario) happen to generate the same GUID or if the process ID is reused rapidly, they could collide. More critically, the \u0060MoveOverExisting\u0060 method retries 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms). If the destination file is held by a virus scanner or another process for longer than ~250ms, the move fails. The code then enters the \u0060finally\u0060 block and calls \u0060TryDelete(temp)\u0060. If the move failed, \u0060temp\u0060 still exists. If the \u0060TryDelete\u0060 fails (e.g., file locked), it swallows the exception. The result is a session file that never updated (stale data) and a temporary file left behind, potentially filling the disk or causing future collisions if the temp name generation isn\u0027t perfectly unique. The comment admits \u0027a save that never lands is a real problem\u0027 but the \u0060finally\u0060 block\u0027s \u0060TryDelete\u0060 might *",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite backoff and that the final exception is re-thrown or logged with context, rather than silently swallowed if the file is held by a scanner.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is largely wrong about the code \u0393\u00C7\u00F6 the last retry attempt is deliberately allowed to throw (so a failed save does surface, not silently fail), GUID collision is not a real risk, and the leftover temp file it worries about is bounded and harmless; its suggested fix asks for behaviour the code already has."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 806,
+            "title": "Potential HTML injection in vendor name rendering if escaping order is flawed",
+            "why": "In \u0060roundCard\u0060, the code constructs the reviewer row as: \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:${vendorColour(row.provider)}\u0022\u003E\u0060 \u002B \u0060${escapeHtml(row.provider)}\u0060 \u002B \u0060\u003C/span\u003E${escapeHtml(row.rest)}\u0060. If \u0060row.provider\u0060 contains a string like \u0060\u003Cscript\u003E\u0060, \u0060escapeHtml\u0060 converts it to \u0060\u0026lt;script\u0026gt;\u0060. However, if the \u0060vendorColour\u0060 function (or the caller) relies on the raw provider name for the style, and the style attribute is interpolated directly into the HTML string without escaping, an attacker could inject a style attribute. Wait, the style is \u0060color:var(...)\u0060, so it\u0027s safe. The real risk is if \u0060row.provider\u0060 is used in a context where it\u0027s not escaped *before* being placed inside the span, or if \u0060row.rest\u0060 contains unescaped HTML. The code escapes \u0060row.provider\u0060 and \u0060row.rest\u0060 separately. The risk is if \u0060row.provider\u0060 is *not* escaped before being used in the \u0060style\u0060 attribute (e.g., if \u0060vendorColour\u0060 returned a hex value that wasn\u0027t quoted, but it returns a CSS variable). The actual flaw",
+            "fix": "Ensure \u0060vendorColour\u0060 is called *after* \u0060escapeHtml\u0060 or that the HTML structure wraps the escaped text correctly, preventing a scenario where a vendor name like \u0060\u003Cscript\u003E\u0060 renders as an active tag if the escaping logic is applied to the wrong part of the string.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding argues itself out of existence mid-sentence \u0393\u00C7\u00F6 both interpolated values are escaped and the style comes from \u0060vendorColour\u0060, not user data \u0393\u00C7\u00F6 leaving a confused non-issue with a fix instruction that would make no difference."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Race condition in round state management could lead to duplicate keys or lost state",
+            "why": "The \u0060nextOpenRounds\u0060 function builds a \u0060Set\u0060 of keys from \u0060cards\u0060. If two rounds have the same \u0060roundKey\u0060 (e.g., same repo, branch, stage, number), the second one will overwrite the first in the Set. This means if a user has two rounds with identical metadata (perhaps from different branches or a bug in ID generation), only one will be tracked in the \u0060open\u0060 state. If the user interacts with the \u0027wrong\u0027 one (the one that was processed last), the state update might not reflect the actual round they clicked. This is a subtle data loss scenario where the UI state diverges from the actual session data.",
+            "fix": "Add a check to ensure \u0060roundKey\u0060 is unique across all rounds before adding to the \u0060open\u0060 set, or handle collisions explicitly.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The premise is wrong: \u0060roundKey\u0060 is the panel\u0027s identity for a card, so two cards sharing one is by definition the same round, and the finding invents a collision scenario with no evidence it can occur while asking for uniqueness machinery the code has no need of."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:34:27 \u001B[32mINF\u001B[0m] coai-mcp#16340 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Concurrent save race condition leaves orphaned scratch files and silent failures (from local) [gating] Round=1 Stage=CodeReview\r | [14:34:27 \u001B[32mINF\u001B[0m] coai-mcp#16340 finding [Major/Security] src_vs_code/src/panelView.ts:806 - Potential HTML injection in vendor name rendering if escaping order is flawed (from local) [gating] Round=1 Stage=CodeReview\r | [14:34:27 \u001B[32mINF\u001B[0m] coai-mcp#16340 finding [Minor/Reliability] src_vs_code/src/openRounds.ts:45 - Race condition in round state management could lead to duplicate keys or lost state (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|2",
+    "startedUtc": "2026-09-05T14:30:16.4059082Z",
+    "finishedUtc": "2026-09-05T14:36:58.1907172Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 94.8,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 38555,
+        "tokensOut": 6237,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The ownership algorithm loses a person\u0027s ownership when they reopen an auto-opened round",
+            "why": "If the panel auto-opens a running round, the person closes it, then reopens it before it finishes, the specified behavior says it becomes theirs; the only described toggle action removes the round from the panel-opened set, so completion can still collapse it.",
+            "fix": "Track explicit person-opened state (or distinguish close from reopen) and add the exact close-then-reopen-then-finish test.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete state-machine gap \u0393\u00C7\u00F6 close-then-reopen leaves the round in the panel-opened set so auto-collapse on completion discards a person\u0027s deliberate reopen \u0393\u00C7\u00F6 with a specific fix and the exact missing test case."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "Escaping is verified only for reviewer rows, leaving spending-row vendor output unprotected",
+            "why": "A session file containing a vendor such as \u0060\u003Cimg src=x onerror=...\u003E\u0060 can be interpolated into a spending row; the plan only requires and tests escaping for a reviewer row, while saying spending rows merely reuse the colour function.",
+            "fix": "Escape vendor text at every spending-row rendering site and test the malicious vendor through both reviewer and spending views.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real XSS-class gap \u0393\u00C7\u00F6 an escaping requirement stated and tested only for one rendering site while a second site interpolates the same untrusted vendor text \u0393\u00C7\u00F6 which is precisely the \u0027measure applied at SOME of its sites\u0027 defect this project has already paid for, and the fix is cheap and concrete."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan claims dead rounds are fixed but has no implementation or verification for missing completion times",
+            "why": "When the server is killed or times out after writing a start but before writing a completion time, elapsed-time rendering can report the age of the round (for example \u0060361m 40s\u0060) as if it were a valid finished duration; none of the build steps or tests covers this state.",
+            "fix": "Define the incomplete-round state and duration fallback explicitly, then add a test for a round with a start and no completion timestamp, including the timeout/kill path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete gap \u0393\u00C7\u00F6 a round with a start timestamp and no completion timestamp after a kill or timeout, whose age then renders as if it were a finished duration \u0393\u00C7\u00F6 and asks for a proportionate fix (define the incomplete state, a duration fallback, and one test for the crash path), which is exactly the durable-status guarantee a plan claiming to fix dead rounds ought to cover."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The prescribed \u0060vendor\u0060 CSS class conflicts with the existing settings-card class",
+            "why": "Following build step 5 emits \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060; the plan itself states \u0060.vendor\u0060 already applies border, radius, and padding, so vendor names render with the settings-card styling and may appear struck through or otherwise malformed.",
+            "fix": "Change the build step and verification to require the shipped collision-free class such as \u0060who\u0060, and test the rendered class/style against the existing stylesheet.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A build step that tells the implementer to emit a class name the plan itself says is already styled for a different purpose is a real, concrete collision that would produce visibly wrong rendering, and the fix (use a distinct class and verify against the stylesheet) is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Build order 3 (panelProvider): Toggling card disclosure triggers a full panel rebuild including blocking CLI probes and remote fetches.",
+            "why": "When a user toggles an accordion card or when an auto-close event fires, re-rendering the card view re-evaluates the entire panel lifecycle (stat-ing the server binary, querying vendor CLIs, fetching GitHub releases, and downloading pricing tables), freezing the UI for up to twenty seconds for a simple expansion toggle.",
+            "fix": "Decouple disclosure toggle state and card DOM updates from full panel provider data refreshes, caching external probes and network queries.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding asserts a specific expensive behavior (accordion toggles re-running CLI probes, GitHub release fetches and pricing downloads, freezing the UI ~20s) about a panelProvider whose code is not shown and which the surrounding change does not evidence \u0393\u00C7\u00F6 it is an unverified performance claim with a fabricated cost figure rather than a defect anyone can act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order 3 \u0026 What must be true (2): Rounds that terminate abnormally without a finish event stay open and accumulate unbounded runtime.",
+            "why": "When a reviewer process crashes, times out, or is aborted without writing a completion timestamp, the round never transitions to \u0027finished\u0027. As a result, the panel measures duration as (now - startTime) indefinitely and the round remains stuck in the auto-opened set.",
+            "fix": "Track heartbeat or check reviewer timeout limits against the start time so orphaned or uncompleted rounds are deterministically resolved to a terminated state and auto-closed.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real reliability gap \u0393\u00C7\u00F6 a round with no terminal event stays open forever, growing its measured duration and never leaving the auto-opened set \u0393\u00C7\u00F6 which is exactly the missing-sweep/non-terminal-state failure the project\u0027s own reliability and durable-status rules require every in-flight state to answer for."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order 5 (panelView): Reusing the class name \u0027.vendor\u0027 applies container card styles to inline text spans.",
+            "why": "In the existing stylesheet, \u0027.vendor\u0027 defines styles for settings cards with borders, border-radii, and padding; wrapping inline vendor names in \u0027\u003Cspan class=\u0022vendor\u0022\u003E\u0027 inherits these block styles, rendering inline vendor text as struck-through or visually malformed.",
+            "fix": "Use a distinct class name such as \u0027who\u0027 or \u0027vendor-name\u0027 specifically scoped for inline vendor label styling.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "A CSS class collision that would visibly break the rendered panel is a concrete defect with a cheap, specific fix, and the reviewer named the mechanism (block card styles on inline spans) rather than just asserting a naming preference."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order 3 \u0026 5: Legacy session rounds lacking per-reviewer details render interactive disclosure toggles with no expandable content.",
+            "why": "Opening session records created prior to per-reviewer tracking renders an expandable disclosure triangle and pointer cursor, but clicking it expands an empty body with no details.",
+            "fix": "Check for the presence of per-reviewer details before rendering disclosure tags, falling back to flat, non-expandable rows for legacy records.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about a legacy-data rendering nuance with no file or code cited and no evidence such records exist, and the worst case is a disclosure triangle that opens to nothing \u0393\u00C7\u00F6 cosmetic and not worth the conditional-rendering machinery it asks for."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Ambiguous ownership logic causes data loss on restart",
+            "why": "The plan relies on the assumption that a round \u0027opened by the panel\u0027 can be identified solely by its presence in a specific set or its current state. If the extension host restarts or the round object is re-hydrated from a session file, the code loses the context of \u0027who opened it\u0027 because no persistent ID links the \u0027opened by panel\u0027 set to the round\u0027s history. Result: A round opened by the panel, finished, and then the extension restarts is treated as \u0027person opened\u0027 (because it\u0027s not in the pruned set) and stays open forever, or conversely, a person\u0027s round is auto-closed because it matches a stale state.",
+            "fix": "Add a deterministic ID field to the round object (e.g., \u0060session_id\u0060 or \u0060round_id\u0060) and use it to match the \u0027opened by panel\u0027 state against the round\u0027s lifecycle events, rather than relying on object identity or timestamp proximity.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a failure mode from an assumed implementation (\u0027object identity or timestamp proximity\u0027) that it never establishes the plan actually uses, and its concrete scenario \u0393\u00C7\u00F6 a round staying open forever after restart \u0393\u00C7\u00F6 is speculation dressed as a Blocking defect, so the fix asks for an ID that likely already exists."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fable gating logic is fundamentally misaligned with system architecture",
+            "why": "The plan assumes \u0060PanelService.FableIsUsable()\u0060 checks if Fable is a \u0027reviewer\u0027 in the provider list. Since Fable is the \u0027calling AI\u0027 and not a configured reviewer, this check returns false on every real machine. Result: The \u0027Split with Fable\u0027 checkbox becomes inert; users toggle it expecting a split, but the system ignores it because it waits for a non-existent reviewer configuration, leading to silent failure where the intended workflow never triggers.",
+            "fix": "Replace the \u0060FableAvailable\u0060 flag with a direct check of the \u0060CommandContext\u0060 for the presence of the Fable model instance or a configuration key that explicitly enables the \u0027Split\u0027 mode, rather than checking a provider list that Fable is not part of.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding rests on an invented premise \u0393\u00C7\u00F6 it asserts a specific method (\u0060PanelService.FableIsUsable()\u0060) and its semantics without any file or line, and no such gating-by-reviewer-list claim is shown to exist in the material under review, so its Blocking severity rests on speculation rather than on code."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Synchronous expensive I/O on UI render path causes 20s latency",
+            "why": "The plan states the toggle must \u0027repaint to build a card\u0027s body\u0027, triggering a sequence of synchronous operations: reading config, stat-ing binary, probing CLIs, and fetching GitHub price tables. Result: When a user toggles the switch or opens a card, the UI freezes for up to 20 seconds while these blocking calls complete, causing the user to think the extension has hung or crashed, leading to double-toggling or premature closure.",
+            "fix": "Cache the result of the configuration read, server stat, CLI probe, and price table fetches in memory or a local store, and only re-evaluate on explicit configuration changes or a defined interval, rather than on every toggle repaint.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a 20-second synchronous UI freeze from the phrase \u0022repaint to build a card\u0027s body\u0022 without any evidence that config reads, binary stats, CLI probes and GitHub price fetches actually run on the repaint path, so the concrete failure it describes is speculation rather than something the code or plan says."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead rounds report incorrect duration due to missing completion state",
+            "why": "The plan admits that \u0027a dead round is never written a completion time\u0027, so the system measures duration from the start time. Result: If a round crashes or times out (e.g., after 10 minutes) but the process doesn\u0027t die, the system calculates duration as \u0027current time - start time\u0027. A round that died 360 minutes ago will report \u0027361m 40s\u0027 instead of \u002710m\u0027, misleading the user about the actual runtime and potentially causing the system to think a long-running process is still active when it is dead.",
+            "fix": "Introduce a \u0027last known state\u0027 timestamp or explicit \u0027completion\u0027 flag in the round object that is written immediately upon the round\u0027s logical finish, rather than inferring completion from the absence of activity or measuring duration from start time.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "A round that died is displayed with an ever-growing elapsed time, which is a real user-visible defect \u0393\u00C7\u00F6 indistinguishable from a still-running round \u0393\u00C7\u00F6 and the proposed fix (a terminal-state stamp written at the logical finish) is small and proportionate, matching the family\u0027s own rule that in-flight state must never stick after a crash."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression causes vendor names to appear struck-through",
+            "why": "The plan notes that the span class \u0060who\u0060 (or \u0060vendor\u0060) inherits a border, radius, and padding from the \u0060.vendor\u0060 class used for the settings card. Result: When a single word is rendered inside this container with tight line spacing, the border/padding creates a visual artifact that looks like a strikethrough line through the text. Users perceive the vendor name as \u0027deleted\u0027 or \u0027invalid\u0027, causing confusion about whether the split actually occurred.",
+            "fix": "Add a specific CSS class for the \u0027vendor\u0027 text span that overrides the default line-height and padding, or explicitly set \u0060display: inline-block\u0060 with \u0060line-height: normal\u0060 to prevent the text from being visually struck through by the container\u0027s border.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a visual artifact \u0393\u00C7\u00F6 a border plus padding on an inline span does not render as a strikethrough \u0393\u00C7\u00F6 and reasons about a CSS inheritance chain it never inspected, so it is a speculative UX defect that does not exist."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy rounds render as empty placeholders with misleading interaction cues",
+            "why": "The plan states that rounds recorded before per-reviewer detail became \u0027disclosures that opened into an apology\u0027. Result: When a user clicks on a legacy round, they see a \u0027hand cursor\u0027 promising detail, but the content is empty or just an apology. This creates a false expectation of data, leading to user frustration when they realize the round has no actionable history, and the \u0027flat line\u0027 rendering makes it indistinguishable from a failed load.",
+            "fix": "Implement a fallback UI state for rounds recorded before per-reviewer detail existed, or explicitly mark them as \u0027legacy\u0027 with a distinct visual indicator, rather than rendering them as \u0027flat lines\u0027 with a hand cursor.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is speculative UX embroidery built on a single phrase from the plan \u0393\u00C7\u00F6 inventing a \u0027hand cursor promising detail\u0027 and \u0027indistinguishable from a failed load\u0027 without evidence, and asking for legacy-badge machinery out of proportion to a historical rendering edge case."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 306.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 393022,
+        "tokensOut": 22587,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 4,
+            "title": "The added duplicate plan falsely remains marked as unimplemented after the change shipped.",
+            "why": "This contradicts the plan\u0027s Definition of Done: \u0022The plan promoted.\u0022 The repository\u0027s authoritative plan states the work is implemented, but this new file says \u0022plan only, nothing implemented yet,\u0022 leaving a stale, contradictory plan artifact.",
+            "fix": "Remove this duplicate todo plan, or promote/update it so its status and checklist accurately reflect the implemented change.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "A brand-new plan in \u0060todo/\u0060 saying \u0022plan only, nothing implemented yet\u0022 is exactly what the planning convention requires, and the finding\u0027s premise \u0393\u00C7\u00F6 a separate authoritative plan already marking this work implemented, making this one a duplicate \u0393\u00C7\u00F6 is asserted without naming that file and is unsupported by anything in the reviewed document."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 157,
+            "title": "Unique scratch names do not prevent concurrent saves from overwriting each other\u0027s session state",
+            "why": "Two MCP servers can load the same session, each record different reviewer progress, and then move its independently serialized snapshot over the shared destination. The later move succeeds, silently discarding the earlier writer\u0027s round trail or pending findings; the retry only handles filesystem contention, not stale snapshots.",
+            "fix": "Serialize writes per session or add optimistic versioning/merge-on-save so a writer cannot replace newer state with an older snapshot.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It correctly identifies that temp\u002Brename buys atomicity but not isolation \u0393\u00C7\u00F6 in the very multi-server, shared-data-dir setup the file\u0027s own comment documents, two writers (including the startup sweep re-saving a whole session) can silently clobber each other\u0027s round trail, which the retry loop cannot address and which matters for a store whose whole purpose is durable status."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 143,
+            "title": "Toggling a round blocks on the full expensive refresh without progress feedback",
+            "why": "When a person opens or closes one card, this handler immediately calls the full refresh path; with the server/configuration checks, vendor probes, release lookup, and price fetches taking up to 20 seconds, the click appears ineffective and the card body does not appear promptly. There is no busy or terminal error state for that interaction.",
+            "fix": "Use a lightweight round-only webview patch for disclosure toggles, or cache/defer the expensive state refresh; if the full refresh is unavoidable, expose an in-progress state and a visible error completion.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The claimed 20-second block is speculative rather than observed \u0393\u00C7\u00F6 every expensive lookup in \u0060render()\u0060 sits behind a \u0060latestCheckedAt\u0060/\u0060cliCheckedAt\u0060/\u0060localCheckedAt\u0060/\u0060pricesCheckedAt\u0060 cache stamp, so a toggle on an already-painted panel re-reads a few small files, and the cited line 143 is the section branch that deliberately does no repaint at all, while the round branch\u0027s immediate render is documented as necessary because a card\u0027s body is only built when open."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Vendor span uses class=\u0022vendor\u0022 which collides with settings card styles in the stylesheet",
+            "why": "The CSS selector .vendor is already defined in the extension stylesheet for settings cards with a border, border radius, and 8px padding. Applying class=\u0022vendor\u0022 to the inline span wrapping the vendor name inside a tight .reviewer line causes the span to inherit card container styles, rendering with borders and padding that read visually as a strike-through box over the vendor text.",
+            "fix": "Change class=\u0022vendor\u0022 to class=\u0022who\u0022 in panelView.ts:810 and update the corresponding assertions in panelView.test.ts and roundCard.test.ts.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 142,
+            "title": "Session persistence uses a fixed scratch name instead of a per-write unique name",
+            "why": "The rule in \u0060.claude/rules/common/review-gate.md\u0060 (inherited from \u0060vendor-routing.md\u0060 logic regarding visibility of errors) and the specific plan deviation states: \u0027A session is saved under its own scratch name, and the move is retried\u0027. The diff shows the scratch file name is now unique (\u0060${file}.{Environment.ProcessId}-{Guid.NewGuid()}.tmp\u0060), but the rule explicitly requires the move to be retried for cases a unique name cannot fix (e.g., a scanner holding the destination). The current implementation retries, but the rule text in \u0060module_server.md\u0060 says \u0027the move is retried briefly for the case a unique name cannot fix\u0027. The implementation does retry. However, the rule in \u0060review-gate.md\u0060 states \u0027The server refuses one without it\u0027 regarding scope. Wait, the rule is about the scratch name. The rule in \u0060module_server.md\u0060 says: \u0027each write goes to a scratch file of its OWN name\u0027. The diff does this. But the rule in \u0060review-gate.md\u0060 says \u0027Never hand a reviewer a bare diff\u0027. This is a new",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 method retries the move operation for the case where a reader or scanner holds the destination file, as explicitly required by the rule.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent and self-refuting \u0393\u00C7\u00F6 it admits mid-text that the code already does the unique scratch name and already retries the move, citing rules that have nothing to do with the issue, so it names no defect a reader could act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save retry loop may hang indefinitely on persistent file locks",
+            "why": "The \u0060MoveOverExisting\u0060 method retries 5 times with a fixed sleep interval (20ms * attempt). If a file lock (e.g., from an antivirus scanner or another process) persists longer than the total retry window (approx 150ms), the code throws. However, if the lock is held by a process that never releases it (rare but possible in enterprise environments), the \u0060Thread.Sleep\u0060 loop might not be sufficient to handle transient spikes, or worse, if the logic is extended, it could spin. More critically, the \u0060MoveOverExisting\u0060 method is called inside a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060. If the file is held by a scanner that intermittently locks/unlocks, the retry might succeed. But if the lock is permanent, it throws. The real risk is that the \u0060MoveOverExisting\u0060 logic is *not* robust enough for high-concurrency scenarios where multiple writers might contend for the same destination file *after* the unique temp name collision is resolved. If the destination file (",
+            "fix": "Ensure the \u0060MoveOverExisting\u0060 retry loop uses a bounded, non-infinite wait strategy (e.g., exponential backoff with a hard cap) or a \u0060CancellationToken\u0060 to prevent the server from hanging indefinitely if the destination file is held by a long-running process (like an antivirus scanner) that never releases it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent and factually wrong about the code \u0393\u00C7\u00F6 the loop is already bounded at 5 attempts (~150ms) and provably cannot hang or spin, the comment above it already states that the last attempt is allowed to throw deliberately, and the \u0027fix\u0027 asks for exactly the bounded behaviour the code already has."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Temporary scratch files accumulate on failed moves due to cleanup timing",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060TryDelete(temp)\u0060 is called in a \u0060finally\u0060 block *after* the \u0060MoveOverExisting\u0060 loop. If \u0060MoveOverExisting\u0060 throws an exception on the final attempt (e.g., \u0060UnauthorizedAccessException\u0060 after 5 retries), the \u0060finally\u0060 block executes and deletes the temp file. However, if the loop succeeds but the \u0060File.Move\u0060 throws *during* the retry (e.g., on attempt 3), the \u0060finally\u0060 block runs, deleting the temp file, but the exception propagates. The critical issue is that if \u0060MoveOverExisting\u0060 throws *before* the loop finishes (e.g., on the first try), the \u0060finally\u0060 block deletes the temp file. But if the loop completes successfully, the temp file is deleted. The real risk is if \u0060MoveOverExisting\u0060 throws *after* a successful move but before the \u0060finally\u0060 block runs (unlikely), or if the \u0060TryDelete\u0060 itself fails silently. More critically, if \u0060MoveOverExisting\u0060 throws on the *last* attempt, the \u0060finally\u0060 block runs, deleting the temp file. But if the loop *succeeds* (all",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of \u0060MoveOverExisting\u0060 or ensure it runs before the retry loop completes, so that if the move fails after the first attempt, the temporary file is cleaned up before the next retry.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent and wrong about the code: the \u0060finally\u0060 correctly deletes the unique scratch file on every path (success, retry, or final throw), no temp file can accumulate, and the suggested fix would break the retry loop by deleting the source before a retry."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 75,
+            "title": "User toggle state may not persist correctly across panel ticks",
+            "why": "When a user closes a card (e.g., \u0060afterToggle(previous, key, false)\u0060), the \u0060open\u0060 set is updated to remove the key. However, if the panel re-renders before the next tick, and the round is still running, the \u0060nextOpenRounds\u0060 logic might re-add it to \u0060open\u0060 if it\u0027s in \u0060autoOpened\u0060. The current logic removes the key from \u0060panelOpened\u0060, but if the round is still running, \u0060nextOpenRounds\u0060 will re-add it to \u0060autoOpened\u0060 and \u0060open\u0060 on the next tick, effectively ignoring the user\u0027s close action. This creates a flicker where the card closes, then re-opens immediately if the round is still running.",
+            "fix": "Ensure \u0060afterToggle\u0060 updates the \u0060open\u0060 set correctly when a user closes a card that was previously auto-opened, and that the \u0060panelOpened\u0060 set is updated to reflect the user\u0027s explicit choice.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is simply wrong about this code \u0393\u00C7\u00F6 \u0060afterToggle\u0060 deliberately keeps the key in \u0060autoOpened\u0060 (with a comment saying exactly why), so \u0060nextOpenRounds\u0060\u0027s \u0060if (!autoOpened.has(key))\u0060 guard cannot re-open a running card the person closed, and the described flicker cannot occur."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Unnecessary recomputation of open rounds state on every render tick",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 calls \u0060nextOpenRounds\u0060 on every render tick (every 5 seconds). This function performs set operations and filtering on the entire list of rounds. While the logic is simple, doing this on every tick for a large number of rounds (e.g., 100\u002B rounds) creates unnecessary CPU overhead. The state should only be recomputed when the \u0060sessions\u0060 data actually changes (e.g., a new round starts, a round finishes, or a user toggles a card).",
+            "fix": "Cache the result of \u0060nextOpenRounds\u0060 and only recompute it when the underlying \u0060sessions\u0060 data changes, rather than on every render tick.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Recomputing a small set operation over a handful of round cards once every five seconds in a VS Code webview costs nothing measurable, and the proposed cache would add invalidation logic \u0393\u00C7\u00F6 and a real staleness risk for the open/closed policy \u0393\u00C7\u00F6 in exchange for no observable gain."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:36:58 \u001B[32mINF\u001B[0m] coai-mcp#23396 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Temporary scratch files accumulate on failed moves due to cleanup timing (from local) [gating] Round=1 Stage=CodeReview\r | [14:36:58 \u001B[32mINF\u001B[0m] coai-mcp#23396 finding [Major/Ux] src_vs_code/src/openRounds.ts:75 - User toggle state may not persist correctly across panel ticks (from local) [gating] Round=1 Stage=CodeReview\r | [14:36:58 \u001B[32mINF\u001B[0m] coai-mcp#23396 finding [Minor/Performance] src_vs_code/src/panelProvider.ts:165 - Unnecessary recomputation of open rounds state on every render tick (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex",
+    "repeat": 1,
+    "lane": 6,
+    "key": "codex|split-once|1",
+    "startedUtc": "2026-09-05T14:33:30.9791686Z",
+    "finishedUtc": "2026-09-05T14:35:18.5180668Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 45,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 13790,
+        "tokensOut": 2260,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Claiming before delivering the command can permanently lose a split.",
+            "why": "If the server atomically records the caller as claimed and then is killed before returning or persisting the split command, a retry sees the claim and receives the autonomy instruction, so the requested split never happens.",
+            "fix": "Define a durable pending-command state or an idempotent delivery protocol that allows an undelivered claim to be safely retried without issuing duplicates.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It posits a crash in a millisecond window between an atomic claim and its response without pointing at any code, and asks for a durable pending-command state or idempotent delivery protocol \u0393\u00C7\u00F6 machinery far out of proportion to a lost split that the caller can simply request again."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define recovery for claims left by killed or abandoned work.",
+            "why": "If a caller receives a split command but crashes before spawning children, or a child dies halfway through its work, the persisted one-time claim has no completion, lease, expiry, or reset semantics; later retries either suppress required work forever or require manual data surgery.",
+            "fix": "Specify a claim state machine with ownership, lease/expiry, retry behavior, and a safe completion criterion for both caller and piece sessions.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A persisted one-time claim with no completion, ownership, expiry or sweep is a real stranding hazard whose failure mode (work permanently suppressed, needing manual data surgery) is exactly the in-flight-state gap this family\u0027s reliability and planning rules require a plan to name, and fixing it at plan stage costs a paragraph."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback has no stable identity definition across branches and reused checkouts.",
+            "why": "Two processes using the same checkout path, or a later unrelated task reusing that path after the original task, can share the fallback claim and cause one task to be treated as an already-split piece or prevent the other from splitting.",
+            "fix": "Define a branch-independent checkout/task identity with lifecycle and collision rules, and specify how it is created and retired when no session id is exported.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "With no file, line, or code shown, the finding is an abstract demand for a full identity lifecycle spec around an unnamed fallback claim \u0393\u00C7\u00F6 it neither points at a concrete defect a reader can check nor scopes the risk, so nobody can act on it."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The current-round verdict requirement is not tied to a persisted review identity.",
+            "why": "A plan that passed in round 1 and then fails after edits in round 2 can still trigger splitting if the implementation reads the stored round-1 verdict; conversely, a retry can lose the current verdict if it is not persisted with the claim.",
+            "fix": "Bind the split decision to the exact review-run identifier and plan content/version, and require a fresh passing verdict for that same round before claiming.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and self-contradictory \u0393\u00C7\u00F6 it names no file, no code was shown, and it hedges on whether the implementation even reads a stale verdict, so it asks for identity/version binding machinery against a hypothesis nobody can act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Cross-process atomicity is asserted without specifying a storage primitive or filesystem contract.",
+            "why": "On a shared network data directory, two servers using process-local locks or a non-atomic read-then-write sequence can both observe an unclaimed key and emit split commands, violating the one-time guarantee.",
+            "fix": "Select and document an atomic primitive supported by the target deployment (for example a transactional database or atomic exclusive-create protocol), including behavior on network filesystems, and verify concurrent contention.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete failure mode \u0393\u00C7\u00F6 two processes both seeing an unclaimed key and each emitting the command, breaking a stated one-time guarantee \u0393\u00C7\u00F6 and demands the one thing that settles it (name the atomic primitive the claim rests on), which is exactly the design gap that separates a real lock from advisory coordination."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The unwritable-store behavior is internally underspecified and can violate the atomicity guarantee.",
+            "why": "With splitting enabled and the store unwritable, \u201Cfails OPEN with a warning\u201D could mean continuing without persistence; two concurrent requests would then both issue commands, while refusing startup would contradict the stated warning-only behavior.",
+            "fix": "Define the exact startup and request behavior, including whether commands are suppressed, how the caller is informed, and how atomic once-only behavior is preserved when persistence is unavailable.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real specification gap \u0393\u00C7\u00F6 \u0027fails open with a warning\u0027 when the persistence backing an atomicity/once-only guarantee is unavailable leaves the actual behavior (suppress commands, refuse startup, or duplicate under concurrency) undefined, which is exactly the kind of hole a careful engineer needs closed before implementation."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 62.1,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 1,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 167999,
+        "tokensOut": 5316,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 102,
+            "title": "Any write-time IOException is mistaken for a competing claim",
+            "why": "If the claim file is created but the timestamp write or stream disposal fails, such as when the disk fills, File.Exists(file) is true, so this handler returns false without warning. PanelService then suppresses the split order, violating the required fail-open behavior and silently disabling the feature for that round.",
+            "fix": "Catch the CreateNew collision separately, but handle IO failures during writing/flushing as store failures: warn and return true (optionally cleaning up the partial file).",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The catch filter \u0060when (File.Exists(file))\u0060 cannot distinguish a lost CreateNew race from a post-creation write/flush failure \u0393\u00C7\u00F6 precisely the full-disk case the method\u0027s own remarks promise to fail OPEN on \u0393\u00C7\u00F6 so that round\u0027s order is silently withheld with no warning, and the fix (scope the collision catch to the CreateNew itself) is small and concrete."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:35:18 \u001B[32mINF\u001B[0m] coai-mcp#18152 reviewer codex/SecurityReliability answered in 61.6s: 1 finding(s), 63578 in / 2786 out tokens Round=1 Stage=CodeReview\r | [14:35:18 \u001B[32mINF\u001B[0m] coai-mcp#18152 round 1 CodeReview proceed: 1 gating finding(s); all 3 reviewers answered; 167999 in / 5316 out tokens (no cost reported) over 61.6s\r | [14:35:18 \u001B[32mINF\u001B[0m] coai-mcp#18152 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:102 - Any write-time IOException is mistaken for a competing claim (from codex) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex",
+    "repeat": 2,
+    "lane": 7,
+    "key": "codex|split-once|2",
+    "startedUtc": "2026-09-05T14:34:27.4804918Z",
+    "finishedUtc": "2026-09-05T14:36:28.3769431Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 40.3,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 13792,
+        "tokensOut": 2051,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The claim is not coupled to command delivery, so a crash can consume the split without issuing any order",
+            "why": "If the server atomically records the caller or checkout as claimed and is killed after that write but before returning or executing the split/autonomy command, the retry sees the claim and emits no command; the required action is permanently lost. If it records after delivery instead, a kill between delivery and recording produces duplicates.",
+            "fix": "Specify a durable pending/delivered protocol with recovery or an idempotent command receipt, and test failures at both sides of the claim so every successful plan is delivered exactly once or remains retryable.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "With no file, line, or quoted code, the finding is a generic distributed-systems template about exactly-once claim/delivery that asserts a crash window nobody has shown exists in this code, and its remedy \u0393\u00C7\u00F6 a durable pending/delivered protocol with recovery plus failure tests on both sides \u0393\u00C7\u00F6 is heavy machinery proposed against an unverified risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback does not define a stable, collision-free checkout identity",
+            "why": "Two independent callers reviewing different plans from the same checkout while session IDs are absent will share the same fallback claim and the second caller will be treated as a piece, suppressing its required split. A reused checkout can also retain a prior claim and suppress a later top-level plan.",
+            "fix": "Define the checkout key precisely, including lifecycle or plan-round semantics, and test concurrent independent plans plus checkout reuse.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete correctness hazard \u0393\u00C7\u00F6 a fallback identity keyed only by checkout collides between concurrent independent callers and persists across checkout reuse, silently suppressing a required split \u0393\u00C7\u00F6 which is the kind of shared-state defect that fails quietly and is worth pinning down before it ships."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The promised atomic cross-process claim has no specified locking or transactional mechanism",
+            "why": "Two servers can both observe no claim and both issue commands before either store update becomes visible; a read-then-write file implementation violates the exactly-one requirement under contention.",
+            "fix": "Specify a supported atomic primitive, stale-lock recovery, and a two-server contention test.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A cross-process \u0027exactly one claim\u0027 guarantee stated without naming the atomic primitive, stale-lock recovery, and a contention test is exactly the design gap this family\u0027s reliability rule was written for \u0393\u00C7\u00F6 a read-then-write claim genuinely does let two servers both proceed."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The unwritable-store behavior is underspecified for initialization, partial writes, and permission changes",
+            "why": "Missing directories, read-only mounts, or disk-full errors can make reads succeed but claims fail; without defined atomic-write and error handling, the service may warn yet duplicate commands or silently disable the feature.",
+            "fix": "Define initialization, temp-write/rename durability, and behavior for each read/write failure; test read-only, missing-directory, disk-full, and changed-permission cases.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It is a generic checklist of filesystem failure modes (\u0027define initialization, atomic writes, disk-full, permission changes, and test all of them\u0027) attached to no file, line, or observed behavior in this change \u0393\u00C7\u00F6 it asks for machinery out of proportion to any risk it can actually point at."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The current-round verdict requirement has no identity or invalidation model",
+            "why": "After a failed review is edited and passes on retry, or after multiple plans run in one caller, a persistent session/checkout claim can suppress the later decision, so behavior is not based on the plan reviewed this round.",
+            "fix": "Persist and compare a plan/round fingerprint or clear state at each new top-level review, and define round boundaries.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding is abstract and speculative \u0393\u00C7\u00F6 it names no file, no code, and no concrete path, and its premise about a persistent session claim suppressing a later decision is not shown to hold in this code, so it asks for fingerprinting machinery against a hypothesized failure rather than an observed one."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The human-visible behavior for an already-split piece is not operationally defined",
+            "why": "A piece may still receive a generic split command unless the response clearly distinguishes piece state and autonomy instruction; after a retry, the person cannot tell whether to split again or build the unit.",
+            "fix": "Specify the response/status schema and precedence for top-level, piece, claimed, and recovery states, then test the retry path.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It anchors to no file or line and asks for a full response/status schema and precedence table for hypothetical states, which is speculative design machinery rather than a concrete defect anyone can act on."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 80.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 213728,
+        "tokensOut": 7978,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 583,
+            "title": "The split-order predicate is evaluated twice instead of being asked once",
+            "why": "The scope requires: \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 The diff calls \u0060OrdersSplit\u0060 to decide whether to claim and then calls it again when creating/logging the commands, so the claim and issued-order conditions are separate evaluations.",
+            "fix": "Evaluate the split-order decision once, use that result for the claim and final command decision, and avoid the second \u0060OrdersSplit\u0060 call.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The two \u0060OrdersSplit\u0060 calls take different arguments \u0393\u00C7\u00F6 \u0060provisional\u0060 (should we spend a claim?) and \u0060context\u0060 (did the claim succeed, so was an order actually issued?) \u0393\u00C7\u00F6 so this is one shared predicate asked about two distinct states, exactly what the scope\u0027s \u0027one question\u0027 demands; collapsing them as the fix proposes would log a split order even when the claim failed."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "The split claim is persisted before the order is successfully delivered",
+            "why": "If the server is killed after TryClaimSplitOrder creates the stamp but before For completes or the MCP response is sent, the next retry sees the caller as already claimed and emits no split order. The requested split is silently lost.",
+            "fix": "Make the claim recoverable: persist a pending order and replay it on retry, or finalize the claim only through a delivery/retry protocol that tolerates a duplicate.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The window is a process death in the few milliseconds between claiming and returning, and all that is lost is one advisory \u0027split this plan\u0027 instruction \u0393\u00C7\u00F6 the conservative direction the code deliberately chose over re-ordering splits \u0393\u00C7\u00F6 so the proposed pending-order-and-replay protocol is machinery far out of proportion to the risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 109,
+            "title": "Any existing-file IOException is treated as another process winning the claim",
+            "why": "When the stamp file exists but is locked, malformed, or the disk becomes full while writing the newly created file, File.Exists(file) is true and this catch returns false without warning. The caller then receives no split order and the documented fail-open behavior is bypassed.",
+            "fix": "Separate the atomic CreateNew collision case from create/write failures; only a confirmed existing-file collision should return false, while all other IO failures must warn and return true.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The \u0060catch (IOException) when (File.Exists(file))\u0060 filter cannot distinguish a CreateNew collision from a write/flush failure after the file was created \u0393\u00C7\u00F6 exactly the full-disk case the class\u0027s own remarks promise will fail OPEN with a warning \u0393\u00C7\u00F6 so a partially-written stamp is silently treated as another process\u0027s claim and can suppress the order (for up to 24h if the truncated timestamp still parses); the fix is small and the code\u0027s documented contract is what it violates."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:36:28 \u001B[32mINF\u001B[0m] coai-mcp#44948 finding [Major/Convention] src_mcp/src/Server/PanelService.cs:583 - The split-order predicate is evaluated twice instead of being asked once (from codex) [gating] Round=1 Stage=CodeReview\r | [14:36:28 \u001B[32mINF\u001B[0m] coai-mcp#44948 finding [Major/Reliability] src_mcp/src/Server/PanelService.cs:578 - The split claim is persisted before the order is successfully delivered (from codex) [gating] Round=1 Stage=CodeReview\r | [14:36:28 \u001B[32mINF\u001B[0m] coai-mcp#44948 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:109 - Any existing-file IOException is treated as another process winning the claim (from codex) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "gemini",
+    "repeat": 1,
+    "lane": 6,
+    "key": "gemini|split-once|1",
+    "startedUtc": "2026-09-05T14:35:18.5954693Z",
+    "finishedUtc": "2026-09-05T14:36:01.7633559Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 8.3,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 2,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 19799,
+        "tokensOut": 919,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027What must be true\u0027 (item 6): Fallback tracking across branches without session ID has no mechanism or key defined.",
+            "why": "Item 6 mandates tracking a client across branches of one checkout when no session ID is exported, but session keys are repo\u002Bbranch and requirement 4/Constraints forbid passing caller IDs or relying on caller memory. Without an explicit cross-branch identifier (e.g., git worktree/repo root hash), any branch change will generate a distinct key, re-triggering recursive plan splitting.",
+            "fix": "Specify the exact fallback identity source when CLAUDE_CODE_SESSION_ID is unset, such as hashing git common-dir/repository root path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete gap between a stated requirement (track a client across branches without a session ID) and the design\u0027s own keying scheme (repo\u002Bbranch), names the consequence (a branch switch mints a new key and re-triggers the split), and proposes a checkable fix \u0393\u00C7\u00F6 exactly the kind of missing-specification a plan reviewer exists to catch."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027What must be true\u0027 (item 5): Failing open on unwritable store contradicts the single-split guarantee and causes recursive splitting.",
+            "why": "If the persistent store is unwritable and fails open by allowing the split command to be issued, every subsequent epic plan review process also fails to record or read claims in the store, causing infinite recursive splitting across all epics.",
+            "fix": "Define failing open to mean proceeding without the split command (treating as already split/piece), rather than granting a split command.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real design defect \u0393\u00C7\u00F6 the direction of the fail-open default \u0393\u00C7\u00F6 where failing open toward \u0027allow the split\u0027 makes the single-split guarantee unenforceable and permits unbounded recursive splitting, and it supplies the cheap correct alternative (fail open by treating the plan as already split), which is exactly the kind of thing worth fixing in the plan rather than discovering at runtime."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027Constraints\u0027: Caller ID path traversal mitigation is stated as an invariant without defining sanitization or encoding.",
+            "why": "CLAUDE_CODE_SESSION_ID or external caller strings could contain directory traversal sequences (\u0027..\u0027, \u0027/\u0027, \u0027\\\\\u0027) or invalid file characters on Windows/POSIX, causing unexpected disk writes or crashes if raw interpolation is attempted.",
+            "fix": "Specify explicit sanitization (e.g. SHA-256 hash or strict alphanumeric slug) for caller IDs before using them in file paths.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The plan asserts a path-traversal invariant for externally-supplied caller IDs without saying how it is enforced, and the finding names a concrete, cheap fix (hash or strict slug at the one place paths are built) \u0393\u00C7\u00F6 exactly the kind of safe-by-construction detail a plan should pin down before an implementer interpolates the raw string."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 34.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 1,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 104696,
+        "tokensOut": 11936,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 112,
+            "title": "Unconditional File.Delete before FileMode.CreateNew creates a race condition that clobbers concurrent valid claims",
+            "why": "When an existing claim is expired or unreadable, two concurrent processes can both pass the StillRemembered check. If Process A finishes writing a fresh claim file, Process B executing \u0027if (File.Exists(file)) File.Delete(file)\u0027 deletes Process A\u0027s new claim and succeeds with its own FileMode.CreateNew, causing both processes to return true and duplicate the split order.",
+            "fix": "Do not delete the file prior to atomic creation; update expired records using atomic file replacement or transactional lock/write operations so that active claims cannot be deleted by a concurrent caller.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional \u0060File.Delete\u0060 before \u0060CreateNew\u0060 genuinely defeats the atomicity the method is built around and falsifies the explicit comment on line 111 that \u0027the CreateNew below is the only race there is\u0027 \u0393\u00C7\u00F6 a real, cheaply fixable hole in the one invariant this code claims, even if the practical cost (a duplicated split order at the 24-hour expiry boundary) makes Major an overstatement."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:36:01 \u001B[32mINF\u001B[0m] coai-mcp#38884 reviewer gemini/SecurityReliability answered in 34.0s: 1 finding(s), 34785 in / 8120 out tokens Round=1 Stage=CodeReview\r | [14:36:01 \u001B[32mINF\u001B[0m] coai-mcp#38884 round 1 CodeReview proceed: 1 gating finding(s); all 3 reviewers answered; 104696 in / 11936 out tokens (no cost reported) over 34.1s\r | [14:36:01 \u001B[32mINF\u001B[0m] coai-mcp#38884 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:112 - Unconditional File.Delete before FileMode.CreateNew creates a race condition that clobbers concurrent valid claims (from gemini) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "gemini",
+    "repeat": 2,
+    "lane": 5,
+    "key": "gemini|split-once|2",
+    "startedUtc": "2026-09-05T14:35:59.1605466Z",
+    "finishedUtc": "2026-09-05T14:36:42.359892Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 15.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 2,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 33916,
+        "tokensOut": 2442,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true (5): Failing open on an unwritable store permits unbounded recursive plan splitting",
+            "why": "If the shared store is unwritable (e.g. read-only filesystem or permission error), \u0027failing open\u0027 means the gate cannot record that a split was claimed and permits another split order. When spawned child epic sessions run against the same unwritable store, they also fail open and issue split orders, recreating the exact infinite epic-of-epics loop the floor is designed to eliminate.",
+            "fix": "Fail closed against splitting when the claim store is unwritable by defaulting to the single-unit autonomy order and logging a warning.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete failure mode where a fail-open claim store lets recursive split orders re-create the unbounded epic-of-epics loop the floor exists to prevent, and proposes the right default (fail closed to a single-unit order with a warning)."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "What must be true (6): Checkout-level fallback without session IDs permanently suppresses future legitimate plan splits",
+            "why": "When a client provides no session ID and the claim is tracked across branches of a single checkout, any claim recorded for a split will match subsequent unrelated user tasks in the same repository checkout, causing all future plans to be incorrectly treated as child pieces and denied splitting.",
+            "fix": "Scope non-session claims to git commit ancestry / root branch lineage or require an ephemeral run marker rather than a persistent checkout-wide claim.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete failure mode of a persistent, checkout-scoped claim \u0393\u00C7\u00F6 a stale claim from one task silently denying splits for every later unrelated plan in that repo \u0393\u00C7\u00F6 and proposes a proportionate fix (ephemeral or lineage-scoped marker), which is exactly the kind of state-lifetime defect an implementer would want caught before shipping."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Constraints: Atomic single-step check-and-claim permanently burns the split attempt if downstream execution fails",
+            "why": "If checking eligibility and claiming the split order occur atomically in a single step during gate evaluation, a crash, network drop, or user cancellation immediately after review leaves the claim marked as spent, causing subsequent retries of the original plan to mistakenly receive the child autonomy order instead of the split order.",
+            "fix": "Key the claim idempotently to the specific plan hash or provide a rollback/expiration mechanism for unfulfilled split dispatches.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding is a speculative what-if built on its own hypothetical (\u0027if checking and claiming occur atomically in a single step\u0027) about a mechanism no code or scope text here establishes exists, so it names no defect in this change and asks for idempotency keys and rollback machinery against an unverified risk."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 27.5,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 90323,
+        "tokensOut": 8524,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "Unconditional File.Delete in TryClaimSplitOrder destroys mutual exclusion during concurrent claims",
+            "why": "When two server instances attempt to claim a split order for the same caller concurrently, both see no active stamp initially. Server A successfully creates the claim file via FileMode.CreateNew. Server B then executes if (File.Exists(file)) File.Delete(file), deleting Server A\u0027s newly created claim file before creating its own with FileMode.CreateNew. Both servers return true and both issue split orders, defeating cross-process atomicity.",
+            "fix": "Do not delete existing files prior to FileMode.CreateNew; attempt atomic creation first, and only inspect or overwrite existing files if an existing claim is confirmed expired under a synchronized check.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional \u0060File.Delete\u0060 before \u0060FileMode.CreateNew\u0060 genuinely voids the cross-process exclusion the method\u0027s own doc comment promises \u0393\u00C7\u00F6 a second server that passes the expiry check can delete a freshly written claim and create its own, so both issue the split order, and the inline comment claiming CreateNew is the only race is provably wrong."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 110,
+            "title": "Unsynchronized Delete-before-CreateNew creates a race window where concurrent claims on expired tokens can throw or conflict improperly",
+            "why": "When a claim expires, two concurrent processes checking \u0060StillRemembered\u0060 will both evaluate it as false. If process A calls \u0060File.Delete(file)\u0060 right after process B executes \u0060new FileStream(file, FileMode.CreateNew...)\u0060, process A will delete process B\u0027s newly created active claim file. Subsequent callers will then find the file missing and issue duplicate split orders despite process B having just claimed it.",
+            "fix": "Do not delete the existing file before opening; instead use an atomic file replace or open with \u0060FileMode.OpenOrCreate\u0060 / \u0060FileMode.Create\u0060 with proper file sharing locks, or catch collision during creation and handle atomic stamp replacement.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew pair genuinely breaks the atomicity the code claims in its own comment (\u0027the CreateNew below is the only race there is\u0027) \u0393\u00C7\u00F6 at the expiry boundary two servers can both delete and both create, so both issue the split order the claim exists to give once \u0393\u00C7\u00F6 and although the consequence is soft and the suggested \u0060FileMode.Create\u0060 fix would make it worse, the defect and the false invariant in the docstring are things the author would want to know."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 102,
+            "title": "Redundant disk reads: \u0060ReadStamp\u0060 is evaluated twice on every unremembered split claim check",
+            "why": "In \u0060TryClaimSplitOrder\u0060, \u0060StillRemembered(ReadStamp(caller), nowUtc)\u0060 performs a synchronous filesystem read (\u0060File.ReadAllText\u0060). In \u0060PanelService.cs\u0060, \u0060OrdersSplit(provisional)\u0060 and subsequent checks evaluate before and inside \u0060TryClaimSplitOrder\u0060, and within \u0060TryClaimSplitOrder\u0060 another disk read is immediately performed even if checked recently.",
+            "fix": "Pass or reuse the already-read timestamp if available or combine the stamp validation and stream creation attempt in a single pass.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It flags one extra small-file read on a path that runs once per review round, as Major/Performance \u0393\u00C7\u00F6 an irrelevant cost, and the duplicated stamp read is deliberate structure (a cheap pre-check before the CreateNew claim), so the suggested merge would trade clarity for nothing."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:36:42 \u001B[32mINF\u001B[0m] coai-mcp#11568 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:105 - Unconditional File.Delete in TryClaimSplitOrder destroys mutual exclusion during concurrent claims (from gemini) [gating] Round=1 Stage=CodeReview\r | [14:36:42 \u001B[32mINF\u001B[0m] coai-mcp#11568 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:110 - Unsynchronized Delete-before-CreateNew creates a race window where concurrent claims on expired tokens can throw or conflict improperly (from gemini) [gating] Round=1 Stage=CodeReview\r | [14:36:42 \u001B[32mINF\u001B[0m] coai-mcp#11568 finding [Major/Performance] src_mcp/src/Server/CallerSessions.cs:102 - Redundant disk reads: \u0060ReadStamp\u0060 is evaluated twice on every unremembered split claim check (from gemini) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "local",
+    "repeat": 1,
+    "lane": 6,
+    "key": "local|split-once|1",
+    "startedUtc": "2026-09-05T14:36:01.840825Z",
+    "finishedUtc": "2026-09-05T14:48:06.6711341Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 140.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 1440,
+        "tokensOut": 1291,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claimed failure does not follow from its own premises \u0393\u00C7\u00F6 a caller whose session id differs still loses or wins one atomic claim, so identity carried in an environment variable cannot produce two simultaneous holders \u0393\u00C7\u00F6 and the proposed fix (a shared lock file in the data directory) is what an atomic claim already is, so it reads as speculative Blocking severity over a mechanism it has misread."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It restates a design the plan already states deliberately (\u0027the caller supplies the floor\u0027) and dresses it as a Blocking defect by inventing a runaway that needs a self-invoking loop no described mechanism has \u0393\u00C7\u00F6 each split is a separate operator-initiated round, not recursion \u0393\u00C7\u00F6 and then asks for persistent depth-counter state out of all proportion to the risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a hypothetical re-run scenario rather than pointing at real code, misreads a deliberate constraint (the verdict is a function of the plan text under review, so re-running the same text simply re-reports the same advice \u0393\u00C7\u00F6 it does not recursively re-split anything), and its fix asks for split-depth metadata tracking that is far out of proportion to the imagined risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a recursive-nesting hazard the plan\u0027s own \u0027split ONCE\u0027 rule already excludes, calls a text file in git \u0027irreversible\u0027, and asks for a preview mechanism out of all proportion to the risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding restates a constraint the design deliberately chose (fail-open with a warning) as if it were a defect, invents a data-loss scenario from that restatement, and then proposes a fix about \u0027split depth\u0027 that has nothing to do with the unwritable-store concern it raises."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 584.3,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 25380,
+        "tokensOut": 3665,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "Nullable callback parameter risks NullReferenceException",
+            "why": "The method signature \u0060Action\u003Cstring\u003E? warn = null\u0060 allows the caller to omit the argument. If the code path reaches \u0060warn?.Invoke\u0060 (line 117) and the caller passed \u0060null\u0060 explicitly or the default was not handled correctly in a specific call site, the warning logic could fail silently or throw if the null check is bypassed in a future refactor. More critically, the test \u0060AnUnwritableStore_GivesTheOrderRatherThanSwallowingIt\u0060 passes a lambda, but \u0060PanelService\u0060 (line 583) passes a lambda. However, the method signature change from \u0060RecordSplitOrder\u0060 to \u0060TryClaimSplitOrder\u0060 introduces a new optional parameter that was not present in the original API contract, potentially breaking callers that rely on positional arguments or implicit defaults if not careful.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 or ensure the caller passes a non-null delegate. The current implementation invokes \u0060warn?.Invoke\u0060 without guaranteeing the caller provides one, risking a \u0060NullReferenceException\u0060 if called without the argument.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about the code: \u0060warn?.Invoke\u0060 is precisely the null-safe form, so no NullReferenceException is possible, and the optional-parameter \u0027breaking callers\u0027 concern is speculative and self-contradictory (it notes both call sites pass a lambda)."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Inconsistent handling of optional warning callback",
+            "why": "The method \u0060TryClaimSplitOrder\u0060 accepts an optional \u0060warn\u0060 callback. While the code uses \u0060warn?.Invoke\u0060, the logic inside the \u0060catch (Exception e)\u0060 block assumes the callback might be null. If a caller passes \u0060null\u0060 explicitly, the warning is swallowed. The rule requires \u0027a warning rather than silently disabling\u0027, but if the callback is null, the warning is silent.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked with a consistent message format or handle the case where \u0060warn\u0060 is null more explicitly if the design requires it to be optional.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The \u0060warn\u0060 callback is optional by design and the caller in production supplies one; a null callback is the caller\u0027s explicit choice, so this finding invents an inconsistency that does not exist and proposes no concrete change."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Inconsistent state propagation for FirstPlanRound",
+            "why": "The code sets \u0060FirstPlanRound: true\u0060 on \u0060provisional\u0060. Then it checks \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060. If true, it creates a new \u0060context\u0060 with \u0060FirstPlanRound\u0060 set to the result of \u0060TryClaimSplitOrder\u0060. If false, it uses \u0060provisional\u0060 as \u0060context\u0060. This means if the order is not split, \u0060FirstPlanRound\u0060 remains true. If the order is split, \u0060FirstPlanRound\u0060 becomes the boolean result of the claim. This logic is complex and potentially confusing, but more importantly, it deviates from the rule that \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The code asks \u0060OrdersSplit\u0060 twice (once for \u0060provisional\u0060, once for \u0060context\u0060 implicitly via the \u0060if\u0060 block) or relies on the state of \u0060provisional\u0060 being consistent.",
+            "fix": "The variable \u0060provisional\u0060 is created but then immediately used to create \u0060context\u0060. The logic \u0060FirstPlanRound: true\u0060 is set on \u0060provisional\u0060, but then \u0060context\u0060 is created from \u0060provisional\u0060 only if \u0060OrdersSplit\u0060 returns true. This creates a potential inconsistency where \u0060FirstPlanRound\u0060 might be true in \u0060provisional\u0060 but false in \u0060context\u0060 if the condition fails, or vice versa depending on the flow.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The code deliberately claims the split order only on rounds that would issue it and asks \u0060OrdersSplit\u0060 once per distinct context \u0393\u00C7\u00F6 exactly the \u0027one question asked once\u0027 pattern the finding claims it violates \u0393\u00C7\u00F6 and the finding names no defect, only restates the control flow as \u0027complex and potentially confusing\u0027 with a contradictory fix that proposes nothing."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Violation of \u0027ONE question asked once\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to decide whether to claim, but then calls \u0060Core.Commands.GateCommands.OrdersSplit(context)\u0060 again in the \u0060if\u0060 block to log. This is two questions. The logging should be based on the result of the claim, not a re-evaluation of the condition.",
+            "fix": "Align the logic to ensure the \u0027one question\u0027 rule is strictly followed. The \u0060OrdersSplit\u0060 check should be the sole determinant for both issuing and claiming.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Redundant or confusing exception handling",
+            "why": "The code has \u0060catch (IOException)\u0060 for the race condition and \u0060catch (Exception e) when (e is IOException or UnauthorizedAccessException)\u0060 for the \u0027fail open\u0027 case. The second catch block is technically redundant because \u0060IOException\u0060 is already caught by the first block. The logic flow suggests the first catch is for the race (file exists), and the second is for other IO errors. However, the \u0060when\u0060 clause in the second catch makes it specific to \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060, which might overlap with the first catch if the order of evaluation is not clear.",
+            "fix": "The \u0060catch (Exception e)\u0060 block catches \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060 specifically, but the outer \u0060catch (IOException)\u0060 handles the race condition. The inner catch for \u0060Exception\u0060 might be redundant or confusing.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is wrong about C#: exception filters are evaluated in order, so the first clause only handles \u0060IOException\u0060 when the file exists and the second clause is the necessary handler for the file-absent IOException and for \u0060UnauthorizedAccessException\u0060 \u0393\u00C7\u00F6 the finding proposes no actual fix and could mislead someone into deleting a live fail-open path."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Warning message clarity",
+            "why": "The warning message \u0027the split-order memory at {Dir} could not be written ({e.Message}) \u2014 the order is being given, and may be given again\u0027 is clear, but the rule requires \u0027a warning rather than silently disabling\u0027. If \u0060warn\u0060 is null, the warning is silent. The rule implies a warning *must* be issued, so the \u0060warn\u0060 parameter should perhaps be required or a default logger used.",
+            "fix": "Ensure the \u0060warn\u0060 callback is invoked with a message that clearly indicates the \u0027fail open\u0027 nature.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The optional \u0060warn\u0060 callback is the caller\u0027s choice and the code already fails open with a message; the finding invents a rule requirement, offers no concrete defect, and its \u0027fix\u0027 asks for exactly what line 128 already does."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 913,
+            "title": "Change in fallback logic for anonymous clients",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The previous implementation used \u0060session.State.SessionId\u0060 (which is repo\u002Bbranch), causing every epic to be treated as a new caller. The new implementation uses \u0060session.State.RepoPath\u0060, which correctly follows the caller across branches. This is a compliance fix, but it changes the behavior significantly.",
+            "fix": "The \u0060CallerFor\u0060 method now uses \u0060session.State.RepoPath\u0060 instead of \u0060session.State.SessionId\u0060. This is a change in the fallback logic.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It merely restates what the code and its own doc comment already say \u0393\u00C7\u00F6 the fallback uses RepoPath and why \u0393\u00C7\u00F6 naming no defect, risk, or violated rule, and its \u0027Major\u0027 Convention severity flags a change that it concedes is correct and compliant."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "API contract change from void to bool",
+            "why": "The method signature changed from \u0060void RecordSplitOrder\u0060 to \u0060bool TryClaimSplitOrder\u0060. This is a breaking change for any caller that relied on the void return. However, the rule requires \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The new return value allows the caller to know if the claim succeeded, which is necessary for the \u0027fail open\u0027 logic.",
+            "fix": "The \u0060TryClaimSplitOrder\u0060 method now returns a \u0060bool\u0060 indicating success, whereas \u0060RecordSplitOrder\u0060 was \u0060void\u0060. This is a change in the API contract.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It flags a signature change on an internal method of a change that is itself introducing the atomic claim \u0393\u00C7\u00F6 the finding\u0027s own text concedes the bool return is necessary and correct, so there is nothing for anyone to act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Atomic claim race window created by pre-delete of expired file",
+            "why": "The code deletes an existing file (\u0060File.Delete(file)\u0060) before attempting \u0060FileMode.CreateNew\u0060. If a second server process checks \u0060StillRemembered\u0060 (returns false), then deletes the file, then attempts \u0060CreateNew\u0060 while the first process is still deleting, the second process\u0027s \u0060CreateNew\u0060 will succeed. This allows two servers to both believe they claimed the order, violating the atomicity guarantee required to prevent \u0027epics of epics\u0027 loops.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call to a separate \u0060if\u0060 block before the \u0060try\u0060 block, or wrap the delete in its own try-catch to ensure the atomic \u0060CreateNew\u0060 is not shadowed by a delete failure.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional pre-delete really does defeat the atomicity the comment claims \u0393\u00C7\u00F6 a process whose stale read happened before a peer\u0027s successful claim will delete that fresh claim file and then win \u0060CreateNew\u0060 itself, so two servers can both believe they claimed; the finding\u0027s stated mechanism and its suggested fix are muddled, but it points at a real hole in a guarantee the code documents as airtight."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 92,
+            "title": "Path traversal vulnerability in caller identity file naming",
+            "why": "The \u0060caller\u0060 string is used directly to construct a file path via \u0060FileFor(caller)\u0060. If a malicious or misbehaving client passes a \u0060caller\u0060 value like \u0060../../etc/passwd\u0060 or \u0060..\\..\\windows\\system32\u0060, the code could write to or overwrite arbitrary files on the server\u0027s filesystem, potentially overwriting configuration or log files, or creating a symlink to a sensitive file.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., remove or replace \u0060..\u0060, \u0060/\u0060, \u0060\\\u0060, and control characters) before using it in \u0060FileFor(caller)\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about this code \u0393\u00C7\u00F6 \u0060FileFor\u0060 never uses the caller string in the path; it hex-encodes a SHA-256 hash of it, which is exactly what the comment two lines above says, so no traversal is possible."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Potential deadlock or hang if file delete is blocked",
+            "why": "If the file to be deleted is locked by another process (e.g., an antivirus scanner or a previous crashed instance), \u0060File.Delete\u0060 will block or throw an exception. If it throws, the \u0060CreateNew\u0060 might not execute, or if it hangs, the server thread blocks. The current catch block only handles \u0060IOException\u0060 from \u0060CreateNew\u0060, not from the delete.",
+            "fix": "Add a timeout to the \u0060File.Delete\u0060 operation or ensure the \u0060try\u0060 block covers the delete operation as well, or use a more robust locking mechanism (e.g., \u0060FileLock\u0060 or \u0060Mutex\u0060) instead of relying solely on \u0060CreateNew\u0060 after a delete.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is wrong about this code \u0393\u00C7\u00F6 \u0060File.Delete\u0060 is already inside the \u0060try\u0060 at line 108 and its IOException/UnauthorizedAccessException is caught by the fail-open handler, and \u0060File.Delete\u0060 throws on a locked file rather than hanging, so neither the stated defect nor the proposed Mutex machinery applies."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Silent failure of split order claim obscures state",
+            "why": "When \u0060TryClaimSplitOrder\u0060 returns \u0060false\u0060 (e.g., due to a race or unwritable store), the code proceeds to use the \u0060provisional\u0060 context without explicitly logging or signaling that the claim failed. A user or downstream process might expect the split order to be active, but it was silently skipped, leading to confusion about why the split didn\u0027t occur.",
+            "fix": "Add a specific log entry or return value indicating that the split order was claimed, and ensure the UI or downstream process reflects this state change immediately.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is wrong about this code \u0393\u00C7\u00F6 the claim already takes a warning callback (\u0060message =\u003E _log.Warning(...)\u0060) for exactly the failed-claim case, and the success path logs \u0060split ordered to caller\u0060, so a failed claim is neither silent nor a state anyone was promised."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file existence check before atomic create",
+            "why": "The code checks \u0060File.Exists(file)\u0060 before attempting \u0060FileMode.CreateNew\u0060. While this is intended to handle expired claims, it adds an extra disk I/O operation. In high-frequency scenarios (e.g., many concurrent splits), this check could become a bottleneck, especially if the file system is slow or the directory is large.",
+            "fix": "Cache the \u0060File.Exists(file)\u0060 check result or use a more efficient file system operation to avoid redundant disk I/O in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The \u0060File.Exists\u0060/\u0060Delete\u0060 pair is there to clear an expired claim so \u0060CreateNew\u0060 can succeed \u0393\u00C7\u00F6 removing it would break correctness, and a once-per-caller-per-24-hours file check is not a performance concern by any measure, so the finding is both wrong about the purpose and disproportionate about the risk."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:48:06 \u001B[32mINF\u001B[0m] coai-mcp#14796 finding [Minor/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - Potential deadlock or hang if file delete is blocked (from local) Round=1 Stage=CodeReview\r | [14:48:06 \u001B[32mINF\u001B[0m] coai-mcp#14796 finding [Minor/Ux] src_mcp/src/Server/PanelService.cs:578 - Silent failure of split order claim obscures state (from local) Round=1 Stage=CodeReview\r | [14:48:06 \u001B[32mINF\u001B[0m] coai-mcp#14796 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file existence check before atomic create (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "local",
+    "repeat": 2,
+    "lane": 3,
+    "key": "local|split-once|2",
+    "startedUtc": "2026-09-05T14:36:05.9598794Z",
+    "finishedUtc": "2026-09-05T14:44:55.3415807Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 32.7,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 1440,
+        "tokensOut": 1291,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It conflates caller identity with mutual exclusion \u0393\u00C7\u00F6 an atomic claim in the shared data directory is what prevents two grants, so a child inheriting a different session id would at worst be refused as a distinct caller rather than race, and the suggested fix (a shared lock in the data directory) is what the constraint it critiques already describes."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It escalates a hypothetical to Blocking: each split here is an explicit, caller-initiated act on progressively smaller plans that terminates on its own content, so the \u0027infinite recursion until token limits\u0027 scenario is invented rather than observed, and a persistent split-depth counter is disproportionate machinery for it."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a runaway \u0027Epics of Epics\u0027 recursion from a constraint that simply says the split verdict is measured from the plan under review, offering no evidence that re-running a plan round re-splits already-split work, and its proposed split-depth metadata is machinery out of proportion to a speculative year-later re-run."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a failure mode from a misreading \u0393\u00C7\u00F6 \u0027a caller is ordered to split ONCE\u0027 is the plan\u0027s own guarantee against re-splitting, and the imagined 4-level hierarchy plus a dry-run preview is machinery for a risk the plan already forecloses."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding merely restates a constraint the design deliberately chose (fail-open with a warning) as if it were a defect, and its proposed fix \u0393\u00C7\u00F6 a \u0027split depth\u0027 check read from plan history \u0393\u00C7\u00F6 addresses a different concern entirely and does not follow from the stated problem."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 496.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 25380,
+        "tokensOut": 5944,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 88,
+            "title": "Atomic claim introduces side-effect dependency via callback parameter",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 By passing an \u0060Action\u003Cstring\u003E? warn\u0060 into the atomic claim method, the method\u0027s return value (the claim result) becomes coupled with a side-effect (logging) that is not part of the atomic state transition. This breaks the purity of the \u0027one question\u0027 contract, as the caller must now manage the logging context for the claim to be complete.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 and the \u0060warn?.Invoke\u0060 call inside the catch block. The rule requires the caller to be ordered ONCE, and the claim logic to be atomic. The current implementation introduces a side-effect (logging a warning) that depends on an external callback, which violates the principle that the condition that issues the order and the condition that claims it are ONE question asked once. The warning is a side effect of the failure mode, not part of the atomic claim itself.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The optional \u0060warn\u0060 callback is a standard, well-documented way to surface a fail-open condition without coupling the class to a logger, and the \u0027one question asked once\u0027 rule is about issuing the split order once per caller \u0393\u00C7\u00F6 not about method purity \u0393\u00C7\u00F6 so the finding misapplies a convention and its fix would delete the only signal that the memory is broken."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Atomic claim logic separated into check-then-delete-then-create, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current implementation performs a \u0060File.Exists\u0060 check, deletes the file if present, and then attempts \u0060CreateNew\u0060. This sequence is not atomic. If another process deletes the file between the check and the \u0060CreateNew\u0060, or if the \u0060CreateNew\u0060 fails because the file was created by another process in that window, the logic returns \u0060false\u0060 (claim lost) or \u0060true\u0060 (claim won) inconsistently. The rule requires a single atomic operation to determine the outcome, not a sequence of operations that can be interrupted.",
+            "fix": "Change the catch block for \u0060IOException\u0060 to not return \u0060false\u0060 when \u0060File.Exists(file)\u0060 is true. The current logic returns \u0060false\u0060 if the file exists (implying a race where someone else claimed it), but the rule requires that \u0027A caller that already holds a claim is a caller already inside a split, and is told so.\u0027 The current implementation returns \u0060false\u0060 for an existing file, which is correct, but the logic \u0060if (File.Exists(file)) { File.Delete(file); }\u0060 followed by \u0060CreateNew\u0060 creates a race window where the file could be deleted by another process between the check and the write, leading to a silent failure or duplicate claim if not handled strictly. The rule \u0027The condition that issues the order and the condition that claims it are ONE question asked once\u0027 implies the check and the claim must be inseparable. The current code separates the existence check (delete) from the atomic creation.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It flags the delete-then-CreateNew sequence as a rule violation but never names a scenario with a real consequence \u0393\u00C7\u00F6 the outcomes it calls \u0027inconsistent\u0027 are in fact correct, its proposed fix (not returning false when the file exists) would actually create the duplicate claims it worries about, and the worst residual case is one repeated instruction, which the code already documents as an accepted fail-open cost."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "FirstPlanRound flag set before atomic claim, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code sets \u0060FirstPlanRound: true\u0060 in the \u0060provisional\u0060 context before calling \u0060TryClaimSplitOrder\u0060. This means the flag is set regardless of whether the claim succeeds. If the claim fails (e.g., due to an unwritable store), the flag remains \u0060true\u0060, but the caller is not actually ordered to split (because the claim failed). This creates a state where the flag says \u0027first round\u0027 but the order was not given, violating the atomicity of the \u0027one question\u0027 contract.",
+            "fix": "Remove the \u0060FirstPlanRound: true\u0060 assignment in the \u0060provisional\u0060 context. The rule states: \u0027A caller is ordered to split ONCE. A plan that is already a piece is told so instead.\u0027 The current code sets \u0060FirstPlanRound\u0060 to \u0060true\u0060 unconditionally, then checks \u0060OrdersSplit\u0060 and claims the order. This means the \u0060FirstPlanRound\u0060 flag is set before the claim is verified, potentially allowing a caller that has already claimed an order to be treated as a first-round caller if the claim fails (e.g., due to an unwritable store). The rule requires that the \u0027claim\u0027 and the \u0027order\u0027 are one question. The current code separates the flag setting from the claim verification.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads the code \u0393\u00C7\u00F6 \u0060FirstPlanRound\u0060 is deliberately provisional so \u0060OrdersSplit\u0060 can ask whether this round would issue the order, and the \u0060with\u0060 expression then overwrites it with the claim\u0027s actual result (false when the claim fails), so the described state never occurs and the proposed fix would break the claim logic."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 907,
+            "title": "Comment misrepresents fallback logic: \u0027Our session\u0027 vs \u0027checkout\u0027",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The comment in \u0060CallerFor\u0060 says: \u0027Our session is repo\u002Bbranch, and an epic arrives on its own branch: a session-keyed fallback would call every epic a fresh caller...\u0027 This implies the fallback is the session, but the code actually falls back to \u0060session.State.RepoPath\u0060 (the checkout). The comment is misleading because it suggests the fallback is the session, when it is actually the checkout. This is a minor deviation because the code is correct, but the comment could confuse a reader about the actual fallback mechanism.",
+            "fix": "Change the fallback from \u0060CallerIdentity.Current()\u0060 to \u0060session.State.RepoPath\u0060 to be consistent with the rule \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The current code uses \u0060CallerIdentity.Current()\u0060 which returns the session ID, but the rule requires that a client with no session ID falls back to the checkout (repo path), not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the fallback is the checkout, not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the backup",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The comment says plainly that an unidentified client falls back to the CHECKOUT rather than to our session \u0393\u00C7\u00F6 exactly what the code does \u0393\u00C7\u00F6 so the finding misreads it, and its \u0027fix\u0027 contradicts itself while admitting the code is correct."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Race condition in atomic claim allows duplicate orders on concurrent access",
+            "why": "The code checks \u0060StillRemembered\u0060 (read), then deletes the file if it exists, then attempts \u0060FileMode.CreateNew\u0060. If two servers run in parallel: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false). Server A deletes the file. Server B deletes the file (no-op). Server A creates the file. Server B attempts to create the file but fails with \u0060IOException\u0060 (file exists). The catch block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060. If Server B\u0027s \u0060CreateNew\u0060 fails because Server A created it, \u0060File.Exists\u0060 is true, so it returns \u0060false\u0060. However, if the file was deleted by Server A *after* Server B\u0027s check but *before* Server B\u0027s delete, or if the timing is such that the file exists but the \u0060CreateNew\u0060 fails for a different reason (e.g., permissions), the logic might be flawed. More critically, the \u0060File.Delete\u0060 is outside the \u0060try\u0060 block in the original logic flow relative to the \u0060CreateNew\u0060 race. Wait, looking closer: The \u0060File.Delete\u0060 is inside the \u0060try\u0060.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or ensure the \u0060File.Exists\u0060 check covers the deletion path before \u0060CreateNew\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding describes the exact behaviour the code already implements correctly (delete and CreateNew are both inside the try, and the IOException-with-File.Exists guard handles the loser of the race), never lands on a concrete failure \u0393\u00C7\u00F6 it visibly walks back its own premise mid-sentence \u0393\u00C7\u00F6 and its \u0027fix\u0027 asks for a change that is already in place."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Split order claimed on rounds that may not issue a command",
+            "why": "The code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to determine if a split should be ordered. If this returns true, it then calls \u0060TryClaimSplitOrder\u0060. However, the \u0060provisional\u0060 context used for the claim includes \u0060FirstPlanRound: true\u0060 (line 573), which is hardcoded. The original logic used \u0060!_callers.SplitAlreadyOrdered(caller, DateTime.UtcNow)\u0060 to determine if it was the first round. By hardcoding \u0060FirstPlanRound: true\u0060 and then checking \u0060OrdersSplit\u0060 *after* the claim, the code risks claiming a split order for a round that might not actually be the \u0027first\u0027 round in the sequence if the logic for determining \u0027first\u0027 is decoupled from the claim. Specifically, if \u0060OrdersSplit\u0060 returns true based on \u0060provisional\u0060, but the claim fails (e.g., due to race), the system might proceed with a split order that was already claimed by another process, or fail to claim it when it should have. The logic flow is: 1. Create provisional with \u0060FirstPlanRound: true\u0060. 2. Check if \u0060pro\u0060",
+            "fix": "Pass the \u0060provisional\u0060 context to \u0060OrdersSplit\u0060 *after* the claim attempt, or ensure the claim is only attempted if \u0060OrdersSplit\u0060 returns true, to avoid claiming a split order on a round that doesn\u0027t actually issue a split command.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about this code \u0393\u00C7\u00F6 the provisional \u0060FirstPlanRound: true\u0060 is deliberately a \u0027would this round issue a split at all\u0027 probe, the claim is only attempted when it would (exactly the fix the finding proposes), and a failed claim flips \u0060FirstPlanRound\u0060 to false so \u0060GateCommands.For\u0060 issues no split; the reasoning also trails off unfinished."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file system checks in atomic claim logic",
+            "why": "The code performs \u0060File.Exists(file)\u0060 (line 95) and then \u0060File.Delete(file)\u0060 (line 97), followed by \u0060new FileStream(file, ...)\u0060 (line 100). In a high-concurrency environment where multiple servers are checking the same caller, this results in multiple file system calls per claim attempt. While \u0060File.Exists\u0060 is a check, the subsequent \u0060Delete\u0060 and \u0060CreateNew\u0060 operations are expensive. If the file exists and is not expired, the code deletes it and then tries to create a new one. This sequence of operations (check, delete, create) can be optimized by using a single atomic operation or by caching the existence check. In a scenario with 100 concurrent servers checking the same caller, this could lead to 300 file system calls per second, potentially causing I/O contention.",
+            "fix": "Cache the \u0060File.Exists\u0060 result or use a single \u0060File.TryOpen\u0060 pattern to avoid redundant file system calls in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claim is wrong about this code: the delete/CreateNew pair happens at most once per caller per 24 hours (a still-remembered stamp returns early, so the delete only runs on an expired claim), and the imagined 300 filesystem calls per second from 100 concurrent servers on one caller has no basis \u0393\u00C7\u00F6 the existence check is also load-bearing for the atomic claim, not redundant."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:44:55 \u001B[32mINF\u001B[0m] coai-mcp#32076 finding [Blocking/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - Race condition in atomic claim allows duplicate orders on concurrent access (from local) [gating] Round=1 Stage=CodeReview\r | [14:44:55 \u001B[32mINF\u001B[0m] coai-mcp#32076 finding [Major/Ux] src_mcp/src/Server/PanelService.cs:578 - Split order claimed on rounds that may not issue a command (from local) [gating] Round=1 Stage=CodeReview\r | [14:44:55 \u001B[32mINF\u001B[0m] coai-mcp#32076 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file system checks in atomic claim logic (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini",
+    "repeat": 1,
+    "lane": 7,
+    "key": "codex,gemini|split-once|1",
+    "startedUtc": "2026-09-05T14:36:28.4571533Z",
+    "finishedUtc": "2026-09-05T14:38:22.8686357Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 34.1,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 48424,
+        "tokensOut": 4596,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The once-only claim has no crash-safe delivery protocol",
+            "why": "If the process records the claim and is killed before emitting the command, later invocations observe the claim and never issue the required order; if it emits first and dies before recording, a retry issues the order twice.",
+            "fix": "Specify a durable outbox/acknowledgement protocol, or an idempotent command identity and recovery rules, and verify both kill points.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It is an unanchored, generic distributed-systems template \u0393\u00C7\u00F6 no file, line, or concrete claim/command site \u0393\u00C7\u00F6 demanding a whole durable-outbox or idempotency protocol be specified, which nobody can act on or verify as written and is out of proportion to a risk it never demonstrates in this code."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how a caller is distinguished from a piece when both inherit the same session id",
+            "why": "A caller retry on its original branch and a child on a new branch can share the inherited identifier; using the claim alone can classify the retry as a piece and send autonomy instead of suppressing the already-issued split, or classify children as callers and reissue the split.",
+            "fix": "Define and persist an unambiguous caller/child identity using checkout and branch/worktree state, with explicit retry and child-creation transitions.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Without any file, plan text, or code to anchor it, the finding is an abstract speculation about identity semantics in an unnamed design \u0393\u00C7\u00F6 it names no line anyone can check and demands persisted identity machinery whose necessity it never demonstrates."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Fail-open storage errors conflict with the exactly-once requirement",
+            "why": "With the data directory unwritable, a passing plan cannot persist its claim; issuing the command on every retry duplicates it, while suppressing it violates the stated fail-open behavior and loses the required order.",
+            "fix": "Specify the fail-open semantics precisely and add a recoverable fallback (for example, an atomic local marker or idempotent command key) that preserves both warning visibility and retry behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Without any file, line, or code shown, this is a speculative narrative about a hypothetical unwritable data directory and an unstated \u0027exactly-once\u0027 requirement; it names no concrete defect anyone could act on and its proposed fix is generic machinery out of proportion to an unevidenced risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The path-safety constraint does not specify a collision-safe encoding for caller ids",
+            "why": "An id such as \u0060..\\..\\outside\u0060 or \u0060C:\\temp\\x\u0060 can escape a na\u00EFve filename join, while distinct ids such as \u0060a/b\u0060 and \u0060a_b\u0060 can collide and cause one caller to suppress another\u0027s command.",
+            "fix": "Store a fixed-length cryptographic digest of the caller id (or a rigorously defined filename encoding), and verify traversal, separator, Unicode, and collision cases.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Without any file, line, or code shown, this is a generic \u0027hash your identifiers\u0027 template that cannot be checked against the actual code \u0393\u00C7\u00F6 it asserts a traversal/collision risk in a path-building scheme nobody can see, and demands a digest plus a Unicode/collision test matrix for a caller-id suppression file, which is machinery out of proportion to an unverified risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not state when eligibility is evaluated relative to claiming",
+            "why": "If a switch-off or failed-plan invocation creates the once-only record before the no-command gate is applied, a later enabled invocation with a passing plan finds the claim and incorrectly emits nothing.",
+            "fix": "Evaluate switch, verdict, and current-round identity first; claim only inside the single eligible issuance operation, and verify disabled-to-enabled and fail-to-pass retries.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Without any code or plan text to anchor it, the finding is a speculative ordering concern about a hypothetical once-only claim that may not exist as described, and it asks for design ceremony out of proportion to an unverified risk."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true #5: Failing open on an unwritable store recreates infinite recursive plan splitting",
+            "why": "When the backing store is read-only or unwritable, \u0027failing open\u0027 allows the split order to be issued while preventing the claim from being recorded. When child epics return for review, their claim checks also fail open, causing every subsequent epic to repeatedly split into sub-epics with no floor.",
+            "fix": "Fail closed on store write failures by suppressing the split order, issuing the autonomy order (\u0027build as one unit\u0027), and logging a warning that splitting is disabled due to storage errors.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, consequential design gap \u0393\u00C7\u00F6 the store write is the only record that stops a plan re-splitting, so failing open on write failure disables the recursion floor rather than degrading gracefully \u0393\u00C7\u00F6 and it proposes the specific fail-closed behaviour (suppress the split, order \u0027build as one unit\u0027, log why), which is exactly the decision a careful engineer would want made explicitly rather than by default."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "What must be true #6: Tracking sessionless clients across a checkout permanently suppresses splitting for future plans",
+            "why": "When a client exports no CLAUDE_CODE_SESSION_ID, recording the split claim at the checkout level permanently marks that checkout as claimed. Any subsequent, completely unrelated top-level plan reviewed in the same checkout will be misidentified as a child piece and forced to build as one unit.",
+            "fix": "Scope sessionless claim tracking to ephemeral invocation identifiers or parent-child git commit lineage rather than a persistent checkout-wide claim.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "With no file, code, or concrete design shown, the finding rests entirely on an assumed implementation \u0393\u00C7\u00F6 a persistent checkout-wide claim keyed on a missing session id \u0393\u00C7\u00F6 that nothing here establishes exists, so it cannot be acted on or verified."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "What must be true #1 \u0026 Constraints: Atomic claim on issuance misclassifies re-reviewed parent plans as child pieces",
+            "why": "Because evaluating eligibility and claiming the split token is a single atomic action, if a user re-runs plan review on the root plan within the same Claude Code session (e.g. after editing the plan or retrying a failed prompt), the claim is already consumed, causing the parent plan to be told to \u0027build as one unit\u0027 instead of splitting.",
+            "fix": "Key the split claim by the combination of session ID and plan digest, or only treat subsequent rounds as child pieces if evaluated on distinct epic branches.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible failure of a one-shot atomic claim \u0393\u00C7\u00F6 a re-run of plan review on the same root plan consumes the token and the parent is then misrouted as a child piece \u0393\u00C7\u00F6 which is exactly the kind of state-keying decision worth settling before implementation, even if the fix ends up being simpler than the one proposed."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 80,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 209972,
+        "tokensOut": 12969,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 106,
+            "title": "Expired-claim cleanup makes the cross-process claim non-atomic",
+            "why": "The scope requires: \u0022The claim is atomic across processes: two servers sharing a data directory cannot both give it.\u0022 One process can delete an expired file after another process has recreated it with a fresh claim, then create its own claim and issue a duplicate order.",
+            "fix": "Make expiration replacement atomic, for example by claiming with an exclusive create/rename protocol that cannot delete a concurrently refreshed claim.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew sequence is a genuine TOCTOU that breaks the scope\u0027s stated cross-process atomicity at the expiry boundary \u0393\u00C7\u00F6 and it directly falsifies the code\u0027s own comment that \u0027the CreateNew below is the only race there is\u0027, so the author needs either the fix or an honest residual-race note in the header."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 114,
+            "title": "Write failures on a newly created claim are incorrectly treated as another process winning",
+            "why": "The scope requires: \u0022An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0022 If \u0060CreateNew\u0060 succeeds but writing the timestamp fails, the file exists, so this catch returns \u0060false\u0060 without warning and withholds the order.",
+            "fix": "Limit the \u0060File.Exists\u0060 collision handling to the \u0060CreateNew\u0060 operation; route failures during writing or closing through the warning-and-return-true path.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The \u0060when (File.Exists(file))\u0060 filter is genuinely over-broad \u0393\u00C7\u00F6 once \u0060CreateNew\u0060 succeeds the file always exists, so any IOException from the write or the disposing flush is misread as a lost race and silently returns false, contradicting the fail-open contract the method\u0027s own remarks state, and the suggested fix (scope the collision catch to the create) is cheap and precise."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 562,
+            "title": "The split-order condition is asked twice instead of once",
+            "why": "The scope constraint says: \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 \u0060OrdersSplit(provisional)\u0060 is evaluated to decide whether to claim, then \u0060OrdersSplit(context)\u0060 is evaluated again to decide whether the order was issued.",
+            "fix": "Evaluate the predicate once into a local boolean, use that boolean for claiming and logging, and derive the command context from that single decision.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The two calls evaluate different states \u0393\u00C7\u00F6 \u0060provisional\u0060 (should we try to claim?) and \u0060context\u0060 (was the order actually issued after the claim succeeded or failed?) \u0393\u00C7\u00F6 so collapsing them into one boolean as suggested would make the log line fire for orders that were never claimed; the code already satisfies the constraint by routing both questions through the product\u0027s own predicate."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 88,
+            "title": "Expired-claim replacement is not atomic across processes",
+            "why": "Two servers can both read the same expired claim, then one can delete the file after the other has created a fresh claim. Both can subsequently create a claim and return true, causing both to issue the split instruction despite the exactly-one requirement.",
+            "fix": "Serialize expiry replacement with an OS-level lock, or use an atomic replacement protocol that never deletes a newly created claim.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew path really can let two servers both claim a caller \u0393\u00C7\u00F6 and it directly refutes the code\u0027s own comment that \u0022the CreateNew below is the only race there is\u0022, which is precisely the residual-window statement this codebase\u0027s reliability rule requires to be honest, even if the proposed OS-lock fix is heavier than the soft consequence warrants."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "A write failure after claim-file creation incorrectly suppresses the split order",
+            "why": "If the disk fills while StreamWriter writes the timestamp, the CreateNew file remains present and the IOException filter returns false because File.Exists(file) is true. The caller therefore receives no order and no warning, contrary to the required fail-open behavior.",
+            "fix": "Track whether this process successfully completed the write; on any create/write failure, remove only its own incomplete claim and return true with a warning.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a real path \u0393\u00C7\u00F6 an IOException while flushing the write, after CreateNew has already put the file on disk \u0393\u00C7\u00F6 where the \u0060when (File.Exists(file))\u0060 filter misreads the failure as \u0027somebody else claimed it\u0027 and returns false with no warning, silently violating the fail-open contract the method\u0027s own remarks declare, and the fix is a few lines rather than disproportionate machinery."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 110,
+            "title": "Unsynchronized deletion of expired claim files creates a TOCTOU race allowing multiple concurrent callers to claim split orders",
+            "why": "When a claim file exists but has expired (or was created \u003E 24h ago), \u0060StillRemembered\u0060 returns false. Multiple concurrent processes or threads reach lines 109-113 simultaneously, where \u0060File.Delete(file)\u0060 is called non-atomically before \u0060new FileStream(file, FileMode.CreateNew, ...)\u0060. If Process A creates the file with \u0060CreateNew\u0060 while Process B executes \u0060File.Delete(file)\u0060, Process B deletes Process A\u0027s freshly created claim and successfully creates its own claim with \u0060FileMode.CreateNew\u0060. Both processes return \u0060true\u0060, violating the mutual exclusion / single claim guarantee.",
+            "fix": "Instead of uncoordinated \u0060File.Delete(file)\u0060 followed by \u0060CreateNew\u0060, write claims to a uniquely named temporary file in the same directory and replace atomically using \u0060File.Move\u0060 with overwrite or atomic filesystem locks, or check timestamp inside a file lock/mutex.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew sequence really is a second race window, which directly refutes the code\u0027s own comment that \u0022the CreateNew below is the only race there is\u0022 \u0393\u00C7\u00F6 and this repository\u0027s reliability rule requires a lock to state its residual race honestly in its header, so a wrong claim there is worth correcting even though the consequence (one repeated instruction) is soft and the Major severity is overstated."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 120,
+            "title": "Exception filter in TryClaimSplitOrder misclassifies other IOExceptions as race collisions if the target file happens to exist",
+            "why": "At line 120, \u0060catch (IOException) when (File.Exists(file))\u0060 assumes that any \u0060IOException\u0060 occurring while \u0060File.Exists(file)\u0060 is true is exclusively a \u0060FileMode.CreateNew\u0060 already-exists collision. However, if another \u0060IOException\u0060 occurs (such as sharing violation, locked file, disk full, or bad file descriptor) while a stale or existing claim file is present on disk, it is caught and treated as \u0060return false\u0060 (another process won the race) rather than failing open with a warning to \u0060warn\u0060 as intended by the reliability specification.",
+            "fix": "Catch \u0060IOException\u0060 and check whether the exception was specifically thrown by \u0060FileMode.CreateNew\u0060 due to file existence (e.g., checking HResult or using \u0060catch (IOException e) when (e is not ... \u0026\u0026 File.Exists(file))\u0060 or restructuring stream creation).",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The broad \u0060when (File.Exists(file))\u0060 filter swallows any post-creation IOException \u0393\u00C7\u00F6 a failed delete of a stale claim, a write that fails on a full disk \u0393\u00C7\u00F6 as \u0027somebody else won the race\u0027, so the file\u0027s explicitly documented fail-open-with-a-warning path is only reachable when the file does not exist, which is a real gap between the stated contract and the code and is fixable simply by scoping the race catch to the CreateNew itself."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:38:22 \u001B[32mINF\u001B[0m] coai-mcp#22276 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - A write failure after claim-file creation incorrectly suppresses the split order (from codex) [gating] Round=1 Stage=CodeReview\r | [14:38:22 \u001B[32mINF\u001B[0m] coai-mcp#22276 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:110 - Unsynchronized deletion of expired claim files creates a TOCTOU race allowing multiple concurrent callers to claim split orders (from gemini) [gating] Round=1 Stage=CodeReview\r | [14:38:22 \u001B[32mINF\u001B[0m] coai-mcp#22276 finding [Minor/Reliability] src_mcp/src/Server/CallerSessions.cs:120 - Exception filter in TryClaimSplitOrder misclassifies other IOExceptions as race collisions if the target file happens to exist (from gemini) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini",
+    "repeat": 2,
+    "lane": 5,
+    "key": "codex,gemini|split-once|2",
+    "startedUtc": "2026-09-05T14:36:42.4609322Z",
+    "finishedUtc": "2026-09-05T14:38:25.969941Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 31.1,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 32576,
+        "tokensOut": 5058,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open unwritable-store requirement contradicts the cross-process atomic-claim guarantee.",
+            "why": "When two servers run with an unwritable shared store, both must either proceed without recording a claim or issue the command despite being unable to claim it; a retry after permissions are restored can therefore issue the split order twice, violating the stated atomicity.",
+            "fix": "Define the guarantee as conditional on a writable store, or fail closed for the command when claiming cannot be durably completed; specify and verify the chosen behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a genuine contradiction between two stated requirements \u0393\u00C7\u00F6 fail-open on an unwritable store versus a cross-process atomic claim \u0393\u00C7\u00F6 and points at a concrete duplicate-command failure, which is exactly the kind of specification gap a reviewer should surface before implementation."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define crash recovery between claiming and issuing the command.",
+            "why": "If the process persists the claim and is killed before emitting the command, the caller is permanently told not to split even though no order was delivered; if it emits first and is killed before persisting the claim, a retry can emit the order twice.",
+            "fix": "Specify a durable state machine or idempotent delivery protocol covering claim, emission, retry, and recovery, and test both kill points.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete two-sided crash window with both kill points and their distinct consequences \u0393\u00C7\u00F6 a stranded claim that permanently suppresses the split, and a duplicated order on retry \u0393\u00C7\u00F6 which is exactly the in-flight-state recovery a plan must decide before implementation rather than after."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Sessionless tracking across branch changes has no identity or lifecycle algorithm.",
+            "why": "With no session id, a checkout that reviews plan A on one branch and plan B on another cannot distinguish a continuation from a new caller; inheriting the old record suppresses a valid split, while replacing it allows the same caller to split repeatedly.",
+            "fix": "Define the checkout identity, branch-transition correlation, record expiry/reset rules, and behavior for concurrent or reused checkouts, then cover those cases in acceptance checks.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It demands a full identity/lifecycle specification for a sessionless tracking scheme without pointing at any actual code path or a concrete failure, so it reads as speculative architecture ceremony rather than a defect anyone can act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The requirement to use the verdict from this review round has no round or input binding.",
+            "why": "A prior failed review can leave a non-split record, then a later passing review of the same caller can incorrectly produce no command; conversely, a prior passing verdict can be reused after the plan changes and trigger an order for a plan that was not reviewed this round.",
+            "fix": "Persist and compare an explicit review-round identifier or canonical plan/verdict input hash, and define invalidation before any claim is made.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding is written in abstract, self-referential terms about \u0022the verdict from this review round\u0022 with no file, symbol, or code path, and its stated failure modes (stale non-split records, reused passing verdicts) cannot be tied to anything concrete an engineer could act on \u0393\u00C7\u00F6 it asks for round identifiers and input hashes without showing the code that lacks them."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "What must be true (Item 1): Scoping split claims strictly to CLAUDE_CODE_SESSION_ID blocks subsequent independent plans within the same CLI session",
+            "why": "Claude Code preserves a single CLAUDE_CODE_SESSION_ID for the entire duration of an interactive CLI process across multiple sequential user prompts. After the first plan splits, the claim is permanently recorded for that session ID; any subsequent, unrelated plan generated later in the same user session will be erroneously treated as an already-split piece and denied the split command.",
+            "fix": "Key the split claim on a composite identifier combining the caller session ID with a stable hash or identifier of the root plan being reviewed.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete lifecycle mismatch \u0393\u00C7\u00F6 a session ID that persists across many independent plans versus a one-shot split claim keyed on it \u0393\u00C7\u00F6 which would silently deny legitimate splits later in the same CLI session, and it proposes a specific composite key fix."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true (Item 5): Failing open on an unwritable store re-introduces infinite epic-splitting recursion",
+            "why": "When the shared storage directory is unwritable (e.g., read-only filesystem or restricted permissions), failing open causes every gate execution on every child branch to treat the split order as unclaimed, repeatedly commanding child epics to split into further epics and directly recreating the unbounded recursion loop.",
+            "fix": "Fail closed on store write failures by emitting a warning and defaulting to the autonomy order (single unit) instead of issuing recurring split orders.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete failure mode \u0393\u00C7\u00F6 a fail-open on an unwritable claim store turning the split-order guard into an unbounded epic-splitting loop \u0393\u00C7\u00F6 and names the safer default, which is exactly the kind of reliability decision an engineer would want to make deliberately rather than by accident."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "What must be true (Item 6): Repository/checkout-level fallback without a session ID permanently suppresses future plan splits across the workspace",
+            "why": "When a client exports no session ID, tracking state across branches at the checkout level without an explicit session boundary or lifetime causes the claim to linger indefinitely, permanently blocking plan splits for any future development work in that checkout.",
+            "fix": "Specify a bounded fallback mechanism for callers without session IDs (e.g., parent process group ID or an ephemeral claim file with a short TTL) rather than unbounded checkout-wide persistence.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete lifecycle hole \u0393\u00C7\u00F6 a checkout-scoped claim with no session boundary or TTL never expires and silently blocks all future plan splits in that checkout \u0393\u00C7\u00F6 and proposes a bounded alternative, which is exactly what a designer would want to fix before implementing."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 72.2,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 285324,
+        "tokensOut": 12623,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 96,
+            "title": "Expired-claim replacement is not atomic across processes",
+            "why": "When an old claim expires, two servers can both pass the initial check; one deletes and recreates the file, while the other deletes that fresh claim and recreates it too. Both return true and issue the split order, so concurrent callers can restart the split loop.",
+            "fix": "Use an atomic replacement/locking protocol that cannot delete a newly created claim between the stale check and claim creation.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew sequence genuinely defeats the atomicity the code claims \u0393\u00C7\u00F6 a second process that passed the stale check can delete the winner\u0027s fresh claim and create its own, so both return true \u0393\u00C7\u00F6 and the inline comment (\u0027the CreateNew below is the only race there is\u0027) asserts the opposite, which is exactly the unstated residual race the repo\u0027s own reliability rule forbids; even though the practical cost is one duplicated instruction, an engineer would want the false claim corrected."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Unconditional deletion of existing claim files causes a race condition where concurrent callers delete fresh claims and both receive split orders",
+            "why": "When two server instances call TryClaimSplitOrder concurrently, both can evaluate StillRemembered as false before any file is written. The first server creates and writes the claim file. The second server then executes File.Delete(file), deleting the first server\u0027s newly created valid claim, and proceeds with FileMode.CreateNew which succeeds. Both servers return true, violating the requirement that exactly one server atomically claims the split order.",
+            "fix": "Do not delete existing files prior to FileMode.CreateNew. Attempt to create the file atomically first, and only inspect or replace an existing file if creation fails due to an already existing file that is verified to be expired under synchronization.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional File.Delete does break the CreateNew atomicity the code explicitly claims on line 111 \u0393\u00C7\u00F6 a second caller that read a null stamp before the first wrote can delete the fresh claim and re-create it, so both are told the order is theirs; the window is narrow (FileShare.None covers only the moment the writer holds the handle) and the cost is a duplicated instruction rather than the Blocking severity suggests, but the defect is real, precisely located, and the fix (CreateNew first, delete only a verified-expired file, then retry) is cheap."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 123,
+            "title": "Catch filter assumes any IOException where the file exists is a concurrent claim, failing closed on disk and I/O errors",
+            "why": "If an expired claim file exists and an I/O error occurs during write operations (e.g. read-only filesystem, disk full, or write-permission failure during creation/open), catch (IOException) when (File.Exists(file)) matches because File.Exists(file) evaluates to true for the pre-existing file. The method returns false without invoking the warning callback, violating the fail-open requirement on unwritable storage.",
+            "fix": "Differentiate between an error caused specifically by the file already existing on FileMode.CreateNew versus general write/disk IOExceptions, ensuring storage write errors invoke warn and return true.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The \u0060when (File.Exists(file))\u0060 filter cannot tell \u0027another process won the race\u0027 from \u0027we created the file and then failed to write it, or could not delete a stale one\u0027, so the fail-open guarantee this file explicitly documents silently becomes fail-closed with no warning \u0393\u00C7\u00F6 the finding\u0027s premise about the *pre-existing* file is imprecise (line 112 deletes it first), but the defect and the fix it points at are real."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:38:25 \u001B[32mINF\u001B[0m] coai-mcp#12512 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:96 - Expired-claim replacement is not atomic across processes (from codex) [gating] Round=1 Stage=CodeReview\r | [14:38:25 \u001B[32mINF\u001B[0m] coai-mcp#12512 finding [Blocking/Reliability] src_mcp/src/Server/CallerSessions.cs:113 - Unconditional deletion of existing claim files causes a race condition where concurrent callers delete fresh claims and both receive split orders (from gemini) [gating] Round=1 Stage=CodeReview\r | [14:38:25 \u001B[32mINF\u001B[0m] coai-mcp#12512 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:123 - Catch filter assumes any IOException where the file exists is a concurrent claim, failing closed on disk and I/O errors (from gemini) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,local|split-once|1",
+    "startedUtc": "2026-09-05T14:36:58.27613Z",
+    "finishedUtc": "2026-09-05T14:41:35.1470296Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 45.3,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 9,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 15236,
+        "tokensOut": 3322,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open unwritable-store requirement contradicts the cross-process atomic-claim guarantee.",
+            "why": "If the store is unwritable and two server processes both warn and continue, neither can record a claim, so both issue the autonomy order; this violates the explicit single-claim guarantee.",
+            "fix": "Define failure behavior that preserves exclusivity\u2014such as refusing to issue the command when claiming is unavailable\u2014or specify an alternative durable coordination mechanism.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a genuine contradiction between two stated requirements \u0393\u00C7\u00F6 a fail-open on an unwritable store cannot coexist with a cross-process single-claim guarantee \u0393\u00C7\u00F6 and names the decision the spec must make, which is exactly what a reviewer holding the scope should catch."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "A process killed after claiming but before emitting the command can permanently lose the order.",
+            "why": "Process A records the claim and is terminated before sending the command; a retry sees the claim and suppresses the order, so the caller is never instructed to act.",
+            "fix": "Use a transactional outbox or a reclaimable lease with an explicit emitted/completed state, and specify recovery after interruption.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, actionable failure \u0393\u00C7\u00F6 a claim persisted before the effect is emitted, with no reclaim or sweep, so a kill in that window silently drops the work forever \u0393\u00C7\u00F6 which is precisely the interrupted-claim guarantee this codebase\u0027s reliability rules require, and it offers a proportionate fix (a reclaimable lease with an explicit emitted state) alongside the heavier outbox option."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback has no defined identity or lifecycle for distinguishing checkouts and tasks.",
+            "why": "Without a session ID, a review on branch A followed by branch B must be associated with one checkout, but two tasks using the same checkout or a reused checkout a year later can inherit the old state and incorrectly skip splitting or receive autonomy instructions.",
+            "fix": "Define a durable per-checkout identity, its storage key and cleanup/expiration rules, and how concurrent tasks or worktrees are isolated without caller-supplied identifiers.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It demands a durable per-checkout identity scheme, storage keys, expiration and worktree isolation for a fallback path, which is machinery well out of proportion to the risk and is speculative without any code cited to show the fallback actually persists state across tasks."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not bind the split verdict to the exact plan text reviewed in the current round.",
+            "why": "A plan passes review, is changed during a resolve/retry step, and then the persisted pass is reused; the system can issue a split order for text that was never given the passing verdict, violating the current-round requirement.",
+            "fix": "Persist the reviewed plan\u0027s content hash or round token and require it to match the plan being acted on before claiming and issuing the order.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete staleness hole \u0393\u00C7\u00F6 a persisted passing verdict being reused after the plan text changed, so an order can be issued for text no reviewer approved \u0393\u00C7\u00F6 and proposes a proportionate fix (a content hash or round token checked before acting), which is exactly the kind of binding a careful engineer would want specified before implementation."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The document specifies invariants but no implementation points, state schema, command boundary, or acceptance checks.",
+            "why": "One implementer could key claims by branch while another keys them by checkout, and neither has a defined observable check for the off, failed-verdict, race, or retry cases; the resulting implementations can disagree while appearing to satisfy the prose.",
+            "fix": "Name the integration boundary, persisted fields and transitions, safe caller-ID encoding, and concrete acceptance scenarios for each invariant before implementation begins.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "For a plan document under review, the absence of a named integration boundary, persisted state and transitions, and observable acceptance checks per invariant is a real gap that lets two implementers key the same claim differently and both appear compliant \u0393\u00C7\u00F6 exactly what a plan round exists to catch."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The concern is misconceived: children inherit environment variables by default, and an atomic claim on the shared data directory excludes a second holder regardless of which identity string each process carries, so the described \u0027two processes both believe they are sole caller\u0027 race does not follow \u0393\u00C7\u00F6 and the proposed fix (a shared lock file in the data directory) is just a restatement of the atomic claim the plan already specifies."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents an unbounded recursion hazard from a plan phrase without any code or state machine to point at, and \u0027infinite epic splitting until token limits\u0027 is speculative alarm rather than a defect a careful engineer could act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a speculative re-run-a-year-later scenario against a constraint that deliberately scopes the verdict to the plan under review, and then asks for split-depth metadata tracking that is disproportionate machinery for a risk it never demonstrates in the code."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a failure mode from a misreading \u0393\u00C7\u00F6 \u0027a caller is ordered to split ONCE\u0027 is the plan\u0027s own guard against re-splitting, and the finding treats the AI-facing instruction as an unguarded user command, then demands a preview mechanism for a hierarchy-depth risk the plan already forecloses."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It flags the behavior the scope explicitly mandates as a constraint (\u0027fails OPEN with a warning\u0027) as if it were a defect, and its proposed fix \u0393\u00C7\u00F6 a split-depth check in plan review \u0393\u00C7\u00F6 has nothing to do with an unwritable store, so there is nothing actionable here."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 231.5,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 192378,
+        "tokensOut": 8502,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 576,
+            "title": "The split predicate is evaluated twice instead of once",
+            "why": "The written constraint says: \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 This code calls \u0060GateCommands.OrdersSplit\u0060 once before claiming and again after constructing the context, so the issuing and claiming decisions are not based on one predicate evaluation.",
+            "fix": "Evaluate \u0060OrdersSplit(provisional)\u0060 once, store the result, and reuse that value both to decide whether to claim and whether to log the split order.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The two calls evaluate different values \u0393\u00C7\u00F6 \u0060OrdersSplit(provisional)\u0060 decides whether to claim, \u0060OrdersSplit(context)\u0060 reflects whether the order actually survived the claim \u0393\u00C7\u00F6 so caching the first result would log a split order even when \u0060TryClaimSplitOrder\u0060 refused it, making the suggested fix a regression rather than a cleanup."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 106,
+            "title": "Concurrent claims can delete a live claim and let multiple processes issue the split order",
+            "why": "When an existing claim is expired, two servers can both pass the initial check; one can create the new claim, while the other executes \u0060File.Delete(file)\u0060 against that newly created file and then also succeeds with \u0060CreateNew\u0060. Both return true, violating the atomic one-order guarantee and reintroducing repeated split instructions.",
+            "fix": "Protect the expiry check, deletion, and creation with an inter-process lock, or use a claim protocol that never deletes a file another process may have created.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew sequence really does break the atomicity the method advertises \u0393\u00C7\u00F6 two processes meeting an expired claim can each delete the other\u0027s fresh file and both return true \u0393\u00C7\u00F6 which directly falsifies the code\u0027s own comment that CreateNew is \u0027the only race there is\u0027, even if the practical cost is a single repeated instruction and the suggested inter-process lock is heavier than the fix needs to be."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "Nullable callback parameter risks NullReferenceException",
+            "why": "The method signature \u0060Action\u003Cstring\u003E? warn = null\u0060 allows the caller to omit the argument. If the code path reaches \u0060warn?.Invoke\u0060 (line 117) and the caller passed \u0060null\u0060 explicitly or the default was not handled correctly in a specific call site, the warning logic could fail silently or throw if the null check is bypassed in a future refactor. More critically, the test \u0060AnUnwritableStore_GivesTheOrderRatherThanSwallowingIt\u0060 passes a lambda, but \u0060PanelService\u0060 (line 583) passes a lambda. However, the method signature change from \u0060RecordSplitOrder\u0060 to \u0060TryClaimSplitOrder\u0060 introduces a new optional parameter that was not present in the original API contract, potentially breaking callers that rely on positional arguments or implicit defaults if not careful.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 or ensure the caller passes a non-null delegate. The current implementation invokes \u0060warn?.Invoke\u0060 without guaranteeing the caller provides one, risking a \u0060NullReferenceException\u0060 if called without the argument.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is factually wrong about C#: \u0060warn?.Invoke\u0060 is a null-conditional call that cannot throw on a null delegate, the optional parameter is the standard idiom for an opt-out warning sink, and the speculation about breaking positional callers is incoherent for a trailing optional argument."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Inconsistent handling of optional warning callback",
+            "why": "The method \u0060TryClaimSplitOrder\u0060 accepts an optional \u0060warn\u0060 callback. While the code uses \u0060warn?.Invoke\u0060, the logic inside the \u0060catch (Exception e)\u0060 block assumes the callback might be null. If a caller passes \u0060null\u0060 explicitly, the warning is swallowed. The rule requires \u0027a warning rather than silently disabling\u0027, but if the callback is null, the warning is silent.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked with a consistent message format or handle the case where \u0060warn\u0060 is null more explicitly if the design requires it to be optional.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is confused \u0393\u00C7\u00F6 \u0060warn\u0060 is optional by design and every call site in the fail-open path already passes a logger; a null callback is the caller\u0027s explicit choice to discard the warning, not a defect, and the suggested fix names no concrete change."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Inconsistent state propagation for FirstPlanRound",
+            "why": "The code sets \u0060FirstPlanRound: true\u0060 on \u0060provisional\u0060. Then it checks \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060. If true, it creates a new \u0060context\u0060 with \u0060FirstPlanRound\u0060 set to the result of \u0060TryClaimSplitOrder\u0060. If false, it uses \u0060provisional\u0060 as \u0060context\u0060. This means if the order is not split, \u0060FirstPlanRound\u0060 remains true. If the order is split, \u0060FirstPlanRound\u0060 becomes the boolean result of the claim. This logic is complex and potentially confusing, but more importantly, it deviates from the rule that \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The code asks \u0060OrdersSplit\u0060 twice (once for \u0060provisional\u0060, once for \u0060context\u0060 implicitly via the \u0060if\u0060 block) or relies on the state of \u0060provisional\u0060 being consistent.",
+            "fix": "The variable \u0060provisional\u0060 is created but then immediately used to create \u0060context\u0060. The logic \u0060FirstPlanRound: true\u0060 is set on \u0060provisional\u0060, but then \u0060context\u0060 is created from \u0060provisional\u0060 only if \u0060OrdersSplit\u0060 returns true. This creates a potential inconsistency where \u0060FirstPlanRound\u0060 might be true in \u0060provisional\u0060 but false in \u0060context\u0060 if the condition fails, or vice versa depending on the flow.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It restates the code\u0027s deliberate, already-commented claim-once pattern as a defect without identifying any behavioural problem \u0393\u00C7\u00F6 the second \u0060OrdersSplit\u0060 call is on \u0060context\u0060 (asking whether the claim succeeded, for logging), and \u0060FirstPlanRound\u0060 staying true when no split is ordered is inert since \u0060For\u0060 won\u0027t issue the order anyway \u0393\u00C7\u00F6 and its \u0027fix\u0027 offers no change at all."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Violation of \u0027ONE question asked once\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to decide whether to claim, but then calls \u0060Core.Commands.GateCommands.OrdersSplit(context)\u0060 again in the \u0060if\u0060 block to log. This is two questions. The logging should be based on the result of the claim, not a re-evaluation of the condition.",
+            "fix": "Align the logic to ensure the \u0027one question\u0027 rule is strictly followed. The \u0060OrdersSplit\u0060 check should be the sole determinant for both issuing and claiming.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The two \u0060OrdersSplit\u0060 calls take different arguments for different purposes \u0393\u00C7\u00F6 the first asks whether to spend a claim, the second asks whether the post-claim context actually issues the order, so the log fires only when a split is really ordered; the finding misreads a deliberate before/after evaluation as a duplicated condition."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Redundant or confusing exception handling",
+            "why": "The code has \u0060catch (IOException)\u0060 for the race condition and \u0060catch (Exception e) when (e is IOException or UnauthorizedAccessException)\u0060 for the \u0027fail open\u0027 case. The second catch block is technically redundant because \u0060IOException\u0060 is already caught by the first block. The logic flow suggests the first catch is for the race (file exists), and the second is for other IO errors. However, the \u0060when\u0060 clause in the second catch makes it specific to \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060, which might overlap with the first catch if the order of evaluation is not clear.",
+            "fix": "The \u0060catch (Exception e)\u0060 block catches \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060 specifically, but the outer \u0060catch (IOException)\u0060 handles the race condition. The inner catch for \u0060Exception\u0060 might be redundant or confusing.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is simply wrong about the code: the first catch is filtered by \u0060when (File.Exists(file))\u0060, so a non-race IOException falls through to the second catch by C#\u0027s well-defined top-to-bottom clause evaluation \u0393\u00C7\u00F6 nothing is redundant, and the finding itself only hedges that it \u0027might be\u0027."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Warning message clarity",
+            "why": "The warning message \u0027the split-order memory at {Dir} could not be written ({e.Message}) \u2014 the order is being given, and may be given again\u0027 is clear, but the rule requires \u0027a warning rather than silently disabling\u0027. If \u0060warn\u0060 is null, the warning is silent. The rule implies a warning *must* be issued, so the \u0060warn\u0060 parameter should perhaps be required or a default logger used.",
+            "fix": "Ensure the \u0060warn\u0060 callback is invoked with a message that clearly indicates the \u0027fail open\u0027 nature.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The optional \u0060warn\u0060 callback is a deliberate injection seam whose null case is the caller\u0027s choice, and the finding\u0027s own \u0027fix\u0027 \u0393\u00C7\u00F6 invoke warn with a clear message \u0393\u00C7\u00F6 is already exactly what the code does, so it names nothing to change."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 913,
+            "title": "Change in fallback logic for anonymous clients",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The previous implementation used \u0060session.State.SessionId\u0060 (which is repo\u002Bbranch), causing every epic to be treated as a new caller. The new implementation uses \u0060session.State.RepoPath\u0060, which correctly follows the caller across branches. This is a compliance fix, but it changes the behavior significantly.",
+            "fix": "The \u0060CallerFor\u0060 method now uses \u0060session.State.RepoPath\u0060 instead of \u0060session.State.SessionId\u0060. This is a change in the fallback logic.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It merely restates what the diff and the method\u0027s own doc comment already explain \u0393\u00C7\u00F6 that the anonymous fallback keys on the checkout rather than the session \u0393\u00C7\u00F6 without alleging a defect, a risk, or any change the author should make."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "API contract change from void to bool",
+            "why": "The method signature changed from \u0060void RecordSplitOrder\u0060 to \u0060bool TryClaimSplitOrder\u0060. This is a breaking change for any caller that relied on the void return. However, the rule requires \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The new return value allows the caller to know if the claim succeeded, which is necessary for the \u0027fail open\u0027 logic.",
+            "fix": "The \u0060TryClaimSplitOrder\u0060 method now returns a \u0060bool\u0060 indicating success, whereas \u0060RecordSplitOrder\u0060 was \u0060void\u0060. This is a change in the API contract.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It flags a signature change on an internal, single-consumer method as an \u0027API contract change\u0027 without naming any broken caller, and its own text concedes the bool return is necessary \u0393\u00C7\u00F6 so it reports what the diff already shows and asks for nothing."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Atomic claim race window created by pre-delete of expired file",
+            "why": "The code deletes an existing file (\u0060File.Delete(file)\u0060) before attempting \u0060FileMode.CreateNew\u0060. If a second server process checks \u0060StillRemembered\u0060 (returns false), then deletes the file, then attempts \u0060CreateNew\u0060 while the first process is still deleting, the second process\u0027s \u0060CreateNew\u0060 will succeed. This allows two servers to both believe they claimed the order, violating the atomicity guarantee required to prevent \u0027epics of epics\u0027 loops.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call to a separate \u0060if\u0060 block before the \u0060try\u0060 block, or wrap the delete in its own try-catch to ensure the atomic \u0060CreateNew\u0060 is not shadowed by a delete failure.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "The pre-delete genuinely breaks the atomicity the adjacent comment claims \u0393\u00C7\u00F6 a process holding a stale \u0027expired\u0027 read can delete a claim another process just created and then CreateNew successfully, so both return true \u0393\u00C7\u00F6 and that false invariant is worth knowing even though the suggested fix (moving or wrapping the delete) would not close the window and the practical cost is one duplicated split order."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 92,
+            "title": "Path traversal vulnerability in caller identity file naming",
+            "why": "The \u0060caller\u0060 string is used directly to construct a file path via \u0060FileFor(caller)\u0060. If a malicious or misbehaving client passes a \u0060caller\u0060 value like \u0060../../etc/passwd\u0060 or \u0060..\\..\\windows\\system32\u0060, the code could write to or overwrite arbitrary files on the server\u0027s filesystem, potentially overwriting configuration or log files, or creating a symlink to a sensitive file.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., remove or replace \u0060..\u0060, \u0060/\u0060, \u0060\\\u0060, and control characters) before using it in \u0060FileFor(caller)\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about this code \u0393\u00C7\u00F6 \u0060FileFor\u0060 never interpolates the caller into the path; it uses a SHA-256 hex digest, so \u0060../\u0060 can never survive into the file name."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Potential deadlock or hang if file delete is blocked",
+            "why": "If the file to be deleted is locked by another process (e.g., an antivirus scanner or a previous crashed instance), \u0060File.Delete\u0060 will block or throw an exception. If it throws, the \u0060CreateNew\u0060 might not execute, or if it hangs, the server thread blocks. The current catch block only handles \u0060IOException\u0060 from \u0060CreateNew\u0060, not from the delete.",
+            "fix": "Add a timeout to the \u0060File.Delete\u0060 operation or ensure the \u0060try\u0060 block covers the delete operation as well, or use a more robust locking mechanism (e.g., \u0060FileLock\u0060 or \u0060Mutex\u0060) instead of relying solely on \u0060CreateNew\u0060 after a delete.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is wrong about the code: \u0060Directory.CreateDirectory\u0060, \u0060File.Exists\u0060 and \u0060File.Delete\u0060 are all inside the \u0060try\u0060 at line 108 and are already covered by both catch clauses, and \u0060File.Delete\u0060 throws rather than hanging, so neither the uncovered-delete claim nor the deadlock it postulates exists."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Silent failure of split order claim obscures state",
+            "why": "When \u0060TryClaimSplitOrder\u0060 returns \u0060false\u0060 (e.g., due to a race or unwritable store), the code proceeds to use the \u0060provisional\u0060 context without explicitly logging or signaling that the claim failed. A user or downstream process might expect the split order to be active, but it was silently skipped, leading to confusion about why the split didn\u0027t occur.",
+            "fix": "Add a specific log entry or return value indicating that the split order was claimed, and ensure the UI or downstream process reflects this state change immediately.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claim already takes a warning callback (\u0060message =\u003E _log.Warning(...)\u0060) and a successful order is logged at Information one line below, so the alleged silence does not exist \u0393\u00C7\u00F6 and a \u0060false\u0060 return is the intended once-per-caller outcome, not a failure to surface."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file existence check before atomic create",
+            "why": "The code checks \u0060File.Exists(file)\u0060 before attempting \u0060FileMode.CreateNew\u0060. While this is intended to handle expired claims, it adds an extra disk I/O operation. In high-frequency scenarios (e.g., many concurrent splits), this check could become a bottleneck, especially if the file system is slow or the directory is large.",
+            "fix": "Cache the \u0060File.Exists(file)\u0060 check result or use a more efficient file system operation to avoid redundant disk I/O in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The File.Exists check exists to clear an expired claim so CreateNew can succeed \u0393\u00C7\u00F6 removing or caching it would break correctness \u0393\u00C7\u00F6 and framing one stat call on a path that runs at most once per caller per 24 hours as a performance bottleneck is wrong about this code."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:41:35 \u001B[32mINF\u001B[0m] coai-mcp#22288 finding [Minor/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - Potential deadlock or hang if file delete is blocked (from local) Round=1 Stage=CodeReview\r | [14:41:35 \u001B[32mINF\u001B[0m] coai-mcp#22288 finding [Minor/Ux] src_mcp/src/Server/PanelService.cs:578 - Silent failure of split order claim obscures state (from local) Round=1 Stage=CodeReview\r | [14:41:35 \u001B[32mINF\u001B[0m] coai-mcp#22288 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file existence check before atomic create (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,local",
+    "repeat": 2,
+    "lane": 4,
+    "key": "codex,local|split-once|2",
+    "startedUtc": "2026-09-05T14:37:11.6075153Z",
+    "finishedUtc": "2026-09-05T14:46:48.7799081Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 54.6,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 15230,
+        "tokensOut": 3230,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The claim protocol has no recovery semantics for a process killed after claiming a split.",
+            "why": "If server A atomically claims a passing plan and is killed before returning or executing the command, the persisted claim can suppress every retry, so the required split never happens; if the claim is made retryable, two servers can issue the command unless lease/ownership behavior is defined.",
+            "fix": "Specify the claim state machine and recovery policy (for example, an expiring lease plus idempotent claim/command identity), and verify kill-before-return, timeout, and retry sequences.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding names no file, quotes no code, and asks for a full lease/idempotency state machine on a claim protocol whose existence and semantics it never establishes \u0393\u00C7\u00F6 it is speculative machinery rather than a defect anyone can act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open unwritable-store requirement contradicts the exactly-once requirement without defining the safe behavior.",
+            "why": "With the switch on and a passing plan, two servers whose shared store is read-only would both be unable to record a claim; if they proceed as \u201Copen,\u201D both issue the split command, violating the atomic cross-process guarantee, while refusing the command would not be fail-open.",
+            "fix": "Define the precedence explicitly: either fail-open means continue without deduplication and relax exactly-once, or fail the gate/command closed when claiming is unavailable; add the corresponding warning and concurrent-server acceptance case.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a genuine contradiction between two stated requirements \u0393\u00C7\u00F6 fail-open on an unwritable claim store versus an exactly-once cross-process guarantee \u0393\u00C7\u00F6 and asks for the precedence to be decided, which is exactly the kind of unspecified behavior that a reviewer with the scope in hand should catch before implementation."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id branch-following mechanism is unspecified and cannot distinguish the required checkout scope.",
+            "why": "A client without \u0060CLAUDE_CODE_SESSION_ID\u0060 can review on branch \u0060feature-a\u0060, then return on \u0060feature-b\u0060 in the same checkout; a repo/branch key creates separate claims, while a repo-only key incorrectly suppresses an independent checkout or worktree, so the promised continuity has no implementable identity definition.",
+            "fix": "Specify how a checkout identity is derived and persisted, including branch changes, multiple worktrees/clones, copied directories, and concurrent clients, and define the key used for claims.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a genuine underspecification \u0393\u00C7\u00F6 a fallback identity for claim/continuity has to define its key, and repo-vs-branch-vs-worktree ambiguity produces real cross-checkout collisions or lost continuity, which is exactly the kind of gap a reviewer should force a decision on before implementation."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how the verdict from the current review round is bound to the split decision.",
+            "why": "If a prior round stored a passing verdict and the resolve loop later reviews a changed plan that fails (or reviews a new plan that passes), a consumer that reads the persisted/latest verdict can issue or suppress the command based on the wrong round; \u201CTHIS round\u201D alone gives no data contract or ordering rule.",
+            "fix": "Require the verdict to carry a review invocation ID and plan content/version (or equivalent immutable round key), and state that only the verdict returned by the current gate invocation may authorize the claim.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a distributed-consistency problem for what is a single synchronous gate invocation \u0393\u00C7\u00F6 \u0027the verdict from this round\u0027 is already unambiguous to the caller holding it, and demanding invocation IDs and plan version keys is machinery far out of proportion to a risk the finding never shows can occur."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The filename-safety constraint does not specify protection against filesystem link and path-length edge cases.",
+            "why": "A caller-controlled ID such as \u0060../../outside\u0060 may be encoded safely but still collide with an existing symlink named for that encoding, causing a file write outside the store; an extremely long ID can also make claim creation fail and enter the unspecified fail-open path.",
+            "fix": "Use a fixed-length cryptographic key rather than raw caller text, create the store with no-follow/atomic primitives (or equivalent), and define bounded-ID and collision handling before command issuance.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about symlink collisions and unbounded-length IDs with no evidence such a store or fail-open path exists here, and demands cryptographic keys and no-follow atomic primitives \u0393\u00C7\u00F6 machinery far out of proportion to a hypothetical, unlocated risk."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It conflates the session-id used to identify the caller with the key of the atomic claim the design already places in the shared data directory, then escalates a speculative \u0027may not inherit the env var correctly\u0027 to Blocking and prescribes the lock file constraint 4 already describes."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It escalates a hypothetical caller mistake into a Blocking \u0027infinite recursion\u0027 claim about a process the plan already bounds by design \u0393\u00C7\u00F6 each split strictly shrinks scope and a person sees every round \u0393\u00C7\u00F6 and the demanded persistent depth-counter metadata is machinery out of proportion to the risk, anchored to no file or line anyone can act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a speculative \u0027run the same plan a year later\u0027 scenario to demand split-depth metadata tracking, when the constraint it quotes already scopes the verdict to the text under review \u0393\u00C7\u00F6 machinery out of proportion to a risk it never shows is real."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a deep-nesting scenario the plan\u0027s own \u0027split ONCE\u0027 rule already forecloses, misreads the caller as a human typing a command, and asks for a dry-run/preview mechanism out of all proportion to a risk it never shows is reachable."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding merely restates a constraint the design explicitly chose (fail-open with a warning) as if it were a defect, and its proposed fix \u0393\u00C7\u00F6 a \u0027split depth\u0027 check read from plan history \u0393\u00C7\u00F6 addresses something entirely different from the unwritable-store concern it describes, so it gives the reader nothing actionable."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 522.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 217537,
+        "tokensOut": 10531,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Expired or partially written claims can be deleted by a competing process",
+            "why": "Two servers can observe an expired claim and both execute the delete-then-CreateNew sequence, allowing the second to delete the first server\u0027s fresh claim and both to issue the split order. Even before expiry, CreateNew exposes an empty file before the stamp is written; a concurrent server can treat it as unclaimed, delete it, and claim the caller too.",
+            "fix": "Write the stamp to a temporary file and atomically publish it, and use an atomic replacement/locking protocol that cannot delete a claim created by another process.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew sequence is a genuine TOCTOU that defeats exactly the cross-process atomicity the code\u0027s own comment claims (\u0022the CreateNew below is the only race there is\u0022), so two servers can both claim an expired caller \u0393\u00C7\u00F6 worth knowing even though the consequence is a soft duplicate order."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 118,
+            "title": "A write failure is misclassified as another process\u0027s claim and fails closed",
+            "why": "If the disk fills or the write/flush fails after CreateNew has created the file, File.Exists(file) is true, so the IOException filter returns false without warning. The caller receives no split order even though the store failure should fail open, and a partial stamp is left behind.",
+            "fix": "Track whether this process created the file and distinguish its write/flush failures from CreateNew collisions; on an own-file write failure, clean up the partial file and warn/return true.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "Accurate and specific: an IOException raised while writing/flushing (including at StreamWriter disposal) satisfies the \u0060when (File.Exists(file))\u0060 filter because CreateNew already made the file, so a store failure is silently reported as another process\u0027s claim \u0393\u00C7\u00F6 the exact fail-closed-without-warning behaviour the method\u0027s own remarks promise never happens \u0393\u00C7\u00F6 and the suggested fix (track own-file creation) is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 88,
+            "title": "Atomic claim introduces side-effect dependency via callback parameter",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 By passing an \u0060Action\u003Cstring\u003E? warn\u0060 into the atomic claim method, the method\u0027s return value (the claim result) becomes coupled with a side-effect (logging) that is not part of the atomic state transition. This breaks the purity of the \u0027one question\u0027 contract, as the caller must now manage the logging context for the claim to be complete.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 and the \u0060warn?.Invoke\u0060 call inside the catch block. The rule requires the caller to be ordered ONCE, and the claim logic to be atomic. The current implementation introduces a side-effect (logging a warning) that depends on an external callback, which violates the principle that the condition that issues the order and the condition that claims it are ONE question asked once. The warning is a side effect of the failure mode, not part of the atomic claim itself.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The optional \u0060warn\u0060 callback is an ordinary, well-documented way to report a fail-open condition without coupling the class to a logger, and the cited rule about the order and the claim being \u0027one question\u0027 is about the decision logic, not about whether a warning may be emitted \u0393\u00C7\u00F6 so the finding invents a purity violation that does not exist and its fix would delete the only signal that the memory is broken."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Atomic claim logic separated into check-then-delete-then-create, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current implementation performs a \u0060File.Exists\u0060 check, deletes the file if present, and then attempts \u0060CreateNew\u0060. This sequence is not atomic. If another process deletes the file between the check and the \u0060CreateNew\u0060, or if the \u0060CreateNew\u0060 fails because the file was created by another process in that window, the logic returns \u0060false\u0060 (claim lost) or \u0060true\u0060 (claim won) inconsistently. The rule requires a single atomic operation to determine the outcome, not a sequence of operations that can be interrupted.",
+            "fix": "Change the catch block for \u0060IOException\u0060 to not return \u0060false\u0060 when \u0060File.Exists(file)\u0060 is true. The current logic returns \u0060false\u0060 if the file exists (implying a race where someone else claimed it), but the rule requires that \u0027A caller that already holds a claim is a caller already inside a split, and is told so.\u0027 The current implementation returns \u0060false\u0060 for an existing file, which is correct, but the logic \u0060if (File.Exists(file)) { File.Delete(file); }\u0060 followed by \u0060CreateNew\u0060 creates a race window where the file could be deleted by another process between the check and the write, leading to a silent failure or duplicate claim if not handled strictly. The rule \u0027The condition that issues the order and the condition that claims it are ONE question asked once\u0027 implies the check and the claim must be inseparable. The current code separates the existence check (delete) from the atomic creation.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The self-contradicting write-up (\u0027returns false for an existing file, which is correct, but\u0393\u00C7\u00AA\u0027) never names the one real window \u0393\u00C7\u00F6 a delete that wipes another process\u0027s fresh claim \u0393\u00C7\u00F6 and instead demands stricter atomicity for a memory the code already documents as failing open, where the whole cost of a lost race is one repeated instruction."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "FirstPlanRound flag set before atomic claim, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code sets \u0060FirstPlanRound: true\u0060 in the \u0060provisional\u0060 context before calling \u0060TryClaimSplitOrder\u0060. This means the flag is set regardless of whether the claim succeeds. If the claim fails (e.g., due to an unwritable store), the flag remains \u0060true\u0060, but the caller is not actually ordered to split (because the claim failed). This creates a state where the flag says \u0027first round\u0027 but the order was not given, violating the atomicity of the \u0027one question\u0027 contract.",
+            "fix": "Remove the \u0060FirstPlanRound: true\u0060 assignment in the \u0060provisional\u0060 context. The rule states: \u0027A caller is ordered to split ONCE. A plan that is already a piece is told so instead.\u0027 The current code sets \u0060FirstPlanRound\u0060 to \u0060true\u0060 unconditionally, then checks \u0060OrdersSplit\u0060 and claims the order. This means the \u0060FirstPlanRound\u0060 flag is set before the claim is verified, potentially allowing a caller that has already claimed an order to be treated as a first-round caller if the claim fails (e.g., due to an unwritable store). The rule requires that the \u0027claim\u0027 and the \u0027order\u0027 are one question. The current code separates the flag setting from the claim verification.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is factually wrong about the code \u0393\u00C7\u00F6 \u0060FirstPlanRound: true\u0060 is only a provisional value used to ask whether this round would order a split, and the context actually passed to \u0060GateCommands.For\u0060 has the flag overwritten by the \u0060TryClaimSplitOrder\u0060 result, so a failed claim yields \u0060false\u0060 and no split order."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 907,
+            "title": "Comment misrepresents fallback logic: \u0027Our session\u0027 vs \u0027checkout\u0027",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The comment in \u0060CallerFor\u0060 says: \u0027Our session is repo\u002Bbranch, and an epic arrives on its own branch: a session-keyed fallback would call every epic a fresh caller...\u0027 This implies the fallback is the session, but the code actually falls back to \u0060session.State.RepoPath\u0060 (the checkout). The comment is misleading because it suggests the fallback is the session, when it is actually the checkout. This is a minor deviation because the code is correct, but the comment could confuse a reader about the actual fallback mechanism.",
+            "fix": "Change the fallback from \u0060CallerIdentity.Current()\u0060 to \u0060session.State.RepoPath\u0060 to be consistent with the rule \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The current code uses \u0060CallerIdentity.Current()\u0060 which returns the session ID, but the rule requires that a client with no session ID falls back to the checkout (repo path), not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the fallback is the checkout, not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the backup",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The comment already says in as many words that the fallback is the CHECKOUT and not the session \u0393\u00C7\u00F6 the finding misreads a clause explaining why a session-keyed fallback was rejected \u0393\u00C7\u00F6 and its own fix text repeatedly concedes the code is correct while proposing a change that would restate what is already there."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Race condition in atomic claim allows duplicate orders on concurrent access",
+            "why": "The code checks \u0060StillRemembered\u0060 (read), then deletes the file if it exists, then attempts \u0060FileMode.CreateNew\u0060. If two servers run in parallel: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false). Server A deletes the file. Server B deletes the file (no-op). Server A creates the file. Server B attempts to create the file but fails with \u0060IOException\u0060 (file exists). The catch block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060. If Server B\u0027s \u0060CreateNew\u0060 fails because Server A created it, \u0060File.Exists\u0060 is true, so it returns \u0060false\u0060. However, if the file was deleted by Server A *after* Server B\u0027s check but *before* Server B\u0027s delete, or if the timing is such that the file exists but the \u0060CreateNew\u0060 fails for a different reason (e.g., permissions), the logic might be flawed. More critically, the \u0060File.Delete\u0060 is outside the \u0060try\u0060 block in the original logic flow relative to the \u0060CreateNew\u0060 race. Wait, looking closer: The \u0060File.Delete\u0060 is inside the \u0060try\u0060.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or ensure the \u0060File.Exists\u0060 check covers the deletion path before \u0060CreateNew\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent \u0393\u00C7\u00F6 it walks through the delete/CreateNew sequence, finds the claimed problem doesn\u0027t exist (\u0027Wait, looking closer: The File.Delete is inside the try\u0027), and its \u0027fix\u0027 asks for code that is already there, so it names no real defect and would waste the reader\u0027s time."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Split order claimed on rounds that may not issue a command",
+            "why": "The code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to determine if a split should be ordered. If this returns true, it then calls \u0060TryClaimSplitOrder\u0060. However, the \u0060provisional\u0060 context used for the claim includes \u0060FirstPlanRound: true\u0060 (line 573), which is hardcoded. The original logic used \u0060!_callers.SplitAlreadyOrdered(caller, DateTime.UtcNow)\u0060 to determine if it was the first round. By hardcoding \u0060FirstPlanRound: true\u0060 and then checking \u0060OrdersSplit\u0060 *after* the claim, the code risks claiming a split order for a round that might not actually be the \u0027first\u0027 round in the sequence if the logic for determining \u0027first\u0027 is decoupled from the claim. Specifically, if \u0060OrdersSplit\u0060 returns true based on \u0060provisional\u0060, but the claim fails (e.g., due to race), the system might proceed with a split order that was already claimed by another process, or fail to claim it when it should have. The logic flow is: 1. Create provisional with \u0060FirstPlanRound: true\u0060. 2. Check if \u0060pro\u0060",
+            "fix": "Pass the \u0060provisional\u0060 context to \u0060OrdersSplit\u0060 *after* the claim attempt, or ensure the claim is only attempted if \u0060OrdersSplit\u0060 returns true, to avoid claiming a split order on a round that doesn\u0027t actually issue a split command.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding misreads the code \u0393\u00C7\u00F6 the claim\u0027s result is fed back into \u0060context\u0060 via the \u0060with\u0060 expression and every command is computed from \u0060context\u0060, so a failed claim already suppresses the split order, and the suggested fix (\u0027only attempt the claim if OrdersSplit returns true\u0027) is precisely what line 578 does."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file system checks in atomic claim logic",
+            "why": "The code performs \u0060File.Exists(file)\u0060 (line 95) and then \u0060File.Delete(file)\u0060 (line 97), followed by \u0060new FileStream(file, ...)\u0060 (line 100). In a high-concurrency environment where multiple servers are checking the same caller, this results in multiple file system calls per claim attempt. While \u0060File.Exists\u0060 is a check, the subsequent \u0060Delete\u0060 and \u0060CreateNew\u0060 operations are expensive. If the file exists and is not expired, the code deletes it and then tries to create a new one. This sequence of operations (check, delete, create) can be optimized by using a single atomic operation or by caching the existence check. In a scenario with 100 concurrent servers checking the same caller, this could lead to 300 file system calls per second, potentially causing I/O contention.",
+            "fix": "Cache the \u0060File.Exists\u0060 result or use a single \u0060File.TryOpen\u0060 pattern to avoid redundant file system calls in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claim is misplaced and unfounded \u0393\u00C7\u00F6 this path runs at most once per caller per 24 hours, not at any meaningful frequency, and the Exists/Delete steps exist to clear an expired stamp so CreateNew can be the single atomic claim; removing them would break the documented design for an imagined I/O load that cannot occur."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:46:48 \u001B[32mINF\u001B[0m] coai-mcp#47960 finding [Blocking/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - Race condition in atomic claim allows duplicate orders on concurrent access (from local) [gating] Round=1 Stage=CodeReview\r | [14:46:48 \u001B[32mINF\u001B[0m] coai-mcp#47960 finding [Major/Ux] src_mcp/src/Server/PanelService.cs:578 - Split order claimed on rounds that may not issue a command (from local) [gating] Round=1 Stage=CodeReview\r | [14:46:48 \u001B[32mINF\u001B[0m] coai-mcp#47960 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file system checks in atomic claim logic (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "gemini,local",
+    "repeat": 1,
+    "lane": 7,
+    "key": "gemini,local|split-once|1",
+    "startedUtc": "2026-09-05T14:38:22.9708666Z",
+    "finishedUtc": "2026-09-05T14:38:23.3534251Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 0,
+        "verdict": "",
+        "error": "the plan stage is over for this session (stage: CodeReview); open a new session for a new plan",
+        "gatingCount": 0,
+        "reviewers": "",
+        "tokensIn": 0,
+        "tokensOut": 0,
+        "costUsd": null,
+        "findings": [],
+        "commands": [],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:38:22 \u001B[32mINF\u001B[0m] coai-mcp#47668 starting: gemini,local enabled, vault: no COAI_CREDS_KEY configured - keyless vendors still work on their own auth\r | [14:38:23 \u001B[32mINF\u001B[0m] coai-mcp#47668 session 83d93ef0 open for bench/split-once-r1",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 1,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": false
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "gemini,local",
+    "repeat": 2,
+    "lane": 7,
+    "key": "gemini,local|split-once|2",
+    "startedUtc": "2026-09-05T14:38:23.4292544Z",
+    "finishedUtc": "2026-09-05T14:44:41.8165152Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 177.8,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 25420,
+        "tokensOut": 2262,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Requirement 5 (fail open on unwritable store) directly violates Requirement 1 (split only once), causing recursive epic splitting",
+            "why": "When the claim store is unwritable (e.g. read-only file system, disk full, or permission error), Requirement 5 dictates failing open with a warning. This causes every subsequent epic plan review to also fail open without recording a claim, resulting in infinite recursive plan splitting \u2014 the exact defect this design intended to eliminate.",
+            "fix": "Fail closed (do not issue a split order, issue the autonomous single-unit order instead) when the claim store cannot be written or verified, and emit a warning.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real interaction defect \u0393\u00C7\u00F6 the claim store is the only thing enforcing split-once, so failing open on a write error silently disables that guarantee and lets every later round re-split \u0393\u00C7\u00F6 and it proposes the cheap, correct alternative (fail closed to the single-unit order with a warning)."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Requirement 6 lacks a concrete fallback identifier mechanism for clients without session IDs",
+            "why": "If a client exports no CLAUDE_CODE_SESSION_ID across branches, the plan provides no defined mechanism to correlate child branches to the root checkout session without requiring the calling AI to pass an identifier (which is forbidden by Constraints). The store will either fail to track the caller or conflate unrelated callers sharing the checkout.",
+            "fix": "Specify the exact fallback identity schema for sessionless clients (e.g. hash of parent PID / worktree root with a TTL lease file) or explicitly scope support to callers exporting a discoverable ancestor session ID.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real hole in the plan \u0393\u00C7\u00F6 a caller-identity scheme whose only stated source is an environment variable the plan cannot guarantee, with no defined fallback and constraints forbidding the obvious one, which is exactly the kind of missing case a scope-versus-diff review exists to surface before implementation."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic cross-process claim on a shared data directory lacks lock reclamation for stale or crashed sessions",
+            "why": "If an initial split command process crashes after writing a claim lock file before fully completing or releasing its session, or if a user re-runs the same top-level session later, the caller remains permanently marked as claimed, preventing future legitimate plan re-evaluations.",
+            "fix": "Define lease expiration / TTL semantics or an explicit session lifecycle cleanup rule for claim records in the shared directory.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and unanchored \u0393\u00C7\u00F6 it names no file or line, invents a \u0027claim lock file\u0027 and \u0027session claim record\u0027 mechanism whose existence in this code it never establishes, and asks for TTL/lease machinery for a failure mode it has not shown can occur here."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misdiagnoses the mechanism \u0393\u00C7\u00F6 a lost or regenerated session id yields a *different* identity, which an atomic claim already excludes, so the described double-claim cannot arise (the real inheritance risk, a child re-entering the parent\u0027s claim, is the opposite of what it argues) \u0393\u00C7\u00F6 and its proposed fix, a shared lock file in the data directory, is what the plan\u0027s atomic claim already specifies."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The plan already provides a floor via the caller and each split is a deliberate invocation rather than an automatic loop, so the \u0027infinite recursion until token limits\u0027 scenario is overstated and the demanded persistent depth-counter file is machinery out of proportion to a bounded, human-triggered operation."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a recursive-splitting scenario the stated constraint does not produce \u0393\u00C7\u00F6 a round judging the text it was handed will split the same plan the same way, not \u0027epics of epics\u0027 \u0393\u00C7\u00F6 and its fix asks for depth-tracking metadata machinery out of proportion to a hypothetical re-run."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a runaway-nesting scenario that contradicts the very plan sentence it quotes (\u0027a caller is ordered to split ONCE\u0027), and asks for a dry-run preview mechanism out of proportion to a hazard it never shows is reachable."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding restates a constraint the scope explicitly required (fail-open with a warning) as if it were a defect, and its proposed fix \u0393\u00C7\u00F6 a split-depth check read from plan history \u0393\u00C7\u00F6 is unrelated to the store-writability concern it describes."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 200.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 105561,
+        "tokensOut": 18398,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 111,
+            "title": "File.Delete before FileMode.CreateNew creates a race that causes concurrent claims to fail open or unlink active claims",
+            "why": "When two server instances concurrently try to claim an unclaimed or expired caller, both can pass the initial StillRemembered check. If Server A creates the file with FileShare.None, Server B enters the try block and calls File.Delete(file). On Windows, deleting a file locked with FileShare.None throws UnauthorizedAccessException or IOException from File.Delete rather than FileStream, hitting the generic fail-open catch block and returning true so both servers issue the split order. On Unix, File.Delete unlinks Server A\u0027s newly created file, allowing Server B\u0027s FileStream(FileMode.CreateNew) to also succeed and return true.",
+            "fix": "Remove the File.Delete call prior to FileMode.CreateNew; if cleaning up an expired claim, delete it only when StillRemembered explicitly confirmed expiration or handle replacement through an atomic temp-file rename / synchronization strategy that does not delete concurrent in-flight claims.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional File.Delete before FileMode.CreateNew genuinely defeats the atomic-claim guarantee the method\u0027s own comment asserts \u0393\u00C7\u00F6 on POSIX a second server can unlink a just-created claim and create its own, and in the expired-claim path both servers can delete-then-create and each return true \u0393\u00C7\u00F6 so it names a real hole in the one property this code exists to provide, even though its Windows analysis is off (a sharing violation surfaces as IOException and is caught by the fail-closed handler, not the fail-open one)."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 88,
+            "title": "Atomic claim introduces side-effect dependency via callback parameter",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 By passing an \u0060Action\u003Cstring\u003E? warn\u0060 into the atomic claim method, the method\u0027s return value (the claim result) becomes coupled with a side-effect (logging) that is not part of the atomic state transition. This breaks the purity of the \u0027one question\u0027 contract, as the caller must now manage the logging context for the claim to be complete.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 and the \u0060warn?.Invoke\u0060 call inside the catch block. The rule requires the caller to be ordered ONCE, and the claim logic to be atomic. The current implementation introduces a side-effect (logging a warning) that depends on an external callback, which violates the principle that the condition that issues the order and the condition that claims it are ONE question asked once. The warning is a side effect of the failure mode, not part of the atomic claim itself.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The optional \u0060warn\u0060 callback is ordinary dependency injection for a logger \u0393\u00C7\u00F6 it does not affect the claim\u0027s atomicity or its return value, and the cited \u0027one question asked once\u0027 rule is about issuing the split order once per caller, not about method purity; removing the warning would delete the only signal that the fail-open path was taken."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Atomic claim logic separated into check-then-delete-then-create, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current implementation performs a \u0060File.Exists\u0060 check, deletes the file if present, and then attempts \u0060CreateNew\u0060. This sequence is not atomic. If another process deletes the file between the check and the \u0060CreateNew\u0060, or if the \u0060CreateNew\u0060 fails because the file was created by another process in that window, the logic returns \u0060false\u0060 (claim lost) or \u0060true\u0060 (claim won) inconsistently. The rule requires a single atomic operation to determine the outcome, not a sequence of operations that can be interrupted.",
+            "fix": "Change the catch block for \u0060IOException\u0060 to not return \u0060false\u0060 when \u0060File.Exists(file)\u0060 is true. The current logic returns \u0060false\u0060 if the file exists (implying a race where someone else claimed it), but the rule requires that \u0027A caller that already holds a claim is a caller already inside a split, and is told so.\u0027 The current implementation returns \u0060false\u0060 for an existing file, which is correct, but the logic \u0060if (File.Exists(file)) { File.Delete(file); }\u0060 followed by \u0060CreateNew\u0060 creates a race window where the file could be deleted by another process between the check and the write, leading to a silent failure or duplicate claim if not handled strictly. The rule \u0027The condition that issues the order and the condition that claims it are ONE question asked once\u0027 implies the check and the claim must be inseparable. The current code separates the existence check (delete) from the atomic creation.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It restates the code\u0027s own acknowledged race without identifying the actual failure (a delete can remove a rival\u0027s just-created claim), its \u0027fix\u0027 contradicts itself and proposes no workable change, and it labels Major a residual whose worst outcome \u0393\u00C7\u00F6 one repeated instruction \u0393\u00C7\u00F6 the design already accepts by failing open."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "FirstPlanRound flag set before atomic claim, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code sets \u0060FirstPlanRound: true\u0060 in the \u0060provisional\u0060 context before calling \u0060TryClaimSplitOrder\u0060. This means the flag is set regardless of whether the claim succeeds. If the claim fails (e.g., due to an unwritable store), the flag remains \u0060true\u0060, but the caller is not actually ordered to split (because the claim failed). This creates a state where the flag says \u0027first round\u0027 but the order was not given, violating the atomicity of the \u0027one question\u0027 contract.",
+            "fix": "Remove the \u0060FirstPlanRound: true\u0060 assignment in the \u0060provisional\u0060 context. The rule states: \u0027A caller is ordered to split ONCE. A plan that is already a piece is told so instead.\u0027 The current code sets \u0060FirstPlanRound\u0060 to \u0060true\u0060 unconditionally, then checks \u0060OrdersSplit\u0060 and claims the order. This means the \u0060FirstPlanRound\u0060 flag is set before the claim is verified, potentially allowing a caller that has already claimed an order to be treated as a first-round caller if the claim fails (e.g., due to an unwritable store). The rule requires that the \u0027claim\u0027 and the \u0027order\u0027 are one question. The current code separates the flag setting from the claim verification.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads the code: \u0060provisional\u0060 is only a hypothetical used to ask whether this round would order a split, and the real \u0060context\u0060 \u0393\u00C7\u00F6 the one \u0060GateCommands.For\u0060 consumes \u0393\u00C7\u00F6 replaces \u0060FirstPlanRound\u0060 with the claim\u0027s actual result, so a failed claim already yields no order."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 907,
+            "title": "Comment misrepresents fallback logic: \u0027Our session\u0027 vs \u0027checkout\u0027",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The comment in \u0060CallerFor\u0060 says: \u0027Our session is repo\u002Bbranch, and an epic arrives on its own branch: a session-keyed fallback would call every epic a fresh caller...\u0027 This implies the fallback is the session, but the code actually falls back to \u0060session.State.RepoPath\u0060 (the checkout). The comment is misleading because it suggests the fallback is the session, when it is actually the checkout. This is a minor deviation because the code is correct, but the comment could confuse a reader about the actual fallback mechanism.",
+            "fix": "Change the fallback from \u0060CallerIdentity.Current()\u0060 to \u0060session.State.RepoPath\u0060 to be consistent with the rule \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The current code uses \u0060CallerIdentity.Current()\u0060 which returns the session ID, but the rule requires that a client with no session ID falls back to the checkout (repo path), not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the fallback is the checkout, not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the backup",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The comment is accurate \u0393\u00C7\u00F6 \u0022our session\u0022 plainly means the server\u0027s own repo\u002Bbranch session, which the code deliberately does NOT key on, falling back to the checkout exactly as documented; the finding misreads it and its \u0022fix\u0022 is self-contradicting and would break the intended identity."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Race condition in atomic claim allows duplicate orders on concurrent access",
+            "why": "The code checks \u0060StillRemembered\u0060 (read), then deletes the file if it exists, then attempts \u0060FileMode.CreateNew\u0060. If two servers run in parallel: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false). Server A deletes the file. Server B deletes the file (no-op). Server A creates the file. Server B attempts to create the file but fails with \u0060IOException\u0060 (file exists). The catch block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060. If Server B\u0027s \u0060CreateNew\u0060 fails because Server A created it, \u0060File.Exists\u0060 is true, so it returns \u0060false\u0060. However, if the file was deleted by Server A *after* Server B\u0027s check but *before* Server B\u0027s delete, or if the timing is such that the file exists but the \u0060CreateNew\u0060 fails for a different reason (e.g., permissions), the logic might be flawed. More critically, the \u0060File.Delete\u0060 is outside the \u0060try\u0060 block in the original logic flow relative to the \u0060CreateNew\u0060 race. Wait, looking closer: The \u0060File.Delete\u0060 is inside the \u0060try\u0060.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or ensure the \u0060File.Exists\u0060 check covers the deletion path before \u0060CreateNew\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding visibly loses its own thread \u0393\u00C7\u00F6 the scenario it walks through ends in the correct behaviour, it then self-corrects mid-sentence, and its concrete fix (\u0027move \u0060File.Delete\u0060 inside the \u0060try\u0060\u0027) asks for something the code at line 112-115 already does; it never names the one genuine window (B deleting A\u0027s fresh claim before its own \u0060CreateNew\u0060), so there is nothing here for someone to act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Split order claimed on rounds that may not issue a command",
+            "why": "The code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to determine if a split should be ordered. If this returns true, it then calls \u0060TryClaimSplitOrder\u0060. However, the \u0060provisional\u0060 context used for the claim includes \u0060FirstPlanRound: true\u0060 (line 573), which is hardcoded. The original logic used \u0060!_callers.SplitAlreadyOrdered(caller, DateTime.UtcNow)\u0060 to determine if it was the first round. By hardcoding \u0060FirstPlanRound: true\u0060 and then checking \u0060OrdersSplit\u0060 *after* the claim, the code risks claiming a split order for a round that might not actually be the \u0027first\u0027 round in the sequence if the logic for determining \u0027first\u0027 is decoupled from the claim. Specifically, if \u0060OrdersSplit\u0060 returns true based on \u0060provisional\u0060, but the claim fails (e.g., due to race), the system might proceed with a split order that was already claimed by another process, or fail to claim it when it should have. The logic flow is: 1. Create provisional with \u0060FirstPlanRound: true\u0060. 2. Check if \u0060pro\u0060",
+            "fix": "Pass the \u0060provisional\u0060 context to \u0060OrdersSplit\u0060 *after* the claim attempt, or ensure the claim is only attempted if \u0060OrdersSplit\u0060 returns true, to avoid claiming a split order on a round that doesn\u0027t actually issue a split command.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding misreads the code \u0393\u00C7\u00F6 the ternary already attempts the claim only when \u0060OrdersSplit(provisional)\u0060 is true and recomputes \u0060context\u0060/\u0060commands\u0060 from the claim\u0027s result, so its proposed fix is exactly what line 578-585 already does, and the truncated rationale describes a race that cannot occur since a failed claim simply sets \u0060FirstPlanRound = false\u0060 and suppresses the command."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file system checks in atomic claim logic",
+            "why": "The code performs \u0060File.Exists(file)\u0060 (line 95) and then \u0060File.Delete(file)\u0060 (line 97), followed by \u0060new FileStream(file, ...)\u0060 (line 100). In a high-concurrency environment where multiple servers are checking the same caller, this results in multiple file system calls per claim attempt. While \u0060File.Exists\u0060 is a check, the subsequent \u0060Delete\u0060 and \u0060CreateNew\u0060 operations are expensive. If the file exists and is not expired, the code deletes it and then tries to create a new one. This sequence of operations (check, delete, create) can be optimized by using a single atomic operation or by caching the existence check. In a scenario with 100 concurrent servers checking the same caller, this could lead to 300 file system calls per second, potentially causing I/O contention.",
+            "fix": "Cache the \u0060File.Exists\u0060 result or use a single \u0060File.TryOpen\u0060 pattern to avoid redundant file system calls in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claim is wrong about this code: the claim path is a once-per-caller-per-24-hours write (guarded by an early return when the stamp is still valid), not a hot loop, and the invented \u0027100 concurrent servers / 300 filesystem calls per second\u0027 scenario is fictional for a per-machine MCP server \u0393\u00C7\u00F6 while the delete-then-CreateNew sequence it wants collapsed is precisely what makes the claim atomic."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:44:41 \u001B[32mINF\u001B[0m] coai-mcp#20088 finding [Blocking/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - Race condition in atomic claim allows duplicate orders on concurrent access (from local) [gating] Round=1 Stage=CodeReview\r | [14:44:41 \u001B[32mINF\u001B[0m] coai-mcp#20088 finding [Major/Ux] src_mcp/src/Server/PanelService.cs:578 - Split order claimed on rounds that may not issue a command (from local) [gating] Round=1 Stage=CodeReview\r | [14:44:41 \u001B[32mINF\u001B[0m] coai-mcp#20088 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file system checks in atomic claim logic (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 5,
+    "key": "codex,gemini,local|split-once|1",
+    "startedUtc": "2026-09-05T14:38:26.0450384Z",
+    "finishedUtc": "2026-09-05T14:46:31.1529897Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 59.2,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 40358,
+        "tokensOut": 4707,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The claim has no recovery semantics when the process dies after claiming but before returning the split command.",
+            "why": "A server atomically claims a passing plan, then is killed before emitting its response; a retry observes the permanent claim and suppresses the only split order, so the required one-time action never occurs.",
+            "fix": "Specify a durable claim state with an idempotent completion record or an expiry/lease that permits safe retry after an interrupted response, and define the crash-recovery sequence.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Without any code or file to anchor it, this is a generic \u0027what if the process dies mid-operation\u0027 objection that demands a lease/idempotency protocol for a hypothetical claim-then-respond step, machinery out of proportion to an unspecified risk it never demonstrates exists in this code."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Following a caller without CLAUDE_CODE_SESSION_ID has no defined identity or branch-lineage mechanism.",
+            "why": "With no exported session ID, a plan on branch \u0060feature/epic-a\u0060 cannot be distinguished from an unrelated plan on that branch, and changing from \u0060feature/root\u0060 to the child branch loses the repo\u002Bbranch key; the system can either issue autonomy to an unrelated plan or fail to follow the real child.",
+            "fix": "Define a durable checkout/worktree lineage key and its creation, propagation, and cleanup rules, including concurrent sibling branches and process restarts, without requiring the AI caller to pass an identifier.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real design hole \u0393\u00C7\u00F6 identifying a session by repo\u002Bbranch alone breaks when a plan\u0027s branch changes or when unrelated plans share a branch, so autonomy could be granted to the wrong work \u0393\u00C7\u00F6 and asks for the lineage/cleanup rules rather than disproportionate machinery."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claiming across servers is promised without specifying an operation that is actually atomic on the shared store.",
+            "why": "Two servers can both read an unclaimed record before either writes it, then both return a split command; a read-then-write implementation violates the one-command guarantee even when they share the data directory.",
+            "fix": "Require a concrete cross-process primitive such as exclusive atomic file creation, an OS lock, or a transactional compare-and-set, and define the behavior on lock contention and stale locks.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real correctness hole \u0393\u00C7\u00F6 a cross-process claim guarantee stated without an atomic primitive, which reduces to a read-then-write race that double-issues a command \u0393\u00C7\u00F6 and asks for exactly the thing the family\u0027s own reliability rule requires (name the atomic operation, plus contention and stale-lock behaviour), which is proportionate rather than over-engineered."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The caller identifier\u0027s file-safe representation is unspecified, leaving traversal and key-collision behavior undefined.",
+            "why": "An identifier such as \u0060../../outside\u0060 or two distinct identifiers that normalize to the same path can write outside the data directory or cause one caller\u0027s claim to suppress another\u0027s order.",
+            "fix": "Encode or hash the opaque identifier into a fixed safe filename (with an explicit collision strategy), keep all paths rooted under the store directory, and reject or safely handle malformed identifiers.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "An identifier used unencoded as a filename in a file-backed claim store is a real traversal-and-collision surface with a concrete, proportionate fix, and \u0027the identifier happens to be safe today\u0027 is exactly the safe-by-content reasoning that has already cost this codebase a sanitiser applied at only some of its sites."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define which verdict is eligible when review retries or resolves the plan in the same round.",
+            "why": "If an initial review fails and the resolve loop later produces a pass, or if a stale pass is stored from an earlier review, the caller may issue a split command for a plan that did not pass this round or suppress a current valid command.",
+            "fix": "Specify the exact verdict event and round identifier used for claiming\u2014after the final current-round verdict is established\u2014and ensure prior-round records cannot satisfy the current claim.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It is a hedged, abstract demand that the plan pin down verdict-and-round semantics without showing the plan actually leaves them open \u0393\u00C7\u00F6 three speculative scenarios (\u0027may issue\u0027, \u0027may suppress\u0027) stated in jargon an implementer could not act on without re-deriving the concern themselves."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true #5] Failing open on an unwritable store reproduces the infinite split loop",
+            "why": "When the store is unwritable (e.g., read-only filesystem, permissions error, or disk full), failing open allows the initial plan to issue a split order without successfully persisting the claim. When the resulting child epics return for review on their own branches, the unwritable store still has no recorded claim, causing each child epic to be ordered to split again and triggering the unbounded \u0027epics of epics\u0027 recursion.",
+            "fix": "Fail closed against issuing split orders when the claim store cannot be written, defaulting to issuing the single-unit autonomy order instead.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete failure mode \u0393\u00C7\u00F6 a fail-open claim store turning an unwritable persistence layer into unbounded epic-splitting recursion \u0393\u00C7\u00F6 and proposes a specific, proportionate fix (fail closed to the single-unit order), which is exactly the kind of reliability gap an engineer would want to know about."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true #6] Checkout-level fallback for missing session IDs permanently suppresses splitting for future independent plans",
+            "why": "When a client does not export CLAUDE_CODE_SESSION_ID, following caller identity across branches of one checkout requires keying the claim to the repository checkout. Once claimed, any subsequent independent feature plan created in the same workspace checkout will match the existing claim, incorrectly treating new root plans as existing pieces and never offering a split order.",
+            "fix": "Bound checkout-level claims with an expiration window or prompt/plan-lineage identifier rather than an indefinite checkout-wide singleton claim.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete lifecycle defect \u0393\u00C7\u00F6 a checkout-keyed claim with no expiry or lineage key makes every later independent plan in that workspace look like a continuation, permanently suppressing the split offer \u0393\u00C7\u00F6 which is exactly the kind of durable-state bug a designer would want to fix before shipping."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a mechanism the reviewed text does not describe \u0393\u00C7\u00F6 it conflates a session-identifying environment variable with the atomicity of the claim itself, and its concern (two processes both believing they hold the claim) is precisely what an atomic claim on the data directory prevents regardless of how the caller identity is propagated, so the \u0027Blocking\u0027 fix it proposes addresses a race that its own premise does not establish."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents an unbounded-recursion catastrophe from a plan sentence about who supplies a floor, without any evidence that splitting is automatic or self-invoking, and demands persistent depth-tracking machinery far out of proportion to a step a human triggers."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a runaway \u0027Epics of Epics\u0027 recursion from a constraint sentence it misreads, without pointing at any code that lacks a split-depth check, and its proposed metadata/depth-tracking machinery is out of proportion to a re-run scenario the user drives deliberately."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a re-split scenario the plan\u0027s own once-only rule already governs, overstates the harm (a text-and-git operation described as irreversible, two splits described as four levels deep), and asks for a dry-run preview far larger than the speculative risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It flags as a defect the exact behaviour the scope\u0027s constraint 5 explicitly mandates (fail open with a warning), and its proposed fix \u0393\u00C7\u00F6 a \u0027split depth\u0027 check read from plan history \u0393\u00C7\u00F6 is unrelated to the unwritable-store concern it describes, so there is nothing actionable or correct here."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 425.8,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 9,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 243320,
+        "tokensOut": 11127,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 576,
+            "title": "The split-order predicate is evaluated twice instead of once",
+            "why": "The scope requires: \u201CThe condition that issues the order and the condition that claims it are ONE question asked once.\u201D \u0060OrdersSplit(provisional)\u0060 is evaluated for claiming, then \u0060OrdersSplit(context)\u0060 is evaluated again for logging after \u0060FirstPlanRound\u0060 has changed, so the two decisions can drift.",
+            "fix": "Store the single predicate result and reuse it for both the claim decision and the post-command handling; do not call \u0060OrdersSplit\u0060 again.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The second call deliberately asks about the post-claim \u0060context\u0060, not \u0060provisional\u0060 \u0393\u00C7\u00F6 it suppresses the log line when \u0060TryClaimSplitOrder\u0060 refused \u0393\u00C7\u00F6 so there is no drift, and the suggested fix of reusing one cached result would make the server log \u0027split ordered\u0027 for an order it never issued."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 96,
+            "title": "Expired claims are deleted non-atomically before renewal",
+            "why": "With two servers sharing the directory, both can observe an expired claim; one can delete and recreate it, after which the other can delete that newly valid claim before its own CreateNew. This can erase a current claim and issue the split order again.",
+            "fix": "Use an atomic renewal/lock protocol or serialize claim replacement per caller; never delete a claim after an uncoordinated existence check.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The race is real \u0393\u00C7\u00F6 the \u0060File.Delete\u0060 before \u0060CreateNew\u0060 lets a second server erase a claim another just made, so both issue the order \u0393\u00C7\u00F6 and it directly disproves the code\u0027s own comment that \u0060CreateNew\u0060 is \u0022the only race there is\u0022, which is exactly the kind of wrong assumption a maintainer needs told even though the blast radius is one duplicated instruction."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "A write failure after file creation is mistaken for a successful claim",
+            "why": "If the file is created but writing the timestamp fails, such as from a full disk, the IOException filter sees File.Exists(file) and returns false without warning. The caller receives no split order, while the incomplete stamp is later unreadable and does not reliably prevent retries.",
+            "fix": "Only treat an IOException as another process winning when an independently verifiable complete claim exists; otherwise warn and return true per the fail-open contract, and remove or quarantine partial files.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It correctly spots that the \u0060catch (IOException) when (File.Exists(file))\u0060 filter cannot tell \u0027another process won the race\u0027 from \u0027I created the file and the write/flush failed\u0027, so that path silently fails CLOSED against the fail-open contract the method documents at length \u0393\u00C7\u00F6 a real gap with a two-line fix (track whether this call created the file), even though the trigger is narrow and the suggested quarantine step is more than the risk warrants."
+          },
+          {
+            "severity": "Nit",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 125,
+            "title": "Non-IOException/UnauthorizedAccessException exceptions in TryClaimSplitOrder will propagate and abort instead of failing open",
+            "why": "TryClaimSplitOrder only catches IOException and UnauthorizedAccessException when failing open. Other exceptions (such as SecurityException or DirectoryNotFoundException if intermediate directory state is corrupted) will throw out of TryClaimSplitOrder and cause the whole tool call / round evaluation to fail rather than failing open as documented.",
+            "fix": "Catch other standard filesystem exceptions (such as DirectoryNotFoundException or PathTooLongException) or avoid catching only IOException/UnauthorizedAccessException if the design principle is to fail open on all filesystem access errors.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The two exceptions it names as escaping \u0393\u00C7\u00F6 DirectoryNotFoundException and PathTooLongException \u0393\u00C7\u00F6 both derive from IOException and are already caught, so the finding is wrong about this code and its remaining residual (an exotic SecurityException) is not worth widening a deliberately narrow catch for."
+          },
+          {
+            "severity": "Nit",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 111,
+            "title": "File.Delete before FileMode.CreateNew introduces a deletion/creation race window when clearing expired claims",
+            "why": "If two processes both discover an expired claim at the same time, both will attempt File.Delete(file). One will succeed in deleting, but if process A deletes and creates before process B calls File.Delete, process B might delete process A\u0027s freshly created new claim before attempting its own CreateNew. While the window is small and bounded to expiry renewal, it can cause both processes to fail or overwrite unexpectedly during claim expiry.",
+            "fix": "Open with FileMode.OpenOrCreate / FileShare.ReadWrite and lock or use atomic rename/replace (e.g. temporary file \u002B atomic move/replace or FileStream locking) instead of non-atomic delete followed by CreateNew.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "Nullable callback parameter risks NullReferenceException",
+            "why": "The method signature \u0060Action\u003Cstring\u003E? warn = null\u0060 allows the caller to omit the argument. If the code path reaches \u0060warn?.Invoke\u0060 (line 117) and the caller passed \u0060null\u0060 explicitly or the default was not handled correctly in a specific call site, the warning logic could fail silently or throw if the null check is bypassed in a future refactor. More critically, the test \u0060AnUnwritableStore_GivesTheOrderRatherThanSwallowingIt\u0060 passes a lambda, but \u0060PanelService\u0060 (line 583) passes a lambda. However, the method signature change from \u0060RecordSplitOrder\u0060 to \u0060TryClaimSplitOrder\u0060 introduces a new optional parameter that was not present in the original API contract, potentially breaking callers that rely on positional arguments or implicit defaults if not careful.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 or ensure the caller passes a non-null delegate. The current implementation invokes \u0060warn?.Invoke\u0060 without guaranteeing the caller provides one, risking a \u0060NullReferenceException\u0060 if called without the argument.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is technically wrong \u0393\u00C7\u00F6 \u0060warn?.Invoke\u0060 is precisely the null-conditional guard that makes a null delegate safe, adding an optional parameter with a default breaks no existing caller, and the rest is speculation about hypothetical future refactors rather than a defect in this code."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Inconsistent handling of optional warning callback",
+            "why": "The method \u0060TryClaimSplitOrder\u0060 accepts an optional \u0060warn\u0060 callback. While the code uses \u0060warn?.Invoke\u0060, the logic inside the \u0060catch (Exception e)\u0060 block assumes the callback might be null. If a caller passes \u0060null\u0060 explicitly, the warning is swallowed. The rule requires \u0027a warning rather than silently disabling\u0027, but if the callback is null, the warning is silent.",
+            "fix": "Ensure the \u0060warn\u0060 action is invoked with a consistent message format or handle the case where \u0060warn\u0060 is null more explicitly if the design requires it to be optional.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is confused \u0393\u00C7\u00F6 \u0060warn\u0060 is optional by design and the only caller that cares passes one; the fail-open path still returns true regardless, so a null callback changes nothing about behaviour and the suggested \u0027fix\u0027 names no actual defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Inconsistent state propagation for FirstPlanRound",
+            "why": "The code sets \u0060FirstPlanRound: true\u0060 on \u0060provisional\u0060. Then it checks \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060. If true, it creates a new \u0060context\u0060 with \u0060FirstPlanRound\u0060 set to the result of \u0060TryClaimSplitOrder\u0060. If false, it uses \u0060provisional\u0060 as \u0060context\u0060. This means if the order is not split, \u0060FirstPlanRound\u0060 remains true. If the order is split, \u0060FirstPlanRound\u0060 becomes the boolean result of the claim. This logic is complex and potentially confusing, but more importantly, it deviates from the rule that \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The code asks \u0060OrdersSplit\u0060 twice (once for \u0060provisional\u0060, once for \u0060context\u0060 implicitly via the \u0060if\u0060 block) or relies on the state of \u0060provisional\u0060 being consistent.",
+            "fix": "The variable \u0060provisional\u0060 is created but then immediately used to create \u0060context\u0060. The logic \u0060FirstPlanRound: true\u0060 is set on \u0060provisional\u0060, but then \u0060context\u0060 is created from \u0060provisional\u0060 only if \u0060OrdersSplit\u0060 returns true. This creates a potential inconsistency where \u0060FirstPlanRound\u0060 might be true in \u0060provisional\u0060 but false in \u0060context\u0060 if the condition fails, or vice versa depending on the flow.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads a deliberate two-step \u0393\u00C7\u00F6 ask whether the order would be given, spend the claim only then, and re-ask on the claimed context \u0393\u00C7\u00F6 as an inconsistency, and the concrete failure it posits (FirstPlanRound true in provisional but the order still wrong) cannot occur, since when OrdersSplit is false no order is issued regardless of the flag."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Violation of \u0027ONE question asked once\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to decide whether to claim, but then calls \u0060Core.Commands.GateCommands.OrdersSplit(context)\u0060 again in the \u0060if\u0060 block to log. This is two questions. The logging should be based on the result of the claim, not a re-evaluation of the condition.",
+            "fix": "Align the logic to ensure the \u0027one question\u0027 rule is strictly followed. The \u0060OrdersSplit\u0060 check should be the sole determinant for both issuing and claiming.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The two \u0060OrdersSplit\u0060 calls ask about different states \u0393\u00C7\u00F6 \u0060provisional\u0060 decides whether a claim is worth attempting, \u0060context\u0060 reflects whether the claim succeeded and the order is actually issued, which is exactly what the log should report \u0393\u00C7\u00F6 so reusing the product\u0027s own predicate here honours the rule rather than breaking it."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Redundant or confusing exception handling",
+            "why": "The code has \u0060catch (IOException)\u0060 for the race condition and \u0060catch (Exception e) when (e is IOException or UnauthorizedAccessException)\u0060 for the \u0027fail open\u0027 case. The second catch block is technically redundant because \u0060IOException\u0060 is already caught by the first block. The logic flow suggests the first catch is for the race (file exists), and the second is for other IO errors. However, the \u0060when\u0060 clause in the second catch makes it specific to \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060, which might overlap with the first catch if the order of evaluation is not clear.",
+            "fix": "The \u0060catch (Exception e)\u0060 block catches \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060 specifically, but the outer \u0060catch (IOException)\u0060 handles the race condition. The inner catch for \u0060Exception\u0060 might be redundant or confusing.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about the code: the first catch carries an exception filter (\u0060when (File.Exists(file))\u0060), so an IOException without the file present falls through to the second catch \u0393\u00C7\u00F6 the fail-open path \u0393\u00C7\u00F6 making it necessary rather than redundant, and the finding proposes no actual change."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 117,
+            "title": "Warning message clarity",
+            "why": "The warning message \u0027the split-order memory at {Dir} could not be written ({e.Message}) \u2014 the order is being given, and may be given again\u0027 is clear, but the rule requires \u0027a warning rather than silently disabling\u0027. If \u0060warn\u0060 is null, the warning is silent. The rule implies a warning *must* be issued, so the \u0060warn\u0060 parameter should perhaps be required or a default logger used.",
+            "fix": "Ensure the \u0060warn\u0060 callback is invoked with a message that clearly indicates the \u0027fail open\u0027 nature.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It flags a hypothetical silence without checking whether any production call site actually omits \u0060warn\u0060, and its stated fix asks for a message that the code already writes verbatim \u0393\u00C7\u00F6 the optional callback is a normal test seam, not a defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 913,
+            "title": "Change in fallback logic for anonymous clients",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The previous implementation used \u0060session.State.SessionId\u0060 (which is repo\u002Bbranch), causing every epic to be treated as a new caller. The new implementation uses \u0060session.State.RepoPath\u0060, which correctly follows the caller across branches. This is a compliance fix, but it changes the behavior significantly.",
+            "fix": "The \u0060CallerFor\u0060 method now uses \u0060session.State.RepoPath\u0060 instead of \u0060session.State.SessionId\u0060. This is a change in the fallback logic.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding merely restates what the code and its own remarks already document \u0393\u00C7\u00F6 that \u0060CallerFor\u0060 falls back to \u0060RepoPath\u0060 to follow a caller across branches \u0393\u00C7\u00F6 and identifies it as correct compliance with the rule, raising no defect, risk, or action for anyone to take."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "API contract change from void to bool",
+            "why": "The method signature changed from \u0060void RecordSplitOrder\u0060 to \u0060bool TryClaimSplitOrder\u0060. This is a breaking change for any caller that relied on the void return. However, the rule requires \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The new return value allows the caller to know if the claim succeeded, which is necessary for the \u0027fail open\u0027 logic.",
+            "fix": "The \u0060TryClaimSplitOrder\u0060 method now returns a \u0060bool\u0060 indicating success, whereas \u0060RecordSplitOrder\u0060 was \u0060void\u0060. This is a change in the API contract.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The \u0027breaking change\u0027 is about an internal method within the same commit that renamed and rewrote it, there are no external consumers of this AOT server\u0027s private type, and the finding\u0027s own text concedes the new bool return is necessary \u0393\u00C7\u00F6 so it names nothing anyone would act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Atomic claim race window created by pre-delete of expired file",
+            "why": "The code deletes an existing file (\u0060File.Delete(file)\u0060) before attempting \u0060FileMode.CreateNew\u0060. If a second server process checks \u0060StillRemembered\u0060 (returns false), then deletes the file, then attempts \u0060CreateNew\u0060 while the first process is still deleting, the second process\u0027s \u0060CreateNew\u0060 will succeed. This allows two servers to both believe they claimed the order, violating the atomicity guarantee required to prevent \u0027epics of epics\u0027 loops.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call to a separate \u0060if\u0060 block before the \u0060try\u0060 block, or wrap the delete in its own try-catch to ensure the atomic \u0060CreateNew\u0060 is not shadowed by a delete failure.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "The pre-delete genuinely breaks the documented atomicity \u0393\u00C7\u00F6 one process can delete a fresh claim another just created and then successfully CreateNew, so both issue the split order \u0393\u00C7\u00F6 and a careful engineer would want to know the \u0027the CreateNew below is the only race there is\u0027 comment is false, even though the finding\u0027s narration of the interleaving is muddled and its proposed fix would not close the window."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 92,
+            "title": "Path traversal vulnerability in caller identity file naming",
+            "why": "The \u0060caller\u0060 string is used directly to construct a file path via \u0060FileFor(caller)\u0060. If a malicious or misbehaving client passes a \u0060caller\u0060 value like \u0060../../etc/passwd\u0060 or \u0060..\\..\\windows\\system32\u0060, the code could write to or overwrite arbitrary files on the server\u0027s filesystem, potentially overwriting configuration or log files, or creating a symlink to a sensitive file.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., remove or replace \u0060..\u0060, \u0060/\u0060, \u0060\\\u0060, and control characters) before using it in \u0060FileFor(caller)\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is simply wrong about this code \u0393\u00C7\u00F6 \u0060FileFor\u0060 hashes the caller with SHA-256 and hex-encodes it, so no caller-controlled characters ever reach the path, and the comment two lines above says exactly that."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Potential deadlock or hang if file delete is blocked",
+            "why": "If the file to be deleted is locked by another process (e.g., an antivirus scanner or a previous crashed instance), \u0060File.Delete\u0060 will block or throw an exception. If it throws, the \u0060CreateNew\u0060 might not execute, or if it hangs, the server thread blocks. The current catch block only handles \u0060IOException\u0060 from \u0060CreateNew\u0060, not from the delete.",
+            "fix": "Add a timeout to the \u0060File.Delete\u0060 operation or ensure the \u0060try\u0060 block covers the delete operation as well, or use a more robust locking mechanism (e.g., \u0060FileLock\u0060 or \u0060Mutex\u0060) instead of relying solely on \u0060CreateNew\u0060 after a delete.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is factually wrong about the code \u0393\u00C7\u00F6 \u0060File.Delete\u0060 is inside the same \u0060try\u0060 at line 108 and its \u0060IOException\u0060/\u0060UnauthorizedAccessException\u0060 are already caught by both handlers \u0393\u00C7\u00F6 and \u0060File.Delete\u0060 throws rather than hanging, so the proposed delete timeout or Mutex is machinery for a risk that does not exist here."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Silent failure of split order claim obscures state",
+            "why": "When \u0060TryClaimSplitOrder\u0060 returns \u0060false\u0060 (e.g., due to a race or unwritable store), the code proceeds to use the \u0060provisional\u0060 context without explicitly logging or signaling that the claim failed. A user or downstream process might expect the split order to be active, but it was silently skipped, leading to confusion about why the split didn\u0027t occur.",
+            "fix": "Add a specific log entry or return value indicating that the split order was claimed, and ensure the UI or downstream process reflects this state change immediately.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claim is wrong about this code \u0393\u00C7\u00F6 \u0060TryClaimSplitOrder\u0060 is handed a warning callback that logs when the claim fails, and the successful path already logs \u0027split ordered to caller\u0027, so the \u0027silent\u0027 failure it describes does not exist."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file existence check before atomic create",
+            "why": "The code checks \u0060File.Exists(file)\u0060 before attempting \u0060FileMode.CreateNew\u0060. While this is intended to handle expired claims, it adds an extra disk I/O operation. In high-frequency scenarios (e.g., many concurrent splits), this check could become a bottleneck, especially if the file system is slow or the directory is large.",
+            "fix": "Cache the \u0060File.Exists(file)\u0060 check result or use a more efficient file system operation to avoid redundant disk I/O in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The File.Exists check runs once per split-order claim \u0393\u00C7\u00F6 a rare, human-paced event, not a hot path \u0393\u00C7\u00F6 and it exists to clear expired claims so CreateNew can succeed, so removing or caching it would break correctness for a performance concern that does not exist here."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:46:31 \u001B[32mINF\u001B[0m] coai-mcp#46156 finding [Minor/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - Potential deadlock or hang if file delete is blocked (from local) Round=1 Stage=CodeReview\r | [14:46:31 \u001B[32mINF\u001B[0m] coai-mcp#46156 finding [Minor/Ux] src_mcp/src/Server/PanelService.cs:578 - Silent failure of split order claim obscures state (from local) Round=1 Stage=CodeReview\r | [14:46:31 \u001B[32mINF\u001B[0m] coai-mcp#46156 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file existence check before atomic create (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "artifacts/bench/plan-B.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 2,
+    "lane": 2,
+    "key": "codex,gemini,local|split-once|2",
+    "startedUtc": "2026-09-05T14:40:31.3207238Z",
+    "finishedUtc": "2026-09-05T14:47:48.1848222Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 152.8,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 10,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 33725,
+        "tokensOut": 5985,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan has no recovery semantics for a process killed between claiming a split and issuing its command",
+            "why": "If server A atomically claims the order and is killed before persisting or emitting the command, server B sees the claim and suppresses it forever; the caller never receives the required split instruction. Conversely, a kill after emission but before recording completion can cause an implementation with retries to emit it twice.",
+            "fix": "Define a durable claim state machine with idempotent command identity, and specify lease/reclaim behavior for pre-emission failure plus the rule for post-emission retry; add checks for both kill points.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A distributed claim-then-emit design with no lease/reclaim on pre-emission death and no idempotency key on retry has two concrete failure modes \u0393\u00C7\u00F6 a permanently suppressed instruction and a duplicated one \u0393\u00C7\u00F6 which is exactly the crash-window gap a careful engineer would want the plan to specify before implementation."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The fallback identity for clients without CLAUDE_CODE_SESSION_ID is underspecified and can conflate independent workflows",
+            "why": "Two independent plans run concurrently in the same checkout without a session id will necessarily share the same checkout-derived key; one can claim the split and cause the other to be treated as an already-split piece, so it receives no split command. The plan requires following one workflow across branch changes but gives no way to distinguish it from another workflow.",
+            "fix": "Specify the exact checkout identity and workflow-keying model, including concurrent invocations and branch switches; either persist an explicit durable workflow token locally or document and enforce that one workflow is allowed per checkout.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete failure mode \u0393\u00C7\u00F6 two concurrent workflows in one checkout collapsing to the same fallback identity so one silently loses its split command \u0393\u00C7\u00F6 and the fix (pin the keying model or enforce one workflow per checkout) is proportionate to a plan that has no session id to fall back on."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not bind the issued command to the exact plan reviewed in the split verdict",
+            "why": "A plan can pass review, then be edited before the caller requests the command; if the implementation stores only the pass/claim state, it will issue a split order based on an earlier round even though the current plan has not passed or has a different split shape, violating the current-round requirement.",
+            "fix": "Persist or compare a canonical plan digest with the verdict and require an exact digest match when claiming/issuing the command; otherwise re-review and refuse the command.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "In a gate whose whole value is that *this* plan passed, leaving the verdict bound to session state rather than to the plan\u0027s content is a real integrity gap \u0393\u00C7\u00F6 a plan edited after passing would still authorize the command \u0393\u00C7\u00F6 and the proposed fix (a canonical digest compared at claim time) is one hash, proportionate to the risk."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "What must be true (5): Failing open on an unwritable store recreates infinite split recursion",
+            "why": "Requirement 5 mandates that an unwritable claim store fails open to avoid disabling the feature. When the persistence store is unwritable (e.g., read-only disk, permission error), the initial plan issues a split order. When the resulting child epics return for review, their checks also encounter the unwritable store, fail open, and issue further split orders, directly causing the infinite \u0027epics of epics\u0027 recursion the design aims to prevent.",
+            "fix": "Fail closed on store write failures by falling back to the autonomy/single-unit order with a warning rather than issuing a split order.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real interaction defect \u0393\u00C7\u00F6 the claim store is the memory that prevents re-splitting, so failing open on an unwritable store removes the only guard against the exact \u0027epics of epics\u0027 recursion the design exists to prevent \u0393\u00C7\u00F6 and it proposes a proportionate fallback rather than new machinery."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "What must be true (6): Checkout-level fallback without a session ID permanently blocks future plans from splitting",
+            "why": "Requirement 6 tracks clients lacking a session ID across branches within a checkout. Without a session identifier or defined lifecycle reset, a claim recorded against a checkout path persists indefinitely. Any subsequent, completely unrelated top-level plan executed in that same checkout will match the existing record and be falsely treated as an existing piece, suppressing its ability to split.",
+            "fix": "Scope fallback tracking to a run-specific handle (such as root commit hash or branch parentage) or require an explicit session boundary before claiming checkout-level state.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete lifecycle hole \u0393\u00C7\u00F6 a checkout-scoped claim with no session identity or reset never expires, so an unrelated later plan in the same checkout is misidentified as an existing piece and silently loses its ability to split, which is exactly the kind of non-terminal-state-with-no-sweep defect the design rules require a plan to answer."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Constraints: Atomic check-and-claim suppresses split orders on subsequent retries if the caller crashes",
+            "why": "The constraints require the check and claim to be a single atomic operation evaluated once during review. If the server atomically records the claim but the calling agent subsequently crashes, is cancelled, or fails to create child branches, any retry within the same caller session will find the claim already consumed and receive the autonomy order instead of being allowed to split.",
+            "fix": "Separate the initial reservation from final claim confirmation, or allow explicit retry semantics when a caller re-submits the exact same plan.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and self-undermining \u0393\u00C7\u00F6 it invents a crash-and-retry scenario against constraints text without any code to point at, and its own premise (a claim consumed once, atomically) is the stated design intent rather than a defect, so the \u0027fix\u0027 asks for reservation/confirmation machinery out of proportion to an unevidenced risk."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Atomic claim across processes relies on transient environment variables rather than persistent state.",
+            "why": "Constraint 4 states \u0027two servers sharing a data directory cannot both give it\u0027 based on an atomic claim. However, Constraint 7 and the \u0027What must be true\u0027 section rely on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to children. If Server A spawns a child process that splits the plan, and Server B (or a different instance of Server A) starts a new process in the same directory before the first child finishes or commits, the new process may not inherit the \u0060CLAUDE_CODE_SESSION_ID\u0060 correctly or may generate a new one. This breaks the \u0027atomic claim\u0027 because two independent processes could simultaneously believe they are the sole \u0027caller\u0027 for the same repo/branch, leading to conflicting split orders and race conditions in the data directory.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent process ID or a shared lock file in the data directory, rather than relying on an environment variable passed to child processes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It conflates caller identity with mutual exclusion \u0393\u00C7\u00F6 an atomic claim in the data directory decides the winner regardless of how each process identifies itself, so a missing or regenerated session id would at worst make one caller unrecognised (over-blocking), never let two hold the same claim \u0393\u00C7\u00F6 and its proposed fix (a shared lock file in the data directory) is the atomic claim the plan already specifies, so the Blocking severity rests on a misreading rather than a defect."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "No mechanism exists to enforce the \u0027floor\u0027 for epics of epics without external state.",
+            "why": "The plan states \u0027A plan that passes is told to split... Epics of epics, with no floor.\u0027 It relies on the \u0027caller\u0027 to supply the floor. If the \u0027caller\u0027 is a human or a script that forgets to pass the floor, or if the \u0027caller\u0027 is a new session that doesn\u0027t know the previous depth, the system will recursively split epics indefinitely. For example, if a user runs the plan on a branch that was already split once, but the \u0027caller\u0027 (the script invoking the plan) doesn\u0027t track that it was already split, the system will split the epic again, creating an infinite recursion of epics until memory or token limits are hit.",
+            "fix": "Add a persistent \u0027split depth\u0027 counter to the plan state or a dedicated metadata file that increments with each split, rather than relying on the caller to supply the floor.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The plan already assigns the floor to the caller, and each split is a deliberate per-invocation act rather than a self-driving loop, so the \u0027infinite recursion until token limits\u0027 scenario is invented rather than observed \u0393\u00C7\u00F6 and a persistent split-depth counter is far more machinery than a human-triggered document workflow warrants, let alone a Blocking verdict."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Split verdict depends on \u0027plan THIS round reviewed\u0027 without verifying if the plan has already been split.",
+            "why": "Constraint 7 states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If a user re-runs the plan on a branch that was already split (e.g., a year later), the system might re-evaluate the \u0027plan\u0027 as if it were new. If the plan\u0027s content hasn\u0027t changed but the \u0027floor\u0027 wasn\u0027t tracked, the system might split an already-split epic again. For instance, a user runs the plan, it splits into Epics. A year later, the user runs the plan again on the same branch. The system sees the \u0027plan\u0027 (the original text) and splits it again, creating \u0027Epics of Epics of Epics\u0027 because the \u0027floor\u0027 was never recorded in the plan\u0027s state.",
+            "fix": "Implement a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a speculative recursion scenario that the quoted constraint already forecloses \u0393\u00C7\u00F6 if the plan handed to the round is already split, that is what gets measured, and re-submitting the original unsplit text would rightly be split again \u0393\u00C7\u00F6 and then asks for depth-tracking metadata machinery out of all proportion to a risk it never demonstrates in any named code."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Human operator has no visibility into the split hierarchy before committing, risking irreversible deep nesting.",
+            "why": "The plan states \u0027A caller is ordered to split ONCE.\u0027 If the user (the \u0027caller\u0027) types the command, pastes it, and hits enter, they have no way to know if the system will split the plan into 2 epics or 4 epics, or if it will split an already-split epic. If the user makes a mistake (e.g., runs the plan on a branch that was already split), they might accidentally create a deep hierarchy of epics that is hard to manage. For example, a user runs the plan on a branch that was already split once, and the system splits it again, creating a hierarchy of 4 levels deep. The user then has to manually flatten this hierarchy, which is time-consuming and error-prone.",
+            "fix": "Add a \u0027dry-run\u0027 or \u0027preview\u0027 step that shows the split hierarchy before committing, allowing the user to verify the depth.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a recursive-nesting failure the plan\u0027s own \u0027split ONCE\u0027 rule forecloses, misreads the \u0027caller\u0027 as a human typing a command, and asks for a dry-run preview out of proportion to a risk it never shows is real."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Unwritable store fails OPEN with a warning rather than failing the entire operation.",
+            "why": "Constraint 5 states \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 If the store is unwritable (e.g., due to permissions or disk full), the system will log a warning but continue. This means the split order might be lost, and the system will proceed as if the split was successful. For example, a user runs the plan, and the store is unwritable. The system logs a warning and continues. The user then commits the split, but the split order was never saved. Later, when the user tries to review the split, the system sees no split order and treats the plan as a single unit, leading to confusion and potential data loss.",
+            "fix": "Add a \u0027split depth\u0027 check in the plan review logic that reads the current depth from the plan\u0027s history or a metadata file, rather than assuming the caller knows it.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding restates a constraint the design explicitly chose (fail-open with a warning) as if it were a defect, and its proposed fix \u0393\u00C7\u00F6 a split-depth check reading plan history \u0393\u00C7\u00F6 addresses a different concern entirely and does not follow from the stated problem."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 283.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 250747,
+        "tokensOut": 17522,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 116,
+            "title": "Claim-write failures are misclassified as another process winning the claim",
+            "why": "If \u0060CreateNew\u0060 succeeds but writing or flushing the timestamp fails (for example, a full disk), the file still exists, so the \u0060IOException when (File.Exists(file))\u0060 handler returns false. The caller therefore receives no split order and no warning, while a partial claim can suppress future orders for up to a day. An expired claim that cannot be deleted has the same silent fail-closed behavior, violating the required fail-open policy.",
+            "fix": "Track whether this invocation successfully created the file and treat only a \u0060CreateNew\u0060 collision before creation as an existing claim; any delete, write, or flush failure must warn and return true, with best-effort cleanup of a partial file.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The \u0060catch (IOException) when (File.Exists(file))\u0060 filter genuinely conflates \u0027another process won the race\u0027 with \u0027our own delete or flush failed after the file existed\u0027, so a disk-full or lock failure returns false with no warning \u0393\u00C7\u00F6 silently fail-CLOSED in the one path the file\u0027s own remarks commit to failing open \u0393\u00C7\u00F6 and the fix is a two-line \u0060created\u0060 flag, so it is proportionate even if the severity and the \u0027suppresses orders for a day\u0027 consequence are somewhat overstated (an unparseable stamp reads back as null)."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 107,
+            "title": "Expired caller-stamp files are never garbage-collected for callers that do not return",
+            "why": "With 1,000,000 unique session IDs over time, each claim leaves a stale file because deletion only runs when that same caller claims again; filesystem allocation can consume gigabytes and eventually make later claims fail open, causing duplicate split instructions.",
+            "fix": "Add bounded cleanup of expired stamp files (for example, opportunistically scan and delete old files with a throttled cleanup pass).",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The volume scenario is fabricated (a million session ids and gigabytes are nonsense for ~50-byte files written only when a split is ordered), but it correctly identifies that \u0060callers/\u0060 is an append-only directory with no retention owner \u0393\u00C7\u00F6 exactly what this repository\u0027s MANDATORY \u0027everything that grows has an owner\u0027 rule requires, and the deletion at line 112 only ever reaps a caller that returns, so the point is worth acting on even if the stated impact is not."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 112,
+            "title": "Unconditional deletion of existing claim files creates a TOCTOU race that breaks atomic claims",
+            "why": "When two server processes race to claim an order (such as when an expired claim exists or both pass StillRemembered before file creation), Server 1 creates and writes the claim file via FileMode.CreateNew, but Server 2 executes File.Delete(file) immediately afterward, destroying Server 1\u0027s claim file and allowing Server 2\u0027s own FileMode.CreateNew call to succeed. Both servers return true, causing duplicate split orders across processes and defeating the atomicity guarantee.",
+            "fix": "Remove the pre-emptive File.Delete(file) before FileMode.CreateNew. Attempt FileMode.CreateNew first, and only handle an existing file if CreateNew throws an IOException by checking if the existing file is expired and replacing it atomically or using FileShare locking.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The expired-claim path really does break the atomicity the code claims \u0393\u00C7\u00F6 after one process deletes the stale file, creates its claim and closes the stream, a second process that already passed the \u0060File.Exists\u0060 check deletes that fresh claim and its own \u0060CreateNew\u0060 succeeds, so both return true and the comment at line 111 asserting \u0060CreateNew\u0060 is the only race is wrong; the impact is bounded (a duplicated split order, and the feature fails open anyway) but the fix is a small reordering, not new machinery."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 88,
+            "title": "Atomic claim introduces side-effect dependency via callback parameter",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 By passing an \u0060Action\u003Cstring\u003E? warn\u0060 into the atomic claim method, the method\u0027s return value (the claim result) becomes coupled with a side-effect (logging) that is not part of the atomic state transition. This breaks the purity of the \u0027one question\u0027 contract, as the caller must now manage the logging context for the claim to be complete.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 and the \u0060warn?.Invoke\u0060 call inside the catch block. The rule requires the caller to be ordered ONCE, and the claim logic to be atomic. The current implementation introduces a side-effect (logging a warning) that depends on an external callback, which violates the principle that the condition that issues the order and the condition that claims it are ONE question asked once. The warning is a side effect of the failure mode, not part of the atomic claim itself.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The optional \u0060warn\u0060 callback is a standard, well-documented way to report a fail-open condition without coupling this class to a logger, and the finding invents a purity requirement the cited rule does not impose \u0393\u00C7\u00F6 removing it would silently discard the only signal that the claim file could not be written."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Atomic claim logic separated into check-then-delete-then-create, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current implementation performs a \u0060File.Exists\u0060 check, deletes the file if present, and then attempts \u0060CreateNew\u0060. This sequence is not atomic. If another process deletes the file between the check and the \u0060CreateNew\u0060, or if the \u0060CreateNew\u0060 fails because the file was created by another process in that window, the logic returns \u0060false\u0060 (claim lost) or \u0060true\u0060 (claim won) inconsistently. The rule requires a single atomic operation to determine the outcome, not a sequence of operations that can be interrupted.",
+            "fix": "Change the catch block for \u0060IOException\u0060 to not return \u0060false\u0060 when \u0060File.Exists(file)\u0060 is true. The current logic returns \u0060false\u0060 if the file exists (implying a race where someone else claimed it), but the rule requires that \u0027A caller that already holds a claim is a caller already inside a split, and is told so.\u0027 The current implementation returns \u0060false\u0060 for an existing file, which is correct, but the logic \u0060if (File.Exists(file)) { File.Delete(file); }\u0060 followed by \u0060CreateNew\u0060 creates a race window where the file could be deleted by another process between the check and the write, leading to a silent failure or duplicate claim if not handled strictly. The rule \u0027The condition that issues the order and the condition that claims it are ONE question asked once\u0027 implies the check and the claim must be inseparable. The current code separates the existence check (delete) from the atomic creation.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claim is misread and the fix is self-contradictory \u0393\u00C7\u00F6 \u0060FileMode.CreateNew\u0060 is the atomic step and the \u0060catch (IOException) when (File.Exists(file))\u0060 already resolves the loser correctly, while the finding first demands that branch be removed and then concedes it is correct, leaving nothing actionable; the one genuinely narrow window it gestures at (a stale-claim delete racing a fresh write) is never named, and the file already states that this path deliberately fails open at the cost of one repeated instruction."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 554,
+            "title": "FirstPlanRound flag set before atomic claim, violating \u0027ONE question\u0027 rule",
+            "why": "The rule states: \u0027The condition that issues the order and the condition that claims it are ONE question asked once.\u0027 The current code sets \u0060FirstPlanRound: true\u0060 in the \u0060provisional\u0060 context before calling \u0060TryClaimSplitOrder\u0060. This means the flag is set regardless of whether the claim succeeds. If the claim fails (e.g., due to an unwritable store), the flag remains \u0060true\u0060, but the caller is not actually ordered to split (because the claim failed). This creates a state where the flag says \u0027first round\u0027 but the order was not given, violating the atomicity of the \u0027one question\u0027 contract.",
+            "fix": "Remove the \u0060FirstPlanRound: true\u0060 assignment in the \u0060provisional\u0060 context. The rule states: \u0027A caller is ordered to split ONCE. A plan that is already a piece is told so instead.\u0027 The current code sets \u0060FirstPlanRound\u0060 to \u0060true\u0060 unconditionally, then checks \u0060OrdersSplit\u0060 and claims the order. This means the \u0060FirstPlanRound\u0060 flag is set before the claim is verified, potentially allowing a caller that has already claimed an order to be treated as a first-round caller if the claim fails (e.g., due to an unwritable store). The rule requires that the \u0027claim\u0027 and the \u0027order\u0027 are one question. The current code separates the flag setting from the claim verification.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads the code: \u0060provisional\u0060 with \u0060FirstPlanRound: true\u0060 is only the hypothetical used to ask whether this round would order a split, and the \u0060context\u0060 that actually feeds \u0060GateCommands.For\u0060 carries the claim\u0027s result \u0393\u00C7\u00F6 so a failed claim does suppress the order, and the suggested fix would break the claim path entirely."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 907,
+            "title": "Comment misrepresents fallback logic: \u0027Our session\u0027 vs \u0027checkout\u0027",
+            "why": "The rule states: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The comment in \u0060CallerFor\u0060 says: \u0027Our session is repo\u002Bbranch, and an epic arrives on its own branch: a session-keyed fallback would call every epic a fresh caller...\u0027 This implies the fallback is the session, but the code actually falls back to \u0060session.State.RepoPath\u0060 (the checkout). The comment is misleading because it suggests the fallback is the session, when it is actually the checkout. This is a minor deviation because the code is correct, but the comment could confuse a reader about the actual fallback mechanism.",
+            "fix": "Change the fallback from \u0060CallerIdentity.Current()\u0060 to \u0060session.State.RepoPath\u0060 to be consistent with the rule \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 The current code uses \u0060CallerIdentity.Current()\u0060 which returns the session ID, but the rule requires that a client with no session ID falls back to the checkout (repo path), not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the fallback is the checkout, not the session. The current code uses \u0060CallerIdentity.Current()\u0060 which is the session ID, and only falls back to \u0060session.State.RepoPath\u0060 if the session ID is empty. This is correct, but the comment in the code says \u0027Our session is repo\u002Bbranch\u0027, which is misleading. The rule requires that the backup",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The comment it attacks actually says the opposite of what the finding claims \u0393\u00C7\u00F6 it explains why the fallback is the checkout rather than our session \u0393\u00C7\u00F6 and the \u0027fix\u0027 is a rambling, self-contradicting loop that concedes the code is correct while proposing a change that would break the exported-session-id path."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Race condition in atomic claim allows duplicate orders on concurrent access",
+            "why": "The code checks \u0060StillRemembered\u0060 (read), then deletes the file if it exists, then attempts \u0060FileMode.CreateNew\u0060. If two servers run in parallel: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false). Server A deletes the file. Server B deletes the file (no-op). Server A creates the file. Server B attempts to create the file but fails with \u0060IOException\u0060 (file exists). The catch block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060. If Server B\u0027s \u0060CreateNew\u0060 fails because Server A created it, \u0060File.Exists\u0060 is true, so it returns \u0060false\u0060. However, if the file was deleted by Server A *after* Server B\u0027s check but *before* Server B\u0027s delete, or if the timing is such that the file exists but the \u0060CreateNew\u0060 fails for a different reason (e.g., permissions), the logic might be flawed. More critically, the \u0060File.Delete\u0060 is outside the \u0060try\u0060 block in the original logic flow relative to the \u0060CreateNew\u0060 race. Wait, looking closer: The \u0060File.Delete\u0060 is inside the \u0060try\u0060.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or ensure the \u0060File.Exists\u0060 check covers the deletion path before \u0060CreateNew\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding argues itself into a contradiction and then prescribes moving \u0060File.Delete\u0060 inside the \u0060try\u0060 block where it already sits, so it names no defect that exists in this code and gives the reader nothing to act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Split order claimed on rounds that may not issue a command",
+            "why": "The code calls \u0060Core.Commands.GateCommands.OrdersSplit(provisional)\u0060 to determine if a split should be ordered. If this returns true, it then calls \u0060TryClaimSplitOrder\u0060. However, the \u0060provisional\u0060 context used for the claim includes \u0060FirstPlanRound: true\u0060 (line 573), which is hardcoded. The original logic used \u0060!_callers.SplitAlreadyOrdered(caller, DateTime.UtcNow)\u0060 to determine if it was the first round. By hardcoding \u0060FirstPlanRound: true\u0060 and then checking \u0060OrdersSplit\u0060 *after* the claim, the code risks claiming a split order for a round that might not actually be the \u0027first\u0027 round in the sequence if the logic for determining \u0027first\u0027 is decoupled from the claim. Specifically, if \u0060OrdersSplit\u0060 returns true based on \u0060provisional\u0060, but the claim fails (e.g., due to race), the system might proceed with a split order that was already claimed by another process, or fail to claim it when it should have. The logic flow is: 1. Create provisional with \u0060FirstPlanRound: true\u0060. 2. Check if \u0060pro\u0060",
+            "fix": "Pass the \u0060provisional\u0060 context to \u0060OrdersSplit\u0060 *after* the claim attempt, or ensure the claim is only attempted if \u0060OrdersSplit\u0060 returns true, to avoid claiming a split order on a round that doesn\u0027t actually issue a split command.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding misreads the code \u0393\u00C7\u00F6 the claim is already gated behind \u0060OrdersSplit(provisional)\u0060, which is exactly the fix it proposes, and its reasoning trails off mid-sentence without identifying any real defect."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file system checks in atomic claim logic",
+            "why": "The code performs \u0060File.Exists(file)\u0060 (line 95) and then \u0060File.Delete(file)\u0060 (line 97), followed by \u0060new FileStream(file, ...)\u0060 (line 100). In a high-concurrency environment where multiple servers are checking the same caller, this results in multiple file system calls per claim attempt. While \u0060File.Exists\u0060 is a check, the subsequent \u0060Delete\u0060 and \u0060CreateNew\u0060 operations are expensive. If the file exists and is not expired, the code deletes it and then tries to create a new one. This sequence of operations (check, delete, create) can be optimized by using a single atomic operation or by caching the existence check. In a scenario with 100 concurrent servers checking the same caller, this could lead to 300 file system calls per second, potentially causing I/O contention.",
+            "fix": "Cache the \u0060File.Exists\u0060 result or use a single \u0060File.TryOpen\u0060 pattern to avoid redundant file system calls in high-frequency scenarios.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claim is misdirected \u0393\u00C7\u00F6 the delete/CreateNew sequence exists for correctness (clearing an expired stamp so CreateNew is the only race), and a per-caller claim happens once per session, not at a rate where three file calls could cause I/O contention; the invented 100-server/300-calls-per-second scenario is not this code\u0027s reality."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[14:47:48 \u001B[32mINF\u001B[0m] coai-mcp#22348 finding [Blocking/Reliability] src_mcp/src/Server/CallerSessions.cs:98 - Race condition in atomic claim allows duplicate orders on concurrent access (from local) [gating] Round=1 Stage=CodeReview\r | [14:47:48 \u001B[32mINF\u001B[0m] coai-mcp#22348 finding [Major/Ux] src_mcp/src/Server/PanelService.cs:578 - Split order claimed on rounds that may not issue a command (from local) [gating] Round=1 Stage=CodeReview\r | [14:47:48 \u001B[32mINF\u001B[0m] coai-mcp#22348 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file system checks in atomic claim logic (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  }
+]

--- a/research/data/bench-2026-09-05/matrix-v0.17.4/tables.md
+++ b/research/data/bench-2026-09-05/matrix-v0.17.4/tables.md
@@ -1,0 +1,87 @@
+# Bench
+
+## Per arm
+
+| arm | stage | runs | verdicts | median time | median findings | gating | useful | tokens in / out | cost |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex` | code | 4 | proceed | 78.7s | 3 | 8 | 4/9 | 893.5k / 23.7k | not reported |
+| `codex` | plan-1 | 4 | proceed | 42.8s | 6 | 18 | 11/21 | 58.1k / 8.2k | not reported |
+| `codex,gemini` | code | 4 | proceed×3, FAILED×1 | 72.2s | 5 | 13 | 11/13 | 856.3k / 40.9k | not reported |
+| `codex,gemini` | plan-1 | 4 | good_enough×2, proceed×2 | 39s | 8 | 25 | 16/31 | 207.1k / 19.5k | not reported |
+| `codex,gemini,local` | code | 4 | proceed | 306.9s | 10 | 31 | 9/44 | 1.4M / 69.3k | not reported |
+| `codex,gemini,local` | plan-1 | 4 | good_enough | 94.8s | 14 | 43 | 23/51 | 153.2k / 21.3k | not reported |
+| `codex,local` | code | 4 | proceed | 390.4s | 9 | 27 | 8/39 | 1M / 35k | not reported |
+| `codex,local` | plan-1 | 4 | good_enough | 54.6s | 10 | 33 | 13/39 | 66.2k / 12.6k | not reported |
+| `gemini` | code | 3 | proceed | 27.5s | 1 | 5 | 3/4 | 322.1k / 27.2k | not reported |
+| `gemini` | plan-1 | 4 | proceed×3, FAILED×1 | 13.5s | 3 | 6 | 5/10 | 68.3k / 4.6k | not reported |
+| `gemini,local` | code | 3 | proceed | 248.6s | 6 | 15 | 1/18 | 512.6k / 52.4k | not reported |
+| `gemini,local` | plan-1 | 4 | good_enough×2, FAILED×1, proceed×1 | 177.8s | 9 | 21 | 9/28 | 78.1k / 11.4k | not reported |
+| `local` | code | 4 | proceed | 496.6s | 7 | 18 | 1/28 | 188.9k / 16k | not reported |
+| `local` | plan-1 | 4 | proceed | 140.4s | 6 | 18 | 6/22 | 8.4k / 5.3k | not reported |
+
+## Who found it alone
+
+| provider | findings written | distinct | also found by another | found by it alone | of those, worth having |
+|---|---|---|---|---|---|
+| `codex` | 111 | 85 | 4 (5%) | 81 (95%) | **48** |
+| `gemini` | 69 | 51 | 2 (4%) | 49 (96%) | **25** |
+| `local` | 186 | 38 | 2 (5%) | 36 (95%) | **4** |
+
+## Per run
+
+| arm | case | # | lane | stage | verdict | time | findings | gating | tokens in / out |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex` | rounds-collapse | 1 | 1 | plan-1 | proceed | 38.8s | 4 | 3 | 15.3k / 1.8k |
+| `codex` | rounds-collapse | 1 | 1 | code | proceed | 78.7s | 2 | 1 | 224.6k / 6k |
+| `codex` | rounds-collapse | 2 | 2 | plan-1 | proceed | 42.8s | 5 | 4 | 15.3k / 2k |
+| `codex` | rounds-collapse | 2 | 2 | code | proceed | 44.6s | 3 | 3 | 287.2k / 4.4k |
+| `gemini` | rounds-collapse | 1 | 3 | plan-1 | proceed | 13.5s | 4 | 2 | 14.6k / 1.3k |
+| `gemini` | rounds-collapse | 1 | 3 | code | proceed | 23.6s | 1 | 1 | 127.1k / 6.7k |
+| `gemini` | rounds-collapse | 2 | 4 | plan-1 | **FAILED** | 0s | 0 | 0 | 0 / 0 |
+| `local` | rounds-collapse | 1 | 7 | plan-1 | proceed | 47.5s | 6 | 5 | 2.8k / 1.3k |
+| `local` | rounds-collapse | 1 | 7 | code | proceed | 62.3s | 4 | 3 | 69.1k / 2.9k |
+| `local` | rounds-collapse | 2 | 5 | plan-1 | proceed | 385.3s | 6 | 5 | 2.8k / 1.3k |
+| `local` | rounds-collapse | 2 | 5 | code | proceed | 74.9s | 5 | 4 | 69.1k / 3.5k |
+| `codex,gemini` | rounds-collapse | 1 | 6 | plan-1 | good_enough | 39s | 9 | 7 | 50.5k / 3.5k |
+| `codex,gemini` | rounds-collapse | 1 | 6 | code | **FAILED** | 0.1s | 0 | 0 | 0 / 0 |
+| `codex,gemini` | rounds-collapse | 2 | 4 | plan-1 | proceed | 41.7s | 7 | 5 | 75.7k / 6.3k |
+| `codex,gemini` | rounds-collapse | 2 | 4 | code | proceed | 63.6s | 5 | 4 | 361k / 15.4k |
+| `codex,local` | rounds-collapse | 1 | 3 | plan-1 | good_enough | 39.3s | 10 | 8 | 17.8k / 3.3k |
+| `codex,local` | rounds-collapse | 1 | 3 | code | proceed | 390.4s | 7 | 6 | 275.8k / 6.9k |
+| `codex,local` | rounds-collapse | 2 | 6 | plan-1 | good_enough | 87.3s | 9 | 8 | 17.8k / 2.7k |
+| `codex,local` | rounds-collapse | 2 | 6 | code | proceed | 185.4s | 9 | 6 | 346.3k / 9.1k |
+| `gemini,local` | rounds-collapse | 1 | 2 | plan-1 | good_enough | 395.8s | 9 | 7 | 24.7k / 5.7k |
+| `gemini,local` | rounds-collapse | 1 | 2 | code | proceed | 248.6s | 6 | 4 | 207.9k / 16.8k |
+| `gemini,local` | rounds-collapse | 2 | 4 | plan-1 | good_enough | 37.5s | 11 | 8 | 28k / 3.5k |
+| `gemini,local` | rounds-collapse | 2 | 4 | code | proceed | 389.4s | 6 | 5 | 199.2k / 17.2k |
+| `codex,gemini,local` | rounds-collapse | 1 | 7 | plan-1 | good_enough | 49.7s | 14 | 11 | 40.6k / 4.4k |
+| `codex,gemini,local` | rounds-collapse | 1 | 7 | code | proceed | 208.7s | 9 | 7 | 484.8k / 18.1k |
+| `codex,gemini,local` | rounds-collapse | 2 | 1 | plan-1 | good_enough | 94.8s | 14 | 11 | 38.6k / 6.2k |
+| `codex,gemini,local` | rounds-collapse | 2 | 1 | code | proceed | 306.9s | 9 | 8 | 393k / 22.6k |
+| `codex` | split-once | 1 | 6 | plan-1 | proceed | 45s | 6 | 6 | 13.8k / 2.3k |
+| `codex` | split-once | 1 | 6 | code | proceed | 62.1s | 1 | 1 | 168k / 5.3k |
+| `codex` | split-once | 2 | 7 | plan-1 | proceed | 40.3s | 6 | 5 | 13.8k / 2.1k |
+| `codex` | split-once | 2 | 7 | code | proceed | 80.4s | 3 | 3 | 213.7k / 8k |
+| `gemini` | split-once | 1 | 6 | plan-1 | proceed | 8.3s | 3 | 2 | 19.8k / 919 |
+| `gemini` | split-once | 1 | 6 | code | proceed | 34.6s | 1 | 1 | 104.7k / 11.9k |
+| `gemini` | split-once | 2 | 5 | plan-1 | proceed | 15.6s | 3 | 2 | 33.9k / 2.4k |
+| `gemini` | split-once | 2 | 5 | code | proceed | 27.5s | 3 | 3 | 90.3k / 8.5k |
+| `local` | split-once | 1 | 6 | plan-1 | proceed | 140.4s | 5 | 4 | 1.4k / 1.3k |
+| `local` | split-once | 1 | 6 | code | proceed | 584.3s | 13 | 6 | 25.4k / 3.7k |
+| `local` | split-once | 2 | 3 | plan-1 | proceed | 32.7s | 5 | 4 | 1.4k / 1.3k |
+| `local` | split-once | 2 | 3 | code | proceed | 496.6s | 7 | 5 | 25.4k / 5.9k |
+| `codex,gemini` | split-once | 1 | 7 | plan-1 | proceed | 34.1s | 8 | 6 | 48.4k / 4.6k |
+| `codex,gemini` | split-once | 1 | 7 | code | proceed | 80s | 7 | 6 | 210k / 13k |
+| `codex,gemini` | split-once | 2 | 5 | plan-1 | good_enough | 31.1s | 7 | 7 | 32.6k / 5.1k |
+| `codex,gemini` | split-once | 2 | 5 | code | proceed | 72.2s | 3 | 3 | 285.3k / 12.6k |
+| `codex,local` | split-once | 1 | 1 | plan-1 | good_enough | 45.3s | 10 | 9 | 15.2k / 3.3k |
+| `codex,local` | split-once | 1 | 1 | code | proceed | 231.5s | 15 | 8 | 192.4k / 8.5k |
+| `codex,local` | split-once | 2 | 4 | plan-1 | good_enough | 54.6s | 10 | 8 | 15.2k / 3.2k |
+| `codex,local` | split-once | 2 | 4 | code | proceed | 522.4s | 9 | 7 | 217.5k / 10.5k |
+| `gemini,local` | split-once | 1 | 7 | plan-1 | **FAILED** | 0s | 0 | 0 | 0 / 0 |
+| `gemini,local` | split-once | 2 | 7 | plan-1 | proceed | 177.8s | 8 | 6 | 25.4k / 2.3k |
+| `gemini,local` | split-once | 2 | 7 | code | proceed | 200.4s | 8 | 6 | 105.6k / 18.4k |
+| `codex,gemini,local` | split-once | 1 | 5 | plan-1 | good_enough | 59.2s | 12 | 11 | 40.4k / 4.7k |
+| `codex,gemini,local` | split-once | 1 | 5 | code | proceed | 425.8s | 18 | 9 | 243.3k / 11.1k |
+| `codex,gemini,local` | split-once | 2 | 2 | plan-1 | good_enough | 152.8s | 11 | 10 | 33.7k / 6k |
+| `codex,gemini,local` | split-once | 2 | 2 | code | proceed | 283.9s | 10 | 7 | 250.7k / 17.5k |

--- a/research/data/bench-2026-09-05/plan-A.md
+++ b/research/data/bench-2026-09-05/plan-A.md
@@ -1,0 +1,90 @@
+# PLAN — a finished round closes itself, vendors keep one colour, and Fable stops being a reviewer
+
+> Status: **plan only, nothing implemented yet.** Scope:
+> `src_mcp/{core/Commands/GateCommands.cs, src/Server/PanelService.cs}`,
+> `src_vs_code/src/{panelProvider.ts, panelView.ts, rounds.ts}`, their tests, the help and the docs.
+>
+> Related docs: [module_extension.md](../research/module_extension.md),
+> [module_server.md](../research/module_server.md),
+> [PLAN_commands_and_autonomy.md](../research/PLAN_commands_and_autonomy.md).
+
+## Three symptoms, reported by the operator
+
+**1. Fable is gated on a reviewer that will never exist.** `PanelService.FableIsUsable()` asks the
+configured REVIEWER providers whether one of them is Fable, and issues the "split with Fable" order
+only then. But Fable is not a reviewer — it is a model of the **calling AI**, which already has it.
+Nobody configures Fable as a vendor in this panel and nobody should, so the check is false on every
+real machine and the switch is inert. Confirmed on this one: `providers` answers codex, gemini,
+local. The measurement that said the order works (22/22 named Fable) only ran because the fixtures
+forced availability to true.
+
+The reasoning that put the check there was sound for a reviewer — *never name a model this machine
+has not got* — and wrong about what Fable is. The operator's box is the whole decision: they know
+what their assistant can run.
+
+**2. A finished round stays open.** Rounds open themselves while they run, which is right, and then
+stay open forever, which fills the list with expanded cards. What should happen: **running →
+expanded; finished → closed again; opened by the person → never touched.** The current wording in
+`panelProvider.expanded` states the opposite as a deliberate choice ("when it finishes it stays as
+they left it") — that judgement is overruled by the person who uses it.
+
+**3. A vendor's name is the same grey as everything else.** In `codex/PlanCritique — running` the
+one word that says WHO is indistinguishable from the row it sits in. It should carry a colour, the
+same colour for the same vendor in every place a vendor is named, and only the vendor word — the
+rest of the line stays as it is.
+
+## What must be true when this is done
+
+1. Ticking *Split with Fable* issues the Fable order. No reviewer list is consulted, and there is no
+   second condition a person cannot see from the panel.
+2. A round that finishes closes itself **if it was this panel that opened it**.
+3. A round the person opened stays open when it finishes; a running round the person closed stays
+   closed; re-opening a card after the panel closed it makes it theirs again.
+4. Every vendor name renders in a colour that is stable for that vendor across the round cards, the
+   live section and the spending rows — and stable across restarts, since it is derived from the
+   name rather than from the order rows arrive in.
+5. The colours come from the editor's own chart palette, so they hold in a light theme as well as a
+   dark one.
+6. Nothing that comes out of a session file reaches the page unescaped.
+
+## Constraints
+
+- One renderer for a reviewer row, not a text one and an HTML one that drift. The text version is
+  what the tests read today.
+- The open/closed sets are pruned to living rounds, as they are now — neither may grow for the life
+  of the extension host.
+- `FableAvailable` is REMOVED rather than left as a field nobody sets: a flag with one caller passing
+  a constant is a condition that will be misread later.
+- No new dependency, and no colour hard-coded in hex: `--vscode-charts-*` adapt to the theme.
+
+## Build order
+
+1. **RED first, three tests**: the Fable order is issued with the switch on and no Fable vendor
+   configured; a round that stops running loses its auto-open; a round the person opened does not.
+2. **`GateCommands`**: drop `FableAvailable` from `CommandContext`; the switch alone decides.
+   `PanelService`: delete `FableIsUsable` and `NamesFable`.
+3. **`panelProvider`**: a second set — the rounds THIS panel opened. A person's toggle removes the
+   key from it; a round that is no longer running and is still in it is closed and dropped.
+4. **`rounds.ts`**: `vendorColour(name)` — a deterministic index into a fixed palette, so a vendor
+   nobody has seen yet still gets a stable colour.
+5. **`panelView`**: the vendor word wrapped in `<span class="vendor" style="color:…">`, escaped; the
+   spending rows use the same function.
+6. Docs: `module_extension.md`, `module_server.md`, the help entry for *Split with Fable*, CHANGELOG.
+
+## Test plan
+
+`src_mcp`: the Fable command is issued with `SplitWithFable` on and nothing else set; it is still
+absent on a code round, on a plan that did not pass, and for a piece of a split.
+
+`src_vs_code`: a running round is auto-opened; the same round, finished, is not; a round the person
+opened stays open across the transition; a running round the person closed stays closed; both sets
+are pruned to living rounds. `vendorColour` is stable for one name, differs for two common names,
+and every colour it can return is a `--vscode-charts-*` variable. A reviewer row escapes a vendor
+name containing `<`.
+
+## Definition of Done
+
+- [ ] The Fable order fires on the checkbox alone, and `FableAvailable` no longer exists.
+- [ ] Finished rounds collapse; the person's own choice survives.
+- [ ] Vendor names are coloured, stably, in every place they appear.
+- [ ] `CoaiMcp.Tests.exe` and `npm test` pass; docs, help and CHANGELOG updated; the plan promoted.

--- a/research/data/bench-2026-09-05/plan-B.md
+++ b/research/data/bench-2026-09-05/plan-B.md
@@ -1,0 +1,28 @@
+# SCOPE — the split order needs a floor, and the caller is what supplies it
+
+With *Split the plan* on, a plan that passes is told to split into 2–4 epics and each into stories.
+Each epic then comes back for its own plan review — correctly — and the gate, with no memory, told
+each one to split into epics as well. Epics of epics, with no floor.
+
+Our session cannot hold that memory: it is keyed repo+branch and its plan stage happens once, so an
+epic returns as a DIFFERENT session on its own branch. The caller is what crosses them, and Claude
+Code exports `CLAUDE_CODE_SESSION_ID` to every child it spawns.
+
+## What must be true
+
+1. A caller is ordered to split ONCE. A plan that is already a piece is told so instead: build as one
+   unit, review its diff, fix, document, test, commit — and say so if it is genuinely too big.
+2. A piece's shape is not re-measured and the Fable order is not issued to it; the autonomy order is.
+3. Switch off → no command at all. A plan that did not pass → no command at all.
+4. The claim is atomic across processes: two servers sharing a data directory cannot both give it.
+5. An unwritable store fails OPEN with a warning rather than silently disabling the feature.
+6. A client that exports no session id is still followed across the branches of one checkout.
+7. The split verdict is measured from the plan THIS round reviewed.
+
+## Constraints
+
+- No change to what the gate decides: verdicts, thresholds and the resolve loop are untouched.
+- The condition that issues the order and the condition that claims it are ONE question asked once.
+- A caller id is somebody else's string and reaches a file name: it must not escape the directory.
+- Everything off by default; an empty command list stays the behaviour of every earlier release.
+- Nothing may be added that requires the calling AI to remember and pass an identifier.

--- a/research/data/bench-2026-09-06/runs.json
+++ b/research/data/bench-2026-09-06/runs.json
@@ -1,0 +1,5322 @@
+[
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex|rounds-collapse|1",
+    "startedUtc": "2026-09-05T20:39:22.2856054Z",
+    "finishedUtc": "2026-09-05T20:41:41.9993863Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 50.8,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 2,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 15282,
+        "tokensOut": 2302,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping requirement covers the whole session-file rendering path, but the plan only changes vendor-name rendering.",
+            "why": "A session file containing markup in another rendered field, such as a plan title or reviewer detail, can still reach the page unescaped and execute or alter the panel despite the vendor-name test passing.",
+            "fix": "Inventory every session-derived field rendered by panelView, route each through the shared escaped renderer, and add a test with markup in each relevant field.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names the exact defect class this codebase\u0027s rules call out \u0393\u00C7\u00F6 a protective measure applied only at the site somebody thought of \u0393\u00C7\u00F6 and points at other session-derived fields reaching the panel unescaped, which is a real injection risk with a proportionate fix (one escaped renderer plus per-field tests)."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "A reviewer process killed halfway can remain permanently auto-expanded because the plan defines completion but not stale-running recovery.",
+            "why": "If the reviewer is killed after the panel adds the round to its auto-open set, the session has no completion timestamp and may continue to report running; the cleanup condition never fires, so the card stays expanded indefinitely.",
+            "fix": "Define and implement stale/dead-round detection using the reviewer timeout or process state, then remove the round from the panel-owned set and test a killed or timed-out round.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding is about a UI panel\u0027s auto-expanded set staying open when a reviewer process dies \u0393\u00C7\u00F6 a cosmetic, self-correcting annoyance in a view a person is looking at anyway, and it demands stale-round detection machinery out of proportion to that risk; it also invents a failure mode from a plan document rather than naming any code that behaves this way."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The test plan does not verify that every vendor display uses the same colour function.",
+            "why": "A regression can leave a vendor coloured in round cards but grey or differently coloured in the live section or spending rows while all listed vendorColour unit tests still pass.",
+            "fix": "Add integration assertions for the same vendor in a round card, live section, and spending row, including consistency after a fresh extension instance.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It asks for cross-view integration tests to guard against a purely hypothetical divergence in a shared colour helper \u0393\u00C7\u00F6 machinery out of proportion to a cosmetic risk that the existing unit tests on the single colour function already cover."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 88.7,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 378768,
+        "tokensOut": 6523,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 4,
+            "title": "The added plan is left marked as unimplemented after this change ships",
+            "why": "The repository rule says: \u0022After every code change: ... Run the plan completion check ... Promote in the same task.\u0022 This diff implements the plan but adds it with status \u0022plan only, nothing implemented yet\u0022 and an unchecked Definition of Done.",
+            "fix": "Promote or update the plan in this change: mark it implemented, complete the Definition of Done, and remove the stale unimplemented status.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The diff adds a new plan document whose status line correctly says nothing is implemented yet \u0393\u00C7\u00F6 the promotion rule applies once the work ships, so the finding misreads a freshly written plan as a stale one and demands a status change that would be false."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 185,
+            "title": "Scratch-file cleanup silently discards I/O failures",
+            "why": "The written rule says: \u0022Handle errors explicitly at every level; never silently swallow one.\u0022 The empty catch around File.Delete discards cleanup failures without logging or surfacing context.",
+            "fix": "Handle the cleanup failure explicitly, such as logging detailed context at the server boundary, or surface it if cleanup is required for correctness.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The swallowed delete is best-effort cleanup of the writer\u0027s own scratch file after the move has already succeeded or thrown \u0393\u00C7\u00F6 its worst outcome is a stray .tmp \u0393\u00C7\u00F6 and the catch is narrowly typed with the reason written beside it, so demanding logging here is ceremony out of proportion to the risk."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 156,
+            "title": "Concurrent saves can silently overwrite newer session state",
+            "why": "Two MCP processes can serialize different snapshots, then each atomically moves its unique temp file over the same destination. The later move wins even if its snapshot was loaded before the other process recorded a round or reviewer finding, erasing that newer trail without an error.",
+            "fix": "Serialize cross-process read-modify-write operations with a named mutex/file lock, or perform a compare-and-retry merge against the current destination before replacing it.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The temp-file collision the code\u0027s own comment records proves two processes were writing the *same* session file concurrently, so the last-writer-wins move can silently drop a round or finding another process just recorded \u0393\u00C7\u00F6 a real lost-update on the durable state this store exists to protect, and the suggested lock/merge is proportionate."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 153,
+            "title": "A failed write leaves its uniquely named scratch file behind",
+            "why": "\u0060File.WriteAllText\u0060 runs before the \u0060try/finally\u0060, so a disk-full, permission, or interrupted write leaves the per-write \u0060.tmp\u0060 file permanently. Repeated failures or process crashes can accumulate partial session files in the sessions directory.",
+            "fix": "Put \u0060File.WriteAllText\u0060 inside the existing \u0060try/finally\u0060, and remove stale session scratch files during startup or before saves.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It correctly identifies that the switch to per-write unique scratch names removed the self-cleaning property of the old fixed name, so a failed or interrupted write now leaves an orphan \u0060.tmp\u0060 forever in a directory with no retention owner \u0393\u00C7\u00F6 a real, if minor, growth surface that this repo\u0027s own reliability rule cares about, and the fix (move the write inside the existing try/finally, sweep leftovers in the startup sweep that already exists) is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 153,
+            "title": "A disclosure toggle still waits for the full expensive panel refresh",
+            "why": "Opening or closing one round calls \u0060render()\u0060 synchronously; on a cold refresh this waits for configuration, server/CLI probes, GitHub metadata, and price-table requests before posting the new HTML. With three vendors and an unavailable network, the person can wait up to the documented ~20 seconds with no progress or terminal error state.",
+            "fix": "Update the disclosure immediately from cached state, and run expensive metadata refreshes independently with a visible refreshing/error status.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The panel already re-runs this same \u0060render()\u0060 on every five-second watcher tick and each probe is TTL-cached (\u0060latestCheckedAt\u0060, \u0060cliCheckedAt\u0060, \u0060localCheckedAt\u0060, \u0060pricesCheckedAt\u0060), so the click path is not specially slow \u0393\u00C7\u00F6 the finding asserts an unsupported ~20s stall and asks for an optimistic-render/background-refresh rework out of proportion to a repaint the code deliberately makes synchronous so an opened card has a body."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/core/Server/SessionStore.cs",
+            "line": 173,
+            "title": "The retry loop blocks the calling thread during every destination lock",
+            "why": "When several MCP servers save the same session concurrently, each denied move sleeps synchronously for up to 200 ms. With ten simultaneous rounds this ties up request/reviewer threads during progress persistence and can materially delay reviewer transitions even though the retry is bounded.",
+            "fix": "Use an async delay in an async save path, or serialize/coalesce per-session writes so contention does not block one thread per writer.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The file could not be produced at the reviewed commit, so the finding is judged on its words alone: it describes a bounded ~200 ms retry on a rare cross-process lock collision during session persistence as a thread-starvation risk and asks for async or per-session write coalescing \u0393\u00C7\u00F6 machinery out of proportion to a contention window that a local stdio MCP server realistically never hits."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:41:41 \u001B[32mINF\u001B[0m] coai-mcp#22668 finding [Minor/Reliability] src_mcp/src/Server/SessionStore.cs:153 - A failed write leaves its uniquely named scratch file behind (from codex) Round=1 Stage=CodeReview\r | [20:41:41 \u001B[32mINF\u001B[0m] coai-mcp#22668 finding [Major/Ux] src_vs_code/src/panelProvider.ts:153 - A disclosure toggle still waits for the full expensive panel refresh (from codex) [gating] Round=1 Stage=CodeReview\r | [20:41:41 \u001B[32mINF\u001B[0m] coai-mcp#22668 finding [Minor/Performance] src_mcp/core/Server/SessionStore.cs:173 - The retry loop blocks the calling thread during every destination lock (from codex) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "gemini",
+    "repeat": 1,
+    "lane": 1,
+    "key": "gemini|rounds-collapse|1",
+    "startedUtc": "2026-09-05T20:41:42.1361162Z",
+    "finishedUtc": "2026-09-05T20:42:17.9073938Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 16.2,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 20674,
+        "tokensOut": 2959,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "CSS class collision between inline vendor span and settings card style",
+            "why": "Step 5 specifies wrapping the vendor name in \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060, but \u0060.vendor\u0060 is already defined in the stylesheet with card-level border, padding, and border-radius rules, causing inline vendor labels in reviewer rows to render distorted with box styling.",
+            "fix": "Use a distinct, non-colliding class name such as \u0060who\u0060 for the inline vendor label.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "A concrete, checkable collision \u0393\u00C7\u00F6 reusing an existing card-level \u0060.vendor\u0060 rule for an inline label would visibly distort the reviewer rows, and the fix (a distinct class name) is proportionate and immediately actionable."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Dead or aborted rounds never receive a finished transition and remain open indefinitely",
+            "why": "Step 3 relies on a round transitioning from running to finished to trigger auto-closure; if a reviewer times out, crashes, or is killed without writing completion metadata, the round stays in the active set indefinitely and calculates unbounded elapsed run time.",
+            "fix": "Add stale-round detection against the reviewer timeout to clean up auto-opened state and finalize display for uncompleted rounds.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding is untethered speculation about a \u0027Step 3\u0027 auto-closure mechanism with no file, line, or code shown \u0393\u00C7\u00F6 it asserts a failure mode without evidence that any such round-state transition exists here, and demands stale-round machinery for a hazard it has not established."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Card disclosure toggle triggers full panel repaint with blocking CLI and network probes",
+            "why": "Toggling round expansion repaints the panel and rebuilds the card body, which synchronously executes binary stat calls, CLI provider probes, GitHub release checks, and pricing table fetches, blocking UI responsiveness.",
+            "fix": "Separate disclosure toggle state updates from card body construction, and cache external CLI and pricing probes asynchronously.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding names no file or code and asserts a causal chain \u0393\u00C7\u00F6 a disclosure toggle synchronously running binary stats, CLI probes, GitHub release checks and pricing fetches \u0393\u00C7\u00F6 that reads as speculation about a webview repaint rather than something located in this code, so nobody can act on it as written."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Placing theme-dependent chart palette logic in the session parser couples data parsing to UI view concerns",
+            "why": "Step 4 places \u0060vendorColour\u0060 in \u0060rounds.ts\u0060 alongside session parsing; independent views such as spending rows must import the session parsing module solely for color resolution, coupling data models to VS Code UI theme chart tokens.",
+            "fix": "Place \u0060vendorColour\u0060 in a standalone UI utility module (e.g., \u0060vendorColour.ts\u0060) imported by both round cards and spending rows.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "A single small colour-mapping helper placed in an already-imported module is a trivial file-organisation preference, not a defect or a rule this code breaks, and the proposed extra module is disproportionate to the risk."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 19.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 2,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 159072,
+        "tokensOut": 5530,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "Completed plan was left in todo/ with outdated \u0027plan only\u0027 status rather than being promoted to research/",
+            "why": "The knowledge base rule states: \u0027Run the plan completion check from planning-docs.md: does this work finish a plan, or has a plan\u0027s status line stopped matching reality? Promote in the same task.\u0027 Furthermore, the Definition of Done in the plan itself specifies \u0027[x] the plan promoted\u0027. The diff adds the completed implementation across C# and TypeScript but leaves the plan in \u0027todo/PLAN_rounds_collapse_and_vendor_colour.md\u0027 with \u0027Status: plan only, nothing implemented yet.\u0027 instead of promoting it to \u0027research/\u0027 with its updated status and recorded deviations.",
+            "fix": "Move \u0027todo/PLAN_rounds_collapse_and_vendor_colour.md\u0027 to \u0027research/PLAN_rounds_collapse_and_vendor_colour.md\u0027 and update the frontmatter/status to reflect implementation completion and deviations (as quoted in the plan doc: \u0027Status: IMPLEMENTED, 2026-09-04\u0027).",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The plan\u0027s status line still reads \u0027plan only, nothing implemented yet\u0027 while the diff implements it, which is exactly the promotion failure planning-docs.md forbids and the repo\u0027s own plan-lifecycle check would flag \u0393\u00C7\u00F6 actionable and rule-backed, despite the finding inventing a DoD line the file does not contain."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Using class=\u0022vendor\u0022 for inline vendor name span causes CSS style collisions with the existing .vendor settings card class",
+            "why": "In the extension stylesheet, \u0027.vendor\u0027 is already styled for settings cards (carrying border, border-radius, and padding). Wrapping inline vendor words in \u003Cspan class=\u0022vendor\u0022\u003E causes them to render with box borders/padding inside tight reviewer lines, making text appear struck-out or broken.",
+            "fix": "Change the span class from \u0022vendor\u0022 to \u0022who\u0022 (or remove conflicting styles from .vendor) so that vendor labels inside reviewer rows do not inherit card styling (.vendor { border, border-radius, padding: 8px }) which strikes through or distorts text in tight rows.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 181,
+            "title": "Synchronous Thread.Sleep inside MoveOverExisting blocks caller thread during live round persistence retries",
+            "why": "When saving round state on every reviewer transition during a high-concurrency burst or file lock contention, synchronous retries with Thread.Sleep(20 * attempt) can block the calling worker thread up to 300ms across 5 attempts on hot progress-reporting paths.",
+            "fix": "Use Task.Delay in an async method or run background saves asynchronously without blocking threads, or keep synchronous retries bounded with very low sleep times (e.g. 5-10ms) and avoid holding caller threads on progress report hooks.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The retry loop is a deliberate, documented, bounded fallback (max ~300ms total, only on rare contention) in a synchronous file-save path of a stdio MCP server, and rearchitecting it to async or shortening sleeps addresses no real observed problem while fighting the crash fix the code was written for."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:42:17 \u001B[32mINF\u001B[0m] coai-mcp#26340 finding [Major/Convention] todo/PLAN_rounds_collapse_and_vendor_colour.md:3 - Completed plan was left in todo/ with outdated \u0027plan only\u0027 status rather than being promoted to research/ (from gemini) [gating] Round=1 Stage=CodeReview\r | [20:42:17 \u001B[32mINF\u001B[0m] coai-mcp#26340 finding [Major/Ux] src_vs_code/src/panelView.ts:810 - Using class=\u0022vendor\u0022 for inline vendor name span causes CSS style collisions with the existing .vendor settings card class (from gemini) [gating] Round=1 Stage=CodeReview\r | [20:42:17 \u001B[32mINF\u001B[0m] coai-mcp#26340 finding [Minor/Reliability] src_mcp/src/Server/SessionStore.cs:181 - Synchronous Thread.Sleep inside MoveOverExisting blocks caller thread during live round persistence retries (from gemini) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T20:42:18.0016663Z",
+    "finishedUtc": "2026-09-05T20:45:38.8613839Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 50.1,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 2761,
+        "tokensOut": 1527,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Immediate data loss of active rounds due to aggressive pruning logic",
+            "why": "Step 3 states \u0027a round that is no longer running and is still in it is closed and dropped\u0027. If a user opens a round, the panel closes it (because it finished), but the user immediately re-opens it while the panel is still active, the logic in step 3 will drop it from the \u0027opened by this panel\u0027 set. If the user then closes it manually, the system loses track of it entirely, or worse, if a round finishes while the panel is idle, it gets dropped before the user can see the \u0027finished\u0027 state, causing the UI to show a ghost of a round that no longer exists in the list.",
+            "fix": "Add a \u0027lastSeenTimestamp\u0027 or \u0027heartbeat\u0027 check to the pruning logic in step 3, ensuring rounds are only dropped if they have been non-running for a duration exceeding the panel\u0027s idle timeout, not immediately upon state change.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a data-loss scenario from a paraphrased sentence about pruning an \u0027opened by this panel\u0027 tracking set \u0393\u00C7\u00F6 no file, no line, and no code shown \u0393\u00C7\u00F6 and its reasoning is internally incoherent (a round that is \u0027no longer running\u0027 being re-opened, a \u0027ghost\u0027 UI state) with a heartbeat/timeout fix that is machinery far out of proportion to any demonstrated risk."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Loss of user intent across extension host restarts",
+            "why": "The plan relies on \u0027a second set \u2014 the rounds THIS panel opened\u0027 being pruned to \u0027living rounds\u0027. If the extension host restarts (common in VS Code), this in-memory set is lost. A round the user explicitly opened will be treated as \u0027panel opened\u0027 and thus closed automatically upon finish, violating requirement #3 (\u0027a round the person opened stays open\u0027). The user\u0027s explicit choice is overwritten by the system\u0027s default behavior because the \u0027person opened\u0027 state was never persisted.",
+            "fix": "Explicitly define the \u0027person opened\u0027 set as a persistent user preference store (e.g., VS Code settings or local storage) rather than a transient in-memory set that is pruned to \u0027living rounds\u0027.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The reasoning inverts itself \u0393\u00C7\u00F6 losing an in-memory set of \u0027rounds this panel opened\u0027 makes it empty, so a surviving round falls into the \u0027person opened\u0027 default and stays open, which is the safe direction, not the auto-close the finding predicts; on top of that an extension-host restart tears down the panel and its view state anyway, so persisting the set is machinery for a failure that does not occur."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy data corruption causes UI breakage and misleading feedback",
+            "why": "The plan notes that \u0027Rounds recorded before per-reviewer detail existed became disclosures that opened into an apology\u0027. If a user has a session file with old data, the new code will render a \u0027hand cursor\u0027 and an \u0027apology\u0027 for having nothing. This is a \u0027wrong outcome\u0027 because the user expects to see their old rounds, not an error message. The system fails to gracefully degrade or migrate legacy data, presenting a UI defect as a feature.",
+            "fix": "Add a \u0027version\u0027 or \u0027schema\u0027 check to the session file parser in \u0060rounds.ts\u0060 before rendering, or provide a default empty state that doesn\u0027t trigger an \u0027apology\u0027 UI.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads the plan\u0027s own sentence \u0393\u00C7\u00F6 the quoted line describes the pre-fix symptom the change removes, not a new legacy-data hazard \u0393\u00C7\u00F6 so it invents a migration/versioning requirement for a defect the diff is already fixing."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Excessive startup latency due to synchronous blocking checks on every render",
+            "why": "The plan admits the toggle repaints \u0027reading the configuration, stat-ing the server binary, probing every vendor CLI, asking GitHub what was published and fetching two price tables \u2014 up to twenty seconds for a triangle\u0027. If a user opens the panel or toggles a setting, the UI freezes for up to 20 seconds. This is a \u0027wrong outcome\u0027 because the user expects an immediate response. The \u0027triangle\u0027 (likely a small UI element) becomes a bottleneck, making the extension feel broken.",
+            "fix": "Cache the result of the configuration read, stat, CLI probe, and GitHub fetch in a persistent store (e.g., \u0060package.json\u0060 or a local cache file) and only re-fetch on explicit user refresh or version change.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It takes a cost the plan itself admits \u0393\u00C7\u00F6 up to twenty seconds of configuration reads, binary stats, CLI probes and network fetches on a repaint \u0393\u00C7\u00F6 and names the user-visible consequence plus a concrete remedy (cache and refresh on demand), which is exactly what someone about to implement that toggle needs to hear before shipping it."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression where vendor names appear struck-out due to CSS class collision",
+            "why": "The plan states the span\u0027s class is \u0060who\u0060 but the stylesheet already has a \u0060.vendor\u0060 class for the settings card. The deviation notes that \u0060.vendor\u0060 meant the settings card, which has \u0027border, radius and eight pixels of padding\u0027. If the new code uses \u0060who\u0060 but the CSS for \u0060.vendor\u0060 is applied to it (or if \u0060who\u0060 inherits styles from a parent that targets \u0060.vendor\u0060), the vendor name will be rendered with \u0027a line THROUGH the text\u0027 (strikethrough) or excessive padding, making it unreadable. This is a direct visual defect caused by the plan\u0027s deviation.",
+            "fix": "Rename the CSS class from \u0060who\u0060 to \u0060vendor\u0060 (or a unique alias like \u0060vendor-name\u0060) and ensure the styling rules for \u0060.vendor\u0060 do not conflict with the existing \u0060.vendor\u0060 settings card class.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and self-contradicting \u0393\u00C7\u00F6 it concedes the new code uses \u0060who\u0060, then invents a hypothetical inheritance from an unrelated \u0060.vendor\u0060 settings-card rule to conjure a strikethrough that nothing in the plan or CSS supports."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Inert switch due to missing runtime validation of the Fable model",
+            "why": "The plan removes \u0060FableAvailable\u0060 and relies on the checkbox alone. However, if the Fable model is not actually loaded (e.g., the user has a different configuration or the model failed to initialize), the \u0027Split with Fable\u0027 order will be issued but fail silently or throw an error. The user sees the checkbox checked but no action occurs, leading to confusion. The plan assumes the model is always available, which is an unstated assumption.",
+            "fix": "Replace the \u0027checkbox alone\u0027 trigger with a \u0027checkbox \u002B explicit confirmation\u0027 or a \u0027checkbox \u002B state check\u0027 that verifies the Fable model is actually loaded in the current context.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about a \u0027Fable model\u0027 load failure without any file or code to anchor it, and the proposed remedy \u0393\u00C7\u00F6 a confirmation dialog or availability state check \u0393\u00C7\u00F6 is exactly the kind of machinery the plan deliberately removed, so it reads as a guess rather than a defect in this change."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Incorrect duration reporting for dead rounds due to missing completion timestamp",
+            "why": "The plan notes a \u0027dead round is never written a completion time, so the panel measured how long ago it started\u0027. If a round dies (e.g., network loss) and never writes a completion time, the system calculates duration as \u0060now - start_time\u0060. This results in a duration of \u0027361m 40s\u0027 on a machine with a 10-minute timeout. The user sees a round that ran for 6 hours when it actually ran for 10 minutes, leading to incorrect billing or analysis.",
+            "fix": "Add a \u0027timeout\u0027 or \u0027max-duration\u0027 check to the round completion logic to prevent \u0027dead rounds\u0027 from claiming incorrect durations.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "A round with no completion timestamp rendering as elapsed-since-start makes a 10-minute timeout read as 6 hours \u0393\u00C7\u00F6 a real reporting defect the plan itself names, and the family\u0027s own rule that an unmeasurable value must not be rendered as a plausible number applies directly."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 150.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 90354,
+        "tokensOut": 5468,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 158,
+            "title": "Scratch file cleanup depends on successful move",
+            "why": "The \u0060finally\u0060 block for \u0060TryDelete(temp)\u0060 is placed *after* the \u0060try\u0060 block that calls \u0060MoveOverExisting\u0060. If \u0060MoveOverExisting\u0060 succeeds and returns, the code exits the \u0060try\u0060 block, but the \u0060finally\u0060 block executes. However, if \u0060MoveOverExisting\u0060 throws an exception (which it does in the loop), the \u0060finally\u0060 block runs. But if the move succeeds, the file is moved to \u0060file\u0060, and the \u0060finally\u0060 block attempts to delete \u0060temp\u0060. This is correct. Wait, looking closer: The \u0060try\u0060 block wraps \u0060MoveOverExisting\u0060. If \u0060MoveOverExisting\u0060 succeeds, it returns. Then the \u0060finally\u0060 block runs. It deletes \u0060temp\u0060. This seems correct. Let\u0027s re-read the rule. The rule is about *persistence* and *atomicity*. The rule says: \u0027A session is saved under its own scratch name, and the move is retried\u0027. The implementation does this. Is there a violation? Ah, the \u0060finally\u0060 block is inside the \u0060Save\u0060 method. The \u0060try\u0060 block is inside \u0060Save\u0060. The \u0060finally\u0060 block runs after the \u0060try\u0060. If \u0060MoveOverExisting\u0060 succeeds, \u0060",
+            "fix": "Move the \u0060MoveOverExisting\u0060 call inside the \u0060try\u0060 block, or ensure the \u0060finally\u0060 block runs regardless of the \u0060try\u0060 block\u0027s success, so that the temporary file is deleted even if the move succeeds.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent \u0393\u00C7\u00F6 it visibly reasons itself in circles, concludes three times that the code is correct, and then asks for a fix that describes what the code already does; the cleanup is already guaranteed by the existing finally."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 165,
+            "title": "Concurrent saves from multiple MCP clients cause session loss due to fixed scratch filename collision",
+            "why": "The \u0060SessionStore.Save\u0060 method writes to a scratch file named \u0060\u003Csession\u003E.json.tmp\u0060 (a fixed path). When two MCP clients (servers) run simultaneously and share the data directory, they both attempt to write to the same scratch file. The second writer overwrites the first\u0027s data, and when both attempt to \u0060File.Move\u0060 the scratch file to the final destination, one fails with \u0060UnauthorizedAccessException\u0060 because the other has already moved it. This causes a round to abort mid-progress (e.g., a nine-reviewer round saving on every transition) and leaves the session in an inconsistent state or lost entirely.",
+            "fix": "Wrap the \u0060File.Move\u0060 call in a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060, retrying up to 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms) before throwing the final exception.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is factually wrong about this code \u0393\u00C7\u00F6 the scratch name is already unique per write (PID \u002B GUID, line 148) and its proposed fix, a bounded retry of File.Move on IOException/UnauthorizedAccessException, is already implemented in MoveOverExisting at the very lines the finding cites."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 807,
+            "title": "Vendor name injection via unescaped HTML in colored span",
+            "why": "The code constructs a \u0060\u003Cspan\u003E\u0060 with \u0060style=\u0022color:${vendorColour(row.provider)}\u0022\u0060 and inner text \u0060${escapeHtml(row.provider)}\u0060. While \u0060row.provider\u0060 is escaped for the text content, the \u0060vendorColour\u0060 function is called on the raw string. If a vendor name contains a quote character (e.g., \u0060O\u0027Reilly\u0060 or a malicious \u0060\u003Cscript\u003E\u0060), it could break out of the \u0060style\u0060 attribute context if \u0060vendorColour\u0060 returns a value that isn\u0027t strictly a CSS variable, or if the escaping logic is applied inconsistently. More critically, if \u0060row.provider\u0060 contains a \u0060\u003C\u0060 character (e.g., \u0060\u003Cscript\u003E\u0060), the test \u0060test(\u0027a vendor name from a session file is still escaped\u0027)\u0060 verifies it is escaped in the text, but the \u0060style\u0060 attribute relies on \u0060vendorColour\u0060 returning a safe string. If \u0060vendorColour\u0060 were to return a value containing a quote (unlikely given the palette, but possible if extended), it could break the attribute. The primary risk is if \u0060row.provider\u0060 is not escaped *before* being passed to \u0060vendorUrl\u0060",
+            "fix": "Ensure \u0060row.provider\u0060 is escaped using \u0060escapeHtml\u0060 *before* being interpolated into the \u0060style\u0060 attribute or the inner text of the \u0060\u003Cspan\u003E\u0060 element, or use a dedicated HTML escaping function that handles both contexts.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding never establishes that \u0060vendorColour\u0060 can return anything but a palette constant \u0393\u00C7\u00F6 it hedges its own claim, invents a nonexistent \u0060vendorUrl\u0060, and its proposed fix (escaping the provider name *before* passing it to the colour lookup) would not address the attribute-context risk it describes, so acting on it costs verification time and yields nothing."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 42,
+            "title": "Potential null reference exception if cards array is empty or undefined",
+            "why": "The \u0060nextOpenRounds\u0060 function assumes \u0060cards\u0060 is always a valid array. If \u0060cards\u0060 is \u0060null\u0060 or \u0060undefined\u0060 (e.g., due to a race condition where the session file is loaded but rounds are not yet populated, or a bug in the caller), calling \u0060cards.map\u0060 or \u0060cards.filter\u0060 will throw a \u0060TypeError\u0060. This would crash the extension\u0027s UI update loop, potentially leaving the panel in a broken state until the user reloads.",
+            "fix": "Add a check to ensure \u0060cards\u0060 is not null or undefined before calling \u0060cards.map\u0060 and \u0060cards.filter\u0060, or initialize \u0060cards\u0060 with an empty array if it might be missing.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "This is a pure TypeScript function whose \u0060cards\u0060 parameter is typed \u0060readonly Card[]\u0060, and the finding invents a hypothetical null caller rather than pointing at one \u0393\u00C7\u00F6 adding defensive checks here would mask a real bug at the call site instead of fixing it."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Concurrent session saves cause fatal crashes due to race conditions on the scratch file",
+            "why": "When two MCP clients (servers) share a data directory, they both attempt to write to the same scratch file path (\u0060\u003Csession\u003E.json.tmp\u0060) simultaneously. The code previously used a fixed name for the scratch file, causing a race where one writer deletes the file while the other tries to move it, or both try to move the same file. This results in \u0060UnauthorizedAccessException\u0060 or \u0060IOException\u0060 in \u0060LiveRound.Persist\u0060, which aborts the round reporting progress. The fix introduces a unique scratch name per write (\u0060{ProcessId}-{Guid}\u0060) and a retry loop for the move operation to handle transient locks from scanners or readers.",
+            "fix": "Wrap the \u0060File.Move\u0060 call in a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060, retrying up to 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms) before throwing the final exception.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The code under review already implements exactly what the finding proposes \u0393\u00C7\u00F6 a per-write unique scratch name and a bounded retry around File.Move \u0393\u00C7\u00F6 so the finding restates the existing fix (and its own comment) as a Blocking defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 165,
+            "title": "Finished rounds may flicker open before closing, causing visual confusion",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 calculates the new state based on the current session data. If the calculation logic (specifically the \u0060nextOpenRounds\u0060 function) determines a round should close, but the UI update is delayed or not atomic with the state change, the user might see the card open for a split second before it closes. This is particularly problematic for \u0027finished\u0027 rounds which are supposed to close automatically; a flicker makes it look like the system is indecisive or buggy. The current code updates \u0060this.rounds\u0060 and returns \u0060this.rounds.open\u0060, but if the rendering logic relies on a separate state variable or if the DOM update is not immediate, the user sees the intermediate state.",
+            "fix": "Ensure the \u0060expanded\u0060 method is called immediately after \u0060nextOpenRounds\u0060 updates the state, and that the \u0060webview.postMessage\u0060 or DOM update happens synchronously within the same render cycle to prevent a flicker where the card is closed before the user sees it open.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and wrong about the code: \u0060expanded\u0060 is called synchronously while building the state object that is immediately rendered in the same \u0060render()\u0060 pass, so there is no intermediate state a user could see, and the finding names no concrete sequence producing the alleged flicker."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Vendor colour calculation is performed redundantly on every render cycle",
+            "why": "The \u0060vendorColour\u0060 function is called inside the \u0060usageRows\u0060 and \u0060roundCard\u0060 functions, which are executed on every render cycle (potentially every 5 seconds). While the hash calculation is fast, doing it repeatedly for the same vendor names (e.g., \u0027codex\u0027, \u0027gemini\u0027) across multiple rows and cards adds unnecessary CPU overhead. A simple cache (e.g., a \u0060Map\u003Cstring, string\u003E\u0060 stored in the module scope) would eliminate this redundant work, especially as the number of vendors or rows grows.",
+            "fix": "Memoize the \u0060vendorColour\u0060 function or cache the result of \u0060vendorColour(r.provider)\u0060 for each unique provider name to avoid recalculating the hash on every render cycle for the same vendor.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Memoizing a trivial string hash over a handful of vendor names, recomputed at most every five seconds in a webview render that already builds and re-parses a whole HTML string, is machinery out of all proportion to a CPU cost that is unmeasurable here."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:45:38 \u001B[32mINF\u001B[0m] coai-mcp#52260 finding [Blocking/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Concurrent session saves cause fatal crashes due to race conditions on the scratch file (from local) [gating] Round=1 Stage=CodeReview\r | [20:45:38 \u001B[32mINF\u001B[0m] coai-mcp#52260 finding [Major/Ux] src_vs_code/src/panelProvider.ts:165 - Finished rounds may flicker open before closing, causing visual confusion (from local) [gating] Round=1 Stage=CodeReview\r | [20:45:38 \u001B[32mINF\u001B[0m] coai-mcp#52260 finding [Minor/Performance] src_vs_code/src/panelView.ts:702 - Vendor colour calculation is performed redundantly on every render cycle (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini|rounds-collapse|1",
+    "startedUtc": "2026-09-05T20:45:39.0118855Z",
+    "finishedUtc": "2026-09-05T20:47:29.4915147Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 48.8,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 38501,
+        "tokensOut": 7808,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The build step still prescribes the conflicting \u0060vendor\u0060 CSS class after the deviation says the shipped class is \u0060who\u0060",
+            "why": "A developer following step 5 wraps the name in \u0060class=\u0022vendor\u0022\u0060; the existing \u0060.vendor\u0060 settings-card rule then adds border, radius, and padding, making vendor names render incorrectly as already observed.",
+            "fix": "Update the build order and acceptance criteria to require the non-conflicting class (\u0060who\u0060) and add a rendered-style regression check.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete internal contradiction in the document \u0393\u00C7\u00F6 a build step still prescribing a class the deviation section says was abandoned because it collides with an existing style rule \u0393\u00C7\u00F6 which would lead anyone following the steps straight back into the observed rendering defect."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The escaping work is limited to reviewer rows while the promise covers every session-file value rendered by the panel",
+            "why": "A session containing a vendor name such as \u0060\u003C/span\u003E\u003Cimg src=x onerror=...\u003E\u0060 in a spending row or another live/round-card path can still be inserted unsafely if only the reviewer-row renderer is changed and tested, violating the stated page-safety guarantee.",
+            "fix": "Use a shared escaped rendering helper for every session-derived HTML insertion and test injection payloads in each distinct rendering path.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names the family\u0027s own recorded defect shape \u0393\u00C7\u00F6 an escape applied at one site while the stated guarantee covers every session-derived value \u0393\u00C7\u00F6 with a concrete injection path (a vendor name in a spending row) and an actionable fix, which is exactly what a careful engineer would want to know before claiming the panel is safe."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how auto-open ownership is reconciled when the panel or extension host misses a completion update",
+            "why": "If a round is auto-opened and then the panel is recreated, hidden, or the host restarts before the next refresh, the in-memory ownership set may be absent when the round becomes finished; the card can remain open despite the promised close-on-finish behavior.",
+            "fix": "Specify the authoritative update and lifecycle behavior, including missed updates and host restart; persist ownership if required, or explicitly scope it to one panel instance and test that scope.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete lifecycle hole \u0393\u00C7\u00F6 in-memory auto-open ownership lost on panel recreation or host restart leaves a card open contrary to the promised close-on-finish behaviour \u0393\u00C7\u00F6 and asks for the cheap resolution of either persisting it or explicitly scoping it to one panel instance, which is exactly the kind of absence a plan review exists to surface."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Completion and a person\u0027s toggle have no defined ordering when they occur concurrently",
+            "why": "If a running auto-opened round finishes while the person clicks it, one update order can remove ownership and close it while another can preserve or reopen it, so the final state may contradict the person\u0027s last action.",
+            "fix": "Define serialized update ordering or a latest-user-intent reconciliation rule, and test the completion/toggle race plus failed refreshes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "With no file, no code, and no concrete state machine cited, this is a generic concurrency worry that names no actual defect a reader could locate or act on, and it demands serialization machinery and race tests out of proportion to an unevidenced UI toggle interaction."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define the visible result when the Fable order fails after the checkbox is enabled",
+            "why": "If the server is unavailable, times out, or rejects the order, the checkbox may remain enabled while the round proceeds without the requested split, silently producing a different result from the person\u0027s action.",
+            "fix": "Specify rollback, disabled, error, and retry behavior for command failure and cover the rejected-command path.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A UI toggle that dispatches a server-side command needs its failure path specified \u0393\u00C7\u00F6 otherwise the checkbox reads as applied while the round silently runs without the split, which is exactly the kind of silent divergence between requested and actual behaviour a plan review should catch."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027Build order\u0027 step 3: Manually closed running round is immediately re-opened on subsequent poll ticks",
+            "why": "When a user collapses an active running round, Step 3 removes the round ID from the auto-opened set. On the subsequent live update or poll tick, the round is still in the \u0027running\u0027 state. Because the plan does not maintain an explicit user-closed suppression set, the auto-expansion logic detects an active running round that is not in the expanded set and immediately re-expands it, preventing users from ever keeping a running round closed.",
+            "fix": "Track an explicit userClosed set of round IDs (or persist user-action overrides per round) so live status updates do not re-trigger auto-expansion on rounds the user explicitly collapsed.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible interaction defect \u0393\u00C7\u00F6 auto-expansion re-firing on every poll tick because collapse only removes from the auto-opened set with no user-closed suppression \u0393\u00C7\u00F6 which makes a running round impossible to keep collapsed, and it proposes the right fix."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027Constraints\u0027 and \u0027Build order\u0027 step 3: Pruning tracking sets to living rounds prevents finished rounds from auto-closing",
+            "why": "The constraints specify pruning open/closed sets strictly to living rounds. When a round finishes, if the collection is pruned before or during session parsing, the finished round ID is evicted from the autoOpened set before the auto-close condition (\u0027round is no longer running and is still in autoOpened\u0027) can detect it, leaving the finished card stuck in the expanded state.",
+            "fix": "Evaluate and apply auto-close transitions on round completion prior to pruning non-living round IDs from tracking state.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents an ordering hazard from its own reading of a plan\u0027s prose \u0393\u00C7\u00F6 nothing here shows pruning happens before the auto-close check, and the described eviction-then-detect race is speculative rather than a defect anyone can act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027Build order\u0027 step 5: Class name collision on .vendor applies card container styling to inline text",
+            "why": "Step 5 instructs wrapping the vendor name in \u0027\u003Cspan class=\u0022vendor\u0022\u003E\u0027. The existing stylesheet uses \u0027.vendor\u0027 for the settings card component (applying borders, radius, and padding). Applying this existing class to inline text in reviewer rows causes the card border and padding to render across the text like a strike-through.",
+            "fix": "Use an unambiguous, dedicated class name (such as \u0027who\u0027 or \u0027vendor-tag\u0027) that targets only inline vendor label formatting.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible collision \u0393\u00C7\u00F6 reusing an existing card-component class for inline text would visibly break the rendering \u0393\u00C7\u00F6 and the fix is a one-word rename, so a careful engineer would want to know before writing the markup."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Section \u0027Build order\u0027 step 3 \u0026 5: Card toggle triggers full provider re-evaluation and external CLI/filesystem probes",
+            "why": "Toggling round expansion is wired through the general panel repaint pipeline. Because the panel provider couples rendering with external probes (stat-ing binaries, checking CLI availability, and fetching price tables), expanding or collapsing a single card incurs significant latency instead of an instantaneous client-side DOM toggle.",
+            "fix": "Handle disclosure expand/collapse state locally within webview DOM or isolate card body rendering from expensive provider-level CLI and price probe routines.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It asserts a coupling between a card\u0027s expand/collapse and expensive CLI/filesystem/price probes without any file or line to anchor it, and the claimed latency cost is speculative rather than demonstrated \u0393\u00C7\u00F6 a plan-stage performance worry about machinery that isn\u0027t shown to work that way."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 61.4,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 451245,
+        "tokensOut": 8295,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 183,
+            "title": "Cleanup failure is silently swallowed in \u0060TryDelete\u0060.",
+            "why": "The project rule says: \u201CHandle errors explicitly at every level; never silently swallow one.\u201D This empty catch hides failed scratch-file cleanup and provides no diagnostic.",
+            "fix": "Record the cleanup failure with the scratch path in server logs, or explicitly propagate/report it instead of using an empty catch.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The empty catch is a deliberate, commented best-effort cleanup of a scratch file the code owns \u0393\u00C7\u00F6 a failed temp delete leaves at most a stray .tmp with no correctness impact, so demanding logging here is machinery out of proportion to the risk and misapplies the \u0027never swallow errors\u0027 rule."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/tests/SessionStoreConcurrencyTests.cs",
+            "line": 40,
+            "title": "The test silently swallows directory cleanup failures.",
+            "why": "The project rule says: \u201CHandle errors explicitly at every level; never silently swallow one.\u201D The empty \u0060IOException\u0060 catch can leave test directories behind without reporting the failure.",
+            "fix": "Report the cleanup failure explicitly, or use a test cleanup mechanism that preserves and surfaces the exception.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The empty catch is a deliberate, idiomatic best-effort cleanup of a temp directory in test teardown \u0393\u00C7\u00F6 Windows file locks routinely delay deletion, and failing or surfacing that would add flakiness with no benefit to anyone acting on it; the coding-style rule about swallowing errors targets production error handling, not disposal of scratch fixtures."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 4,
+            "title": "The completed plan is left marked as not implemented.",
+            "why": "The project rule says: \u201CAfter every code change: ... Run the plan completion check ... Promote in the same task.\u201D This diff implements the plan while adding a todo document whose status says \u201Cplan only, nothing implemented yet,\u201D leaving the knowledge base contradictory.",
+            "fix": "Promote or remove the todo plan and update its status to match the implemented change in the same task.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "If the same change implements the plan, leaving it in \u0060todo/\u0060 marked \u0022nothing implemented yet\u0022 breaks a convention this repo actively enforces (\u0060plan-lifecycle.mjs\u0060 in CI flags a finished plan left in \u0060todo/\u0060), and the status line also omits the required date \u0393\u00C7\u00F6 a real, actionable gap rather than a nitpick."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 155,
+            "title": "Concurrent saves still silently overwrite one another",
+            "why": "Two MCP servers can save the same session from stale snapshots. Distinct scratch files prevent collisions, but whichever replacement runs last discards the other writer\u0027s round or reviewer-progress updates, leaving an incomplete session with no error.",
+            "fix": "Serialize saves per session across processes, or reload and merge the destination immediately before replacement; test that concurrent updates from both writers survive.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The file\u0027s own comment records that two servers on this machine save the same session file concurrently, so the unique-scratch-name fix cured the crash but left a genuine last-writer-wins lost-update on the round trail \u0393\u00C7\u00F6 a residual race the repo\u0027s own reliability rule says must at minimum be named in the primitive\u0027s header, and the reader of that comment could easily believe concurrency is now handled."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 193,
+            "title": "Failed scratch-file cleanup is silently ignored",
+            "why": "If the final move remains locked after retries, cleanup can also fail and leave the uniquely named temporary file behind. Repeated failures can accumulate unbounded files in the sessions directory, with no diagnostic or cleanup sweep.",
+            "fix": "Log cleanup failures and remove stale scratch files using a bounded startup or save-time cleanup policy.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "A leftover scratch file requires the move to fail after five retries \u0393\u00C7\u00F6 which already throws and surfaces the save failure loudly \u0393\u00C7\u00F6 and then the delete to fail too, so \u0027unbounded accumulation\u0027 overstates a rare, tiny, self-announcing residue, and a startup sweep is machinery out of proportion to it."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 138,
+            "title": "Toggling a round still waits for the full expensive refresh with no progress state",
+            "why": "When a person opens or closes a card, the message handler immediately calls \u0060refresh()\u0060. That refresh performs the configuration, server-binary, vendor-CLI, GitHub-release, and price-table work described in the plan, which can take about 20 seconds; during that interval the webview gives no processing/disabled/error state, so the click appears ignored and repeated clicks can queue conflicting refreshes.",
+            "fix": "Render the local round-toggle state immediately and defer or isolate the expensive probes; if a full refresh is unavoidable, expose a persisted/in-flight UI state and disable the toggle until it completes or fails.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The premise is wrong for this code: the probe results are all cached behind \u0060*CheckedAt\u0060 timestamps and the panel already re-renders on a five-second watcher tick, so a toggle does not trigger a ~20-second fetch, and the proposed in-flight/disabled machinery is disproportionate to a repaint that converges on the same local state anyway."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "Unpromoted plan in todo/ violates knowledge base sync and Definition of Done promotion rules",
+            "why": "The change adds a plan in todo/ with status \u0027Status: **plan only, nothing implemented yet.**\u0027 even though the entire change implements the plan, the header note of the plan in the prompt explicitly states \u0027Status: IMPLEMENTED, 2026-09-04\u0027, and rule .claude/rules/shared/common/knowledge-base.md requires running the plan completion check and promoting in the same task.",
+            "fix": "Update the plan status to IMPLEMENTED / remove from todo/ and move/promote to research/ as required by the plan lifecycle workflow.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "If the same change implements the plan, leaving it in \u0060todo/\u0060 still saying \u0022nothing implemented yet\u0022 is a real, checkable breach of this repository\u0027s mandatory plan-lifecycle rule \u0393\u00C7\u00F6 the exact failure it records as having let twelve stale plans pile up \u0393\u00C7\u00F6 and the finding names the file, the rule and the fix."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 156,
+            "title": "Unbounded scratch file accumulation when process terminates before or during MoveOverExisting",
+            "why": "Each call to Save generates a uniquely named scratch file with Guid and ProcessId ($file.pid-guid.tmp). If the server process crashes, is killed (e.g., kill -9 / taskkill / host restart), or encounters an unhandled runtime error during or prior to MoveOverExisting, the scratch file is never deleted because TryDelete in the finally block is not executed. Because Save is called on every reviewer state transition (a dozen times per round across multiple clients), orphaned scratch files will permanently accumulate in the sessions directory over time on shared hosts or long-lived developer environments, violating self-hosted retention and unbounded disk growth constraints.",
+            "fix": "Add a startup sweep in SessionStore initialization to enumerate and delete orphaned \u0060*.tmp*\u0060 files under SessionsDir whose owning PID is no longer alive or whose timestamp is older than a brief threshold.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The orphan window is real (a kill between WriteAllText and the move leaves a \u0060.tmp\u0060 that nothing ever reclaims) and the fix drops straight into the SweepOrphanedRounds startup hook this class already has, which is exactly the named-retention-owner obligation the repo\u0027s own rules impose \u0393\u00C7\u00F6 even though the finding\u0027s stated accumulation rate (per-save rather than per-crash) and its Major severity are overstated."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "CSS style injection via unescaped provider name in style attribute",
+            "why": "In roundCard and usageRows, vendorColour(row.provider) / vendorColour(r.provider) is interpolated directly into the style attribute (\u0060style=\u0022color:${vendorColour(...)}\u0022\u0060) without HTML attribute escaping. Although vendorColour currently checks ANCHORED or returns theme variables from an internal palette/hash, if a malformed provider name containing quotes or CSS escape sequences reaches this path or if vendorColour is modified to return customized strings, it could break out of the style attribute.",
+            "fix": "Ensure the output of vendorColour is escaped or strictly validated before being injected into HTML attributes.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The sink is safe only because of what \u0060vendorColour\u0060 happens to return today, and this repository\u0027s own security rule (\u0022safe by construction, not safe by content\u0022 \u0393\u00C7\u00F6 the measured \u0022it is only a constant icon\u0022 case) says a style-attribute interpolation should be escaped or validated at the site regardless of the current value; the fix is one call and closes the class."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 181,
+            "title": "Synchronous Thread.Sleep in retry loop blocks async/event loop execution during concurrent session save contention",
+            "why": "When multiple concurrent writers or background virus scanners hold lock contention on a session file under Windows, Save() calls MoveOverExisting() which performs synchronous Thread.Sleep(20 * attempt) on the thread. In an MCP server handling JSON-RPC requests, blocking threads with sleep degrades response latency across all concurrent tool calls and operations sharing thread pool capacity.",
+            "fix": "Make Save asynchronous (\u0060SaveAsync\u0060) or use non-blocking delays/yields, or if synchronous execution is mandatory, avoid escalating thread sleep delays or use atomic non-blocking swap strategies.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The retry only fires on rare contention and sleeps at most 200 ms in total across four attempts on a deliberately synchronous save path, so calling it a Major performance defect \u0393\u00C7\u00F6 and proposing an async rewrite of Save \u0393\u00C7\u00F6 is machinery far out of proportion to the risk, on top of invoking an \u0027event loop\u0027 that .NET does not have."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Class collision with \u0027.vendor\u0027 stylesheet rule applies unintended card styling to inline vendor span",
+            "why": "In the plan deviations it was noted that \u0027.vendor already meant the settings card in this stylesheet, so the word came out wearing a border, a radius and eight pixels of padding... reported as struck-out vendor names\u0027. In the implemented diff at line 810 of panelView.ts, reviewerRows are still rendered using \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:...\u0022\u003E\u0060 rather than the intended \u0060.who\u0060 class, causing the CSS clash to distort the inline reviewer line layout.",
+            "fix": "Change \u0060\u003Cspan class=\u0022vendor\u0022\u0060 to \u0060\u003Cspan class=\u0022who\u0022\u0060 in \u0060src_vs_code/src/panelView.ts\u0060 and update the matching test fixtures.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It infers a live CSS clash from a plan-deviation note that records the problem as already found and dealt with, and never quotes the \u0060.vendor\u0060 rule \u0393\u00C7\u00F6 which sits in this very file \u0393\u00C7\u00F6 so its central claim is unverified and most likely already resolved on the stylesheet side."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 67,
+            "title": "Redundant intermediate array allocations and Set re-allocations on every periodic tick in nextOpenRounds",
+            "why": "Every 5-second polling tick, \u0060nextOpenRounds\u0060 converts arrays to Sets and repeatedly filters through spread arrays \u0060[...open]\u0060, \u0060[...autoOpened]\u0060, \u0060[...panelOpened]\u0060 while mapping over all cards multiple times (\u0060cards.filter.map\u0060, \u0060cards.map\u0060). At larger session counts (e.g. 10x input with hundreds of rounds in history), this generates unnecessary garbage on the UI update cycle.",
+            "fix": "Iterate cards once to compute running and alive keys, and prune the sets in place before converting to return arrays.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The function operates on a handful of round keys in a 5-second UI tick where allocation cost is utterly negligible, and the suggested in-place mutation would trade away the immutability the codebase mandates for no measurable gain."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:47:29 \u001B[32mINF\u001B[0m] coai-mcp#51232 finding [Major/Performance] src_mcp/src/Server/SessionStore.cs:181 - Synchronous Thread.Sleep in retry loop blocks async/event loop execution during concurrent session save contention (from gemini) [gating] Round=1 Stage=CodeReview\r | [20:47:29 \u001B[32mINF\u001B[0m] coai-mcp#51232 finding [Minor/Ux] src_vs_code/src/panelView.ts:810 - Class collision with \u0027.vendor\u0027 stylesheet rule applies unintended card styling to inline vendor span (from gemini) Round=1 Stage=CodeReview\r | [20:47:29 \u001B[32mINF\u001B[0m] coai-mcp#51232 finding [Minor/Performance] src_vs_code/src/openRounds.ts:67 - Redundant intermediate array allocations and Set re-allocations on every periodic tick in nextOpenRounds (from gemini) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T20:47:29.577521Z",
+    "finishedUtc": "2026-09-05T20:51:19.8301801Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 60.5,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 9,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 17851,
+        "tokensOut": 3941,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The ownership flow never specifies how manually reopening an auto-collapsed round makes it person-owned",
+            "why": "After the panel auto-opens a running round and later collapses it on completion, the person can click it open, but step 3 only removes ownership when toggling and never says to add the round to the person\u0027s set. A later refresh or state transition can therefore collapse it again, violating the promise that reopening makes it theirs.",
+            "fix": "Define and test the manual-open transition: when a person opens a collapsed round, add it to the person-owned set and preserve it across subsequent transitions.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete gap in the state machine \u0393\u00C7\u00F6 the manual-reopen transition has no defined effect on the person-owned set, so a later auto-collapse can undo the person\u0027s action, which is exactly the kind of unspecified transition a careful implementer would want nailed down before building."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The blanket session-file escaping guarantee is verified for only one reviewer field",
+            "why": "A session containing an HTML payload in a spending-row vendor, round title, reviewer name, or another session-derived field can still reach an unescaped template interpolation even though the only stated escaping test covers a reviewer vendor name. That can produce rendered markup or script injection in the panel.",
+            "fix": "Enumerate every session-derived value rendered by panelView and require escaping at each HTML boundary, with tests covering at least spending vendor names and round metadata as well as reviewer names.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and self-undermined \u0393\u00C7\u00F6 it argues from the absence of tests rather than from any identified unescaped interpolation, names no file or line, and asks for a broad enumeration-plus-test sweep without establishing that any session-derived field actually reaches the panel unescaped."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not verify that all vendor-name renderers use the shared colour mapping",
+            "why": "The test plan checks vendorColour and one reviewer row, but not the live section or spending rows. An implementation can leave either location grey, pass all listed tests, and still violate the promise that the same vendor has the same colour everywhere.",
+            "fix": "Add rendering assertions for reviewer, live, and spending rows using the same vendor names, verifying both the colour and the escaped vendor text in each location.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It points at a real gap in the test plan \u0393\u00C7\u00F6 a shared colour mapping asserted at only one of its three render sites is exactly the \u0027applied at SOME of its sites\u0027 defect, and the missing assertions are cheap and checkable."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The build step contradicts the documented shipped class name and can reintroduce the known vendor styling defect",
+            "why": "The deviations explicitly require class \u0060who\u0060 because the existing \u0060.vendor\u0060 selector applies card border, radius, and padding styles, but step 5 instructs the implementer to emit \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060. Following the build order causes vendor names to render with the malformed settings-card styling.",
+            "fix": "Change the build step to require the shipped \u0060who\u0060 class, or explicitly rename/remove the conflicting stylesheet selector before using \u0060vendor\u0060.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete internal contradiction in the document \u0393\u00C7\u00F6 the deviations record \u0060who\u0060 as the shipped class precisely because \u0060.vendor\u0060 carries card styling, yet the build step tells the implementer to emit \u0060class=\u0022vendor\u0022\u0060 \u0393\u00C7\u00F6 so following the steps literally reintroduces the very rendering defect the deviation was written to prevent, which is exactly the kind of scope-versus-instruction mismatch a reader must fix before implementing."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Immediate data loss of active rounds due to aggressive pruning logic",
+            "why": "Step 3 states \u0027a round that is no longer running and is still in it is closed and dropped\u0027. If a user opens a round, the panel closes it (because it finished), but the user immediately re-opens it while the panel is still active, the logic in step 3 will drop it from the \u0027opened by this panel\u0027 set. If the user then closes it manually, the system loses track of it entirely, or worse, if a round finishes while the panel is idle, it gets dropped before the user can see the \u0027finished\u0027 state, causing the UI to show a ghost of a round that no longer exists in the list.",
+            "fix": "Add a \u0027lastSeenTimestamp\u0027 or \u0027heartbeat\u0027 check to the pruning logic in step 3, ensuring rounds are only dropped if they have been non-running for a duration exceeding the panel\u0027s idle timeout, not immediately upon state change.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a failure narrative from a paraphrase of a plan step \u0393\u00C7\u00F6 it names no file, describes state transitions and a \u0027panel idle timeout\u0027 that nothing here establishes, and its own scenario is internally incoherent (pruning a finished round from a tracking set is the intended behaviour, not data loss), so it asks for heartbeat machinery against a risk it never demonstrated."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Loss of user intent across extension host restarts",
+            "why": "The plan relies on \u0027a second set \u2014 the rounds THIS panel opened\u0027 being pruned to \u0027living rounds\u0027. If the extension host restarts (common in VS Code), this in-memory set is lost. A round the user explicitly opened will be treated as \u0027panel opened\u0027 and thus closed automatically upon finish, violating requirement #3 (\u0027a round the person opened stays open\u0027). The user\u0027s explicit choice is overwritten by the system\u0027s default behavior because the \u0027person opened\u0027 state was never persisted.",
+            "fix": "Explicitly define the \u0027person opened\u0027 set as a persistent user preference store (e.g., VS Code settings or local storage) rather than a transient in-memory set that is pruned to \u0027living rounds\u0027.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete state-durability gap \u0393\u00C7\u00F6 an in-memory \u0027opened by the person\u0027 set does not survive an extension host restart, so a stated requirement silently breaks in a common scenario, which is exactly what the durable-status rule demands be persisted."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy data corruption causes UI breakage and misleading feedback",
+            "why": "The plan notes that \u0027Rounds recorded before per-reviewer detail existed became disclosures that opened into an apology\u0027. If a user has a session file with old data, the new code will render a \u0027hand cursor\u0027 and an \u0027apology\u0027 for having nothing. This is a \u0027wrong outcome\u0027 because the user expects to see their old rounds, not an error message. The system fails to gracefully degrade or migrate legacy data, presenting a UI defect as a feature.",
+            "fix": "Add a \u0027version\u0027 or \u0027schema\u0027 check to the session file parser in \u0060rounds.ts\u0060 before rendering, or provide a default empty state that doesn\u0027t trigger an \u0027apology\u0027 UI.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a legacy-data corruption scenario from a plan sentence that describes the very problem being fixed, and asks for schema versioning/migration machinery for a UI disclosure that at worst shows an empty state \u0393\u00C7\u00F6 it is speculative rather than a defect in this code."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Excessive startup latency due to synchronous blocking checks on every render",
+            "why": "The plan admits the toggle repaints \u0027reading the configuration, stat-ing the server binary, probing every vendor CLI, asking GitHub what was published and fetching two price tables \u2014 up to twenty seconds for a triangle\u0027. If a user opens the panel or toggles a setting, the UI freezes for up to 20 seconds. This is a \u0027wrong outcome\u0027 because the user expects an immediate response. The \u0027triangle\u0027 (likely a small UI element) becomes a bottleneck, making the extension feel broken.",
+            "fix": "Cache the result of the configuration read, stat, CLI probe, and GitHub fetch in a persistent store (e.g., \u0060package.json\u0060 or a local cache file) and only re-fetch on explicit user refresh or version change.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding misreads the plan\u0027s own words \u0393\u00C7\u00F6 the quoted sentence is the plan describing the cost it exists to remove (which is why the work is being planned), and it invents a 20-second UI freeze on every render and every settings toggle that the text does not claim, so the \u0027defect\u0027 and its caching fix are aimed at a problem the plan already addresses."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression where vendor names appear struck-out due to CSS class collision",
+            "why": "The plan states the span\u0027s class is \u0060who\u0060 but the stylesheet already has a \u0060.vendor\u0060 class for the settings card. The deviation notes that \u0060.vendor\u0060 meant the settings card, which has \u0027border, radius and eight pixels of padding\u0027. If the new code uses \u0060who\u0060 but the CSS for \u0060.vendor\u0060 is applied to it (or if \u0060who\u0060 inherits styles from a parent that targets \u0060.vendor\u0060), the vendor name will be rendered with \u0027a line THROUGH the text\u0027 (strikethrough) or excessive padding, making it unreadable. This is a direct visual defect caused by the plan\u0027s deviation.",
+            "fix": "Rename the CSS class from \u0060who\u0060 to \u0060vendor\u0060 (or a unique alias like \u0060vendor-name\u0060) and ensure the styling rules for \u0060.vendor\u0060 do not conflict with the existing \u0060.vendor\u0060 settings card class.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and self-contradictory \u0393\u00C7\u00F6 it concedes the class is \u0060who\u0060, then invents a strikethrough/padding regression from a hypothetical \u0060.vendor\u0060 inheritance that CSS class naming does not produce, so it describes no defect that exists."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Inert switch due to missing runtime validation of the Fable model",
+            "why": "The plan removes \u0060FableAvailable\u0060 and relies on the checkbox alone. However, if the Fable model is not actually loaded (e.g., the user has a different configuration or the model failed to initialize), the \u0027Split with Fable\u0027 order will be issued but fail silently or throw an error. The user sees the checkbox checked but no action occurs, leading to confusion. The plan assumes the model is always available, which is an unstated assumption.",
+            "fix": "Replace the \u0027checkbox alone\u0027 trigger with a \u0027checkbox \u002B explicit confirmation\u0027 or a \u0027checkbox \u002B state check\u0027 that verifies the Fable model is actually loaded in the current context.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a failure mode from an assumption it never checked \u0393\u00C7\u00F6 it names no file, no code, and no evidence that the Fable model can be unavailable in this context, and its proposed fix adds a confirmation dialog and availability probe out of proportion to a speculative risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Incorrect duration reporting for dead rounds due to missing completion timestamp",
+            "why": "The plan notes a \u0027dead round is never written a completion time, so the panel measured how long ago it started\u0027. If a round dies (e.g., network loss) and never writes a completion time, the system calculates duration as \u0060now - start_time\u0060. This results in a duration of \u0027361m 40s\u0027 on a machine with a 10-minute timeout. The user sees a round that ran for 6 hours when it actually ran for 10 minutes, leading to incorrect billing or analysis.",
+            "fix": "Add a \u0027timeout\u0027 or \u0027max-duration\u0027 check to the round completion logic to prevent \u0027dead rounds\u0027 from claiming incorrect durations.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real observable defect \u0393\u00C7\u00F6 a round that dies without a completion timestamp renders as elapsed-since-start, so the panel shows 6 hours for a 10-minute-timeout round, which is exactly the family\u0027s \u0027absent is not zero\u0027 failure and misleads anyone reading durations for cost or analysis."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 169.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 381619,
+        "tokensOut": 9704,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 187,
+            "title": "Scratch-file cleanup silently swallows I/O failures",
+            "why": "The empty catch violates the rule: \u0022Handle errors explicitly at every level; never silently swallow one.\u0022 A failed cleanup is discarded without logging or signaling, potentially leaving orphaned scratch files unnoticed.",
+            "fix": "Log the cleanup failure with context, or let it propagate if cleanup failure must fail the save.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "TryDelete is best-effort cleanup of a process-unique scratch file whose failure has no consequence \u0393\u00C7\u00F6 a comment on the call site already explains it, and the coding-style rule about swallowed errors targets meaningful failures, not a doomed temp-file unlink."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The plan status contradicts the implemented change",
+            "why": "The file says \u0022Status: plan only, nothing implemented yet.\u0022 This violates the rule: \u0022Run the plan completion check from [planning-docs.md](planning-docs.md): does this work finish a plan, or has a plan\u0027s status line stopped matching reality? Promote in the same task.\u0022 The plan is implemented by this diff but remains an unfinished todo.",
+            "fix": "Promote the plan according to the project convention and mark its status as implemented/completed.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding assumes the diff implements the plan, but the file under review is the plan document itself being added in the state its own convention requires \u0393\u00C7\u00F6 a new plan lives in \u0060todo/\u0060 with a \u0027plan only\u0027 status, so demanding promotion at the moment of authoring is wrong about this change."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 155,
+            "title": "Concurrent saves still overwrite each other\u0027s session state",
+            "why": "Two MCP servers can load the same session, then save different reviewer transitions. Unique scratch names prevent the old temp-file collision, but each overwrite move still makes the last writer win, so a slower stale snapshot can erase rounds or findings written by the other server even though both saves report success.",
+            "fix": "Serialize cross-process read/modify/write operations through the final move, or reload and merge the current session under an interprocess lock before committing.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The comment at line 142-147 establishes that multiple servers share one data directory and write the same session file concurrently, so the last-writer-wins whole-file overwrite genuinely can erase another server\u0027s persisted rounds \u0393\u00C7\u00F6 a real durability risk the unique-scratch-name fix does not address."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 179,
+            "title": "Save retries synchronously and blocks the caller during file contention",
+            "why": "When a destination file is briefly locked, each save sleeps for 20, 40, 60, and 80 ms, blocking the thread that is reporting reviewer progress for up to 200 ms; repeated contention across a multi-reviewer round delays progress and ties up concurrent server work.",
+            "fix": "Make persistence asynchronous with non-blocking delays, or move the bounded retry off the reviewer/request path.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The sleeps only occur on the rare contention path and total at most 200 ms of a bounded, deliberately-documented retry on a small session-file write \u0393\u00C7\u00F6 asking for an async persistence rework is machinery well out of proportion to the cost."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 153,
+            "title": "Scratch file cleanup may be skipped if MoveOverExisting throws on the final attempt",
+            "why": "The \u0060finally\u0060 block for \u0060MoveOverExisting\u0060 is placed after the \u0060try\u0060 block. If \u0060MoveOverExisting\u0060 throws an exception on its final attempt (line 153), the \u0060finally\u0060 block executes, but the \u0060try\u0060 block for the move itself is not entered in a way that guarantees the \u0060finally\u0060 block runs *after* the loop completes if the loop exits via \u0060return\u0060. Wait, looking closer: \u0060MoveOverExisting\u0060 is called inside a \u0060try\u0060 block. If it throws on the last attempt, the \u0060finally\u0060 block runs. However, if \u0060MoveOverExisting\u0060 throws *before* the \u0060try\u0060 block is entered (unlikely) or if the logic is flawed. Actually, the issue is that \u0060MoveOverExisting\u0060 is called inside a \u0060try\u0060 block. If it throws, the \u0060finally\u0060 block runs. But if \u0060MoveOverExisting\u0060 succeeds, the \u0060finally\u0060 block runs. The problem is that \u0060MoveOverExisting\u0060 is called *inside* the \u0060try\u0060 block, but the \u0060finally\u0060 block is attached to that \u0060try\u0060. If \u0060MoveOverExisting\u0060 throws on the last attempt, the \u0060finally\u0060 block runs. But if \u0060MoveOverExisting\u0060 *",
+            "fix": "Move the \u0060MoveOverExisting\u0060 call inside the \u0060try\u0060 block, or ensure the \u0060finally\u0060 block runs regardless of the \u0060MoveOverExisting\u0060 result, so that the temporary file is deleted even if the move fails after the first attempt.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent \u0393\u00C7\u00F6 it visibly reasons in circles and contradicts itself \u0393\u00C7\u00F6 and its premise is wrong: \u0060MoveOverExisting\u0060 is already inside the \u0060try\u0060, so the \u0060finally\u0060 runs and deletes the scratch file whether the move succeeds or throws on the final attempt."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 165,
+            "title": "Concurrent saves can silently fail or crash a round due to file lock contention",
+            "why": "When two MCP clients (servers) share a data directory and save the same session file simultaneously, they previously wrote to a fixed scratch path (\u0060\u003Csession\u003E.json.tmp\u0060). The diff changes this to a unique scratch path per write, but the \u0060File.Move\u0060 operation to the final destination is still vulnerable. If a third process (e.g., an antivirus scanner, a file indexer, or another writer) holds the destination file open for a moment, \u0060File.Move\u0060 throws \u0060UnauthorizedAccessException\u0060. The current implementation retries briefly (20ms increments), but if the lock persists beyond the 5 attempts (total ~250ms), the exception propagates. In \u0060LiveRound.Persist\u0060, this exception aborts the round\u0027s progress reporting, potentially leaving the round in a \u0027running\u0027 state on the UI while the server thinks it failed, or worse, crashing the server thread if not caught higher up. The test \u0060EightWritersOnOneSession_DoNotDenyEachOther\u0060 verifies the unique scratch name prevents collision, but the retry logic (",
+            "fix": "Wrap the \u0060File.Move\u0060 call in a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060, retrying up to 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms) before allowing the exception to propagate.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding\u0027s fix \u0393\u00C7\u00F6 wrap File.Move in a retry loop catching IOException and UnauthorizedAccessException with escalating backoff before rethrowing \u0393\u00C7\u00F6 is exactly what MoveOverExisting already does at lines 169-184, so it asks for code that is verbatim present in the file it cites."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Concurrent saves can leave orphaned scratch files or fail to clean up on error",
+            "why": "In \u0060SessionStore.Save\u0060, the \u0060finally\u0060 block unconditionally calls \u0060TryDelete(temp)\u0060. If \u0060MoveOverExisting\u0060 throws after the file is moved (e.g., a rare race where the destination is locked immediately after move but before the loop exits, or if the move succeeds but the file handle is held), the \u0060finally\u0060 block attempts to delete the *destination* file (since \u0060temp\u0060 was moved to \u0060file\u0060) or a non-existent temp file. More critically, if \u0060MoveOverExisting\u0060 retries 5 times and fails, the \u0060finally\u0060 block runs. If the temp file was successfully moved in a previous attempt (unlikely but possible with the retry logic) or if the move succeeds but the \u0060finally\u0060 block runs before the move completes fully in a concurrent scenario, the cleanup logic might delete the wrong file or leave a \u0060.tmp\u0060 file behind if the move fails but the temp file is already gone (e.g., moved by another process). The specific risk is that \u0060TryDelete\u0060 swallows exceptions, so a failure to clean up a \u0060.tmp\u0060 file is silent,\u79EF",
+            "fix": "Move the \u0060File.Delete(temp)\u0060 call inside the \u0060try\u0060 block of the \u0060MoveOverExisting\u0060 loop, or ensure the \u0060finally\u0060 block only attempts to delete the temp file if the move succeeded or if the temp file still exists.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about the code: \u0060temp\u0060 is a unique per-write path that no longer exists after a successful move (so \u0060TryDelete\u0060 is a harmless no-op and can never touch the destination or another writer\u0027s scratch file), and the only real residue \u0393\u00C7\u00F6 a swallowed delete failure on an already-failing save \u0393\u00C7\u00F6 is trivial, not Blocking."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 161,
+            "title": "UI flicker on round state transition due to synchronous state update",
+            "why": "The \u0060expanded\u0060 method in \u0060panelProvider.ts\u0060 calls \u0060nextOpenRounds\u0060 synchronously and updates \u0060this.rounds\u0060. If the calculation is heavy (e.g., many rounds), the UI might flicker or freeze. More importantly, the \u0060afterToggle\u0060 function is called on message receipt, which triggers a repaint. If the user clicks a card while the 5-second tick is running, the state might be updated twice in quick succession, causing a visual glitch where a card opens/closes unexpectedly.",
+            "fix": "Add a visible loading state or spinner in the UI when \u0060nextOpenRounds\u0060 is recalculating, or ensure the UI doesn\u0027t flicker between open/closed states during the 5-second tick.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding speculates about flicker and freezing from a trivial list computation over a handful of rounds, and the code it points at already documents the deliberate immediate repaint on toggle; the suggested fix (a spinner for a synchronous array filter) is machinery far out of proportion to any real risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Inefficient state management with repeated array conversions",
+            "why": "The \u0060nextOpenRounds\u0060 function creates new arrays (\u0060[...open]\u0060, \u0060[...autoOpened]\u0060, etc.) on every tick. While the number of rounds is likely small, if a user has hundreds of historical rounds, these conversions and filtering operations could become a bottleneck on the main thread, causing UI lag during the 5-second refresh cycle.",
+            "fix": "Use \u0060Set\u0060 for \u0060open\u0060, \u0060autoOpened\u0060, and \u0060panelOpened\u0060 internally to avoid repeated array conversions and filtering, especially if the number of rounds grows large.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The function already uses Sets internally and only converts to arrays at the boundary because the exported state is a readonly array type; the suggested change is a no-op against a handful of round keys per five-second tick, and the pruning the finding calls a bottleneck is precisely what keeps the sets small."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:51:19 \u001B[32mINF\u001B[0m] coai-mcp#53576 finding [Blocking/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Concurrent saves can leave orphaned scratch files or fail to clean up on error (from local) [gating] Round=1 Stage=CodeReview\r | [20:51:19 \u001B[32mINF\u001B[0m] coai-mcp#53576 finding [Major/Ux] src_vs_code/src/panelProvider.ts:161 - UI flicker on round state transition due to synchronous state update (from local) [gating] Round=1 Stage=CodeReview\r | [20:51:19 \u001B[32mINF\u001B[0m] coai-mcp#53576 finding [Minor/Performance] src_vs_code/src/openRounds.ts:45 - Inefficient state management with repeated array conversions (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "gemini,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T20:51:19.9123911Z",
+    "finishedUtc": "2026-09-05T20:54:27.0108808Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 20.3,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 25532,
+        "tokensOut": 2526,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 3 and test plan assume synchronous session completion, failing to close cards for aborted, timed-out, or dead rounds",
+            "why": "The plan relies on a round transitioning from running to not running while the panel tracks it. When a reviewer process times out, crashes, or is killed without writing a clean finish state, the round never emits a completion event. The panel logic retains the key in the auto-opened set or indefinitely computes duration from start time, leaving stale open cards that never auto-collapse.",
+            "fix": "Add an explicit state transition check and timeout/dead-round cleanup rule in panelProvider that collapses auto-opened cards when a round terminates abnormally or goes missing from active session state.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete failure mode \u0393\u00C7\u00F6 a round that ends abnormally never emits the completion event the panel\u0027s auto-collapse depends on, leaving a card stuck open and a duration ticking forever \u0393\u00C7\u00F6 which is a real reliability gap the plan\u0027s happy-path state transition does not cover, and the fix (an explicit terminal/missing-from-active-state check) is proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 3 triggers expensive full card repaints and heavy I/O on auto-collapse events",
+            "why": "Toggling open/closed states triggers a full card view re-render. As documented in the retro, repainting reads configuration, stats binaries, and queries external vendor CLIs. When multiple background rounds finish and collapse automatically, this causes multi-second UI freezes and high I/O latency in the webview.",
+            "fix": "Decouple open/closed disclosure state toggling from card body rebuilds, or cache vendor and CLI metadata so collapse events only update DOM visibility.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It asserts a multi-second freeze and heavy vendor-CLI I/O on collapse from a plan\u0027s build-order step with no file, line, or measurement behind it \u0393\u00C7\u00F6 a speculative performance claim about a webview repaint path it never opened, and the proposed decoupling/caching is machinery out of proportion to an unquantified risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order step 5 reuses existing \u0027.vendor\u0027 CSS selector which applies card styles to inline text spans",
+            "why": "Step 5 proposes wrapping vendor names in \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060. In the existing stylesheet, \u0060.vendor\u0060 targets settings cards (carrying borders, border-radius, and padding), causing inline vendor text to render with misplaced card styling resembling struck-out text.",
+            "fix": "Use a distinct class name such as \u0060who\u0060 or \u0060vendor-label\u0060 in step 5 to avoid collision with settings card styles.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "A CSS class-name collision that would visibly misrender the new inline vendor labels is a real, concrete defect with a one-word fix, and it is exactly the kind of thing a plan author cannot see without knowing the existing stylesheet."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Immediate data loss of active rounds due to aggressive pruning logic",
+            "why": "Step 3 states \u0027a round that is no longer running and is still in it is closed and dropped\u0027. If a user opens a round, the panel closes it (because it finished), but the user immediately re-opens it while the panel is still active, the logic in step 3 will drop it from the \u0027opened by this panel\u0027 set. If the user then closes it manually, the system loses track of it entirely, or worse, if a round finishes while the panel is idle, it gets dropped before the user can see the \u0027finished\u0027 state, causing the UI to show a ghost of a round that no longer exists in the list.",
+            "fix": "Add a \u0027lastSeenTimestamp\u0027 or \u0027heartbeat\u0027 check to the pruning logic in step 3, ensuring rounds are only dropped if they have been non-running for a duration exceeding the panel\u0027s idle timeout, not immediately upon state change.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a failure scenario from a paraphrased sentence \u0393\u00C7\u00F6 it names no file, cites no code, and its reasoning about \u0027losing track\u0027 and \u0027ghost rounds\u0027 is speculative narrative rather than a defect anyone could locate or act on, and the proposed heartbeat machinery is disproportionate to a hazard never shown to exist."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Loss of user intent across extension host restarts",
+            "why": "The plan relies on \u0027a second set \u2014 the rounds THIS panel opened\u0027 being pruned to \u0027living rounds\u0027. If the extension host restarts (common in VS Code), this in-memory set is lost. A round the user explicitly opened will be treated as \u0027panel opened\u0027 and thus closed automatically upon finish, violating requirement #3 (\u0027a round the person opened stays open\u0027). The user\u0027s explicit choice is overwritten by the system\u0027s default behavior because the \u0027person opened\u0027 state was never persisted.",
+            "fix": "Explicitly define the \u0027person opened\u0027 set as a persistent user preference store (e.g., VS Code settings or local storage) rather than a transient in-memory set that is pruned to \u0027living rounds\u0027.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete way a stated requirement breaks \u0393\u00C7\u00F6 an in-memory \u0027opened by the person\u0027 set does not survive an extension host restart, so a user-opened round would then be auto-closed \u0393\u00C7\u00F6 and names the fix (persist the intent), which is exactly the kind of state-durability gap a plan reviewer should catch before implementation."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy data corruption causes UI breakage and misleading feedback",
+            "why": "The plan notes that \u0027Rounds recorded before per-reviewer detail existed became disclosures that opened into an apology\u0027. If a user has a session file with old data, the new code will render a \u0027hand cursor\u0027 and an \u0027apology\u0027 for having nothing. This is a \u0027wrong outcome\u0027 because the user expects to see their old rounds, not an error message. The system fails to gracefully degrade or migrate legacy data, presenting a UI defect as a feature.",
+            "fix": "Add a \u0027version\u0027 or \u0027schema\u0027 check to the session file parser in \u0060rounds.ts\u0060 before rendering, or provide a default empty state that doesn\u0027t trigger an \u0027apology\u0027 UI.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding misreads a plan note about a defect that was already fixed as if it described new behaviour, and invents a legacy-data migration concern for what is a rendering guard on empty per-reviewer detail \u0393\u00C7\u00F6 no code is shown that it correctly describes."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Excessive startup latency due to synchronous blocking checks on every render",
+            "why": "The plan admits the toggle repaints \u0027reading the configuration, stat-ing the server binary, probing every vendor CLI, asking GitHub what was published and fetching two price tables \u2014 up to twenty seconds for a triangle\u0027. If a user opens the panel or toggles a setting, the UI freezes for up to 20 seconds. This is a \u0027wrong outcome\u0027 because the user expects an immediate response. The \u0027triangle\u0027 (likely a small UI element) becomes a bottleneck, making the extension feel broken.",
+            "fix": "Cache the result of the configuration read, stat, CLI probe, and GitHub fetch in a persistent store (e.g., \u0060package.json\u0060 or a local cache file) and only re-fetch on explicit user refresh or version change.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It quotes the plan\u0027s own statement of the problem back as if it were an undiscovered defect, adds an unsupported \u0027the UI freezes\u0027 claim (a panel repaint doing config reads, CLI probes and network fetches is asynchronous, not a blocked render), and proposes caching state in \u0060package.json\u0060, which is not a cache store."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression where vendor names appear struck-out due to CSS class collision",
+            "why": "The plan states the span\u0027s class is \u0060who\u0060 but the stylesheet already has a \u0060.vendor\u0060 class for the settings card. The deviation notes that \u0060.vendor\u0060 meant the settings card, which has \u0027border, radius and eight pixels of padding\u0027. If the new code uses \u0060who\u0060 but the CSS for \u0060.vendor\u0060 is applied to it (or if \u0060who\u0060 inherits styles from a parent that targets \u0060.vendor\u0060), the vendor name will be rendered with \u0027a line THROUGH the text\u0027 (strikethrough) or excessive padding, making it unreadable. This is a direct visual defect caused by the plan\u0027s deviation.",
+            "fix": "Rename the CSS class from \u0060who\u0060 to \u0060vendor\u0060 (or a unique alias like \u0060vendor-name\u0060) and ensure the styling rules for \u0060.vendor\u0060 do not conflict with the existing \u0060.vendor\u0060 settings card class.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and self-contradicting \u0393\u00C7\u00F6 it concedes the code uses a distinct \u0060who\u0060 class and then invents a strikethrough/padding regression from an imagined inheritance from an unrelated \u0060.vendor\u0060 settings-card rule, with no evidence any such cascade exists."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Inert switch due to missing runtime validation of the Fable model",
+            "why": "The plan removes \u0060FableAvailable\u0060 and relies on the checkbox alone. However, if the Fable model is not actually loaded (e.g., the user has a different configuration or the model failed to initialize), the \u0027Split with Fable\u0027 order will be issued but fail silently or throw an error. The user sees the checkbox checked but no action occurs, leading to confusion. The plan assumes the model is always available, which is an unstated assumption.",
+            "fix": "Replace the \u0027checkbox alone\u0027 trigger with a \u0027checkbox \u002B explicit confirmation\u0027 or a \u0027checkbox \u002B state check\u0027 that verifies the Fable model is actually loaded in the current context.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a failure mode from an unstated premise \u0393\u00C7\u00F6 nothing here shows a Fable model that can fail to load or a checkbox whose order silently no-ops \u0393\u00C7\u00F6 and its fix asks for an availability-check and confirmation step that reintroduces the very state the plan deliberately removed."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Incorrect duration reporting for dead rounds due to missing completion timestamp",
+            "why": "The plan notes a \u0027dead round is never written a completion time, so the panel measured how long ago it started\u0027. If a round dies (e.g., network loss) and never writes a completion time, the system calculates duration as \u0060now - start_time\u0060. This results in a duration of \u0027361m 40s\u0027 on a machine with a 10-minute timeout. The user sees a round that ran for 6 hours when it actually ran for 10 minutes, leading to incorrect billing or analysis.",
+            "fix": "Add a \u0027timeout\u0027 or \u0027max-duration\u0027 check to the round completion logic to prevent \u0027dead rounds\u0027 from claiming incorrect durations.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "A round that died leaving no completion time renders as a six-hour duration on a ten-minute timeout, which is a real display defect that misleads anyone reading rounds for cost or latency, and the finding names both the symptom and a workable fix."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 166.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 288232,
+        "tokensOut": 18240,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "Implemented plan is committed to todo/ with unpromoted status \u0027plan only, nothing implemented yet\u0027",
+            "why": "The rule states verbatim: \u0022**Run the plan completion check** from [planning-docs.md](planning-docs.md): does this work finish a plan, or has a plan\u0027s status line stopped matching reality? Promote in the same task.\u0022 (.claude/rules/shared/common/knowledge-base.md). This diff implements and ships all three features in extension 0.29.4 / server 0.16.0, but commits the plan into \u0060todo/\u0060 with \u0060Status: **plan only, nothing implemented yet.**\u0060 and unchecked Definition of Done items.",
+            "fix": "Move \u0060todo/PLAN_rounds_collapse_and_vendor_colour.md\u0060 to \u0060research/PLAN_rounds_collapse_and_vendor_colour.md\u0060, update its status line to \u0060Status: **IMPLEMENTED, 2026-09-04.**\u0060, and check off the Definition of Done checklist.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "If the same commit ships the three features, leaving the plan in \u0060todo/\u0060 still saying \u0022nothing implemented yet\u0022 breaks planning-docs.md\u0027s promotion rule and would go red in the family\u0027s own \u0060plan-lifecycle.mjs\u0060 CI check, so it names a real, mechanically-enforced defect with an exact fix."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 193,
+            "title": "TryDelete silently catches and swallows IOException and UnauthorizedAccessException without logging",
+            "why": "The rule states verbatim: \u0022Handle errors explicitly at every level; never silently swallow one.\u0022 and \u0022detailed context in server-side logs.\u0022 (.claude/rules/shared/common/coding-style.md). In \u0060SessionStore.TryDelete\u0060, the \u0060catch (Exception e) when (e is IOException or UnauthorizedAccessException)\u0060 block is completely empty.",
+            "fix": "Log the caught exception to server-side logs (e.g. at debug level) rather than leaving an empty catch block.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The empty catch is a deliberate best-effort cleanup of a uniquely-named scratch file whose failure costs nothing but a stray .tmp, and the method\u0027s name plus the adjacent comment already declare that intent \u0393\u00C7\u00F6 adding a logger to this static helper is ceremony out of proportion to the risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 810,
+            "title": "Reviewer row vendor span uses class .vendor which collides with settings card styling.",
+            "why": "In panelView.ts:810, the vendor badge is rendered as \u003Cspan class=\u0022vendor\u0022 ...\u003E. In the extension stylesheet, .vendor styles the outer settings card with a border, border-radius, and 8px padding. Applied to an inline single-word span inside a compact reviewer line, this renders padding and borders across the text, making the vendor name look struck through and malformed.",
+            "fix": "Change the span class from \u0027vendor\u0027 to a dedicated class such as \u0027who\u0027 that does not collide with settings card styles.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 139,
+            "title": "Toggling a round disclosure executes a full repaint that re-probes CLIs and remote endpoints.",
+            "why": "When a user clicks a round disclosure triangle to view reviewer details, the webview message triggers this.repaint(). Repainting executes full provider discovery, filesystem stats, CLI health probes, GitHub version checks, and pricing table fetches, causing noticeable UI latency (up to several seconds) just to expand or collapse a card.",
+            "fix": "Decouple round card toggling from the full environment/CLI discovery repaint or update the card state in the webview directly.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The claim is wrong about this code: every probe it names is TTL-cached behind \u0060cliCheckedAt\u0060/\u0060pricesCheckedAt\u0060/\u0060localCheckedAt\u0060/\u0060latestCheckedAt\u0060 and \u0060render()\u0060 already runs on the watcher\u0027s five-second tick, so a toggle costs a cache check, not a re-probe \u0393\u00C7\u00F6 and the suggested fix (patch the card in the webview) is ruled out by the adjacent comment explaining that a card\u0027s body is only built when it is open."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 805,
+            "title": "Legacy rounds without reviewer detail render as collapsible disclosure elements that expand into empty content.",
+            "why": "roundCard unconditionally renders all rounds as \u003Cdetails class=\u0022round\u0022\u003E disclosures even if reviewerStates is missing or empty. For older recorded sessions lacking reviewer detail, the UI displays a clickable disclosure indicator that expands into blank space.",
+            "fix": "Check if round.reviewerStates has items; if empty, render the summary as a flat non-collapsible row instead of a \u003Cdetails\u003E disclosure.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The claim is wrong about this code \u0393\u00C7\u00F6 line 824 already handles the empty case explicitly, rendering \u0022This round recorded no reviewer detail.\u0022 rather than blank space, so the described symptom cannot occur."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/tests/SessionStoreConcurrencyTests.cs",
+            "line": 1,
+            "title": "New test file uses C# syntax in a TypeScript project context",
+            "why": "The file \u0060src_mcp/tests/SessionStoreConcurrencyTests.cs\u0060 is a new file in the diff. It uses C# syntax (\u0060using Xunit\u0060, \u0060FluentAssertions\u0060, \u0060CoaiMcp.Core.Rounds\u0060). This is correct for the \u0060src_mcp\u0060 project. Wait, the diff shows \u0060src_mcp/tests/SessionStoreConcurrencyTests.cs\u0060 as a new file. The project structure implies \u0060src_mcp\u0060 is C# and \u0060src_vs_code\u0060 is TypeScript. The file uses C# syntax (\u0060using Xunit\u0060, \u0060FluentAssertions\u0060, \u0060CoaiMcp.Core.Rounds\u0060). This is consistent with the C# project. The finding is about the *rule* compliance. Let\u0027s look for a rule violation. Ah, the rule \u0060development-workflow.md\u0060 says:",
+            "fix": "Replace \u0060using Xunit;\u0060 with \u0060using Xunit;\u0060 (or remove the import if the project uses \u0060node:test\u0060 for this file, but the file uses \u0060Xunit\u0060 so keep it). However, the file is a new test file in a TypeScript project (\u0060src_vs_code\u0060) but uses C# syntax (\u0060using Xunit\u0060, \u0060FluentAssertions\u0060, \u0060CoaiMcp.Core.Rounds\u0060). The file path is \u0060src_mcp/tests/SessionStoreConcurrencyTests.cs\u0060 but the diff shows it as a new file in \u0060src_mcp/tests/\u0060. Wait, the diff shows \u0060src_mcp/tests/SessionStoreConcurrencyTests.cs\u0060 as a new file. The project structure implies \u0060src_mcp\u0060 is C# and \u0060src_vs_code\u0060 is TypeScript. The file uses C# syntax (\u0060using Xunit\u0060, \u0060FluentAssertions\u0060, \u0060CoaiMcp.Core.Rounds\u0060). This is consistent with the C# project. The finding is about the *rule* compliance. Let\u0027s look for a rule violation. Ah, the rule \u0060development-workflow.md\u0060 says:",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is incoherent thinking-out-loud that contradicts itself twice, identifies no actual problem (it concludes the C# file is correctly placed in the C# project), and its \u0027fix\u0027 asks to replace \u0060using Xunit;\u0060 with \u0060using Xunit;\u0060."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 165,
+            "title": "Concurrent session saves cause silent round failure due to file lock contention",
+            "why": "When two MCP clients (servers) share a data directory and both attempt to save the session simultaneously, they previously collided on a fixed scratch filename (\u0060\u003Csession\u003E.json.tmp\u0060). The new code fixes the filename collision but retains a retry loop for the \u0060File.Move\u0060 operation. If a third-party process (e.g., an antivirus scanner or Windows indexer) holds the destination file open during the move, the retry loop will exhaust after 5 attempts and throw \u0060UnauthorizedAccessException\u0060. This exception bubbles up from \u0060LiveRound.Persist\u0060, causing the current round to abort mid-execution. The operator sees a round disappear or fail without a clear reason, and the session state is left in an inconsistent state where the round trail is truncated.",
+            "fix": "Wrap the \u0060File.Move\u0060 call in a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060, retrying up to 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms) before allowing the exception to propagate.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding\u0027s proposed fix \u0393\u00C7\u00F6 a bounded retry loop around File.Move catching IOException/UnauthorizedAccessException with increasing backoff \u0393\u00C7\u00F6 is exactly what MoveOverExisting already implements at lines 169-184, so it asks for code that is verbatim present and its \u0027Blocking\u0027 framing rests on a misreading of the diff."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 807,
+            "title": "Vendor name injection via unescaped HTML attribute in style tag",
+            "why": "The code constructs a \u0060\u003Cspan\u003E\u0060 with an inline \u0060style\u0060 attribute: \u0060style=\u0022color:${vendorColour(row.provider)}\u0022\u0060. While \u0060vendorColour\u0060 returns a CSS variable string (e.g., \u0060var(--vscode-charts-blue)\u0060), the \u0060row.provider\u0060 value is passed to \u0060vendorColour\u0060. If a malicious vendor name (e.g., \u0060\u0027; background: red; --custom: blue\u0027\u0060) is injected into the session file, it could potentially break out of the expected CSS variable format or, more critically, if \u0060vendorColour\u0060 were to return a raw hex value or if the escaping logic shifts, an attacker could inject arbitrary CSS properties. More dangerously, if \u0060row.provider\u0060 itself is not escaped before being used in a context where it might be interpreted as HTML (though here it\u0027s inside a string interpolation), it could lead to XSS if the \u0060vendorColour\u0060 function were to return a value containing a closing quote and a script tag. Specifically, if \u0060vendorColour\u0060 returned \u0060var(--color); background: url(\u0027javascript:alert(1)\u0027)\u0060, the style attribute is",
+            "fix": "Ensure \u0060escapeHtml\u0060 is applied to the \u0060row.provider\u0060 string *before* it is interpolated into the \u0060style\u0060 attribute, or use a dedicated CSS variable mapping that is pre-escaped, to prevent attribute injection if a vendor name contains quotes.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It never establishes that \u0060vendorColour\u0060 can return anything but a fixed palette string \u0393\u00C7\u00F6 the whole case rests on hypotheticals (\u0027if it were to return a raw hex value\u0027, \u0027if the escaping logic shifts\u0027) \u0393\u00C7\u00F6 and its proposed fix, escaping \u0060row.provider\u0060 before passing it into a colour lookup, would not affect the attribute it claims is vulnerable."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 42,
+            "title": "Potential null reference exception in openRounds state calculation",
+            "why": "The \u0060nextOpenRounds\u0060 function assumes \u0060cards\u0060 is always a valid array. If the \u0060PanelProvider\u0060 passes an empty array or a null value (e.g., during initial load before sessions are fully parsed), the \u0060cards.map\u0060 and \u0060cards.filter\u0060 calls will throw a runtime error. This would crash the extension\u0027s UI thread, causing the rounds panel to freeze or disappear until the user reloads the window. While the current code path likely ensures \u0060cards\u0060 is an array, the lack of defensive programming makes it fragile against future changes or race conditions in data loading.",
+            "fix": "Add a check to ensure \u0060cards\u0060 is not null or undefined before calling \u0060cards.map\u0060 and \u0060cards.filter\u0060, and handle the case where \u0060isRunning\u0060 returns a non-boolean value gracefully.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "TypeScript\u0027s type signature already guarantees \u0060cards\u0060 is a readonly array, the caller is internal, and adding null guards to a pure function against a hypothetical future caller is defensive machinery out of proportion to a risk that cannot occur in this code."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 135,
+            "title": "User toggle state may not persist across reloads if not properly synced with server state",
+            "why": "The \u0060afterToggle\u0060 function correctly removes the key from \u0060panelOpened\u0060, but the \u0060expanded\u0060 getter in \u0060panelProvider.ts\u0060 (line 161) relies on \u0060nextOpenRounds\u0060 which is called inside the \u0060expanded\u0060 method. If the user reloads the extension or the view refreshes, the \u0060openRounds\u0060 state (which holds \u0060panelOpened\u0060) must be correctly initialized from the previous state. The current implementation initializes \u0060rounds\u0060 to \u0060NOTHING_OPEN\u0060 at class construction (line 97), meaning a user\u0027s manual open/close state is lost on extension reload unless persisted elsewhere. The finding is that the state is not persisted to disk or VS Code storage, so a reload resets the UI to the default \u0027auto-open\u0027 behavior, losing the user\u0027s explicit choice.",
+            "fix": "Ensure \u0060afterToggle\u0060 is called immediately upon receiving the \u0060round\u0060 message, and that the \u0060expanded\u0060 set is derived from \u0060nextOpenRounds\u0060 before rendering, so the UI reflects the state change instantly without waiting for the next 5-second tick.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The complaint is that ephemeral view state resets on reload \u0393\u00C7\u00F6 a deliberate design shared with \u0060openSections\u0060 and \u0060usageWindow\u0060, whose default (running open, finished closed) is the documented policy \u0393\u00C7\u00F6 and the proposed fix describes behaviour the code already implements at lines 136\u0393\u00C7\u00F4140, with line references that don\u0027t match the file."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Vendor colour calculation is performed on every render without caching",
+            "why": "The \u0060vendorColour\u0060 function (line 702) performs a string trim, lowercasing, and a hash calculation (FNV-1a) for every reviewer row rendered. While the hash is fast, if the list of reviewers grows significantly (e.g., hundreds of rounds), this calculation happens on every render cycle. Caching the result in a \u0060Map\u003Cstring, string\u003E\u0060 would reduce CPU usage on the main thread during frequent UI updates.",
+            "fix": "Memoize the \u0060vendorColour\u0060 calculation or cache the result in a Map to avoid recalculating the hash for every reviewer row render, especially if the list of reviewers grows large.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Micro-optimizing an FNV-1a hash over at most a handful of vendor rows in a webview that repaints every five seconds is machinery out of all proportion to the cost, and the premise that reviewer rows grow into the hundreds is wrong \u0393\u00C7\u00F6 the list is one card per vendor."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:54:26 \u001B[32mINF\u001B[0m] coai-mcp#13972 finding [Minor/Reliability] src_vs_code/src/openRounds.ts:42 - Potential null reference exception in openRounds state calculation (from local) Round=1 Stage=CodeReview\r | [20:54:26 \u001B[32mINF\u001B[0m] coai-mcp#13972 finding [Major/Ux] src_vs_code/src/panelProvider.ts:135 - User toggle state may not persist across reloads if not properly synced with server state (from local) [gating] Round=1 Stage=CodeReview\r | [20:54:26 \u001B[32mINF\u001B[0m] coai-mcp#13972 finding [Minor/Performance] src_vs_code/src/panelView.ts:702 - Vendor colour calculation is performed on every render without caching (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "rounds-collapse",
+      "planFile": "research/PLAN_rounds_collapse_and_vendor_colour.md",
+      "commit": "267e07a",
+      "baseRef": "afe7fc7"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|rounds-collapse|1",
+    "startedUtc": "2026-09-05T20:54:27.0972421Z",
+    "finishedUtc": "2026-09-05T20:58:22.5365535Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 38.2,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 11,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 47654,
+        "tokensOut": 6806,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The blanket escaping guarantee is not verified for all session-derived fields rendered by the page",
+            "why": "A session containing \u0060\u003Cimg src=x onerror=...\u003E\u0060 in a round title, model label, or another non-reviewer field can still execute if that renderer inserts it as HTML; the only specified escaping test covers a vendor name in one reviewer row.",
+            "fix": "Inventory every session-file value rendered by panelView and add context-appropriate escaping tests for each HTML/text attribute path, or centralize rendering through an escaping helper.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It names no file, line, or concrete unescaped field \u0393\u00C7\u00F6 it speculates that escaping *might* be missing elsewhere and asks for a full inventory, which is an audit request rather than an identified defect a reader can act on."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The color requirement is unverified for the live section and spending rows",
+            "why": "A build can color reviewer rows and pass the vendorColour unit tests while leaving a common vendor gray in the live section or spending table, violating the promised cross-location consistency.",
+            "fix": "Add rendering tests that place the same vendor in a round card, live section, and spending row and assert each uses the same palette variable.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It asks for cross-location rendering tests to guard a purely cosmetic palette consistency concern, with no evidence any such inconsistency exists \u0393\u00C7\u00F6 machinery out of proportion to the risk, and unanchored to any file or line."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Following the build step\u0027s \u0060vendor\u0060 class reactivates the existing settings-card styling on vendor text",
+            "why": "The plan says to emit \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060 even though it also states \u0060.vendor\u0060 already applies a border, radius, padding, and a line-through-like visual in the stylesheet; implementing the step literally makes inline vendor names render incorrectly.",
+            "fix": "Specify and use the dedicated \u0060who\u0060 class (or rename/update the existing stylesheet selector) consistently in the implementation and tests.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It flags a concrete implementation collision \u0393\u00C7\u00F6 reusing an existing \u0060.vendor\u0060 selector whose card styling would visibly corrupt inline vendor names \u0393\u00C7\u00F6 and names a specific fix, which is exactly the kind of thing an implementer would want caught before writing the markup."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Build order (panelProvider / panelView): Card expand/collapse toggles trigger the full panel refresh pipeline with external probes",
+            "why": "When a user clicks a round disclosure triangle or a round finishes and updates its open/closed state, re-rendering the view through the existing panel data pipeline executes heavy I/O (reading config, stat-ing binaries, probing CLI vendors, fetching GitHub releases, and downloading pricing tables), resulting in up to 20 seconds of UI latency for a simple card toggle.",
+            "fix": "Isolate card expansion/collapse to client-side DOM toggle state, or cache external probe results so view state updates do not re-trigger CLI and network probes.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "A card expand/collapse re-running CLI probes, binary stats and network fetches on the render path is a real, user-visible latency defect with a concrete fix (cache probes or make view state client-side), and it names the exact trigger and the components involved rather than restating the code."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order (panelView): Proposed class name \u0060.vendor\u0060 collides with existing settings card CSS styles",
+            "why": "Wrapping the vendor name in \u0060\u003Cspan class=\u0022vendor\u0022\u003E\u0060 applies existing stylesheet rules for \u0060.vendor\u0060 (border, border-radius, and 8px padding designed for settings cards), rendering inline vendor names in tight reviewer rows with border boxes that appear as struck-through text.",
+            "fix": "Use a distinct inline class name such as \u0060who\u0060 or \u0060vendor-name\u0060 that has no style collisions in the extension stylesheet.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "A CSS class-name collision that would visibly break the reviewer rows is a concrete, checkable defect with a cheap fix, and the kind of thing a plan reviewer is well placed to catch before the markup is written."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Build order (panelProvider): Auto-close logic assumes rounds always terminate with a completion record and ignores dead or timed-out rounds",
+            "why": "When a reviewer process crashes, gets killed, or times out without persisting a completion timestamp, the round never transitions to \u0027finished\u0027; the panel treats it as indefinitely running, continuously calculates duration from start time, and keeps the card permanently expanded.",
+            "fix": "Add a liveness/timeout check against the configured reviewer timeout so dead or uncompleted rounds are marked expired, closed, and capped in elapsed time calculation.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding names no file and no code was provided, and it argues from a speculative premise about a panel\u0027s auto-close logic that cannot be checked \u0393\u00C7\u00F6 it is a plausible-sounding reliability story rather than a defect established in this code."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Build order (panelView): Legacy session records lacking per-reviewer detail render as misleading empty expandable disclosures",
+            "why": "Opening historical session files recorded before per-reviewer tracking existed renders an expandable disclosure chevron and hand cursor, but expanding the card displays an empty container with no reviewer breakdown.",
+            "fix": "Condition the expandable disclosure wrapper on whether per-reviewer detail items exist; render legacy records without detail as flat rows.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative about a hypothetical legacy-record shape with no file or line to check, and even if real, an empty expander on old session records is a trivial cosmetic edge case not worth acting on."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Immediate data loss of active rounds due to aggressive pruning logic",
+            "why": "Step 3 states \u0027a round that is no longer running and is still in it is closed and dropped\u0027. If a user opens a round, the panel closes it (because it finished), but the user immediately re-opens it while the panel is still active, the logic in step 3 will drop it from the \u0027opened by this panel\u0027 set. If the user then closes it manually, the system loses track of it entirely, or worse, if a round finishes while the panel is idle, it gets dropped before the user can see the \u0027finished\u0027 state, causing the UI to show a ghost of a round that no longer exists in the list.",
+            "fix": "Add a \u0027lastSeenTimestamp\u0027 or \u0027heartbeat\u0027 check to the pruning logic in step 3, ensuring rounds are only dropped if they have been non-running for a duration exceeding the panel\u0027s idle timeout, not immediately upon state change.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a failure story out of one sentence of a plan \u0393\u00C7\u00F6 a UI panel dropping a finished round from its own bookkeeping set is not data loss, the described scenarios are internally incoherent, and the proposed heartbeat machinery is far out of proportion to a set that only tracks what a panel opened."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Loss of user intent across extension host restarts",
+            "why": "The plan relies on \u0027a second set \u2014 the rounds THIS panel opened\u0027 being pruned to \u0027living rounds\u0027. If the extension host restarts (common in VS Code), this in-memory set is lost. A round the user explicitly opened will be treated as \u0027panel opened\u0027 and thus closed automatically upon finish, violating requirement #3 (\u0027a round the person opened stays open\u0027). The user\u0027s explicit choice is overwritten by the system\u0027s default behavior because the \u0027person opened\u0027 state was never persisted.",
+            "fix": "Explicitly define the \u0027person opened\u0027 set as a persistent user preference store (e.g., VS Code settings or local storage) rather than a transient in-memory set that is pruned to \u0027living rounds\u0027.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It gets the failure direction backwards \u0393\u00C7\u00F6 losing an in-memory set of rounds *this panel opened* makes every round look person-opened (stays open), not auto-closed, so the named violation of requirement #3 cannot happen; and demanding persistent preference storage for transient panel bookkeeping that a host restart tears down anyway is machinery out of proportion to a Blocking call."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Legacy data corruption causes UI breakage and misleading feedback",
+            "why": "The plan notes that \u0027Rounds recorded before per-reviewer detail existed became disclosures that opened into an apology\u0027. If a user has a session file with old data, the new code will render a \u0027hand cursor\u0027 and an \u0027apology\u0027 for having nothing. This is a \u0027wrong outcome\u0027 because the user expects to see their old rounds, not an error message. The system fails to gracefully degrade or migrate legacy data, presenting a UI defect as a feature.",
+            "fix": "Add a \u0027version\u0027 or \u0027schema\u0027 check to the session file parser in \u0060rounds.ts\u0060 before rendering, or provide a default empty state that doesn\u0027t trigger an \u0027apology\u0027 UI.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads a plan sentence describing a fixed defect as an unhandled legacy-data hazard, then asks for schema versioning for what is just an empty-detail render \u0393\u00C7\u00F6 machinery out of proportion to a non-issue."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "",
+            "line": 0,
+            "title": "Excessive startup latency due to synchronous blocking checks on every render",
+            "why": "The plan admits the toggle repaints \u0027reading the configuration, stat-ing the server binary, probing every vendor CLI, asking GitHub what was published and fetching two price tables \u2014 up to twenty seconds for a triangle\u0027. If a user opens the panel or toggles a setting, the UI freezes for up to 20 seconds. This is a \u0027wrong outcome\u0027 because the user expects an immediate response. The \u0027triangle\u0027 (likely a small UI element) becomes a bottleneck, making the extension feel broken.",
+            "fix": "Cache the result of the configuration read, stat, CLI probe, and GitHub fetch in a persistent store (e.g., \u0060package.json\u0060 or a local cache file) and only re-fetch on explicit user refresh or version change.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It reports the plan\u0027s own stated symptom back as a defect \u0393\u00C7\u00F6 the twenty-second re-probe on a toggle is the thing the plan is describing in order to address it \u0393\u00C7\u00F6 and dresses it up with a mechanism the code does not have (async probes in an extension host do not \u0027freeze\u0027 the UI) plus a fix that suggests caching state in \u0060package.json\u0060."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Visual regression where vendor names appear struck-out due to CSS class collision",
+            "why": "The plan states the span\u0027s class is \u0060who\u0060 but the stylesheet already has a \u0060.vendor\u0060 class for the settings card. The deviation notes that \u0060.vendor\u0060 meant the settings card, which has \u0027border, radius and eight pixels of padding\u0027. If the new code uses \u0060who\u0060 but the CSS for \u0060.vendor\u0060 is applied to it (or if \u0060who\u0060 inherits styles from a parent that targets \u0060.vendor\u0060), the vendor name will be rendered with \u0027a line THROUGH the text\u0027 (strikethrough) or excessive padding, making it unreadable. This is a direct visual defect caused by the plan\u0027s deviation.",
+            "fix": "Rename the CSS class from \u0060who\u0060 to \u0060vendor\u0060 (or a unique alias like \u0060vendor-name\u0060) and ensure the styling rules for \u0060.vendor\u0060 do not conflict with the existing \u0060.vendor\u0060 settings card class.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is speculative and self-contradictory \u0393\u00C7\u00F6 it concedes the code uses class \u0060who\u0060 while \u0060.vendor\u0060 styles a different element, then invents a strikethrough/padding regression from an inheritance mechanism CSS classes do not have, so it names no real defect."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Inert switch due to missing runtime validation of the Fable model",
+            "why": "The plan removes \u0060FableAvailable\u0060 and relies on the checkbox alone. However, if the Fable model is not actually loaded (e.g., the user has a different configuration or the model failed to initialize), the \u0027Split with Fable\u0027 order will be issued but fail silently or throw an error. The user sees the checkbox checked but no action occurs, leading to confusion. The plan assumes the model is always available, which is an unstated assumption.",
+            "fix": "Replace the \u0027checkbox alone\u0027 trigger with a \u0027checkbox \u002B explicit confirmation\u0027 or a \u0027checkbox \u002B state check\u0027 that verifies the Fable model is actually loaded in the current context.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a failure mode from an unstated assumption about a plan whose text isn\u0027t shown, names no file or line, and proposes extra confirmation machinery out of proportion to a checkbox-driven \u0027Split with Fable\u0027 switch."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Incorrect duration reporting for dead rounds due to missing completion timestamp",
+            "why": "The plan notes a \u0027dead round is never written a completion time, so the panel measured how long ago it started\u0027. If a round dies (e.g., network loss) and never writes a completion time, the system calculates duration as \u0060now - start_time\u0060. This results in a duration of \u0027361m 40s\u0027 on a machine with a 10-minute timeout. The user sees a round that ran for 6 hours when it actually ran for 10 minutes, leading to incorrect billing or analysis.",
+            "fix": "Add a \u0027timeout\u0027 or \u0027max-duration\u0027 check to the round completion logic to prevent \u0027dead rounds\u0027 from claiming incorrect durations.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "A round that died is shown as having run for six hours on a machine with a ten-minute timeout \u0393\u00C7\u00F6 a wrong number the operator reads as duration and cost, and the finding names both the cause (no completion time written) and a workable fix."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 109 lines, 6 build step(s), 5 file(s) named, 5 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 197.1,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 623328,
+        "tokensOut": 16529,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "The committed plan still says the implemented change is not implemented",
+            "why": "The rule says: \u0022After every code change: ... Run the plan completion check from [planning-docs.md](planning-docs.md): does this work finish a plan, or has a plan\u0027s status line stopped matching reality? Promote in the same task.\u0022 This diff implements the plan but adds it with \u0060Status: **plan only, nothing implemented yet.**\u0060.",
+            "fix": "Promote or remove the todo plan and update its status to reflect that the change is implemented.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "If the same commit carries both the plan and its implementation, the \u0060plan only, nothing implemented yet\u0060 status is a real, checkable violation of this repo\u0027s plan-lifecycle rule \u0393\u00C7\u00F6 one its own CI tool (\u0060plan-lifecycle.mjs\u0060) turns red \u0393\u00C7\u00F6 and a stale status line is exactly the failure the conventions document at length, so the author would want it fixed in the same task."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 185,
+            "title": "Scratch-file cleanup silently swallows filesystem errors",
+            "why": "The written rule says: \u0022Handle errors explicitly at every level; never silently swallow one.\u0022 The new \u0060TryDelete\u0060 catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060 with an empty body, hiding cleanup failures and their context.",
+            "fix": "Handle the cleanup failure explicitly, such as logging detailed context to stderr/server logs while preserving the original save exception.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "This is textbook best-effort cleanup of the writer\u0027s own uniquely-named scratch file inside a \u0060finally\u0060 \u0393\u00C7\u00F6 swallowing there is deliberate (throwing would mask the real save failure, which the finding itself concedes), the intent is already documented in the comment, and plumbing a logger into this small store to report a stray temp file is machinery out of proportion to the risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/SessionStoreConcurrencyTests.cs",
+            "line": 39,
+            "title": "Test teardown silently swallows directory deletion failures",
+            "why": "The written rule says: \u0022Handle errors explicitly at every level; never silently swallow one.\u0022 \u0060Dispose\u0060 catches \u0060IOException\u0060 and does nothing, so failed cleanup can leave temporary test data behind without any diagnostic.",
+            "fix": "Report teardown failures explicitly or make disposal fail the test with the caught exception and cleanup path.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "A best-effort temp-directory cleanup in test teardown is exactly where swallowing an IOException is correct \u0393\u00C7\u00F6 failing the test on a cleanup race would create the flake it pretends to prevent, and the coding-style rule about silent failures is aimed at production error paths, not disposal of a throwaway directory."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 168,
+            "title": "Concurrent saves can still overwrite newer session state with an older snapshot",
+            "why": "Unique scratch names prevent scratch-file collisions, but unconditional overwrite remains last-writer-wins. If server A saves an older snapshot after server B saves a newer reviewer-progress snapshot, A replaces B\u0027s file and completed reviewer state disappears.",
+            "fix": "Serialize saves per session or add version checking/merging before replacement so stale snapshots cannot overwrite newer state.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It correctly identifies that the unique-scratch-name fix only removed the temp-file collision while the destination write remains unfenced last-writer-wins, so in the very multi-server, nine-reviewer-transition scenario the comment describes, a stale snapshot can silently erase completed reviewer state \u0393\u00C7\u00F6 a real durability risk worth knowing about even if the eventual answer is per-session serialization rather than versioning."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 140,
+            "title": "Round-toggle clicks wait for the full expensive panel rebuild without showing progress",
+            "why": "Opening or closing a card calls \u0060refresh()\u0060, whose auxiliary checks can take up to 20 seconds. The click gives no acknowledgement and the card does not repaint until unrelated configuration, CLI, GitHub, and price lookups finish, leaving the person unable to tell whether the action worked.",
+            "fix": "Render the local round state immediately and defer or cache the slow auxiliary lookups; alternatively show an explicit busy state while the refresh runs.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The claim is speculative and misreads the code \u0393\u00C7\u00F6 the auxiliary lookups it asks to cache already are cached behind \u0060latestCheckedAt\u0060/\u0060cliCheckedAt\u0060/\u0060pricesCheckedAt\u0060/\u0060localCheckedAt\u0060, and the very same \u0060render()\u0060 (not \u0060refresh()\u0060) already runs on the watcher\u0027s five-second tick, so a toggle adds no new latency class and the invented 20-second figure has no support in the code shown."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 807,
+            "title": "The reviewer vendor span uses the existing \u0060.vendor\u0060 class despite that class styling settings cards",
+            "why": "The plan explicitly notes that \u0060.vendor\u0060 already carries settings-card border, radius, and padding styles. Applying it to each inline reviewer name makes a vendor word inherit card styling, producing malformed reviewer rows instead of only colouring the word.",
+            "fix": "Use the dedicated neutral class intended for reviewer names (for example \u0060who\u0060) and style only its colour.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 61,
+            "title": "Every five-second refresh rebuilds and filters several collections across all retained rounds",
+            "why": "With 10,000 visible/history cards, each tick allocates sets for all running and alive keys, spreads \u0060panelOpened\u0060, and scans all three collections again. This repeats even when no round changed, adding tens of thousands of key operations and allocations to every periodic repaint.",
+            "fix": "Retain internal sets and update/prune them only when session keys or running status changes; convert to arrays only when the renderer needs them.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It hypothesizes a 10,000-card panel that this rounds view will never have \u0393\u00C7\u00F6 the work is a handful of set operations over a short, already-pruned list every five seconds \u0393\u00C7\u00F6 and its fix would trade the file\u0027s deliberate purity and testability for retained mutable state to save nothing measurable."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 193,
+            "title": "TryDelete silently swallows exceptions with an empty catch block",
+            "why": "File deletion failures are caught and ignored with an empty block, breaking the written rule: \u0022Handle errors explicitly at every level; never silently swallow one.\u0022",
+            "fix": "Log caught exceptions or handle them explicitly instead of discarding them in an empty catch body.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The empty catch is a deliberate, documented best-effort cleanup of the writer\u0027s own scratch file \u0393\u00C7\u00F6 narrowly typed to IOException/UnauthorizedAccessException with a comment explaining why failure is harmless \u0393\u00C7\u00F6 so this is a rule cited against the one case it doesn\u0027t govern, and logging a failed temp delete adds noise rather than information."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "todo/PLAN_rounds_collapse_and_vendor_colour.md",
+            "line": 3,
+            "title": "Completed plan added to todo/ with unpromoted \u0027plan only\u0027 status",
+            "why": "The change implements the plan and releases version 0.29.4, but leaves the plan file under todo/ stating \u0027Status: **plan only, nothing implemented yet.**\u0027, breaking the rule: \u00224. Run the plan completion check from [planning-docs.md](planning-docs.md): does this work finish a plan, or has a plan\u0027s status line stopped matching reality? Promote in the same task.\u0022",
+            "fix": "Update the status header to reflect implementation and promote the document from todo/ to research/ in the same change.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The repo\u0027s planning-docs rule explicitly requires promoting a finished plan to research/ with an IMPLEMENTED status in the same task, and a shipped plan left in todo/ saying \u0027nothing implemented yet\u0027 is exactly the drift that rule (and its CI check) exists to catch."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 149,
+            "title": "Concurrent saves to the same session within a single process can race on final atomic replacement",
+            "why": "While unique temp files prevent collisions during staging, when multiple threads or parallel tasks persist the same session simultaneously (e.g. rapid reviewer status updates), MoveOverExisting can encounter IOException/UnauthorizedAccessException on Windows when overwriting the destination file concurrently, relying solely on fixed 5-retry backoff which could exhaust retries under high contention.",
+            "fix": "Wrap the save operation in a shared per-session lock/mutex or file-sharing lock so concurrent in-process saves to the same session file sequence their move operations rather than colliding during MoveOverExisting.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The code already documents and handles exactly this case with a bounded retry on the move, and the proposed in-process lock would not help the real scenario the comment names (several server processes sharing one data dir), so it adds machinery without closing the window."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 702,
+            "title": "Unsanitized vendor name is passed into CSS style attribute in usageRows",
+            "why": "\u0060vendorColour(r.provider)\u0060 and inline \u0060style=\u0022color:${vendorColour(r.provider)}\u0022\u0060 safely return CSS vars for known/hashed values, but \u0060r.provider\u0060 in \u0060data-id=\u0022${escapeHtml(r.provider)}\u0022\u0060 assumes escaping, whereas if a malicious provider name contains CSS injection sequences, passing it unvalidated into inline style contexts or CSS generation could lead to CSS injection if vendor names are crafted.",
+            "fix": "Sanitize or validate \u0060r.provider\u0060 (e.g., ensure it conforms to an identifier pattern or strictly strip dangerous style characters/quotes) before interpolating into the inline \u0060style\u0060 attribute.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding contradicts itself \u0393\u00C7\u00F6 it concedes \u0060vendorColour\u0060 returns a fixed CSS var or hashed colour, so the provider string never reaches the style attribute at all, and it names no path by which a crafted value could get there."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 181,
+            "title": "Synchronous Thread.Sleep in retry loop blocks ASP.NET Core / JSON-RPC server worker threads",
+            "why": "When concurrent writers or transient file locks (e.g. indexer/AV) trigger retries in MoveOverExisting, Thread.Sleep(20 * attempt) synchronously blocks the calling thread for up to 200ms per save across 5 attempts. Because LiveRound.Persist is called on every reviewer status update across multi-reviewer rounds, blocking worker threads causes thread pool starvation and delays concurrent round execution and JSON-RPC dispatch.",
+            "fix": "Make SessionStore persistence async (or Task-based) using await Task.Delay(20 * attempt) or keep retry delays non-blocking for background server tasks.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The retry sleep only runs on the rare contention path (bounded at ~200ms total, zero on the normal path) in an already fully synchronous file-write method on a stdio MCP server \u0393\u00C7\u00F6 the finding invents an ASP.NET Core worker-pool that isn\u0027t there and asks for an async refactor out of all proportion to the risk."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 136,
+            "title": "Immediate repaint on every disclosure toggle triggers heavy unmemoized reads across entire panel state",
+            "why": "When a person clicks to toggle a round card, panelProvider.ts immediately calls repaint() (reading config, probing CLIs, parsing sessions/usage/prices) synchronously rather than rendering solely the toggled details content or batching updates. If the user rapidly expands/collapses cards, it triggers redundant costly I/O and pricing queries.",
+            "fix": "Avoid full environment and provider re-probing on disclosure toggle, or update only the target card webview state on toggle.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The immediate repaint is deliberate and documented one line below the flagged call (an opened card\u0027s body is only built when open), \u0060render()\u0060 is a few small file reads plus one config read whose network probes are timestamp-cached (\u0060cliCheckedAt\u0060, \u0060pricesCheckedAt\u0060, \u0060localCheckedAt\u0060) and already runs on a five-second tick, so a human-speed click adds nothing worth restructuring for."
+          },
+          {
+            "severity": "Nit",
+            "category": "Performance",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 80,
+            "title": "Redundant Set allocation and array spread in afterToggle on every card click",
+            "why": "afterToggle performs [...new Set([...previous.open, key])] allocating multiple intermediate arrays and Sets on every user toggle event even when key is already present or known unique.",
+            "fix": "Check previous.open.includes(key) before appending or use a Set directly.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "A per-click allocation of a few small arrays over a handful of round keys is imperceptible, and the suggested guard would add branching to a clean pure function to save nothing measurable."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 153,
+            "title": "Scratch file leak on failed move after first retry",
+            "why": "The \u0060try\u0060 block wraps \u0060MoveOverExisting\u0060, which contains a loop. If the move succeeds on the first attempt, the \u0060finally\u0060 block runs and deletes the temp file. However, if the move fails on the first attempt (throwing an exception), the loop catches it and retries. If the move succeeds on a subsequent attempt, the \u0060finally\u0060 block runs. But if the move fails on *all* attempts, the exception propagates out of \u0060MoveOverExisting\u0060, and the \u0060finally\u0060 block runs. Wait, looking closer: \u0060MoveOverExisting\u0060 is called inside a \u0060try\u0060. If \u0060MoveOverExisting\u0060 throws (after all retries), the \u0060finally\u0060 runs. If it succeeds, the \u0060finally\u0060 runs. The issue is that if \u0060MoveOverExisting\u0060 throws on the *first* attempt, it catches the exception, sleeps, and retries. If it succeeds on the second attempt, it returns. The \u0060finally\u0060 block then runs. This seems correct. Let\u0027s re-read the code. Ah, the \u0060try\u0060 block is around \u0060MoveOverExisting\u0060. If \u0060MoveOverExisting\u0060 throws, the \u0060finally\u0060 runs. If it succeeds, the \u0060if",
+            "fix": "Move the \u0060MoveOverExisting\u0060 call inside the \u0060try\u0060 block, or ensure the \u0060finally\u0060 block runs regardless of the move\u0027s success, so that the temporary file is deleted even if the move fails after the first attempt.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is self-refuting rambling that talks itself into agreeing the code is correct, and its suggested fix (\u0027move the call inside the try block\u0027) asks for something the code already does \u0393\u00C7\u00F6 the \u0060finally\u0060 deletes the scratch file on every path."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Concurrent saves from multiple MCP clients cause session loss due to fixed scratch filename collision",
+            "why": "The \u0060SessionStore.Save\u0060 method writes to a scratch file named \u0060\u003Csession\u003E.json.tmp\u0060 (a fixed path). When two MCP clients (servers) run simultaneously and share a data directory, they attempt to write to the same scratch file. The second writer overwrites the first\u0027s data, and when both try to \u0060File.Move\u0060 the same scratch file to the destination, one fails with \u0060UnauthorizedAccessException\u0060. This causes the round reporting progress to abort silently or throw, leaving the session in an inconsistent state or lost entirely. The fix introduces a unique scratch filename per write (using ProcessId and Guid) to eliminate the collision, and adds a retry loop for the move operation to handle transient locks on the destination file.",
+            "fix": "Wrap the \u0060File.Move\u0060 call in a \u0060try\u0060 block that catches \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060, retrying up to 5 times with exponential backoff (20ms, 40ms, 60ms, 80ms, 100ms) before allowing the exception to propagate.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding describes a defect that no longer exists in the reviewed code \u0393\u00C7\u00F6 the scratch name is already per-write unique (ProcessId \u002B Guid, line 148) and the retry loop it proposes as the fix is already implemented in MoveOverExisting (lines 169-184), so it merely restates the comment the code carries."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_vs_code/src/panelView.ts",
+            "line": 807,
+            "title": "Vendor name color injection risks XSS if the provider name contains quotes or special characters",
+            "why": "The code constructs an inline style: \u0060style=\u0022color:${vendorColour(row.provider)}\u0022\u0060. While \u0060vendorColour\u0060 returns a safe CSS variable string, the \u0060row.provider\u0060 itself is escaped in the text content (\u0060escapeHtml(row.provider)\u0060). However, if the \u0060vendorColour\u0060 function were to return a value containing a quote (e.g., if it returned a hex color with a quote, though unlikely here), or if the \u0060row.provider\u0060 string itself is used in a way that isn\u0027t fully escaped before being placed in the style attribute, an attacker could inject attributes. More critically, the \u0060row.provider\u0060 is used in the text content *after* the span tag. If \u0060row.provider\u0060 contains a \u0060\u003E\u0060 character, it could prematurely close the span. The current code escapes \u0060row.provider\u0060 for the text content, but the \u0060vendorColour\u0060 function is called on the raw string. If a vendor name is \u0060\u003Cscript\u003E\u0060, the output is \u0060\u003Cspan class=\u0022vendor\u0022 style=\u0022color:...\u0022\u003E\u003Cscript\u003E\u003C/span\u003E\u0060. The \u0060escapeHtml\u0060 is applied to the *text* inside the span, but:",
+            "fix": "Ensure \u0060escapeHtml\u0060 is applied to the \u0060row.provider\u0060 string *before* it is interpolated into the \u0060style\u0060 attribute, or use a dedicated CSS variable mapping that is pre-escaped, to prevent a vendor name like \u0060codex\u0022 onclick=\u0022alert(1)\u0060 from breaking out of the span.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is self-refuting and wrong about the visible code \u0393\u00C7\u00F6 \u0060row.provider\u0060 IS escaped in the text content, the only unescaped interpolation is \u0060vendorColour\u0060\u0027s return which the finding itself concedes is a safe constant and never bothered to open, and its proposed fix (escape \u0060row.provider\u0060 before the style attribute) targets a value that is not interpolated there, so it raises a Major security alarm on a hypothetical it did not check."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/SessionStore.cs",
+            "line": 175,
+            "title": "Session save race condition leaves orphaned temp files if move fails on last attempt",
+            "why": "When two servers write to the same session file, they use unique temp names. If \u0060MoveOverExisting\u0060 fails on the last attempt (e.g., due to a file lock), the \u0060finally\u0060 block runs \u0060TryDelete(temp)\u0060. However, if \u0060MoveOverExisting\u0060 succeeds but \u0060TryDelete\u0060 throws (e.g., file in use by another process), the exception is swallowed, leaving the temp file behind. Over time, this accumulates orphaned \u0060.tmp\u0060 files, consuming disk space and potentially causing \u0060UnauthorizedAccessException\u0060 on subsequent saves if the temp file name collides with a new one.",
+            "fix": "Move the \u0060TryDelete(temp)\u0060 call inside the \u0060try\u0060 block of the \u0060Save\u0060 method, or ensure it runs after the \u0060MoveOverExisting\u0060 call completes, so that if the move succeeds but the delete fails, the temp file is cleaned up. Currently, if \u0060MoveOverExisting\u0060 throws on the last attempt, the \u0060finally\u0060 block runs, but if \u0060MoveOverExisting\u0060 succeeds and \u0060TryDelete\u0060 throws, the exception is swallowed. The real issue is that \u0060TryDelete\u0060 is called in a \u0060finally\u0060 block of the \u0060Save\u0060 method, but the \u0060MoveOverExisting\u0060 call is inside a \u0060try\u0060 block that catches exceptions. If \u0060MoveOverExisting\u0060 throws on the last attempt, the \u0060finally\u0060 block runs, but if it succeeds, the \u0060finally\u0060 block runs. The problem is that \u0060TryDelete\u0060 is called in a \u0060finally\u0060 block of the \u0060Save\u0060 method, but the \u0060MoveOverExisting\u0060 call is inside a \u0060try\u0060 block that catches exceptions. If \u0060MoveOverExisting\u0060 throws on the last attempt, the \u0060finally\u0060 block runs, but if it succeeds, the \u0060finally\u0060 block runs. The real issue is that \u0060Try",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about the code \u0393\u00C7\u00F6 the temp name is unique per write so collisions cannot recur, a failed TryDelete leaves at most one stray scratch file rather than a growing hazard, and the \u0027fix\u0027 is incoherent, restating the same finally-block behavior in a degenerate loop without identifying any actual defect."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_vs_code/src/panelProvider.ts",
+            "line": 135,
+            "title": "No visual feedback during panel repaint after toggle",
+            "why": "When a user toggles a round card, the panel repaints immediately. If the repaint takes longer than the 5-second tick interval (e.g., due to heavy DOM updates or slow rendering), the user sees a blank card or a flicker. This is especially problematic if the user clicks multiple times quickly, as the state might not update correctly before the next tick.",
+            "fix": "Add a visible loading state or spinner when the panel is repainting after a toggle, or ensure the repaint is instantaneous. Currently, the user sees a blank card or a flicker if the repaint takes longer than 5 seconds.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The concern is fabricated \u0393\u00C7\u00F6 a webview repaint is a local HTML replacement measured in milliseconds and has no relationship to the 5-second polling tick, so the described blank card, flicker, and lost-click scenarios don\u0027t apply to this code, and the proposed spinner is machinery for a risk that doesn\u0027t exist."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_vs_code/src/openRounds.ts",
+            "line": 45,
+            "title": "Inefficient set pruning in openRounds logic",
+            "why": "The \u0060nextOpenRounds\u0060 function filters the \u0060open\u0060, \u0060autoOpened\u0060, and \u0060panelOpened\u0060 sets against the \u0060alive\u0060 set on every tick. While the number of rounds is typically small, this operation is O(n) for each set. If the number of rounds grows (e.g., hundreds of rounds over a long session), this could become a performance bottleneck, especially if the function is called frequently.",
+            "fix": "Use a \u0060Map\u0060 or \u0060Set\u0060 for \u0060alive\u0060 instead of filtering the array on every tick. Currently, \u0060alive\u0060 is created by mapping all cards to keys and filtering the open sets against it. This is O(n) for each set, which is acceptable for small lists but could become a bottleneck if the number of rounds grows significantly.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The \u0060alive\u0060 set already IS a Set and the filters are O(n) over a list bounded by the rounds that exist \u0393\u00C7\u00F6 the code\u0027s own comment says pruning was added deliberately for that reason, so the finding both misreads the code and asks for optimization proportionate to nothing."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[20:58:22 \u001B[32mINF\u001B[0m] coai-mcp#41628 finding [Major/Reliability] src_mcp/src/Server/SessionStore.cs:175 - Session save race condition leaves orphaned temp files if move fails on last attempt (from local) [gating] Round=1 Stage=CodeReview\r | [20:58:22 \u001B[32mINF\u001B[0m] coai-mcp#41628 finding [Minor/Ux] src_vs_code/src/panelProvider.ts:135 - No visual feedback during panel repaint after toggle (from local) Round=1 Stage=CodeReview\r | [20:58:22 \u001B[32mINF\u001B[0m] coai-mcp#41628 finding [Minor/Performance] src_vs_code/src/openRounds.ts:45 - Inefficient set pruning in openRounds logic (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "src_bench/cases/split-once.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex|split-once|1",
+    "startedUtc": "2026-09-05T20:58:22.6116477Z",
+    "finishedUtc": "2026-09-05T21:00:22.668524Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 25.2,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 13794,
+        "tokensOut": 1182,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open unwritable-store behavior makes the once-only atomic claim impossible",
+            "why": "If two server processes share an unwritable data directory, both encounter the warning and proceed without recording a claim, so both issue the split order. This directly violates both the once-only caller guarantee and the cross-process atomicity guarantee.",
+            "fix": "Define fail-open as refusing to issue the order when the claim cannot be durably recorded, or provide another durable coordination mechanism; specify and test the resulting retry behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a real contradiction between a stated once-only/cross-process atomicity guarantee and a fail-open path that skips recording the claim, which would let two processes both issue the order \u0393\u00C7\u00F6 a defect worth fixing or explicitly re-specifying."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan has no crash-consistent ordering for claiming versus returning the command",
+            "why": "If the process records the claim and is killed before returning the command, a retry can observe the claim and issue nothing, so the caller never receives the required order. If it returns the command before claiming, a concurrent process can issue it twice.",
+            "fix": "Specify an atomic claim/response protocol, including crash recovery (for example, a durable pending record that can be completed or safely retried), and test termination at each boundary.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Without any code, file, or plan text to anchor it, this is a generic distributed-systems template about atomic claim/response ordering that could be pasted onto almost any design, and it asks for durable pending records and crash-point testing without showing that this system has a claim step, a crash window, or concurrent issuers at all."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback cannot distinguish independent callers in one checkout",
+            "why": "Two separate callers that export no session id but run plans from the same checkout will share whatever checkout-derived identity is used; the second caller can be treated as an already-split piece and receive autonomy instead of the required split order. Conversely, without a defined lifecycle, a new run in the same checkout years later can inherit the old caller\u0027s claim.",
+            "fix": "Define the fallback identity and its lifetime/expiry or explicit reset semantics, and specify how concurrent or sequential independent callers in the same checkout are distinguished without requiring them to pass an identifier.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It is a speculative architecture objection about a fallback identity with no file, no line, and no code shown \u0393\u00C7\u00F6 nothing here establishes that such a checkout-derived fallback exists or that colliding callers are a real path, so the demanded lifecycle/expiry machinery is out of proportion to an unverified risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not define how a claim is bound to the plan reviewed in the current round",
+            "why": "After a plan is edited and reviewed again in the same caller context, a claim keyed only by caller can cause the new round to reuse the prior split/piece decision, even if the new plan is now too large or no longer passes. The stated current-round measurement therefore has no implementable persistence rule.",
+            "fix": "Persist a stable digest or review-round identifier derived from the exact reviewed plan and verdict, define when it is created and invalidated, and cover edits, resolve-loop retries, and failed reviews.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "Keying a cached split/piece decision by caller alone is a real staleness bug \u0393\u00C7\u00F6 an edited plan in the same session would silently reuse the prior round\u0027s decision \u0393\u00C7\u00F6 and asking for a plan-text digest with defined creation/invalidation is a proportionate, implementable fix rather than speculative machinery."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "Filename safety is stated but collision behavior is unspecified",
+            "why": "A sanitization scheme that replaces separators can map distinct caller IDs such as \u0060a/b\u0060 and \u0060a_b\u0060 to the same file, causing one caller to consume the other\u0027s claim and suppress its order; ad hoc handling can also leave platform-specific reserved names or length failures.",
+            "fix": "Specify an injective bounded encoding (or a cryptographic digest with stored original metadata), plus handling for length limits, reserved names, and verification of directory containment.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It names no file, quotes no code, and speculates about a sanitization scheme it never located \u0393\u00C7\u00F6 then demands an injective encoding, reserved-name handling and containment checks for a hypothetical collision it has not shown exists."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 94.7,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 166950,
+        "tokensOut": 5474,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 91,
+            "title": "The claim implementation violates the project\u2019s immutability rule by deleting existing state in place",
+            "why": "The rule says, \u201CALWAYS create new objects, NEVER mutate existing ones.\u201D \u0060File.Delete(file)\u0060 mutates persisted caller state before the replacement claim is successfully written, so a failed write can destroy the existing claim.",
+            "fix": "Write the replacement claim to a temporary file and atomically replace the expired claim only after the new contents are complete.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It misapplies an in-memory immutability rule to filesystem state and its stated harm is empty \u0393\u00C7\u00F6 the delete only ever runs on a claim \u0060StillRemembered\u0060 has already judged expired, so a failed write destroys nothing of value in a feature that deliberately fails open, making the proposed temp-file-and-replace machinery disproportionate."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 101,
+            "title": "Expired-claim deletion is not atomic with the claim",
+            "why": "Two processes can both read an expired stamp, then process A creates a fresh claim, process B deletes that fresh claim and creates its own claim. Both return true and both issue the split order, violating the cross-process exactly-once guarantee.",
+            "fix": "Serialize the expired-claim check, deletion, and CreateNew operation with a cross-process lock, or replace the expired file atomically without deleting a newly-created claim.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew sequence really does let two processes both win right after a 24-hour expiry, which falsifies the code\u0027s own comment that \u0027the CreateNew below is the only race there is\u0027 \u0393\u00C7\u00F6 a documented invariant that a future reader would trust, so it is worth either fixing or correcting even if the practical cost is one duplicated instruction rather than Blocking."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "The claim is consumed before the split command is successfully delivered",
+            "why": "If the server claims the order and then crashes, the response is cancelled, or the client disconnects before receiving the command, a retry sees the remembered claim and receives the piece/autonomy instruction instead. The original plan is never told to split and there is no recovery path.",
+            "fix": "Persist the claimed decision and replay the same split-order response until delivery is acknowledged, or claim only through an idempotent operation that can reconstruct the pending command after restart.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It correctly notes that a once-per-caller claim is consumed before the response is delivered, but the only loss in that rare crash/disconnect window is one advisory split instruction, and the proposed remedy \u0393\u00C7\u00F6 a delivery-acknowledgement/replay protocol over an MCP tool call \u0393\u00C7\u00F6 is machinery far out of proportion to that stake."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 114,
+            "title": "A failed claim write can be mistaken for another process winning",
+            "why": "When FileStream or StreamWriter fails after CreateNew creates the file, File.Exists(file) is true and the IOException filter returns false without warning. The caller is therefore told it did not win even though no complete claim was persisted, silently withholding the split order on full-disk or partial-write failures.",
+            "fix": "Distinguish an actual CreateNew collision from failures during directory/file creation or writing; delete an incomplete file where safe and return true with the fail-open warning for all write failures.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The \u0060catch (IOException) when (File.Exists(file))\u0060 filter genuinely cannot distinguish a lost CreateNew race from a write/flush failure on the file this call just created, so an IO failure mid-write silently returns false with no warning \u0393\u00C7\u00F6 a real hole in the fail-open policy the method\u0027s own docs promise, fixable by scoping the collision catch to the constructor."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[21:00:22 \u001B[32mINF\u001B[0m] coai-mcp#52576 finding [Major/Reliability] src_mcp/src/Server/PanelService.cs:573 - The claim is consumed before the split command is successfully delivered (from codex) [gating] Round=1 Stage=CodeReview\r | [21:00:22 \u001B[32mINF\u001B[0m] coai-mcp#52576 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:114 - A failed claim write can be mistaken for another process winning (from codex) [gating] Round=1 Stage=CodeReview\r | [21:00:22 \u001B[32mINF\u001B[0m] coai-mcp#52576 settings reloaded - the panel\u0027s file changed on disk",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "src_bench/cases/split-once.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "gemini",
+    "repeat": 1,
+    "lane": 1,
+    "key": "gemini|split-once|1",
+    "startedUtc": "2026-09-05T21:00:22.7478842Z",
+    "finishedUtc": "2026-09-05T21:00:58.0952171Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 15.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 3,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 25841,
+        "tokensOut": 2672,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Failing open on an unwritable claim store triggers the infinite recursive split loop",
+            "why": "Requirement 5 states an unwritable store fails OPEN. In an environment with an unwritable state directory (e.g. read-only volume, restrictive permissions, or full disk), the gate cannot persist the claim and thus repeatedly evaluates every incoming epic review as unclimbed, issuing split orders indefinitely to child epics and reintroducing the unbounded recursion.",
+            "fix": "Fail safe by treating an unwritable store as already claimed (or defaulting to the single-unit autonomy order) and logging a warning instead of issuing split orders.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete failure mode where the stated fail-open behavior on an unwritable claim store lets the same epic be re-split forever, which is exactly the unbounded recursion the claim mechanism exists to prevent, and it proposes a specific safer default."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "One-shot atomic claim permanently blocks retrying a top-level plan split if child creation fails",
+            "why": "Because evaluating eligibility and claiming the caller ID are coupled into a single atomic action upon issuing the order, if the caller crashes, times out, or fails to create the child epics, any retry of the top-level plan review in that same session will find the claim already consumed and mistakenly force execution as a single piece.",
+            "fix": "Separate the split reservation from final epic dispatch or associate the claim with the plan\u0027s hash so re-reviewing the un-split parent plan remains eligible for splitting.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The finding is a speculative reliability story about a one-shot claim whose existence, coupling and retry semantics it asserts without naming any file or line, and with no code to anchor it the described failure path cannot be shown to exist in this code."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Checkout-wide caller tracking without a session ID permanently suppresses splitting for subsequent independent plans",
+            "why": "Requirement 6 mandates tracking callers across branches of one checkout when no CLAUDE_CODE_SESSION_ID exists. If the fallback claim is keyed to the repository checkout, the first plan split in that workspace consumes the single split allowance for the entire checkout, causing all future unrelated plans in that workspace to be treated as child pieces.",
+            "fix": "Scope fallback caller tracking to a bounded run context (such as parent process hierarchy or root-plan content fingerprint) rather than persistent checkout-level state.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete, plausible failure mode \u0393\u00C7\u00F6 a checkout-scoped fallback claim would let the first plan permanently consume the split allowance for every later unrelated plan in that workspace \u0393\u00C7\u00F6 and pairs it with a proportionate fix (scope the claim to a bounded run context), which is exactly the kind of design consequence someone implementing the no-session-ID fallback would want flagged before shipping."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 19.6,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 1,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 104644,
+        "tokensOut": 8417,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 111,
+            "title": "Unconditional File.Delete causes a TOCTOU race where concurrent claims both succeed",
+            "why": "When two server instances concurrently call TryClaimSplitOrder for an unclaimed caller, both see StillRemembered as false. The first process creates the claim file with FileMode.CreateNew. The second process then reaches File.Exists, deletes the first process\u0027s newly created valid claim file, and recreates it. Both processes return true and issue duplicate split orders, breaking atomicity across processes.",
+            "fix": "Avoid unconditionally deleting existing files before FileMode.CreateNew; only remove or overwrite an existing claim after verifying that the file on disk is still expired.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional \u0060File.Delete\u0060 at line 112 genuinely defeats the \u0060CreateNew\u0060 atomicity the surrounding doc comment is built around \u0393\u00C7\u00F6 a second process that passed its stamp check can delete a claim another process just wrote and re-claim it \u0393\u00C7\u00F6 and the inline comment on line 111 (\u0027an expired claim is cleared first\u0027) is factually wrong about code that clears any claim, expired or not, so this is a real defect a careful engineer would want fixed."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[21:00:57 \u001B[32mINF\u001B[0m] coai-mcp#54908 reviewer gemini/SecurityReliability answered in 17.8s: 1 finding(s), 32646 in / 3618 out tokens Round=1 Stage=CodeReview\r | [21:00:57 \u001B[32mINF\u001B[0m] coai-mcp#54908 round 1 CodeReview proceed: 1 gating finding(s); all 3 reviewers answered; 104644 in / 8417 out tokens (no cost reported) over 17.8s\r | [21:00:57 \u001B[32mINF\u001B[0m] coai-mcp#54908 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:111 - Unconditional File.Delete causes a TOCTOU race where concurrent claims both succeed (from gemini) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "src_bench/cases/split-once.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "local|split-once|1",
+    "startedUtc": "2026-09-05T21:00:58.1759578Z",
+    "finishedUtc": "2026-09-05T21:02:38.4913832Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 27.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 1 reviewers answered",
+        "tokensIn": 1440,
+        "tokensOut": 1214,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Transient Caller ID causes split order loss on session restart",
+            "why": "The plan relies on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to child processes to maintain context across branches. If the parent process (the \u0027caller\u0027) terminates or the session ID changes between the \u0027split\u0027 command and the \u0027review\u0027 command (e.g., due to a server restart or a new terminal session), the child process receives a different ID. The system, keyed by \u0060repo\u002Bbranch\u0060, treats this as a new, unlinked session. Result: The \u0027split\u0027 order is lost, the epic is built as a single unit without the required review loop, and the system silently fails to split, violating the \u0027no command at all\u0027 rule for unverified splits.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent entity (e.g., a specific process ID or a shared lock file) rather than a transient string passed via environment variables, and implement a check to ensure the \u0027caller\u0027 is still active before processing the split.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Lack of persistent state causes infinite recursion or missed splits",
+            "why": "The plan states \u0027A caller is ordered to split ONCE\u0027 but relies on the caller passing an ID to children. If the \u0027caller\u0027 is just a string passed via environment variables, and the system is keyed by \u0060repo\u002Bbranch\u0060, a child process (which is a new session) might re-evaluate the \u0027split\u0027 condition. If the child process doesn\u0027t see the \u0027already split\u0027 flag (because it\u0027s not in the shared memory or file), it will issue another split command. Result: An infinite loop of splitting epics into epics, or a scenario where a split is missed because the \u0027caller\u0027 ID was not passed correctly to a specific child, leading to a \u0027piece\u0027 being built as a single unit when it should have been split.",
+            "fix": "Introduce a persistent state file (e.g., \u0060.fable_split_state.json\u0060) in the repo root that records the \u0027split\u0027 status and the \u0027caller\u0027 ID, ensuring the state survives across different session IDs and process restarts.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Verdict measured from \u0027THIS round\u0027 creates race condition with split execution",
+            "why": "The plan states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If the \u0027split\u0027 command is issued in Round 1, but the \u0027review\u0027 happens in Round 2 (after a delay or a different session), the system might re-evaluate the \u0027split\u0027 condition based on the new round\u0027s context. If the \u0027split\u0027 was already done in Round 1, but the system thinks it\u0027s a new round, it might issue another split. Result: A piece is split twice, creating duplicate epics or a fragmented codebase that doesn\u0027t match the original plan\u0027s intent.",
+            "fix": "Add a verification step that checks if the \u0027split\u0027 verdict was actually applied to the current branch before proceeding to the \u0027build\u0027 phase, rather than assuming the \u0027caller\u0027 handled it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Silent failure on missing session ID hides split logic errors",
+            "why": "The plan states \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 If a client (e.g., a human user or a CI pipeline) runs the command without exporting \u0060CLAUDE_CODE_SESSION_ID\u0060, the system assumes it can follow the branches. However, without the ID, the system cannot link the child sessions to the parent. Result: The user sees no error, but the split logic fails silently. The epics are built as single units, and the user only discovers the error when the code review fails or the build is incomplete, leading to wasted time and confusion.",
+            "fix": "Add a user-facing warning or error message when the \u0027split\u0027 order is issued but the \u0027caller\u0027 ID is missing or invalid, rather than silently disabling the feature.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Irreversible split order with no rollback mechanism",
+            "why": "The plan states \u0027A caller is ordered to split ONCE\u0027 and \u0027A piece\u0027s shape is not re-measured.\u0027 If the split order is issued and the system commits to it, but the conditions change (e.g., the codebase grows significantly, or the \u0027caller\u0027 ID changes), there is no way to undo the split. Result: The system is stuck with a fragmented codebase that no longer matches the original plan\u0027s intent, and the user must manually merge or re-split, leading to potential conflicts and lost work.",
+            "fix": "Define a clear \u0027rollback\u0027 mechanism or a \u0027dry-run\u0027 mode that allows the system to verify the split order before committing to the split, ensuring that the \u0027split\u0027 can be undone if the conditions change.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 72.3,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 46662,
+        "tokensOut": 3105,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/tests/SplitOrderTests.cs",
+            "line": 231,
+            "title": "Test leaves environment in a dirty state",
+            "why": "The test sets \u0060CLAUDE_CODE_SESSION_ID\u0060 to null but fails to restore it in the \u0060finally\u0060 block. This violates the convention that tests should be isolated and leave the environment unchanged, potentially causing flaky tests in subsequent runs.",
+            "fix": "Add \u0060Environment.SetEnvironmentVariable(\u0022CLAUDE_CODE_SESSION_ID\u0022, claude);\u0060 inside the \u0060finally\u0060 block to restore the environment variable after the test.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 85,
+            "title": "Test leaves temporary file on disk",
+            "why": "The test creates a file at \u0060file\u0060 but only deletes it in the \u0060finally\u0060 block if the test passes. If the test fails before the \u0060File.Delete(file)\u0060 line, the file remains on disk, violating the convention of clean test artifacts.",
+            "fix": "Add \u0060File.Delete(file);\u0060 inside the \u0060finally\u0060 block to ensure the temporary file is cleaned up after the test.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 101,
+            "title": "Test leaves temporary file on disk",
+            "why": "The test creates a file at \u0060file\u0060 but only deletes it in the \u0060finally\u0060 block if the test passes. If the test fails before the \u0060File.Delete(file)\u0060 line, the file remains on disk, violating the convention of clean test artifacts.",
+            "fix": "Add \u0060File.Delete(file);\u0060 inside the \u0060finally\u0060 block to ensure the temporary file is cleaned up after the test.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 118,
+            "title": "Test leaves temporary file on disk",
+            "why": "The test creates a file at \u0060file\u0060 but only deletes it in the \u0060finally\u0060 block if the test passes. If the test fails before the \u0060File.Delete(file)\u0060 line, the file remains on disk, violating the convention of clean test artifacts.",
+            "fix": "Add \u0060File.Delete(file);\u0060 inside the \u0060finally\u0060 block to ensure the temporary file is cleaned up after the test.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 135,
+            "title": "Test leaves temporary file on disk",
+            "why": "The test creates a file at \u0060file\u0060 but only deletes it in the \u0060finally\u0060 block if the test passes. If the test fails before the \u0060File.Delete(file)\u0060 line, the file remains on disk, violating the convention of clean test artifacts.",
+            "fix": "Add \u0060File.Delete(file);\u0060 inside the \u0060finally\u0060 block to ensure the temporary file is cleaned up after the test.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 152,
+            "title": "Test leaves temporary file on disk",
+            "why": "The test creates a file at \u0060file\u0060 but only deletes it in the \u0060finally\u0060 block if the test passes. If the test fails before the \u0060File.Delete(file)\u0060 line, the file remains on disk, violating the convention of clean test artifacts.",
+            "fix": "Add \u0060File.Delete(file);\u0060 inside the \u0060finally\u0060 block to ensure the temporary file is cleaned up after the test.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 169,
+            "title": "Test leaves temporary file on disk",
+            "why": "The test creates a file at \u0060file\u0060 but only deletes it in the \u0060finally\u0060 block if the test passes. If the test fails before the \u0060File.Delete(file)\u0060 line, the file remains on disk, violating the convention of clean test artifacts.",
+            "fix": "Add \u0060File.Delete(file);\u0060 inside the \u0060finally\u0060 block to ensure the temporary file is cleaned up after the test.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 186,
+            "title": "Test leaves temporary file on disk",
+            "why": "The test creates a file at \u0060file\u0060 but only deletes it in the \u0060finally\u0060 block if the test passes. If the test fails before the \u0060File.Delete(file)\u0060 line, the file remains on disk, violating the convention of clean test artifacts.",
+            "fix": "Add \u0060File.Delete(file);\u0060 inside the \u0060finally\u0060 block to ensure the temporary file is cleaned up after the test.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 203,
+            "title": "Test leaves temporary file on disk",
+            "why": "The test creates a file at \u0060file\u0060 but only deletes it in the \u0060finally\u0060 block if the test passes. If the test fails before the \u0060File.Delete(file)\u0060 line, the file remains on disk, violating the convention of clean test artifacts.",
+            "fix": "Add \u0060File.Delete(file);\u0060 inside the \u0060finally\u0060 block to ensure the temporary file is cleaned up after the test.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 103,
+            "title": "Race condition in atomic claim logic due to unguarded file deletion",
+            "why": "The code checks \u0060File.Exists(file)\u0060 and then immediately calls \u0060File.Delete(file)\u0060. If another process (or a concurrent thread in a different server instance) deletes the file between these two lines, or if the file is locked, the subsequent \u0060FileMode.CreateNew\u0060 will fail with an \u0060IOException\u0060. The current catch block for \u0060IOException\u0060 checks \u0060File.Exists(file)\u0060 again. If the file was deleted by a rival process, this check returns false, causing the method to return \u0060false\u0060 (claim failed) instead of \u0060true\u0060 (claim succeeded but stale file removed). This creates a race where two servers can both see the file as \u0027expired\u0027 and both fail to claim, or one succeeds while the other fails incorrectly, breaking the atomicity guarantee.",
+            "fix": "Wrap the \u0060File.Delete\u0060 call in a try/catch block to handle the case where the file is deleted by another process between the existence check and the delete operation, or where the file is locked.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Potential path traversal via unsanitized caller ID in file path",
+            "why": "The \u0060caller\u0060 string is used directly to construct a file path via \u0060FileFor(caller)\u0060. If a malicious or malformed caller ID contains path separators (e.g., \u0060../\u0060 or \u0060..\\\u0060) or null bytes, the resulting file could be written outside the intended \u0060dataDir\u0060 directory. This allows an attacker to overwrite arbitrary files on the server\u0027s filesystem (e.g., \u0060config.json\u0060, \u0060logs/audit.log\u0060) or create files in sensitive locations, potentially leading to privilege escalation or configuration poisoning.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., using \u0060Path.GetFileName\u0060 or a regex) before using it in \u0060FileFor(caller)\u0060 to ensure it doesn\u0027t contain path separators or null bytes that could escape the intended directory.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "Potential deadlock or indefinite wait on file lock during atomic claim",
+            "why": "The code uses \u0060FileMode.CreateNew\u0060 which throws if the file exists. If the file exists but is locked by another process (e.g., a previous instance of the server that crashed but didn\u0027t release the handle), the \u0060CreateNew\u0060 call might block or fail immediately depending on the OS and file system. The current catch block only handles \u0060IOException\u0060 and \u0060UnauthorizedAccessException\u0060. If the file is locked, the operation might hang or fail in a way that isn\u0027t handled, leading to a hung server or a silent failure where the split order is not recorded.",
+            "fix": "Add a timeout or retry mechanism for the \u0060FileMode.CreateNew\u0060 operation, or ensure the \u0060IOException\u0060 catch block handles the specific case of a file being locked by another process more robustly.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Atomic claim race condition due to pre-check delete",
+            "why": "The code deletes an expired file before attempting \u0060FileMode.CreateNew\u0060. If the delete succeeds but the subsequent \u0060CreateNew\u0060 fails (e.g., due to a race where another process created the file), the method returns \u0060false\u0060 (via the \u0060IOException\u0060 catch). However, if the delete fails (e.g., file locked by another process), the code proceeds to \u0060CreateNew\u0060 which might succeed, but the logic assumes the delete was successful. More critically, if \u0060File.Exists(file)\u0060 is true but the file is deleted by another process between the check and the \u0060CreateNew\u0060, the \u0060CreateNew\u0060 will throw \u0060IOException\u0060. The current catch block checks \u0060File.Exists(file)\u0060 again. If the file was deleted by a *third* party, \u0060File.Exists\u0060 returns false, and it returns \u0060false\u0060 (claim lost). If the file was deleted by *this* process (the delete above), it returns \u0060false\u0060 (claim lost). The logic is flawed: if the delete succeeds, we expect \u0060CreateNew\u0060 to succeed. If \u0060CreateNew\u0060 fails, it means someone else beat us. But if \u0060",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call to a separate \u0060if\u0060 block before the \u0060try\u0060 block, or wrap the delete in its own try/catch to ensure the atomic \u0060CreateNew\u0060 is not skipped if the delete fails.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It gestures at the pre-check delete but its stated mechanism is wrong \u0393\u00C7\u00F6 a failed delete throws and is caught, and every case it enumerates ends in the safe \u0027claim lost\u0027 direction \u0393\u00C7\u00F6 while it misses the actual race (a stale reader deleting a freshly written claim and both callers returning true), and its proposed fix of moving or wrapping the delete changes nothing."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Ambiguous failure state for split order claim",
+            "why": "When \u0060TryClaimSplitOrder\u0060 returns \u0060false\u0060 (line 103), it could mean the caller already claimed it (handled by the early return at line 92) OR it could mean the file was created by another process between the check and the \u0060CreateNew\u0060. The current code returns \u0060false\u0060 in both cases, but the caller (PanelService) treats \u0060false\u0060 as \u0027already claimed\u0027 (line 578: \u0060FirstPlanRound = ...\u0060). If the claim failed due to a race condition (store contention), the caller might incorrectly assume it\u0027s a \u0027piece\u0027 and skip the split order, leading to a silent failure where the split is not ordered despite being the first round.",
+            "fix": "Add a fallback check or a specific error message when \u0060TryClaimSplitOrder\u0060 returns \u0060false\u0060 due to the \u0060IOException\u0060 catch block (line 103) to distinguish between \u0027already claimed\u0027 and \u0027store failure\u0027.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The code already passes a warning-logging delegate into \u0060TryClaimSplitOrder\u0060 for exactly the store-failure path, and failing closed (not ordering a split when the once-per-caller claim cannot be taken) is the deliberate, safer behaviour \u0393\u00C7\u00F6 a lost claim to a genuine race means someone else took it, so suppressing the order is correct, not a silent bug."
+          },
+          {
+            "severity": "Nit",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Redundant file existence check in hot path",
+            "why": "The code checks \u0060File.Exists(file)\u0060 twice: once at line 95 to decide whether to delete, and again in the \u0060catch\u0060 block at line 103. While not a major bottleneck, in a high-frequency scenario (e.g., many concurrent plan rounds), this double-check adds unnecessary I/O overhead. A single check or a more robust locking mechanism would be more efficient.",
+            "fix": "Cache the \u0060File.Exists\u0060 check result or use a more efficient file locking mechanism if the directory is accessed frequently.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The second \u0060File.Exists\u0060 sits in an exception filter that only runs on the rare IOException path, not in any hot path, and this file-per-caller claim happens at most once per session \u0393\u00C7\u00F6 the performance concern is imaginary and the suggested \u0027caching\u0027 would break the race detection the check exists for."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[21:02:38 \u001B[32mINF\u001B[0m] coai-mcp#55112 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:97 - Atomic claim race condition due to pre-check delete (from local) [gating] Round=1 Stage=CodeReview\r | [21:02:38 \u001B[32mINF\u001B[0m] coai-mcp#55112 finding [Minor/Ux] src_mcp/src/Server/PanelService.cs:578 - Ambiguous failure state for split order claim (from local) Round=1 Stage=CodeReview\r | [21:02:38 \u001B[32mINF\u001B[0m] coai-mcp#55112 finding [Nit/Performance] src_mcp/src/Server/CallerSessions.cs:95 - Redundant file existence check in hot path (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "src_bench/cases/split-once.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini|split-once|1",
+    "startedUtc": "2026-09-05T21:02:38.5719976Z",
+    "finishedUtc": "2026-09-05T21:04:45.2419387Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 39.5,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 7,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 37919,
+        "tokensOut": 2381,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The atomic claim-and-issue requirement has no crash-safe delivery protocol",
+            "why": "If a server durably claims the order and is killed before emitting it, the caller never receives the required command; if it emits first and is killed before recording the claim, a retry can emit the command twice. A single check/claim question does not make this cross-process sequence atomic.",
+            "fix": "Specify a durable state machine or transactional outbox with explicit states, recovery/replay behavior, and an idempotency key so crashes before and after command delivery produce exactly one observable order.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "With no file, no code, and no visible design under review, this is a generic distributed-systems template demanding an outbox and state machine for an unnamed sequence \u0393\u00C7\u00F6 the reviewer cannot show the claim-then-emit ordering exists here, so there is nothing an engineer can act on."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Failing open on an unwritable store makes the cross-process uniqueness guarantee impossible",
+            "why": "When two servers share a read-only or full data directory, neither can persist a claim; if both fail open as required, both issue the split command for the same passing plan, violating the stated atomicity guarantee.",
+            "fix": "Define the precedence explicitly: treat claim-storage failure as a visible error that withholds the command, or replace the store with an authority that remains writable; do not permit command issuance when uniqueness cannot be established.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "With no code, file, or line to anchor it, the finding argues abstractly from a premise it supplies itself (\u0027if both fail open as required\u0027) about a claim store, a split command and a uniqueness guarantee that nothing here shows exist \u0393\u00C7\u00F6 so an engineer receiving it has no site to inspect and no way to tell whether the described precedence conflict is real."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-id fallback does not define a stable, collision-free identity across branch sessions",
+            "why": "A client without CLAUDE_CODE_SESSION_ID can review the same checkout on two branches or revisit it after a restart, but the plan only says it is followed across branches of one checkout. Without specifying the exact checkout identity, branch/review identity, normalization, and lifetime, unrelated plans may share a claim or the same plan may receive repeated orders.",
+            "fix": "Define and test a deterministic fallback key derived from a stable checkout/repository identity plus the reviewed plan revision, with documented behavior for restarts, branch changes, concurrent processes, and checkout moves.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It demands a full identity specification \u0393\u00C7\u00F6 normalization, restarts, concurrent processes, checkout moves \u0393\u00C7\u00F6 for a fallback path whose only stated requirement is following one checkout across branches, which is machinery well out of proportion to the risk and reads as speculative rather than naming a concrete failure in this design."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "\u201CMeasured from the plan THIS round reviewed\u201D is not made enforceable by a plan revision or content binding",
+            "why": "A passing review can be claimed, then the plan can be edited or a retry can review different content in the same session; a session-only claim can cause the command to describe or authorize the wrong plan, while an unchanged session can also suppress a legitimate new review.",
+            "fix": "Capture an immutable review-round identifier or canonical plan hash in the verdict and claim record, and require the order to match that exact revision.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real time-of-check/time-of-use hole in a gate whose whole value is that the approval refers to the exact plan reviewed \u0393\u00C7\u00F6 a session-scoped claim lets an edited plan inherit a passing verdict \u0393\u00C7\u00F6 and the fix (hash or round id bound into the verdict) is proportionate to that risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not specify the user-visible outcome for retries, restarts, and already-claimed orders",
+            "why": "After a timeout or process restart, a caller may retry a passing plan; without defined responses for pending, already claimed, failed claim, and recovered delivery states, it can either show no command despite a successful review or present duplicate/conflicting instructions to the person.",
+            "fix": "Specify the observable result for each retry state, including warning text and whether the caller should resume, wait, or review again, and include those states in acceptance checks.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It is a generic \u0027specify all retry/idempotency states\u0027 demand made with no file, no code, and no reference to anything actually in this change \u0393\u00C7\u00F6 boilerplate that would apply to any plan and gives the person nothing concrete to act on."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Failing open on unwritable store causes infinite recursive split loops",
+            "why": "Requirement 5 states: \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature\u0027. In a split-plan workflow where memory is persisted to this store, failing open means claims never persist. When child epics are reviewed, claim checks continually fail to find prior claims and fail open, re-issuing split orders on every recursive plan review and creating an infinite split loop (the exact failure mode the floor is meant to prevent).",
+            "fix": "Fail safe/closed with respect to re-splitting: if the store is unwritable, warn and treat the plan as already split (issue the autonomy order / build as one unit) rather than issuing another split order.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It challenges the direction of failure for what is actually an idempotency/loop guard \u0393\u00C7\u00F6 arguing that fail-open disables the very floor meant to stop recursive re-splitting \u0393\u00C7\u00F6 and offers a concrete alternative, which is exactly the kind of design consequence an author would want flagged even if they ultimately keep the fail-open requirement."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Fallback tracking across branches without session ID lacks a concrete anchor mechanism",
+            "why": "Requirement 6 mandates: \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 Requirement 1 \u0026 Constraints state the caller is not asked to pass IDs and our session is keyed repo\u002Bbranch (so branches change per epic). Without CLAUDE_CODE_SESSION_ID or a defined local checkout anchor (e.g. git common dir, persistent checkout ID, or PPID tracking), branch switches by non-Claude callers will look like independent sessions, causing subsequent epics on new branches to be ordered to split again.",
+            "fix": "Specify the exact checkout-level persistent anchor mechanism (e.g., \u0060.git\u0060 metadata directory hash or local repo root state file) used to track splits when no session environment variable is present.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a concrete contradiction between a stated requirement (follow a session across branches of one checkout without a session id) and the stated keying scheme (repo\u002Bbranch), and asks for the one missing decision \u0393\u00C7\u00F6 the checkout-level anchor \u0393\u00C7\u00F6 which is exactly the kind of gap a plan must close before implementation."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "Untrusted caller identifier lacks sanitization specification before filesystem mapping",
+            "why": "Constraint states: \u0027A caller id is somebody else\u0027s string and reaches a file name: it must not escape the directory.\u0027 If CLAUDE_CODE_SESSION_ID or other caller IDs contain path traversal tokens (\u0060..\u0060, \u0060/\u0060, \u0060\\\u0060, null bytes, or invalid Windows filename characters like \u0060:\u0060), the store may attempt to write outside the state directory or throw filesystem errors on Windows/Linux.",
+            "fix": "Define a deterministic sanitization/hashing step (e.g. SHA-256 hash or strict alphanumeric sanitization \u0060[a-zA-Z0-9_-]\u0060) before using caller IDs in filesystem paths.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real, concrete hazard \u0393\u00C7\u00F6 an externally supplied caller id becoming a file name \u0393\u00C7\u00F6 and the constraint it cites explicitly requires that the id must not escape the directory, so specifying a sanitization/hashing step is exactly what an implementer needs to know."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 87,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 4,
+        "reviewers": "5 of 6 reviewers answered; failed: gemini/SecurityReliability: unparseable: the vendor returned an empty answer after one repair attempt (the answer was kept at C:\\Users\\strug\\AppData\\Local\\coai-mcp\\unparseable\\gemini-SecurityReliability-20260905-210430-488.txt)",
+        "tokensIn": 350125,
+        "tokensOut": 11967,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 58,
+            "title": "The atomicity test mutates an existing array to collect parallel results",
+            "why": "This breaks the written rule: \u0022ALWAYS create new objects, NEVER mutate existing ones.\u0022 \u0060claims[i] = ...\u0060 mutates the shared \u0060claims\u0060 array from parallel workers.",
+            "fix": "Collect the results with a projection such as \u0060Enumerable.Range(0, servers.Count).AsParallel().Select(i =\u003E servers[i].TryClaimSplitOrder(\u0022session-a\u0022, now)).ToArray()\u0060 instead of assigning into a pre-existing array.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Applying the immutability convention to a local results array inside a parallel test is a misreading of a rule aimed at shared domain data \u0393\u00C7\u00F6 the array is test-local, the indexed writes are the standard race-free way to collect Parallel.For results, and the suggested rewrite changes nothing about correctness or readability."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 92,
+            "title": "Expired-claim deletion is not atomic with the new claim",
+            "why": "With an expired claim present, process A can observe it as expired, process B can delete and recreate it, and A can then delete B\u0027s fresh claim before creating its own. Both TryClaimSplitOrder calls return true, so two servers issue the split order despite the atomicity requirement.",
+            "fix": "Replace the delete-then-CreateNew sequence with an atomic replace/claim protocol, such as creating a uniquely named claim and atomically moving it into place only when the existing claim is still the expired file being replaced.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The race is real and precisely traced \u0393\u00C7\u00F6 the non-atomic Exists/Delete/CreateNew sequence lets a second claimant delete the first\u0027s fresh claim and both return true \u0393\u00C7\u00F6 and it directly falsifies the in-code claim on line 111 that CreateNew is the only race, in a mechanism whose entire stated purpose is cross-process atomicity."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "A write failure is mistaken for another process winning the claim",
+            "why": "If FileStream creation succeeds but writing or disposing the StreamWriter fails, the IOException handler sees the partially created file and returns false as if another server claimed it. The current round therefore emits no split order, and the partial claim remains until a later call cleans it up.",
+            "fix": "Handle CreateNew contention separately from failures while writing the claim; on write/flush failure remove the file if still owned by this attempt, warn, and return true to preserve the documented fail-open behavior.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The \u0060when (File.Exists(file))\u0060 filter genuinely cannot distinguish \u0027another process won the CreateNew race\u0027 from \u0027I created the file and then failed writing/flushing it\u0027 \u0393\u00C7\u00F6 and in the latter case the method silently returns false, breaking the fail-open contract the surrounding doc comment insists on, which is a real conflation a careful engineer would want fixed with a small \u0060created\u0060 flag."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "A process crash after claiming but before returning the response suppresses the caller\u0027s split order",
+            "why": "A kill-9 or transport failure after CreateNew succeeds but before PanelService sends the answer leaves a valid claim on disk even though the person never received the split instruction. Retrying within the 24-hour window is treated as a piece and receives autonomy instructions instead of the required split order.",
+            "fix": "Make the persisted record distinguish a claimed-but-not-delivered order from a completed order and recover/retry unacknowledged claims, or defer finalizing the claim until the response handoff is durably recorded.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The crash window between the CreateNew write and the response is vanishingly narrow and its cost is one instruction not given \u0393\u00C7\u00F6 a failure the file already documents as soft on both sides (24h forgetting, AlreadySplitCommand) \u0393\u00C7\u00F6 so demanding delivery-acknowledgement bookkeeping and a recovery sweep is machinery far out of proportion to the risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 915,
+            "title": "Anonymous clients in one checkout incorrectly share a single split-order claim",
+            "why": "If neither session environment variable is set, every plan in the checkout uses the same \u0060repo:{session.State.RepoPath}\u0060 key. After one plan claims its order, an unrelated large plan started in that checkout within the retention window is told it is already a piece and is not split, leading to an unnecessarily oversized unit of work.",
+            "fix": "Persist a checkout/client nonce that is stable across child branches but distinct for independent MCP clients or task lifetimes, and use that nonce instead of the repository path alone.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The \u0060\u003Cremarks\u003E\u0060 directly above the cited line already names this exact scenario as the deliberate, cheaper trade-off \u0393\u00C7\u00F6 and the suggested nonce is undeliverable for a client that identifies itself in no way at all, which is the premise of the fallback, so the finding restates the code\u0027s own documented decision without engaging its reasoning."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[21:04:45 \u001B[32mINF\u001B[0m] coai-mcp#53312 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:95 - A write failure is mistaken for another process winning the claim (from codex) [gating] Round=1 Stage=CodeReview\r | [21:04:45 \u001B[32mINF\u001B[0m] coai-mcp#53312 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:95 - A process crash after claiming but before returning the response suppresses the caller\u0027s split order (from codex) [gating] Round=1 Stage=CodeReview\r | [21:04:45 \u001B[32mINF\u001B[0m] coai-mcp#53312 finding [Major/Ux] src_mcp/src/Server/PanelService.cs:915 - Anonymous clients in one checkout incorrectly share a single split-order claim (from codex) [gating] Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "src_bench/cases/split-once.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,local|split-once|1",
+    "startedUtc": "2026-09-05T21:04:45.3559472Z",
+    "finishedUtc": "2026-09-05T21:07:01.569463Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 30.1,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 9,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 15234,
+        "tokensOut": 2355,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan promises an atomic cross-process claim without specifying a mechanism that can provide it",
+            "why": "If two servers start with the same data directory and both observe an unclaimed passing plan before either persists its claim, both can issue the split order, violating the exactly-once requirement.",
+            "fix": "Specify the storage primitive and transaction/locking protocol for claim creation, including behavior on contention, crash, and stale locks, and require a race test with two concurrent servers.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A plan that claims exactly-once cross-process claiming without naming the atomic primitive is exactly the defect reliability.md was written about \u0393\u00C7\u00F6 two processes both see \u0027unclaimed\u0027 and both act \u0393\u00C7\u00F6 and the fix asks for the one sentence (which atomic operation, and what happens on crash/stale lock) that decides whether the design works at all."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The claim-and-command sequence has no crash-safe delivery semantics",
+            "why": "If the process records the claim and is killed before emitting the command, the order is lost; if it emits the command and is killed before recording the claim, retrying can issue it twice.",
+            "fix": "Define a durable state machine or idempotent command protocol covering pre-emit, post-emit, timeout, retry, and process restart, with explicit tests for each interruption point.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "With no file, line, or concrete code path, this is a generic crash-consistency lecture that demands a durable state machine and interruption tests for an unnamed sequence \u0393\u00C7\u00F6 the reader has nothing to act on and no evidence the risk is real here."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Following clients without session IDs is underspecified and cannot reliably identify one checkout across branches",
+            "why": "A client that exports no \u0060CLAUDE_CODE_SESSION_ID\u0060 can create a child session on another branch or worktree, but the plan defines neither the stable checkout identity nor how concurrent checkouts, clones, and branch deletion are distinguished; the same caller may therefore be split repeatedly or unrelated callers may share one claim.",
+            "fix": "Define the fallback identity and its lifecycle, including canonical checkout/worktree detection, branch handling, concurrency, and cleanup, then test a no-session-ID parent-to-child flow.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real gap in the plan \u0393\u00C7\u00F6 a fallback identity for clients without a session ID is left undefined, and without a specified checkout/worktree identity and lifecycle the gate can split one caller across rounds or merge unrelated ones, which is exactly the kind of omission a scope-driven review should surface."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "The caller identifier path-safety promise has no encoding or validation rule",
+            "why": "A caller ID such as \u0060../../outside\u0060, \u0060C:\\temp\\x\u0060, or a long reserved filename can be interpolated into the store path and escape the data directory or make claiming fail unpredictably.",
+            "fix": "Specify a fixed safe encoding (for example, hash the opaque ID to a bounded filename), and test traversal, separators, reserved names, very long IDs, Unicode, and collisions.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "A caller-supplied identifier interpolated into a filesystem path is a genuine traversal risk, and specifying a bounded safe encoding plus tests for separators, reserved names and length is proportionate rather than excessive."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The current-round verdict requirement is not represented in the claim key or stored record",
+            "why": "After a passing review is claimed, a revised plan on the same repo and branch can be reviewed in a later round, yet an implementation keyed only by repo/branch/caller would treat the old claim as authoritative and suppress the new round or reuse the wrong verdict.",
+            "fix": "Define a stable round/plan fingerprint derived from the plan reviewed this round and bind both the verdict and claim to it, with explicit behavior when the plan changes or the review fails.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It invents a claim/verdict-caching mechanism (\u0027an implementation keyed only by repo/branch/caller\u0027) that is hypothesized rather than shown, names no file or line, and asks for a plan-fingerprint scheme out of proportion to a risk it never demonstrates exists in this code."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Transient Caller ID causes split order loss on session restart",
+            "why": "The plan relies on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to child processes to maintain context across branches. If the parent process (the \u0027caller\u0027) terminates or the session ID changes between the \u0027split\u0027 command and the \u0027review\u0027 command (e.g., due to a server restart or a new terminal session), the child process receives a different ID. The system, keyed by \u0060repo\u002Bbranch\u0060, treats this as a new, unlinked session. Result: The \u0027split\u0027 order is lost, the epic is built as a single unit without the required review loop, and the system silently fails to split, violating the \u0027no command at all\u0027 rule for unverified splits.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent entity (e.g., a specific process ID or a shared lock file) rather than a transient string passed via environment variables, and implement a check to ensure the \u0027caller\u0027 is still active before processing the split.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a failure mode from an assumed implementation detail \u0393\u00C7\u00F6 it asserts session keying by \u0060repo\u002Bbranch\u0060 and simultaneously that a changed \u0060CLAUDE_CODE_SESSION_ID\u0060 would break that keying, which contradicts itself, and its fix (process IDs or lock files as \u0027caller\u0027 identity) is heavier machinery than a resumable, repo\u002Bbranch-keyed session state needs."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Lack of persistent state causes infinite recursion or missed splits",
+            "why": "The plan states \u0027A caller is ordered to split ONCE\u0027 but relies on the caller passing an ID to children. If the \u0027caller\u0027 is just a string passed via environment variables, and the system is keyed by \u0060repo\u002Bbranch\u0060, a child process (which is a new session) might re-evaluate the \u0027split\u0027 condition. If the child process doesn\u0027t see the \u0027already split\u0027 flag (because it\u0027s not in the shared memory or file), it will issue another split command. Result: An infinite loop of splitting epics into epics, or a scenario where a split is missed because the \u0027caller\u0027 ID was not passed correctly to a specific child, leading to a \u0027piece\u0027 being built as a single unit when it should have been split.",
+            "fix": "Introduce a persistent state file (e.g., \u0060.fable_split_state.json\u0060) in the repo root that records the \u0027split\u0027 status and the \u0027caller\u0027 ID, ensuring the state survives across different session IDs and process restarts.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is built entirely on stacked hypotheticals about a mechanism it admits it hasn\u0027t seen (\u0027if the caller is just a string passed via environment variables\u0027), invents an infinite-recursion scenario from that guess, and proposes a persistent state file as machinery out of proportion to a risk it never established exists."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Verdict measured from \u0027THIS round\u0027 creates race condition with split execution",
+            "why": "The plan states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If the \u0027split\u0027 command is issued in Round 1, but the \u0027review\u0027 happens in Round 2 (after a delay or a different session), the system might re-evaluate the \u0027split\u0027 condition based on the new round\u0027s context. If the \u0027split\u0027 was already done in Round 1, but the system thinks it\u0027s a new round, it might issue another split. Result: A piece is split twice, creating duplicate epics or a fragmented codebase that doesn\u0027t match the original plan\u0027s intent.",
+            "fix": "Add a verification step that checks if the \u0027split\u0027 verdict was actually applied to the current branch before proceeding to the \u0027build\u0027 phase, rather than assuming the \u0027caller\u0027 handled it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a stateful \u0027split command applied to a branch\u0027 mechanism that the quoted sentence does not describe \u0393\u00C7\u00F6 it just says the verdict is measured against the plan text of the round that produced it \u0393\u00C7\u00F6 so the double-split race and its proposed verification step are speculation about a system that doesn\u0027t work that way."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Silent failure on missing session ID hides split logic errors",
+            "why": "The plan states \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 If a client (e.g., a human user or a CI pipeline) runs the command without exporting \u0060CLAUDE_CODE_SESSION_ID\u0060, the system assumes it can follow the branches. However, without the ID, the system cannot link the child sessions to the parent. Result: The user sees no error, but the split logic fails silently. The epics are built as single units, and the user only discovers the error when the code review fails or the build is incomplete, leading to wasted time and confusion.",
+            "fix": "Add a user-facing warning or error message when the \u0027split\u0027 order is issued but the \u0027caller\u0027 ID is missing or invalid, rather than silently disabling the feature.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding contradicts the very plan sentence it quotes \u0393\u00C7\u00F6 that a client exporting no session id is still followed across the branches of one checkout, i.e. the fallback is the designed behaviour \u0393\u00C7\u00F6 so it asserts a silent failure the design explicitly covers, with no file or evidence to back the claim."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Irreversible split order with no rollback mechanism",
+            "why": "The plan states \u0027A caller is ordered to split ONCE\u0027 and \u0027A piece\u0027s shape is not re-measured.\u0027 If the split order is issued and the system commits to it, but the conditions change (e.g., the codebase grows significantly, or the \u0027caller\u0027 ID changes), there is no way to undo the split. Result: The system is stuck with a fragmented codebase that no longer matches the original plan\u0027s intent, and the user must manually merge or re-split, leading to potential conflicts and lost work.",
+            "fix": "Define a clear \u0027rollback\u0027 mechanism or a \u0027dry-run\u0027 mode that allows the system to verify the split order before committing to the split, ensuring that the \u0027split\u0027 can be undone if the conditions change.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a rollback/dry-run requirement for a one-shot advisory instruction to split work, treating a cheap re-runnable planning decision as an irreversible committed migration \u0393\u00C7\u00F6 machinery out of proportion to a risk the plan\u0027s own \u0027split once, don\u0027t re-measure\u0027 rule exists to avoid."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 105.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 8,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 271917,
+        "tokensOut": 8393,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 57,
+            "title": "The concurrency test mutates a shared claims array from parallel workers",
+            "why": "The written rule says: \u0022ALWAYS create new objects, NEVER mutate existing ones.\u0022 \u0060claims[i] = ...\u0060 mutates a pre-existing shared array concurrently.",
+            "fix": "Collect each worker\u0027s result without assigning into a shared array, then count the collected values.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "Writing distinct indices of a pre-sized array from Parallel.For is a standard, race-free result-collection idiom, and the immutability rule targets domain objects and shared state, not a test\u0027s local accumulator \u0393\u00C7\u00F6 this is a style objection with no defect behind it."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/SplitOrderTests.cs",
+            "line": 214,
+            "title": "The test mutates process-wide environment state",
+            "why": "The written rule says: \u0022ALWAYS create new objects, NEVER mutate existing ones.\u0022 \u0060Environment.SetEnvironmentVariable\u0060 changes shared global state and can affect other tests in the process.",
+            "fix": "Inject an isolated caller/environment provider into the service under test instead of changing process-wide environment variables.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The test already saves and restores the environment variables in a try/finally, and applying the immutability rule for domain objects to a test that must exercise env-var fallback behaviour is a misreading \u0393\u00C7\u00F6 the finding also asks for a dependency-injection refactor out of proportion to the risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 96,
+            "title": "Expired claims are deleted before the replacement claim is created",
+            "why": "With an expired claim file, a process executes \u0060File.Delete(file)\u0060 and can be killed before \u0060CreateNew\u0060 runs. The caller is then unclaimed, so a later plan round issues another split order; two servers can also race through this delete-then-create window. This violates the required atomic claim and leaves a crash-recovery gap.",
+            "fix": "Claim the existing file under an exclusive OS handle and replace its contents while holding that handle, or use an atomic transactional store; never remove the old claim before the new claim is installed.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The window only exists when the claim has already EXPIRED \u0393\u00C7\u00F6 in which case reissuing the order is the intended behaviour, so the crash case leaves exactly the state the design permits \u0393\u00C7\u00F6 and the residual two-server race costs one repeated instruction, precisely the cost the code\u0027s fail-open comment already accepts, making Major severity and a transactional-store fix out of proportion."
+          },
+          {
+            "severity": "Major",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 101,
+            "title": "Expired-claim replacement is not atomic and can issue duplicate split instructions",
+            "why": "After a claim expires, two servers can both observe the old file, one can create the replacement, and the other can then delete that new file before creating its own replacement. Both calls return true, so concurrent MCP clients can trigger duplicate split-plan work.",
+            "fix": "Replace the expired file atomically, such as by renaming it to a unique temporary name and treating rename/create races as a lost claim; never delete a shared claim after another process may have recreated it.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "The delete-then-CreateNew sequence genuinely reopens the race that CreateNew was added to close, and it directly falsifies the code\u0027s own comment claiming \u0022the CreateNew below is the only race there is\u0022 \u0393\u00C7\u00F6 worth knowing even though the impact is one duplicated instruction rather than the Major/Performance label the finding attaches."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 87,
+            "title": "CallerSessions.cs violates the rule that unwritable stores fail open with a warning rather than silently disabling the feature.",
+            "why": "The rule states: \u0027An unwritable store fails OPEN with a warning rather than silently disabling the feature.\u0027 The implementation passes a \u0060warn\u0060 callback into the method, meaning the store itself does not emit the warning; it relies on the caller to do so. This shifts the responsibility of the \u0027warning\u0027 signal away from the store, violating the specific requirement that the store *fails open with a warning*.",
+            "fix": "Remove the \u0060Action\u003Cstring\u003E? warn\u0060 parameter from \u0060TryClaimSplitOrder\u0060 and the \u0060warn?.Invoke\u0060 call inside the method. The rule requires the caller to handle the warning, not the store.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The code does fail open and does warn \u0393\u00C7\u00F6 via an injected callback, which is exactly how this family\u0027s rules say a library reports (take an ILogger/callback, never configure a sink) \u0393\u00C7\u00F6 and the finding\u0027s own fix contradicts its premise by demanding the caller own the warning it just faulted the store for delegating."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 108,
+            "title": "CallerSessions.cs catches a generic Exception for the \u0027fail open\u0027 warning, potentially masking other errors.",
+            "why": "The rule requires a specific behavior for an \u0027unwritable store\u0027. The current code catches \u0060Exception\u0060 (specifically \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060 in the \u0060when\u0060 clause, but the outer catch is generic) and emits a warning. While the \u0060when\u0060 clause filters, the structure \u0060catch (Exception e) when (...)\u0060 is slightly ambiguous compared to the explicit requirement. More critically, the rule says \u0027fails OPEN with a warning\u0027, implying the store *itself* must generate the warning. The current implementation passes a callback, which is a deviation from the store being the source of the warning.",
+            "fix": "Change the \u0060catch (Exception e)\u0060 block to only catch \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060 (or restructure to avoid catching generic exceptions that might swallow other errors), ensuring the warning is only emitted for storage-specific failures.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The code already catches only IOException and UnauthorizedAccessException via the exception filter \u0393\u00C7\u00F6 no other error is swallowed \u0393\u00C7\u00F6 and the callback-based warning is a deliberate, correct decoupling rather than a rule violation, so the finding is factually wrong about the code it reviews."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 108,
+            "title": "CallerSessions.cs may not emit a warning if the exception is not IOException or UnauthorizedAccessException.",
+            "why": "The rule states \u0027An unwritable store fails OPEN with a warning\u0027. The code catches \u0060Exception\u0060 but only invokes the warning if the exception is \u0060IOException\u0060 or \u0060UnauthorizedAccessException\u0060. If another exception occurs (e.g., \u0060DirectoryNotFoundException\u0060 if the parent path is missing), the method returns \u0060true\u0060 (fail open) but the warning might not be emitted if the \u0060when\u0060 clause filters it out, or if the generic catch block doesn\u0027t handle it as expected. The rule implies a consistent warning for *any* unwritable state.",
+            "fix": "Ensure the \u0060warn\u0060 callback is invoked *before* returning \u0060true\u0060 in the exception block, or ensure the logic guarantees the warning is emitted for *every* unwritable scenario as per the rule.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is wrong about the code: the warn callback is already invoked on every path that returns true in that block, \u0060DirectoryNotFoundException\u0060 is an \u0060IOException\u0060 so it is covered, and an exception outside the filter would propagate rather than silently fail open as the finding claims \u0393\u00C7\u00F6 so its proposed fix is a no-op."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Security",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 93,
+            "title": "Path traversal via unvalidated caller ID in file creation",
+            "why": "The \u0060caller\u0060 string is used directly as a filename component in \u0060FileFor(caller)\u0060. If a client passes a caller ID like \u0060../../etc/passwd\u0060 or \u0060..\\..\\windows\\system32\u0060, the code creates a file at \u0060data_dir/../../etc/passwd\u0060 (or equivalent on Windows). This allows an attacker to overwrite arbitrary files on the host filesystem with a timestamped split-order record, potentially corrupting logs, config files, or even overwriting executable binaries if they have write access to the target path.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., \u0060Path.GetFileName\u0060 or regex validation) before using it in \u0060FileFor(caller)\u0060 to ensure it contains only valid filename characters and does not escape the data directory.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is factually wrong about this code \u0393\u00C7\u00F6 \u0060FileFor\u0060 hashes the caller with SHA-256 and hex-encodes it, so the filename is always 16 hex characters and cannot contain traversal sequences, a point the comment at lines 157-159 states explicitly."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 96,
+            "title": "Race condition in expired claim cleanup causes spurious failures",
+            "why": "The code checks \u0060if (File.Exists(file))\u0060 and then deletes it. If another process (or a concurrent thread) deletes the file between these two lines, \u0060File.Delete\u0060 will throw an \u0060IOException\u0060. The current catch block only handles \u0060IOException\u0060 when the file *still exists* (\u0060when (File.Exists(file))\u0060). If the file is gone, the exception bubbles up, potentially crashing the request or leaving the caller in an inconsistent state where the claim was not claimed but the error was not logged as a warning.",
+            "fix": "Wrap the \u0060File.Delete(file)\u0060 call in a try-catch block to handle cases where the file is deleted by another process between the existence check and the delete operation, or where the file is locked.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Wrong on both counts: \u0060File.Delete\u0060 does not throw when the file is already gone, and even if it did the second catch clause (\u0060catch (Exception e) when (e is IOException or UnauthorizedAccessException)\u0060) catches IOException unconditionally, so nothing bubbles up unhandled."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 98,
+            "title": "File lock contention causes silent split-order loss",
+            "why": "The code uses \u0060FileMode.CreateNew\u0060 which fails if the file exists. If two processes race to claim the same caller, one will succeed and the other will fail with \u0060IOException\u0060. The current logic catches this and returns \u0060false\u0060 (claim failed). However, if the file is locked by a third party (e.g., an antivirus scanner or a previous crashed process holding a handle), \u0060CreateNew\u0060 might fail with a different error code or hang, causing the split order to be missed entirely without a warning, leading to the caller being treated as a new split target incorrectly.",
+            "fix": "Add a timeout or retry logic to the \u0060FileMode.CreateNew\u0060 operation, or ensure the \u0060IOException\u0060 catch block handles the specific case of a file being locked by another process (e.g., \u0060ERROR_SHARING_VIOLATION\u0060 on Windows).",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The mechanism it describes is wrong for this code \u0393\u00C7\u00F6 \u0060FileStream\u0060 with \u0060CreateNew\u0060 throws a sharing violation immediately rather than hanging, and the outcome it predicts (\u0022treated as a new split target\u0022) is the opposite of what the \u0060when (File.Exists(file))\u0060 filter returns \u0393\u00C7\u00F6 and the retry/error-code machinery it asks for is out of proportion to a feature whose worst case is one repeated instruction that \u0060AlreadySplitCommand\u0060 already covers."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 912,
+            "title": "Potential null reference or empty key in checkout fallback",
+            "why": "The code falls back to \u0060repo:{session.State.RepoPath}\u0060 if no session ID is present. If \u0060session.State.RepoPath\u0060 is null or empty (which can happen if the session was created in an unusual state or the repo path was not set), the resulting caller ID becomes \u0060repo:\u0060 or \u0060repo:null\u0060. This creates a unique key that might not match the actual checkout path used by other processes, causing the split order to be missed or duplicated incorrectly.",
+            "fix": "Ensure the \u0060CallerFor\u0060 method handles the case where \u0060session.State.RepoPath\u0060 is null or empty, falling back to a default identifier (e.g., \u0060repo:unknown\u0060) to prevent null reference exceptions or empty string keys.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It speculates about a null/empty \u0060RepoPath\u0060 that a session opened against a validated git checkout cannot realistically have, misstates the risk (string interpolation of null throws nothing), and its proposed \u0060repo:unknown\u0060 fallback would make collisions more likely rather than less."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 103,
+            "title": "Atomic claim race condition due to non-atomic delete before create",
+            "why": "The code checks \u0060File.Exists(file)\u0060 and deletes it, then attempts \u0060FileMode.CreateNew\u0060. If a second server process enters between the delete and the \u0060CreateNew\u0060, it will see the file exists (or not) and potentially fail the claim or allow a duplicate. Specifically, if Server A deletes the file, Server B sees it\u0027s gone and tries to create, but Server A\u0027s \u0060CreateNew\u0060 fails because B created it first, or vice versa. The current logic \u0060if (File.Exists(file)) File.Delete(file)\u0060 followed by \u0060CreateNew\u0060 is not atomic. If two servers race: Server A deletes, Server B deletes (no-op), Server A creates (success), Server B tries to create (fails). But if Server A deletes, Server B creates, Server A tries to create (fails). The race is between the delete and the create. The \u0060catch (IOException) when (File.Exists(file))\u0060 handles the case where another process created it *after* the delete but *before* the \u0060CreateNew\u0060, returning false. However, if the file exists *before* the delete (stale), it is a",
+            "fix": "Move the \u0060File.Delete\u0060 call to a separate \u0060try\u0060 block or wrap it in a \u0060try/catch\u0060 that ignores \u0060FileNotFoundException\u0060, ensuring the atomic \u0060CreateNew\u0060 is not blocked by a stale file deletion race.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Every race it actually spells out is one the code already handles correctly (the loser\u0027s \u0060CreateNew\u0060 throws and the \u0060catch (IOException) when (File.Exists(file))\u0060 returns false), it never names the one genuinely unhandled window \u0393\u00C7\u00F6 a stale-read process deleting another\u0027s freshly written claim \u0393\u00C7\u00F6 and its proposed fix (catching \u0060FileNotFoundException\u0060 around a \u0060File.Delete\u0060 that does not throw on a missing file) would change nothing, so a Major-severity report here costs more attention than it returns on a deliberately fail-open feature."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 578,
+            "title": "Split order claimed but not verified before logging",
+            "why": "The code calls \u0060TryClaimSplitOrder\u0060 and assigns the result to \u0060FirstPlanRound\u0060, but then logs \u0027split ordered\u0027 based on \u0060Core.Commands.GateCommands.OrdersSplit(context)\u0060. If \u0060TryClaimSplitOrder\u0060 returns false (e.g., due to a race or unwritable store), the log still says \u0027split ordered\u0027 if the predicate is true, creating a discrepancy between the log and the actual state. The log should reflect the claim result.",
+            "fix": "Pass the \u0060provisional\u0060 context to \u0060OrdersSplit\u0060 and use the result of \u0060TryClaimSplitOrder\u0060 to determine if the split was actually claimed, rather than assuming it was.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about the code: the log guard already evaluates \u0060OrdersSplit(context)\u0060 \u0393\u00C7\u00F6 the post-claim context whose \u0060FirstPlanRound\u0060 carries the \u0060TryClaimSplitOrder\u0060 result \u0393\u00C7\u00F6 so a failed claim suppresses the log, and the suggested fix of passing \u0060provisional\u0060 would introduce exactly the discrepancy it alleges."
+          },
+          {
+            "severity": "Minor",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 103,
+            "title": "Redundant file system calls in claim logic",
+            "why": "The code calls \u0060File.Exists\u0060 and then \u0060File.Delete\u0060, then \u0060new FileStream\u0060 with \u0060CreateNew\u0060. This involves three separate file system calls. A more efficient approach would be to attempt \u0060CreateNew\u0060 directly and handle the \u0060IOException\u0060 if the file exists, or use a single \u0060FileStream\u0060 with \u0060FileMode.OpenOrCreate\u0060 and a lock, though the current logic is acceptable for low-frequency operations.",
+            "fix": "Cache the \u0060File.Exists\u0060 check result or use a single \u0060FileStream\u0060 operation to avoid multiple file system calls.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "A once-per-caller claim write is not a performance path, the finding itself concedes the current logic is acceptable, and the Exists/Delete pair is deliberate expiry clearing that the suggested \u0060OpenOrCreate\u0060\u002Block would actually break."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "Missing documentation for file sharing strategy",
+            "why": "The use of \u0060FileShare.None\u0060 with \u0060CreateNew\u0060 ensures exclusive access, but without documentation, it\u0027s unclear if this is intentional or a side effect. It prevents other processes from opening the file while it\u0027s being written, which is correct for atomicity but should be documented.",
+            "fix": "Add a comment explaining why \u0060FileShare.None\u0060 is used and how it interacts with the \u0060CreateNew\u0060 mode.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The file is already unusually heavily documented about exactly this \u0393\u00C7\u00F6 the remarks on TryClaimSplitOrder name CreateNew as the atomic half and explain the race it closes \u0393\u00C7\u00F6 and FileShare.None on a write stream held for two lines is standard, low-risk boilerplate that needs no further comment."
+          },
+          {
+            "severity": "Nit",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Parameter name \u0060warn\u0060 is ambiguous",
+            "why": "The \u0060warn\u0060 parameter is used to log a warning when the store is unwritable, but the name \u0060warn\u0060 is generic. A more descriptive name like \u0060onWriteFailure\u0060 or \u0060onClaimFailure\u0060 would clarify its purpose.",
+            "fix": "Rename \u0060warn\u0060 parameter to \u0060onWriteFailure\u0060 or similar to better reflect its purpose.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The parameter is an optional \u0060Action\u003Cstring\u003E? warn\u0060 on a method whose XML remarks already explain the fail-open warning, so the name is clear in context and renaming it changes nothing a reader or caller would notice."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[21:07:01 \u001B[32mINF\u001B[0m] coai-mcp#39800 finding [Minor/Performance] src_mcp/src/Server/CallerSessions.cs:103 - Redundant file system calls in claim logic (from local) Round=1 Stage=CodeReview\r | [21:07:01 \u001B[32mINF\u001B[0m] coai-mcp#39800 finding [Minor/Architecture] src_mcp/src/Server/CallerSessions.cs:105 - Missing documentation for file sharing strategy (from local) Round=1 Stage=CodeReview\r | [21:07:01 \u001B[32mINF\u001B[0m] coai-mcp#39800 finding [Nit/Convention] src_mcp/src/Server/CallerSessions.cs:95 - Parameter name \u0060warn\u0060 is ambiguous (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "src_bench/cases/split-once.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "gemini,local|split-once|1",
+    "startedUtc": "2026-09-05T21:07:01.6818253Z",
+    "finishedUtc": "2026-09-05T21:08:46.3247274Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 17.7,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 6,
+        "reviewers": "all 2 reviewers answered",
+        "tokensIn": 28391,
+        "tokensOut": 4695,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true: #5] Failing open on unwritable store triggers unbounded epic-of-epic recursion",
+            "why": "If the claim store is unwritable (e.g., read-only filesystem, permission failure, or full disk), failing open treats every returning child epic as un-split. The gate will issue another split order on each branch review, directly causing the infinite epic-of-epic recursion loop that this feature was designed to terminate.",
+            "fix": "Fail closed on storage failure by defaulting to the single-unit autonomy order (or raising an explicit error) instead of re-issuing a split order.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete fail-open path where a storage failure turns the very safeguard meant to stop epic-of-epic recursion into the trigger for it, and names a specific alternative (fail closed to single-unit) that a careful engineer would want to decide on explicitly."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "[What must be true: #6] Checkout-level tracking without a session ID permanently suppresses future plan splits in the repository",
+            "why": "When a client exports no session ID and tracking falls back to the checkout across branches, the split claim persists indefinitely for that checkout directory. Future, completely unrelated plans reviewed in the same workspace will be misidentified as child pieces of an earlier split and blocked from ever splitting.",
+            "fix": "Define the checkout-level state keying and lifecycle boundary (such as scoping to base commit SHA or an explicit TTL/reset trigger) so subsequent independent plan reviews do not inherit old claims.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete lifecycle gap \u0393\u00C7\u00F6 checkout-keyed state with no session ID and no reset boundary persists across unrelated plans, silently suppressing a future split \u0393\u00C7\u00F6 which is a real defect a careful engineer would want fixed before shipping."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "[Constraints] Direct sanitization of external session IDs into file names risks collisions and empty keys",
+            "why": "If an external caller session ID string contains path traversal characters (\u0027..\u0027, \u0027/\u0027) or invalid filename characters and is sanitized by stripping or escaping, distinct session IDs can collide or collapse into empty strings, breaking cross-session claim isolation.",
+            "fix": "Derive claim file names by computing a deterministic cryptographic hash (e.g., SHA-256) of the caller ID string rather than directly formatting the raw string into the filesystem path.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "It is a speculative, file-less hypothetical about a sanitization scheme it never confirms exists, and it proposes hashing session IDs into opaque file names \u0393\u00C7\u00F6 machinery out of proportion to a risk it has not shown is present in this code."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Transient Caller ID causes split order loss on session restart",
+            "why": "The plan relies on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to child processes to maintain context across branches. If the parent process (the \u0027caller\u0027) terminates or the session ID changes between the \u0027split\u0027 command and the \u0027review\u0027 command (e.g., due to a server restart or a new terminal session), the child process receives a different ID. The system, keyed by \u0060repo\u002Bbranch\u0060, treats this as a new, unlinked session. Result: The \u0027split\u0027 order is lost, the epic is built as a single unit without the required review loop, and the system silently fails to split, violating the \u0027no command at all\u0027 rule for unverified splits.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent entity (e.g., a specific process ID or a shared lock file) rather than a transient string passed via environment variables, and implement a check to ensure the \u0027caller\u0027 is still active before processing the split.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a failure mode from an assumed implementation detail \u0393\u00C7\u00F6 it asserts a session-ID-keyed environment variable mechanism and simultaneously says the system is keyed by repo\u002Bbranch, contradicting itself, and its proposed fix (process IDs or lock files for a \u0027caller\u0027) is disproportionate machinery for a plan-level concern that names no file or line to check."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Lack of persistent state causes infinite recursion or missed splits",
+            "why": "The plan states \u0027A caller is ordered to split ONCE\u0027 but relies on the caller passing an ID to children. If the \u0027caller\u0027 is just a string passed via environment variables, and the system is keyed by \u0060repo\u002Bbranch\u0060, a child process (which is a new session) might re-evaluate the \u0027split\u0027 condition. If the child process doesn\u0027t see the \u0027already split\u0027 flag (because it\u0027s not in the shared memory or file), it will issue another split command. Result: An infinite loop of splitting epics into epics, or a scenario where a split is missed because the \u0027caller\u0027 ID was not passed correctly to a specific child, leading to a \u0027piece\u0027 being built as a single unit when it should have been split.",
+            "fix": "Introduce a persistent state file (e.g., \u0060.fable_split_state.json\u0060) in the repo root that records the \u0027split\u0027 status and the \u0027caller\u0027 ID, ensuring the state survives across different session IDs and process restarts.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is a speculative chain built on its own guesses about the mechanism (\u0027If the caller is just a string passed via environment variables...\u0027), invents an infinite-recursion scenario the plan does not describe, and prescribes a state file for a risk it never established \u0393\u00C7\u00F6 it reads as a reviewer reasoning about a design it did not actually see."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Verdict measured from \u0027THIS round\u0027 creates race condition with split execution",
+            "why": "The plan states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If the \u0027split\u0027 command is issued in Round 1, but the \u0027review\u0027 happens in Round 2 (after a delay or a different session), the system might re-evaluate the \u0027split\u0027 condition based on the new round\u0027s context. If the \u0027split\u0027 was already done in Round 1, but the system thinks it\u0027s a new round, it might issue another split. Result: A piece is split twice, creating duplicate epics or a fragmented codebase that doesn\u0027t match the original plan\u0027s intent.",
+            "fix": "Add a verification step that checks if the \u0027split\u0027 verdict was actually applied to the current branch before proceeding to the \u0027build\u0027 phase, rather than assuming the \u0027caller\u0027 handled it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding invents a stateful \u0027split executed twice\u0027 failure by misreading a sentence about which plan text a verdict is measured against, and its reasoning (\u0027the system might\u0027, \u0027it might issue another split\u0027) is speculation about a mechanism it never establishes exists."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Silent failure on missing session ID hides split logic errors",
+            "why": "The plan states \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 If a client (e.g., a human user or a CI pipeline) runs the command without exporting \u0060CLAUDE_CODE_SESSION_ID\u0060, the system assumes it can follow the branches. However, without the ID, the system cannot link the child sessions to the parent. Result: The user sees no error, but the split logic fails silently. The epics are built as single units, and the user only discovers the error when the code review fails or the build is incomplete, leading to wasted time and confusion.",
+            "fix": "Add a user-facing warning or error message when the \u0027split\u0027 order is issued but the \u0027caller\u0027 ID is missing or invalid, rather than silently disabling the feature.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real silent-degradation risk \u0393\u00C7\u00F6 a feature whose activation depends on an environment variable that may be absent, failing invisibly rather than telling the operator \u0393\u00C7\u00F6 and asks only for a warning, which is proportionate."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Irreversible split order with no rollback mechanism",
+            "why": "The plan states \u0027A caller is ordered to split ONCE\u0027 and \u0027A piece\u0027s shape is not re-measured.\u0027 If the split order is issued and the system commits to it, but the conditions change (e.g., the codebase grows significantly, or the \u0027caller\u0027 ID changes), there is no way to undo the split. Result: The system is stuck with a fragmented codebase that no longer matches the original plan\u0027s intent, and the user must manually merge or re-split, leading to potential conflicts and lost work.",
+            "fix": "Define a clear \u0027rollback\u0027 mechanism or a \u0027dry-run\u0027 mode that allows the system to verify the split order before committing to the split, ensuring that the \u0027split\u0027 can be undone if the conditions change.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a rollback/dry-run requirement for what is a one-time prompt-level instruction to a caller, treating an irreversible-data-migration risk that the described mechanism does not actually create, so the machinery asked for is out of proportion to any real hazard."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 86.8,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 5,
+        "reviewers": "all 6 reviewers answered",
+        "tokensIn": 151778,
+        "tokensOut": 9555,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 112,
+            "title": "Unconditional File.Delete before FileMode.CreateNew destroys concurrent claims and breaks atomic arbitration",
+            "why": "When two server instances concurrently invoke TryClaimSplitOrder for an unclaimed or expired caller, both pass the initial StillRemembered check. If server A creates the claim file first, server B proceeds into the try block, executes File.Delete(file), wipes server A\u0027s freshly created claim, and successfully creates its own file with FileMode.CreateNew. Both processes return true and issue duplicate split orders.",
+            "fix": "Do not delete existing files prior to FileMode.CreateNew; attempt FileMode.CreateNew directly first, and only inspect or delete an expired claim file if creation fails due to the file already existing, using atomic file locking or atomic replacement (e.g. creating a unique temporary file and replacing if expired).",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional \u0060File.Delete\u0060 before \u0060CreateNew\u0060 genuinely reopens the exact race the method\u0027s own remarks claim it closes \u0393\u00C7\u00F6 a second server can wipe a freshly written claim and also return true \u0393\u00C7\u00F6 so the documented atomic-arbitration guarantee is false as written, and the suggested fix (try \u0060CreateNew\u0060 first, inspect expiry only on failure) is small and correct."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/tests/SplitOrderTests.cs",
+            "line": 231,
+            "title": "Test leaves environment in a dirty state",
+            "why": "The test sets \u0060CLAUDE_CODE_SESSION_ID\u0060 to null but fails to restore it in the \u0060finally\u0060 block. This violates the convention that tests should not pollute global state, potentially causing flaky tests in subsequent runs.",
+            "fix": "Add \u0060Environment.SetEnvironmentVariable(\u0022CLAUDE_CODE_SESSION_ID\u0022, claude);\u0060 inside the \u0060finally\u0060 block to restore the environment variable after the test.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It is factually wrong about this code \u0393\u00C7\u00F6 \u0060CLAUDE_CODE_SESSION_ID\u0060 is already restored in the \u0060finally\u0060 at line 227, and the test it points at (line 231) never touches that variable, so the prescribed fix is unrelated to the cited site."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 103,
+            "title": "Race condition in atomic claim logic allows duplicate orders on concurrent access",
+            "why": "The code checks \u0060File.Exists(file)\u0060 and then deletes it before attempting \u0060FileMode.CreateNew\u0060. If two servers run in parallel (e.g., two MCP clients), both can pass the existence check, both delete the file, and both proceed to \u0060CreateNew\u0060. The second \u0060CreateNew\u0060 will fail with \u0060IOException\u0060, but the catch block at line 109 (\u0060catch (IOException) when (File.Exists(file))\u0060) will return \u0060false\u0060 (claim lost) only if the file still exists. If the second server deleted the file, it won\u0027t exist, so the catch condition fails, and the method falls through to return \u0060true\u0060 (incorrectly claiming success) or throws an unhandled exception depending on the exact flow. More critically, if the first server deletes the file and the second server\u0027s \u0060CreateNew\u0060 succeeds, both servers believe they have claimed the order. The logic assumes a single-threaded or strictly serialized environment, but the test \u0060TheClaimIsATOMIC_SoTwoServersCannotBothGiveTheOrder\u0060 proves this is a real-world scenario.",
+            "fix": "Wrap the \u0060File.Delete\u0060 call in a try/catch block to handle the case where the file is deleted by another process between the existence check and the delete operation, or where the file is locked.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The described mechanism is wrong about this code \u0393\u00C7\u00F6 \u0060FileMode.CreateNew\u0060 is atomic, so the loser\u0027s create fails and is correctly handled by the \u0060catch (IOException) when (File.Exists(file))\u0060 arm (mis-cited as line 109), and the proposed fix of wrapping \u0060File.Delete\u0060 in try/catch changes nothing since Delete is a no-op on a missing file and a locked-file IOException already yields the correct \u0060false\u0060."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 912,
+            "title": "Path traversal vulnerability via unchecked caller identity",
+            "why": "The \u0060CallerFor\u0060 method constructs a caller ID from \u0060session.State.RepoPath\u0060 (e.g., \u0060repo:/home/user/project\u0060). If a malicious user controls the repo path or if the path contains characters like \u0060..\u0060 or \u0060/\u0060, the resulting filename passed to \u0060FileFor\u0060 could escape the intended data directory. For example, if \u0060RepoPath\u0060 is \u0060/home/user/../etc/passwd\u0060, the file created could be \u0060/home/user/etc/passwd\u0060 (overwriting a system file) or \u0060/home/user/data/etc/passwd\u0060 depending on how \u0060FileFor\u0060 handles the path. The code relies on \u0060FileFor\u0060 to create the file, but if \u0060FileFor\u0060 simply concatenates the directory and the caller string without normalization, an attacker could write to arbitrary locations.",
+            "fix": "Sanitize the \u0060caller\u0060 string (e.g., \u0060repo:{session.State.RepoPath}\u0060) to ensure it contains only safe characters for a filename before being used in \u0060FileFor(caller)\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents an attacker for a value the local operator supplies themselves and stakes a Major security claim on an unverified guess about how \u0060FileFor\u0060 builds the path \u0393\u00C7\u00F6 the reviewer could have opened that function instead of hedging with \u0027depending on how it handles the path\u0027."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 113,
+            "title": "Potential NullReferenceException if warn callback is null",
+            "why": "The \u0060TryClaimSplitOrder\u0060 method accepts an optional \u0060Action\u003Cstring\u003E? warn\u0060 parameter. If a caller passes \u0060null\u0060 (which is valid per the signature), the line \u0060warn?.Invoke(...)\u0060 will execute correctly. However, if the code inside the catch block assumes \u0060warn\u0060 is non-null (e.g., if the null-conditional operator was accidentally removed or if the logic changes), a \u0060NullReferenceException\u0060 could occur. While the current code uses \u0060warn?.Invoke\u0060, it\u0027s a minor risk if the signature changes or if the caller forgets to pass a lambda.",
+            "fix": "Add a check to ensure the \u0060warn\u0060 action is not null before invoking it, or ensure the caller always passes a non-null action.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The code already uses \u0060warn?.Invoke\u0060, which is null-safe by construction, and the finding admits this \u0393\u00C7\u00F6 it flags a hypothetical defect that would only exist if someone later removed the operator, which is not a real issue in this code."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 573,
+            "title": "Hardcoded FirstPlanRound value obscures logic flow",
+            "why": "The code sets \u0060FirstPlanRound: true\u0060 in the \u0060provisional\u0060 context, then later updates it based on the result of \u0060TryClaimSplitOrder\u0060. This means the initial value is always \u0060true\u0060, regardless of whether the caller has already claimed an order. The logic relies on the subsequent assignment to update it. This makes the code harder to read and understand, as the initial value seems redundant or misleading. A clearer approach would be to determine the claim status first, then set \u0060FirstPlanRound\u0060 accordingly.",
+            "fix": "Add a comment or log entry explaining why \u0060FirstPlanRound\u0060 is hardcoded to \u0060true\u0060 before the claim is taken.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The pattern is a deliberate, already-commented two-step \u0393\u00C7\u00F6 a provisional context whose own predicate \u0060OrdersSplit\u0060 decides whether the claim is even taken \u0393\u00C7\u00F6 and the finding\u0027s own fix (add a comment) asks for something the surrounding lines already supply, while misreading a clear \u0060with\u0060-expression as obscure."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Atomic claim race condition due to eager file deletion",
+            "why": "The code deletes an existing file (\u0060File.Delete(file)\u0060) before attempting \u0060FileMode.CreateNew\u0060. If two servers run in parallel: Server A checks \u0060StillRemembered\u0060 (false), Server B checks \u0060StillRemembered\u0060 (false). Server A deletes the file. Server B deletes the file (or finds it gone). Both then attempt \u0060CreateNew\u0060. If the delete is slow or fails partially, or if the file is recreated between delete and create by a third process, the atomicity guarantee of \u0060CreateNew\u0060 is compromised. More critically, if \u0060File.Delete\u0060 throws (e.g., file locked by another process), the code falls into the \u0060catch (IOException)\u0060 block which returns \u0060false\u0060, but the \u0060CreateNew\u0060 might have already been attempted or the state is inconsistent. The specific race: if \u0060File.Delete\u0060 succeeds but \u0060CreateNew\u0060 fails because another process created it in the millisecond gap, the code returns \u0060false\u0060 (correct). However, if \u0060File.Delete\u0060 fails (e.g., permission denied on the file itself), the code catches \u0060IOException\u0060?",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call to a separate \u0060if\u0060 block before the \u0060try\u0060 block, or wrap the delete in its own try/catch to ensure the atomic \u0060CreateNew\u0060 is not skipped if the delete fails.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "unjudged",
+            "verdict": ""
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 580,
+            "title": "Silent failure of split order claim in race conditions",
+            "why": "When \u0060TryClaimSplitOrder\u0060 returns \u0060false\u0060 due to the \u0060IOException\u0060 catch block (line 103), it implies another process claimed the order. However, the code does not distinguish between \u0027another process claimed it\u0027 and \u0027the store was unwritable\u0027. If the store is unwritable, the caller might think they lost the race when they actually just failed to write. This leads to a scenario where a user sees no split order issued, but the system silently assumes another process took it, potentially causing the current task to be treated as a \u0027piece\u0027 when it should have been a \u0027split\u0027.",
+            "fix": "Add a fallback mechanism or a distinct error state if \u0060TryClaimSplitOrder\u0060 returns \u0060false\u0060 due to the \u0060IOException\u0060 race (line 103), or log a specific warning that the claim was lost to a race, not just a generic \u0027could not be written\u0027.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The claim path already routes a message to \u0060_log.Warning\u0060 at line 582 and fails closed (no split ordered, retriable next round), so this amounts to asking for finer wording in a log line for a low-stakes advisory claim \u0393\u00C7\u00F6 and the finding\u0027s own quote of the existing \u0027could not be written\u0027 message suggests the I/O case is already distinguishable."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Potential for lost claims due to delete race",
+            "why": "The \u0060File.Delete(file)\u0060 at line 97 is executed before the atomic \u0060CreateNew\u0060. If the file exists and is locked by another process, \u0060Delete\u0060 might throw. The current code catches \u0060IOException\u0060 only if \u0060File.Exists(file)\u0060 is true *after* the delete attempt (line 102). If the delete throws, the code falls to the \u0060catch (Exception)\u0060 block (line 106) which returns \u0060true\u0060 (open failure). This means if the delete fails, the code assumes the store is unwritable and returns \u0060true\u0060, potentially allowing a duplicate claim if the file was actually deleted by another process but the delete threw. The logic is: if delete throws, we assume \u0027unwritable\u0027 and return true. But if the file was deleted by another process, we should return false. The current logic conflates \u0027delete failed\u0027 with \u0027store unwritable\u0027.",
+            "fix": "Ensure the \u0060File.Delete\u0060 is wrapped in a try-catch or handled explicitly to prevent it from masking the \u0060CreateNew\u0060 failure.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads the control flow \u0393\u00C7\u00F6 a \u0060File.Delete\u0060 that throws \u0060IOException\u0060 on a locked file leaves the file present, so the first catch\u0027s \u0060when (File.Exists(file))\u0060 filter matches and returns false rather than falling through to the fail-open branch; the residual \u0060UnauthorizedAccessException\u0060 path is the deliberate, documented fail-open on an already-expired stamp, and the proposed try/catch around the delete would change no observable behaviour."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[21:08:46 \u001B[32mINF\u001B[0m] coai-mcp#42808 finding [Major/Reliability] src_mcp/src/Server/CallerSessions.cs:97 - Atomic claim race condition due to eager file deletion (from local) [gating] Round=1 Stage=CodeReview\r | [21:08:46 \u001B[32mINF\u001B[0m] coai-mcp#42808 finding [Minor/Ux] src_mcp/src/Server/PanelService.cs:580 - Silent failure of split order claim in race conditions (from local) Round=1 Stage=CodeReview\r | [21:08:46 \u001B[32mINF\u001B[0m] coai-mcp#42808 finding [Minor/Architecture] src_mcp/src/Server/CallerSessions.cs:97 - Potential for lost claims due to delete race (from local) Round=1 Stage=CodeReview",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  },
+  {
+    "case": {
+      "name": "split-once",
+      "planFile": "src_bench/cases/split-once.md",
+      "commit": "7133c2f",
+      "baseRef": "4a27a17"
+    },
+    "arm": "codex,gemini,local",
+    "repeat": 1,
+    "lane": 1,
+    "key": "codex,gemini,local|split-once|1",
+    "startedUtc": "2026-09-05T21:08:46.4127651Z",
+    "finishedUtc": "2026-09-05T21:12:06.8784749Z",
+    "stages": [
+      {
+        "stage": "plan-1",
+        "seconds": 42.4,
+        "verdict": "good_enough",
+        "error": "",
+        "gatingCount": 12,
+        "reviewers": "all 3 reviewers answered",
+        "tokensIn": 49225,
+        "tokensOut": 5721,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The fail-open unwritable-store rule contradicts the exactly-once split guarantee.",
+            "why": "If two servers share an unwritable data directory, both can warn, fail to persist a claim, and issue the split command; the required atomic once-only behavior is then violated.",
+            "fix": "Define an explicit degraded-mode policy: either fail closed with no command, or use a durable claim service/store that remains writable; specify and test the chosen behavior.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The finding is a speculative reliability objection to a design it cites no file or line for, and with no code shown it cannot be judged as naming a real defect in this change \u0393\u00C7\u00F6 it reads as an abstract policy demand rather than something a careful engineer could act on."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan has no crash-safe protocol for claiming and issuing the command.",
+            "why": "If the process persists the claim and is killed before spawning the command, the caller is never told to split; if it spawns first and dies before persisting, a retry issues the command twice.",
+            "fix": "Specify a durable state machine with recovery semantics (for example, pending/issued plus idempotent command delivery), and test kills between each transition.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It names a narrow crash window in generic terms without pointing at anything in the design, and its remedy \u0393\u00C7\u00F6 a full durable state machine plus kill-injection tests at every transition \u0393\u00C7\u00F6 is machinery far out of proportion to a process whose death also takes the caller waiting on it, so calling it Blocking is unwarranted."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "The no-session-ID fallback does not define a stable checkout identity that also separates shared worktrees.",
+            "why": "Two worktrees or clones of the same repository sharing the data directory may either fail to follow one workflow across branch changes or collide and suppress one another, depending on whether the fallback uses path or repository identity.",
+            "fix": "Define the fallback key precisely, including worktree path/identity, branch changes, clone relocation, and concurrent checkouts, and add those cases to verification.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It names no file and hedges on the actual behavior (\u0027depending on whether the fallback uses path or repository identity\u0027), so it is a speculative demand for a full identity specification and four new verification scenarios rather than a defect the reviewer established exists."
+          },
+          {
+            "severity": "Major",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "Sanitizing caller IDs into filenames can make distinct sessions claim the same record.",
+            "why": "Caller IDs such as \u0060a/b\u0060 and \u0060a_b\u0060 can normalize to the same filename, so one caller can consume or suppress another caller\u0027s split order; truncation or case folding can create the same problem.",
+            "fix": "Use a fixed-length cryptographic encoding or hash of the opaque caller ID as the filename, with an explicit length and collision policy.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "Sanitizing an opaque caller ID into a filename is a real collision hazard \u0393\u00C7\u00F6 two distinct callers mapping to one record lets one session consume or block another\u0027s state \u0393\u00C7\u00F6 and the proposed fixed-length encoding/hash is a proportionate, standard fix."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "The plan does not bind the split command to the verdict from the current review round.",
+            "why": "After a passing review is stored, a revised plan can fail the next review while stale passing state remains; a caller that reads the old state can still issue the split command.",
+            "fix": "Persist the current review event/version and verdict together, require the command decision to reference that exact round, and verify pass-then-fail and fail-then-pass sequences.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "It names a real staleness hazard \u0393\u00C7\u00F6 a stored \u0027passed\u0027 verdict outliving the plan revision it was about, letting a gated command fire on an outdated round \u0393\u00C7\u00F6 and the fix (tie the decision to a specific round identity, test pass-then-fail and fail-then-pass) is proportionate for a gate whose entire value is refusing to let stale approval through."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "SCOPE / What must be true #5: Failing open on an unwritable store recreates the infinite recursive split loop",
+            "why": "When the persistent state store cannot be written (e.g., permission error, read-only disk), failing open means every plan review is treated as unclaimed and issues the split order. When the child epic reviews run in new sessions, they will also fail to record the claim and issue split orders again, directly causing unbounded epic recursion (\u0027epics of epics\u0027).",
+            "fix": "Specify fail-closed semantics for split claims when storage is unwritable (default to treating plans as single-unit pieces rather than issuing recursive split orders) or halt the review with an explicit actionable error.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete failure mode \u0393\u00C7\u00F6 a fail-open claim store turning an unwritable disk into unbounded recursive epic splitting \u0393\u00C7\u00F6 and names the requirement it violates plus a specific fail-closed remedy, which is exactly the kind of design decision a careful engineer would want settled before shipping."
+          },
+          {
+            "severity": "Major",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "SCOPE / What must be true #6: Tracking session-less clients across branches collides concurrent runs in shared checkouts",
+            "why": "Without a session ID, scoping a split claim to \u0027the branches of one checkout\u0027 requires keying against the local repository path. Two distinct user tasks or concurrent subagents operating in the same repository checkout will share this key, causing one task to falsely inherit the other\u0027s split claim and suppress required plan splitting.",
+            "fix": "Define a concrete, collision-safe fallback key for clients without session IDs (e.g., parent process tree ID or explicit checkout-scoped lease mechanism) instead of an unkeyed repository-wide flag.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "It identifies a concrete collision: a repo-path-keyed \u0027already split\u0027 flag is shared by concurrent sessions or subagents in one checkout, so one task silently inherits another\u0027s claim and skips required plan splitting \u0393\u00C7\u00F6 a real design hole in the scope\u0027s stated requirement, with an actionable fix direction."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "SCOPE / What must be true #1 \u0026 #2: Piece size validation contradicts the prohibition on shape re-measurement",
+            "why": "Requirement 1 promises that a piece will \u0027say so if it is genuinely too big\u0027, while Requirement 2 dictates that \u0027a piece\u0027s shape is not re-measured\u0027. A piece cannot detect or report being oversized if its shape and dimensions cannot be evaluated during piece review.",
+            "fix": "Clarify that while the Fable split order is bypassed, standard gate size threshold evaluation still runs during single-unit autonomy review to catch oversized pieces.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "no",
+            "verdict": "The claimed contradiction is manufactured \u0393\u00C7\u00F6 reporting that a piece is oversized and re-measuring a piece\u0027s shape/split order are separable concerns, as the finding\u0027s own suggested fix concedes, so this is a wording quibble over scope text dressed up as a Major reliability defect."
+          },
+          {
+            "severity": "Minor",
+            "category": "Security",
+            "file": "",
+            "line": 0,
+            "title": "SCOPE / Constraints: Unsanitized caller IDs used as file names risk filesystem traversal and invalid characters",
+            "why": "Relying on external session strings directly as filenames risks path traversal (e.g., \u0027../\u0027) or filesystem errors on OSes with strict filename constraints (such as Windows prohibiting colons or slashes in filenames).",
+            "fix": "Hash the caller session ID (e.g., SHA-256) or strictly whitelist alphanumeric characters before using it as a filename in the data directory.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "Using an externally-supplied session/caller ID directly as a filename is a genuine path-traversal and invalid-character risk, especially on Windows, and the suggested hash-or-whitelist fix is cheap and proportionate."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Transient Caller ID causes split order loss on session restart",
+            "why": "The plan relies on \u0060CLAUDE_CODE_SESSION_ID\u0060 being exported to child processes to maintain context across branches. If the parent process (the \u0027caller\u0027) terminates or the session ID changes between the \u0027split\u0027 command and the \u0027review\u0027 command (e.g., due to a server restart or a new terminal session), the child process receives a different ID. The system, keyed by \u0060repo\u002Bbranch\u0060, treats this as a new, unlinked session. Result: The \u0027split\u0027 order is lost, the epic is built as a single unit without the required review loop, and the system silently fails to split, violating the \u0027no command at all\u0027 rule for unverified splits.",
+            "fix": "Explicitly define the \u0027caller\u0027 as a persistent entity (e.g., a specific process ID or a shared lock file) rather than a transient string passed via environment variables, and implement a check to ensure the \u0027caller\u0027 is still active before processing the split.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a failure mode from an assumed implementation detail \u0393\u00C7\u00F6 the plan keys sessions by repo\u002Bbranch, not by the environment-passed ID, so the described \u0027split order lost when the ID changes\u0027 scenario doesn\u0027t follow, and its fix (process IDs or lock files for a persistent \u0027caller\u0027) is heavier machinery than the stated risk warrants."
+          },
+          {
+            "severity": "Blocking",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Lack of persistent state causes infinite recursion or missed splits",
+            "why": "The plan states \u0027A caller is ordered to split ONCE\u0027 but relies on the caller passing an ID to children. If the \u0027caller\u0027 is just a string passed via environment variables, and the system is keyed by \u0060repo\u002Bbranch\u0060, a child process (which is a new session) might re-evaluate the \u0027split\u0027 condition. If the child process doesn\u0027t see the \u0027already split\u0027 flag (because it\u0027s not in the shared memory or file), it will issue another split command. Result: An infinite loop of splitting epics into epics, or a scenario where a split is missed because the \u0027caller\u0027 ID was not passed correctly to a specific child, leading to a \u0027piece\u0027 being built as a single unit when it should have been split.",
+            "fix": "Introduce a persistent state file (e.g., \u0060.fable_split_state.json\u0060) in the repo root that records the \u0027split\u0027 status and the \u0027caller\u0027 ID, ensuring the state survives across different session IDs and process restarts.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is built entirely on speculation about mechanisms it admits it does not know (\u0027if the caller is just a string passed via environment variables\u0027), invents an infinite-split failure mode from that guess, and prescribes a state file for a risk it never established exists in the design."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "",
+            "line": 0,
+            "title": "Verdict measured from \u0027THIS round\u0027 creates race condition with split execution",
+            "why": "The plan states \u0027The split verdict is measured from the plan THIS round reviewed.\u0027 If the \u0027split\u0027 command is issued in Round 1, but the \u0027review\u0027 happens in Round 2 (after a delay or a different session), the system might re-evaluate the \u0027split\u0027 condition based on the new round\u0027s context. If the \u0027split\u0027 was already done in Round 1, but the system thinks it\u0027s a new round, it might issue another split. Result: A piece is split twice, creating duplicate epics or a fragmented codebase that doesn\u0027t match the original plan\u0027s intent.",
+            "fix": "Add a verification step that checks if the \u0027split\u0027 verdict was actually applied to the current branch before proceeding to the \u0027build\u0027 phase, rather than assuming the \u0027caller\u0027 handled it.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a failure mode from a hedged reading of one sentence \u0393\u00C7\u00F6 that the verdict is measured against the plan text of the round under review is what PREVENTS stale measurement, not a race \u0393\u00C7\u00F6 and the proposed fix asks the gate to police whether a caller applied a split to a branch, machinery well out of proportion to a speculative risk it gives no concrete trigger for."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "",
+            "line": 0,
+            "title": "Silent failure on missing session ID hides split logic errors",
+            "why": "The plan states \u0027A client that exports no session id is still followed across the branches of one checkout.\u0027 If a client (e.g., a human user or a CI pipeline) runs the command without exporting \u0060CLAUDE_CODE_SESSION_ID\u0060, the system assumes it can follow the branches. However, without the ID, the system cannot link the child sessions to the parent. Result: The user sees no error, but the split logic fails silently. The epics are built as single units, and the user only discovers the error when the code review fails or the build is incomplete, leading to wasted time and confusion.",
+            "fix": "Add a user-facing warning or error message when the \u0027split\u0027 order is issued but the \u0027caller\u0027 ID is missing or invalid, rather than silently disabling the feature.",
+            "role": "PlanCritique",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "A feature that silently no-ops when an optional environment variable is absent \u0393\u00C7\u00F6 leaving the user to discover the failure only when downstream work comes out wrong \u0393\u00C7\u00F6 is a real UX defect, and asking for a warning at the point the split order is issued is a proportionate fix."
+          },
+          {
+            "severity": "Minor",
+            "category": "Architecture",
+            "file": "",
+            "line": 0,
+            "title": "Irreversible split order with no rollback mechanism",
+            "why": "The plan states \u0027A caller is ordered to split ONCE\u0027 and \u0027A piece\u0027s shape is not re-measured.\u0027 If the split order is issued and the system commits to it, but the conditions change (e.g., the codebase grows significantly, or the \u0027caller\u0027 ID changes), there is no way to undo the split. Result: The system is stuck with a fragmented codebase that no longer matches the original plan\u0027s intent, and the user must manually merge or re-split, leading to potential conflicts and lost work.",
+            "fix": "Define a clear \u0027rollback\u0027 mechanism or a \u0027dry-run\u0027 mode that allows the system to verify the split order before committing to the split, ensuring that the \u0027split\u0027 can be undone if the conditions change.",
+            "role": "PlanCritique",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It invents a scenario the plan\u0027s own design excludes \u0393\u00C7\u00F6 the split is a one-time, deliberate decision by a caller, not an automated commitment needing rollback \u0393\u00C7\u00F6 and asks for dry-run/undo machinery far out of proportion to a decision a person can simply make differently next time."
+          }
+        ],
+        "commands": [
+          "Split this plan into 2-4 logically complete STORIES. It is not broad enough to need epics. (Measured from the plan you sent: 29 lines, 7 build step(s), 0 file(s) named, 1 area(s) touched. That is a heuristic \u2014 if it is wrong for this plan, say so in your summary and do what is right.) After EVERY story: call review_code on that story\u0027s diff, resolve every finding, fix what you accepted, update the documentation and the tests, and commit. Only then start the next one. A story that is not reviewed, documented, tested and committed is not finished.",
+          "Do the SPLIT itself with Fable at its highest available version \u2014 deciding what the epics and stories are is the judgement that shapes everything after it. Then implement: ordinary stories on Opus, and anything where being wrong is expensive \u2014 payments, money, authentication, security, architecture, data migration \u2014 on Fable (max) again. Name the model you used for each story in your summary.",
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      },
+      {
+        "stage": "code",
+        "seconds": 157.9,
+        "verdict": "proceed",
+        "error": "",
+        "gatingCount": 10,
+        "reviewers": "all 9 reviewers answered",
+        "tokensIn": 414516,
+        "tokensOut": 22492,
+        "costUsd": null,
+        "findings": [
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/src/Server/PanelService.cs",
+            "line": 587,
+            "title": "The split-order predicate is evaluated twice instead of once",
+            "why": "The scope requires: \u0022The condition that issues the order and the condition that claims it are ONE question asked once.\u0022 The changed code calls GateCommands.OrdersSplit(provisional) for claiming and GateCommands.OrdersSplit(context) again for logging. Store and reuse one predicate result.",
+            "fix": "Evaluate OrdersSplit once, use that result to decide whether to claim, and derive logging from the same stored result.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The two calls take different arguments \u0393\u00C7\u00F6 \u0060provisional\u0060 (FirstPlanRound always true) versus \u0060context\u0060 (FirstPlanRound set by whether the claim succeeded) \u0393\u00C7\u00F6 so the second call answers whether an order was actually issued; caching one result would log \u0027split ordered\u0027 even when the claim was refused."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/tests/SplitOrderTests.cs",
+            "line": 215,
+            "title": "The test mutates process-wide environment state",
+            "why": "The coding-style rule says: \u0022ALWAYS create new objects, NEVER mutate existing ones.\u0022 SetEnvironmentVariable changes shared process state, allowing concurrent tests or production code in the same process to observe the temporary null values.",
+            "fix": "Inject caller identity through a test seam instead of changing process-wide environment variables; otherwise isolate this test from the suite and restore state safely.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "It misapplies the immutability rule (about data objects, not a test\u0027s process environment) and demands a fix the code already has \u0393\u00C7\u00F6 the env vars are saved and restored in a \u0060finally\u0060, and they are precisely the seam whose absence this test exists to exercise."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 112,
+            "title": "A write failure is mistaken for another process claiming the order",
+            "why": "When \u0060FileStream\u0060 or \u0060StreamWriter\u0060 fails after \u0060CreateNew\u0060 has created the file\u2014for example, a full disk during the write\u2014the \u0060IOException\u0060 filter sees that the file exists and returns \u0060false\u0060. The caller then emits no split order and no warning, violating the fail-open requirement; the partial claim can also suppress future orders until expiry.",
+            "fix": "Only treat an existing file as a competing claim when the \u0060CreateNew\u0060 operation itself fails; separately catch write/flush failures, remove any partial file where safe, warn, and return \u0060true\u0060.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "no",
+            "verdict": "The conflation is real but requires a disk failure in the microseconds between CreateNew and a 40-byte write, its worst outcome is exactly the one repeated instruction the design already accepts losing, and the finding\u0027s stated consequence is wrong \u0393\u00C7\u00F6 a truncated stamp parses as null, so future orders are not suppressed."
+          },
+          {
+            "severity": "Major",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 122,
+            "title": "A write failure after creating the claim file is silently treated as an existing claim",
+            "why": "When the filesystem accepts FileMode.CreateNew but runs out of space while StreamWriter.Write writes the timestamp, the file still exists, so the filtered IOException catch returns false. The caller emits no split command and no warning, contrary to the fail-open behavior; the person sees the feature silently do nothing.",
+            "fix": "Only return false for a proven competing claim (for example, catch the CreateNew failure separately); let write/flush failures invoke the warning path and return true.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "codex"
+            ],
+            "useful": "yes",
+            "verdict": "Accurate and specific: the \u0060when (File.Exists(file))\u0060 filter cannot distinguish a competing claim from a write/flush failure on the file this call itself just created via CreateNew, so an IOException during \u0060writer.Write\u0060/dispose silently returns false with no warning \u0393\u00C7\u00F6 the exact opposite of the fail-open contract the method\u0027s own remarks document \u0393\u00C7\u00F6 and the fix (scope the filter to the CreateNew failure, or track whether we created it) is small and proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 115,
+            "title": "Unconditional File.Delete before FileMode.CreateNew creates a TOCTOU race where concurrent callers delete and overwrite active claims",
+            "why": "When two server instances concurrently invoke TryClaimSplitOrder for an unclaimed caller, both pass the initial StillRemembered check before the file is created. Server 1 creates the claim file with FileMode.CreateNew and returns true. Server 2 then executes File.Delete(file), deleting Server 1\u0027s newly created active claim without verifying its timestamp, and successfully creates its own file with FileMode.CreateNew. Both servers return true, causing duplicate split orders to be issued to the same caller.",
+            "fix": "Do not delete the claim file prior to FileMode.CreateNew; let FileMode.CreateNew fail when the file exists, and only remove or overwrite an existing claim file if its recorded timestamp is verified to be expired.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "gemini"
+            ],
+            "useful": "yes",
+            "verdict": "The unconditional \u0060File.Delete\u0060 before \u0060CreateNew\u0060 genuinely defeats the atomicity the method\u0027s own remarks claim \u0393\u00C7\u00F6 a second server that read no stamp can delete a freshly written, still-valid claim (unprotected by FileShare.None on Unix, and after stream disposal on Windows) and both callers return true, plus a transient IOException in ReadStamp silently clobbers a live claim; the suggested fix is small and proportionate."
+          },
+          {
+            "severity": "Major",
+            "category": "Convention",
+            "file": "src_mcp/tests/SplitOrderTests.cs",
+            "line": 231,
+            "title": "Test cleanup leaves environment dirty for subsequent tests",
+            "why": "The test sets \u0060CLAUDE_CODE_SESSION_ID\u0060 to null but only restores \u0060_caller\u0060 in the \u0060finally\u0060 block. The original value of \u0060claude\u0060 is not restored. This violates the convention that tests must leave the environment in a clean state, potentially causing flaky tests or side effects in other tests that rely on the session ID being present.",
+            "fix": "Add \u0060Environment.SetEnvironmentVariable(\u0022CLAUDE_CODE_SESSION_ID\u0022, claude);\u0060 inside the \u0060finally\u0060 block.",
+            "role": "Architecture",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is wrong about this code \u0393\u00C7\u00F6 line 227 already restores \u0060CLAUDE_CODE_SESSION_ID\u0060 in the \u0060finally\u0060, so the proposed fix is a no-op, and its description of what the test does is simply inaccurate."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/SplitOrderTests.cs",
+            "line": 231,
+            "title": "Potential null reference when restoring environment variable",
+            "why": "If \u0060claude\u0060 was originally null (meaning no session ID was set), the code \u0060Environment.SetEnvironmentVariable(\u0022CLAUDE_CODE_SESSION_ID\u0022, claude)\u0060 will set it to null. While this might be intended, it\u0027s safer to explicitly handle the null case to ensure the environment is restored exactly as it was, or to a known default state.",
+            "fix": "Change \u0060Environment.SetEnvironmentVariable(\u0022CLAUDE_CODE_SESSION_ID\u0022, claude);\u0060 to \u0060Environment.SetEnvironmentVariable(\u0022CLAUDE_CODE_SESSION_ID\u0022, claude ?? string.Empty);\u0060 or ensure \u0060claude\u0060 is never null before assignment.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "Restoring a variable to null is exactly correct \u0393\u00C7\u00F6 \u0060SetEnvironmentVariable(name, null)\u0060 deletes it, which is the true original state, and the suggested \u0060?? string.Empty\u0060 fix would actually be wrong on .NET since empty also deletes but muddles intent."
+          },
+          {
+            "severity": "Minor",
+            "category": "Convention",
+            "file": "src_mcp/tests/CallerSessionsTests.cs",
+            "line": 85,
+            "title": "Test leaves temporary file on disk",
+            "why": "The test creates a file at \u0060file\u0060 to simulate an unwritable store but only deletes it after the assertion. While the test cleans up, it\u0027s better practice to ensure cleanup happens in a \u0060finally\u0060 block or use a \u0060using\u0060 statement to guarantee the file is removed even if an exception occurs before the explicit delete.",
+            "fix": "Add \u0060File.Delete(file);\u0060 after the test assertion in \u0060AnUnwritableStore_GivesTheOrderRatherThanSwallowingIt\u0060.",
+            "role": "Architecture",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is self-contradicting \u0393\u00C7\u00F6 the cleanup it asks for (\u0060File.Delete(file)\u0060) is already there on line 84, and a stray temp file on the rare exception path is not worth try/finally ceremony in a test."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 103,
+            "title": "Race condition in atomic claim logic allows duplicate orders on concurrent failure",
+            "why": "The code checks \u0060File.Exists(file)\u0060 inside the \u0060catch (IOException)\u0060 block to determine if a race occurred. However, if a second process deletes the file *after* the first process\u0027s \u0060CreateNew\u0060 fails but *before* the catch block executes, the check returns false, causing the method to return \u0060false\u0060 (claim lost) instead of \u0060true\u0060 (claim granted). This breaks the atomicity guarantee where exactly one caller must succeed. Specifically, if two servers race: Server A creates file, Server B fails \u0060CreateNew\u0060, Server B deletes file (race), Server A deletes file (race), both return false or one returns true incorrectly depending on timing.",
+            "fix": "Move the \u0060File.Delete(file)\u0060 call to a separate \u0060if\u0060 block before the \u0060try\u0060 block, or ensure the \u0060File.Exists\u0060 check inside the catch block is robust against the file being deleted by a concurrent process between the check and the delete.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads the control flow \u0393\u00C7\u00F6 when \u0060File.Exists\u0060 is false the second catch returns true (the deliberate fail-open path), not the \u0027claim lost\u0027 it describes \u0393\u00C7\u00F6 and its fix (moving the delete outside the try) changes nothing, so the Major label rests on a scenario this code does not exhibit, over an outcome (one repeated instruction) the design already accepts by name."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Missing pre-check for existing claim allows race condition",
+            "why": "The code checks \u0060StillRemembered(ReadStamp(caller), nowUtc)\u0060 before the \u0060try\u0060 block, but this only checks the *content* of the file. If the file exists but is stale (expired), it is deleted. However, if a second process creates a *new* claim file between the \u0060StillRemembered\u0060 check and the \u0060CreateNew\u0060, the current process might still succeed in \u0060CreateNew\u0060 if the second process\u0027s file is deleted by the current process\u0027s \u0060File.Delete\u0060 logic, or vice versa. The logic assumes only one process will ever try to claim at a time, but with parallel servers, two processes can both see the file as \u0027not remembered\u0027 and both attempt \u0060CreateNew\u0060. The \u0060CreateNew\u0060 will fail for one, but the subsequent \u0060File.Delete\u0060 in the catch block might delete the *other* process\u0027s file if they are racing on the same file name.",
+            "fix": "Add a check for \u0060File.Exists(file)\u0060 *before* the \u0060try\u0060 block to handle the case where the file was already claimed by another process before the current process even started its \u0060CreateNew\u0060 attempt.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "It lands on a real hole the code\u0027s own comment denies \u0393\u00C7\u00F6 the \u0060File.Delete\u0060 at line 114 reopens the window \u0060CreateNew\u0060 was meant to close, so a second process that passed its \u0060StillRemembered\u0060 check can delete a rival\u0027s fresh claim and both get the one order \u0393\u00C7\u00F6 even though the finding\u0027s reasoning is muddled (there is no \u0060File.Delete\u0060 in the catch block) and its proposed pre-check fix is wrong and would break expiry."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 110,
+            "title": "Silent failure on write error returns success, losing the claim",
+            "why": "If \u0060CreateNew\u0060 succeeds but \u0060StreamWriter.Write\u0060 fails (e.g., disk full, permission denied mid-write), the method returns \u0060true\u0060 (claim granted) even though the file content might be partial or missing. The caller then believes it has claimed the order, but the file might be empty or corrupted, leading to a state where the claim is \u0027lost\u0027 but the caller thinks it succeeded. This is a \u0027fail open\u0027 scenario that can lead to duplicate orders if the next process reads an empty file and thinks it\u0027s unclaimed.",
+            "fix": "Change the \u0060catch (Exception e)\u0060 block to check \u0060File.Exists(file)\u0060 *before* returning \u0060true\u0060 to ensure the file was actually created by this process, or use a more robust atomic check.",
+            "role": "SecurityReliability",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "It misreads the control flow \u0393\u00C7\u00F6 a failed write/flush inside the \u0060using\u0060 throws into \u0060catch (IOException) when (File.Exists(file))\u0060, which returns false, so the file-exists check it proposes as the fix is already there, and the residual case (a truncated stamp that fails to parse) simply re-issues one instruction, which is the documented fail-open trade."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 105,
+            "title": "Partial write can lead to stale or missing claim data",
+            "why": "If the \u0060StreamWriter.Write\u0060 call is interrupted (e.g., by a crash or disk full), the file might contain partial data. The next process reading this file might interpret it as a valid claim (if the timestamp is parseable) or an invalid one, leading to inconsistent behavior. The current logic assumes the write is atomic, but \u0060StreamWriter\u0060 is not atomic.",
+            "fix": "Add a check to ensure the file content is valid (e.g., non-empty, correct format) after writing before returning \u0060true\u0060.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The file holds one short timestamp line whose partial write either fails to parse (falling back to the already-documented fail-open path) or loses sub-second precision on a 24-hour window, and the proposed post-write validation cannot run in the crash scenario it names \u0393\u00C7\u00F6 machinery out of proportion to a harmless outcome."
+          },
+          {
+            "severity": "Minor",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 95,
+            "title": "Directory named as file can cause unexpected behavior",
+            "why": "If the \u0060file\u0060 path is actually a directory (e.g., due to a previous run or manual intervention), \u0060File.Exists(file)\u0060 returns true, but \u0060FileMode.CreateNew\u0060 might fail or behave unexpectedly. The code does not explicitly check if the path is a directory before attempting to write to it.",
+            "fix": "Add a check to ensure the file is not a directory before attempting to write to it.",
+            "role": "SecurityReliability",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "A directory appearing at a SHA-256-named \u0060.txt\u0060 path inside the server\u0027s own data dir is a scenario nobody will hit, and the code already handles it acceptably \u0393\u00C7\u00F6 \u0060CreateNew\u0060 throws \u0060UnauthorizedAccessException\u0060/\u0060IOException\u0060, which the existing catches turn into the documented fail-open behaviour with a warning, so the suggested pre-check adds machinery out of proportion to the risk."
+          },
+          {
+            "severity": "Major",
+            "category": "Reliability",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 97,
+            "title": "Stale file deletion race condition causes silent claim failure",
+            "why": "The code checks \u0060StillRemembered\u0060 (which reads the file), then deletes the file, then attempts \u0060FileMode.CreateNew\u0060. If a previous process crashed while holding the file open or if the file system is slow, the \u0060Delete\u0060 might succeed but the subsequent \u0060CreateNew\u0060 might fail with \u0060IOException\u0060 because the file handle is still held by the OS or a previous process. The current catch block \u0060catch (IOException) when (File.Exists(file))\u0060 returns \u0060false\u0060, treating this as \u0027someone else claimed it\u0027. However, if the file was just deleted by this thread but the OS hasn\u0027t released the handle, \u0060File.Exists\u0060 returns true, and the method returns \u0060false\u0060 (claim lost) instead of retrying or failing open. This causes a valid caller to be told \u0027already split\u0027 when it wasn\u0027t, breaking the \u0027one split per caller\u0027 guarantee.",
+            "fix": "Move the \u0060File.Delete\u0060 call inside the \u0060try\u0060 block, immediately after the \u0060StillRemembered\u0060 check, or wrap the delete in its own try/catch to ensure the atomic \u0060CreateNew\u0060 is not blocked by a stale file from a previous failed attempt.",
+            "role": "UxDxPerformance",
+            "isGating": true,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The suggested fix is already in place \u0393\u00C7\u00F6 the \u0060File.Delete\u0060 sits inside the \u0060try\u0060 at lines 112\u0393\u00C7\u00F4115 \u0393\u00C7\u00F6 and the speculative handle-not-released chain would surface as \u0060UnauthorizedAccessException\u0060 (the fail-open branch) rather than the IOException path described, while the stated consequence (a claim wrongly refused) is the opposite of the \u0027one split per caller\u0027 guarantee it claims is broken."
+          },
+          {
+            "severity": "Minor",
+            "category": "Ux",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 915,
+            "title": "Anonymous client collision on unrelated tasks in same checkout",
+            "why": "When a client has no session ID, the code falls back to \u0060repo:{session.State.RepoPath}\u0060. If a user starts two unrelated tasks (e.g., \u0027Refactor Auth\u0027 and \u0027Fix Login Bug\u0027) in the same checkout within 24 hours, the second task will see the first task\u0027s split order and be told \u0027This plan is a PIECE of a split that is already under way\u0027. The user sees a confusing \u0027piece\u0027 message for a brand new, unrelated task, potentially causing them to think the split logic is broken or that their new task is dependent on the old one.",
+            "fix": "Change the fallback logic in \u0060CallerFor\u0060 to include a unique identifier for the specific task or branch if the session ID is missing, or document the \u0027unrelated task\u0027 collision risk more explicitly in the UI logs.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "yes",
+            "verdict": "Judged on its words alone, since the file could not be produced at the reviewed commit: it names a concrete, user-visible failure \u0393\u00C7\u00F6 a coarse \u0060repo:{RepoPath}\u0060 fallback key letting a prior split order bleed into an unrelated new plan so the user is wrongly told their plan is a \u0027PIECE\u0027 of a split \u0393\u00C7\u00F6 which is a real state-collision risk a careful engineer would want to know about, even though the suggested fix is vague."
+          },
+          {
+            "severity": "Nit",
+            "category": "Performance",
+            "file": "src_mcp/src/Server/CallerSessions.cs",
+            "line": 96,
+            "title": "Unnecessary file existence check before delete",
+            "why": "The code calls \u0060File.Delete(file)\u0060 without checking if the file exists first. While \u0060File.Delete\u0060 is idempotent (throws if not found), doing so adds an extra system call. In a high-frequency scenario where the file is often missing (e.g., after a crash), this adds unnecessary overhead. A simple \u0060if (File.Exists(file))\u0060 check before delete would reduce I/O.",
+            "fix": "Add a check for \u0060File.Exists\u0060 before \u0060File.Delete\u0060 to avoid an unnecessary file system call if the file is already gone.",
+            "role": "UxDxPerformance",
+            "isGating": false,
+            "providers": [
+              "local"
+            ],
+            "useful": "no",
+            "verdict": "The finding is factually wrong about the code \u0393\u00C7\u00F6 lines 112-115 already contain the exact \u0060if (File.Exists(file))\u0060 guard it asks for \u0393\u00C7\u00F6 and even if it were absent, saving one stat call on a once-per-caller-per-day path is noise."
+          }
+        ],
+        "commands": [
+          "Work AUTONOMOUSLY. Say that you are working autonomously, and keep saying what you are writing right now as you go. Autonomous means these orders, not a mood: (1) every bug and every problem spot gets a RED-GREEN-RED test \u2014 a failing test first, then the fix, then the test green, then a check that the test really fails without the fix; (2) the documentation is updated with every change \u2014 the README, the manifest if there is one, the module docs and every other file that describes what you changed; (3) before any release, run ALL the tests that exist, not only the ones near your change; (4) if the repository has a release or pull request process, do it \u2014 and on a pull request, wait about five minutes, then check whether automatic comments appeared, read them and fix what they name; (5) if a deploy triggers automatically, verify the result against the target environment \u2014 dev, stage or test \u2014 and read its logs for errors before calling it done; (6) re-read your own code against the repository\u0027s rules and follow them, not only the ones you remember. A question that does not block you is not asked now: write it down and put every one of them at the END of your final summary. A question that DOES block you is asked at once \u2014 but before you ask it, re-read every epic and story you have written so far and gather every other blocking question you can foresee, so the person is interrupted once with all of them rather than repeatedly with one. Where you can proceed under a stated assumption, do that instead of asking, and say what you assumed."
+        ],
+        "resolveRefused": ""
+      }
+    ],
+    "harnessError": "",
+    "serverSaid": "[21:12:06 \u001B[32mINF\u001B[0m] coai-mcp#25608 finding [Minor/Ux] src_mcp/src/Server/CallerSessions.cs:915 - Anonymous client collision on unrelated tasks in same checkout (from local) Round=1 Stage=CodeReview\r | [21:12:06 \u001B[32mINF\u001B[0m] coai-mcp#25608 finding [Nit/Performance] src_mcp/src/Server/CallerSessions.cs:96 - Unnecessary file existence check before delete (from local) Round=1 Stage=CodeReview\r | [21:12:06 \u001B[32mINF\u001B[0m] coai-mcp#25608 settings reloaded - the panel\u0027s file changed on disk",
+    "onDisk": {
+      "rounds": 2,
+      "stillRunning": 0,
+      "pending": 0,
+      "note": "",
+      "config": {
+        "onExhausted": "GoodEnough",
+        "roles": {
+          "PlanCritique": {
+            "maxRounds": 1,
+            "threshold": 6
+          },
+          "Architecture": {
+            "maxRounds": 2,
+            "threshold": 5
+          },
+          "SecurityReliability": {
+            "maxRounds": 1,
+            "threshold": 5
+          },
+          "UxDxPerformance": {
+            "maxRounds": 1,
+            "threshold": 5
+          }
+        }
+      },
+      "clean": true
+    },
+    "settings": {
+      "mismatches": [],
+      "checked": [
+        "PlanCritique rounds",
+        "PlanCritique threshold",
+        "Architecture threshold",
+        "SecurityReliability rounds",
+        "SecurityReliability threshold",
+        "UxDxPerformance rounds",
+        "UxDxPerformance threshold",
+        "on-exhausted",
+        "COAI_AUTONOMOUS",
+        "COAI_SPLIT_PLAN",
+        "COAI_SPLIT_WITH_FABLE"
+      ],
+      "ok": true
+    },
+    "judgedBy": "claude-opus-5"
+  }
+]

--- a/research/data/bench-2026-09-06/settings.md
+++ b/research/data/bench-2026-09-06/settings.md
@@ -1,0 +1,25 @@
+# The settings this campaign ran under
+
+From `C:\Users\strug\AppData\Local\coai-mcp\settings.json`, with `--set` on top.
+
+Server: `C:\Users\strug\AppData\Roaming/Code/User/globalStorage/remsoftdev.connect-other-ais/coai-mcp.exe`
+
+CLAUDE.md snippet in the checkout: **none — CLAUDE.md carries no snippet marker**
+
+```
+  COAI_AUTONOMOUS = true
+  COAI_ESCALATION_MINUTES = 10
+  COAI_MAX_PER_PROVIDER = 3
+  COAI_ON_EXHAUSTED = good_enough
+  COAI_PROMPTS_PER_ROUND = {"Architecture":["conventions"],"SecurityReliability":["security-reliability","sec-attack"],"UxDxPerformance":["uxdx-…
+  COAI_ROUNDS_PLANCRITIQUE = 1
+  COAI_ROUNDS_SECURITYRELIABILITY = 1
+  COAI_ROUNDS_UXDXPERFORMANCE = 1
+  COAI_SPLIT_PLAN = true
+  COAI_SPLIT_WITH_FABLE = true
+  COAI_THRESHOLD_ARCHITECTURE = 5
+  COAI_THRESHOLD_PLANCRITIQUE = 6
+  COAI_THRESHOLD_SECURITYRELIABILITY = 5
+  COAI_THRESHOLD_UXDXPERFORMANCE = 5
+  COAI_VENDORS = <3 vendor(s), listed above>
+```

--- a/research/data/bench-2026-09-06/tables.md
+++ b/research/data/bench-2026-09-06/tables.md
@@ -1,0 +1,61 @@
+# Bench
+
+## Per arm
+
+| arm | stage | runs | verdicts | median time | median findings | gating | useful | tokens in / out | cost |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex` | code | 2 | proceed | 94.7s | 6 | 7 | 4/10 | 545.7k / 12k | not reported |
+| `codex` | plan-1 | 2 | proceed | 50.8s | 5 | 6 | 3/8 | 29.1k / 3.5k | not reported |
+| `codex,gemini` | code | 2 | proceed | 87s | 12 | 12 | 7/17 | 801.4k / 20.3k | not reported |
+| `codex,gemini` | plan-1 | 2 | good_enough | 48.8s | 9 | 14 | 10/17 | 76.4k / 10.2k | not reported |
+| `codex,gemini,local` | code | 2 | proceed | 197.1s | 20 | 22 | 7/35 | 1M / 39k | not reported |
+| `codex,gemini,local` | plan-1 | 2 | good_enough | 42.4s | 14 | 23 | 10/28 | 96.9k / 12.5k | not reported |
+| `codex,local` | code | 2 | proceed | 169.6s | 16 | 15 | 2/25 | 653.5k / 18.1k | not reported |
+| `codex,local` | plan-1 | 2 | good_enough | 60.5s | 11 | 18 | 8/21 | 33.1k / 6.3k | not reported |
+| `gemini` | code | 2 | proceed | 19.6s | 3 | 3 | 2/3 | 263.7k / 13.9k | not reported |
+| `gemini` | plan-1 | 2 | proceed | 16.2s | 4 | 6 | 3/7 | 46.5k / 5.6k | not reported |
+| `gemini,local` | code | 2 | proceed | 166.6s | 11 | 12 | 2/18 | 440k / 27.8k | not reported |
+| `gemini,local` | plan-1 | 2 | good_enough×1, proceed×1 | 20.3s | 10 | 13 | 7/18 | 53.9k / 7.2k | not reported |
+| `local` | code | 2 | proceed | 150.6s | 15 | 10 | 0/10 | 137k / 8.6k | not reported |
+| `local` | plan-1 | 2 | proceed | 50.1s | 7 | 9 | 2/7 | 4.2k / 2.7k | not reported |
+
+## Who found it alone
+
+| provider | findings written | distinct | also found by another | found by it alone | of those, worth having |
+|---|---|---|---|---|---|
+| `codex` | 75 | 60 | 5 (8%) | 55 (92%) | **22** |
+| `gemini` | 52 | 43 | 4 (9%) | 39 (91%) | **19** |
+| `local` | 118 | 59 | 3 (5%) | 56 (95%) | **5** |
+
+## Per run
+
+| arm | case | # | lane | stage | verdict | time | findings | gating | tokens in / out |
+|---|---|---|---|---|---|---|---|---|---|
+| `codex` | rounds-collapse | 1 | 1 | plan-1 | proceed | 50.8s | 3 | 2 | 15.3k / 2.3k |
+| `codex` | rounds-collapse | 1 | 1 | code | proceed | 88.7s | 6 | 3 | 378.8k / 6.5k |
+| `gemini` | rounds-collapse | 1 | 1 | plan-1 | proceed | 16.2s | 4 | 3 | 20.7k / 3k |
+| `gemini` | rounds-collapse | 1 | 1 | code | proceed | 19.4s | 3 | 2 | 159.1k / 5.5k |
+| `local` | rounds-collapse | 1 | 1 | plan-1 | proceed | 50.1s | 7 | 5 | 2.8k / 1.5k |
+| `local` | rounds-collapse | 1 | 1 | code | proceed | 150.6s | 7 | 6 | 90.4k / 5.5k |
+| `codex,gemini` | rounds-collapse | 1 | 1 | plan-1 | good_enough | 48.8s | 9 | 7 | 38.5k / 7.8k |
+| `codex,gemini` | rounds-collapse | 1 | 1 | code | proceed | 61.4s | 12 | 8 | 451.2k / 8.3k |
+| `codex,local` | rounds-collapse | 1 | 1 | plan-1 | good_enough | 60.5s | 11 | 9 | 17.9k / 3.9k |
+| `codex,local` | rounds-collapse | 1 | 1 | code | proceed | 169.6s | 9 | 7 | 381.6k / 9.7k |
+| `gemini,local` | rounds-collapse | 1 | 1 | plan-1 | good_enough | 20.3s | 10 | 7 | 25.5k / 2.5k |
+| `gemini,local` | rounds-collapse | 1 | 1 | code | proceed | 166.6s | 11 | 7 | 288.2k / 18.2k |
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | plan-1 | good_enough | 38.2s | 14 | 11 | 47.7k / 6.8k |
+| `codex,gemini,local` | rounds-collapse | 1 | 1 | code | proceed | 197.1s | 20 | 12 | 623.3k / 16.5k |
+| `codex` | split-once | 1 | 1 | plan-1 | proceed | 25.2s | 5 | 4 | 13.8k / 1.2k |
+| `codex` | split-once | 1 | 1 | code | proceed | 94.7s | 4 | 4 | 167k / 5.5k |
+| `gemini` | split-once | 1 | 1 | plan-1 | proceed | 15.6s | 3 | 3 | 25.8k / 2.7k |
+| `gemini` | split-once | 1 | 1 | code | proceed | 19.6s | 1 | 1 | 104.6k / 8.4k |
+| `local` | split-once | 1 | 1 | plan-1 | proceed | 27.9s | 5 | 4 | 1.4k / 1.2k |
+| `local` | split-once | 1 | 1 | code | proceed | 72.3s | 15 | 4 | 46.7k / 3.1k |
+| `codex,gemini` | split-once | 1 | 1 | plan-1 | good_enough | 39.5s | 8 | 7 | 37.9k / 2.4k |
+| `codex,gemini` | split-once | 1 | 1 | code | proceed | 87s | 5 | 4 | 350.1k / 12k |
+| `codex,local` | split-once | 1 | 1 | plan-1 | good_enough | 30.1s | 10 | 9 | 15.2k / 2.4k |
+| `codex,local` | split-once | 1 | 1 | code | proceed | 105.9s | 16 | 8 | 271.9k / 8.4k |
+| `gemini,local` | split-once | 1 | 1 | plan-1 | proceed | 17.7s | 8 | 6 | 28.4k / 4.7k |
+| `gemini,local` | split-once | 1 | 1 | code | proceed | 86.8s | 9 | 5 | 151.8k / 9.6k |
+| `codex,gemini,local` | split-once | 1 | 1 | plan-1 | good_enough | 42.4s | 14 | 12 | 49.2k / 5.7k |
+| `codex,gemini,local` | split-once | 1 | 1 | code | proceed | 157.9s | 16 | 10 | 414.5k / 22.5k |

--- a/src_bench/CoaiBench.Tests/JudgeReadsTheCodeItJudgesTests.cs
+++ b/src_bench/CoaiBench.Tests/JudgeReadsTheCodeItJudgesTests.cs
@@ -84,4 +84,28 @@ public sealed class JudgeReadsTheCodeItJudgesTests
         arguments.Should().Contain("--disallowedTools");
         arguments.Should().ContainInOrder("--output-format", "json");
     }
+
+    [Fact]
+    public void AFindingThatNamesALineBeyondTheFile_IsNotACrash()
+    {
+        // It was. A reviewer citing line 500 of a fifty-line file made the window start at 420 and
+        // end at 50, and Enumerable.Range was handed a count of -369:
+        //   System.ArgumentOutOfRangeException ... (Parameter 'count')
+        // That took down the whole judgement on its FOURTEENTH run of fourteen, and because the pass
+        // saved once at the end, thirteen judged runs went with it (2026-09-06, the 0.18.0 matrix).
+        var file = string.Join('\n', Enumerable.Range(1, 50).Select(n => $"line {n}"));
+
+        Judge.Window(file, line: 500, radius: 80).Should().BeEmpty("there is nothing there to show");
+        Judge.Window(file, line: 120, radius: 80).Should().Contain("50: line 50").And.NotContain("39: line 39",
+            "but a window that still overlaps the file shows the part that is there");
+    }
+
+    [Fact]
+    public void AWindowNeverRunsPastEitherEndOfTheFile()
+    {
+        var file = string.Join('\n', Enumerable.Range(1, 10).Select(n => $"line {n}"));
+
+        Judge.Window(file, line: 1, radius: 80).Should().Contain("1: line 1").And.Contain("10: line 10");
+        Judge.Window(file, line: 10, radius: 80).Should().Contain("10: line 10");
+    }
 }

--- a/src_bench/CoaiBench.Tests/JudgementSurvivesBeingInterruptedTests.cs
+++ b/src_bench/CoaiBench.Tests/JudgementSurvivesBeingInterruptedTests.cs
@@ -1,0 +1,97 @@
+using Xunit;
+using FluentAssertions;
+using CoaiBench.Judging;
+using CoaiBench.Model;
+
+namespace CoaiBench.Tests;
+
+/// <summary>
+/// A judgement stopped half way keeps the half it did.
+/// </summary>
+/// <remarks>
+/// Written after the campaign of 2026-09-05: the Fable judgement was stopped twelve runs in — on
+/// purpose, to change the model — and every one of those twelve was lost, because the pass wrote
+/// its file once, after the loop. Twelve runs is around a hundred CLI turns. The run is the unit of
+/// work, so the run is the unit of saving; and a pass restarted over the same file must not pay for
+/// the answers already in it.
+/// </remarks>
+public sealed class JudgementSurvivesBeingInterruptedTests
+{
+    private const string Opus = "claude-opus-5";
+    private static readonly Case Work = new("split-once", "artifacts/bench/plan-B.md", "7133c2f", "4a27a17");
+
+    private static RunRecord Run(string arm, string judgedBy = "") =>
+        new(Work, arm, 1, 1)
+        {
+            JudgedBy = judgedBy,
+            Stages =
+            [
+                new StageResult("CodeReview", 12.0)
+                {
+                    Findings = [new Finding(Title: "something", File: "a.cs", Line: 4)],
+                },
+            ],
+        };
+
+    private static Task<RunRecord> Judged(RunRecord run, CancellationToken ct) =>
+        Task.FromResult(run with { JudgedBy = Opus });
+
+    [Fact]
+    public async Task EveryJudgedRunIsOnDiskBeforeTheNextOneStarts()
+    {
+        var saves = new List<IReadOnlyList<RunRecord>>();
+        var seen = 0;
+
+        var run = () => JudgePass.RunAsync(
+            [Run("codex"), Run("gemini"), Run("local")],
+            Opus,
+            async (r, ct) =>
+            {
+                // The interruption, made deterministic: the third run never comes back.
+                seen++;
+                return seen == 3 ? throw new OperationCanceledException() : await Judged(r, ct);
+            },
+            (runs, _) => { saves.Add([.. runs]); return Task.CompletedTask; },
+            (_, _) => { },
+            TestContext.Current.CancellationToken);
+
+        await run.Should().ThrowAsync<OperationCanceledException>();
+
+        saves.Should().HaveCount(2, "each finished run is written as soon as it is finished");
+        saves[^1].Count(r => r.JudgedBy == Opus).Should().Be(2, "and what was written is what was judged");
+    }
+
+    [Fact]
+    public async Task ARestartedPassOnlyJudgesWhatThisJudgeHasNotJudged()
+    {
+        var asked = new List<string>();
+
+        await JudgePass.RunAsync(
+            [Run("codex", Opus), Run("gemini"), Run("local", Opus)],
+            Opus,
+            (r, ct) => { asked.Add(r.Arm); return Judged(r, ct); },
+            (_, _) => Task.CompletedTask,
+            (_, _) => { },
+            TestContext.Current.CancellationToken);
+
+        asked.Should().Equal(["gemini"], "the other two were already judged by this judge");
+    }
+
+    [Fact]
+    public async Task ADIFFERENTJudgeRejudgesEverything()
+    {
+        // Half a file in one model's opinion and half in another's is not a measurement. Changing the
+        // judge is asking for a new judgement, which is exactly what "switch to Opus" meant.
+        var asked = new List<string>();
+
+        await JudgePass.RunAsync(
+            [Run("codex", "claude-fable-5-1"), Run("gemini", "claude-fable-5-1")],
+            Opus,
+            (r, ct) => { asked.Add(r.Arm); return Judged(r, ct); },
+            (_, _) => Task.CompletedTask,
+            (_, _) => { },
+            TestContext.Current.CancellationToken);
+
+        asked.Should().Equal(["codex", "gemini"]);
+    }
+}

--- a/src_bench/CoaiBench.Tests/JudgementSurvivesBeingInterruptedTests.cs
+++ b/src_bench/CoaiBench.Tests/JudgementSurvivesBeingInterruptedTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 using FluentAssertions;
 using CoaiBench.Judging;
 using CoaiBench.Model;
+using CoaiBench.Store;
 
 namespace CoaiBench.Tests;
 
@@ -93,5 +94,45 @@ public sealed class JudgementSurvivesBeingInterruptedTests
             TestContext.Current.CancellationToken);
 
         asked.Should().Equal(["codex", "gemini"]);
+    }
+
+    [Fact]
+    public async Task ASaveLeavesNoHalfWrittenFileBehind()
+    {
+        // The file is now rewritten after EVERY run, so there is a reader arriving mid-write where
+        // there was none: the table verb, or a person watching a campaign. It is written beside
+        // itself and moved over, so what a reader opens is always a whole file.
+        var dir = Directory.CreateTempSubdirectory("coai-save-").FullName;
+        var file = Path.Combine(dir, "deeper", "runs.json");
+
+        try
+        {
+            await RunStore.SaveAsync(file, [Run("codex"), Run("gemini")], CancellationToken.None);
+
+            File.Exists(file + ".writing").Should().BeFalse("the temporary file is moved, not left behind");
+            (await RunStore.LoadAsync(file, CancellationToken.None)).Should().HaveCount(2);
+
+            await RunStore.SaveAsync(file, [Run("local", Opus)], CancellationToken.None);
+            var reread = await RunStore.LoadAsync(file, CancellationToken.None);
+
+            reread.Should().ContainSingle().Which.JudgedBy.Should().Be(Opus, "a save replaces the file whole");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TheLineForARunSaysWhetherAnythingWasPaidFor()
+    {
+        // A silent skip and a very fast judgement look identical from the outside, and the difference
+        // is whether the run cost anything. So a kept run says it was kept.
+        var run = Run("codex,gemini");
+
+        JudgePass.Line(run, judgedNow: true).Should().Contain("codex,gemini")
+            .And.Contain("split-once").And.Contain("0/1 worth having")
+            .And.NotContain("kept");
+        JudgePass.Line(run, judgedNow: false).Should().Contain("(kept - already judged)");
     }
 }

--- a/src_bench/CoaiBench.Tests/OverlapTests.cs
+++ b/src_bench/CoaiBench.Tests/OverlapTests.cs
@@ -1,0 +1,156 @@
+using Xunit;
+using FluentAssertions;
+using CoaiBench.Judging;
+using CoaiBench.Model;
+
+namespace CoaiBench.Tests;
+
+/// <summary>
+/// What each provider found that nobody else found.
+/// </summary>
+/// <remarks>
+/// The per-arm table says how much of a provider's output was worth having, and that is not the
+/// number a second provider is bought on. `local` scoring 14 % of its own output is one thing;
+/// `local` finding nothing codex did not already find is a different thing, and only this pass can
+/// tell them apart. Asked for on 2026-09-05, after exactly that misreading.
+/// </remarks>
+public sealed class OverlapTests
+{
+    private static readonly Case Work = new("split-once", "artifacts/bench/plan-B.md", "7133c2f", "4a27a17");
+
+    private static Finding Found(string provider, string file, int line, string title, string useful = "unjudged") =>
+        new(File: file, Line: line, Title: title, Providers: [provider]) { Useful = useful };
+
+    private static RunRecord Run(string arm, params Finding[] findings) =>
+        new(Work, arm, 1, 1)
+        {
+            Stages = [new StageResult("CodeReview", 10.0) { Findings = findings }],
+        };
+
+    // ---------- what counts as the same finding ----------
+
+    [Fact]
+    public void TwoProvidersNamingTheSameLineAndTheSameProblem_FoundOneThing()
+    {
+        Overlap.SameThing(
+            Found("codex", "src/Panel.cs", 40, "session file opened without FileShare"),
+            Found("gemini", "src/Panel.cs", 44, "FileShare missing when the session file is opened"))
+            .Should().BeTrue("the same place and the same subject, differently worded");
+    }
+
+    [Fact]
+    public void TheSameWordsAboutADifferentFile_AreTwoThings()
+    {
+        Overlap.SameThing(
+            Found("codex", "src/Panel.cs", 40, "session file opened without FileShare"),
+            Found("gemini", "src/Rounds.cs", 40, "session file opened without FileShare"))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheSamePlaceButADifferentSubject_AreTwoThings()
+    {
+        Overlap.SameThing(
+            Found("codex", "src/Panel.cs", 40, "session file opened without FileShare"),
+            Found("gemini", "src/Panel.cs", 42, "magic number should become a named constant"))
+            .Should().BeFalse("one file can hold two problems");
+    }
+
+    [Fact]
+    public void AFindingThatCitesNoLine_CannotDisagreeAboutWhere()
+    {
+        Overlap.SameThing(
+            Found("codex", "src/Panel.cs", 0, "session file opened without FileShare"),
+            Found("local", "src/Panel.cs", 900, "the session file is opened without FileShare"))
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void FindingsWithNoFileAtAll_AreHeldToAHigherBarOnWording()
+    {
+        Overlap.SameThing(
+            Found("codex", "", 0, "the plan never says what happens when the round is cancelled"),
+            Found("gemini", "", 0, "the plan never says what happens when the round is cancelled"))
+            .Should().BeTrue();
+
+        Overlap.SameThing(
+            Found("codex", "", 0, "the plan never says what happens when a round is cancelled"),
+            Found("gemini", "", 0, "documentation would benefit from a diagram"))
+            .Should().BeFalse();
+    }
+
+    // ---------- the counts ----------
+
+    [Fact]
+    public void AProviderThatOnlyEverRepeatsAnother_HasFoundNothingOfItsOwn()
+    {
+        var overlaps = Overlap.Across(
+        [
+            Run("codex", Found("codex", "src/Panel.cs", 40, "session file opened without FileShare", "yes")),
+            Run("local", Found("local", "src/Panel.cs", 41, "the session file is opened without FileShare")),
+        ]);
+
+        var local = overlaps.Single(o => o.Provider == "local");
+        local.Distinct.Should().Be(1);
+        local.Only.Should().Be(0, "codex named it too");
+        local.Shared.Should().Be(1);
+    }
+
+    [Fact]
+    public void TheHeadlineNumberIsWhatOnlyThisProviderFoundAndTheJudgeKept()
+    {
+        var overlaps = Overlap.Across(
+        [
+            Run("codex",
+                Found("codex", "src/Panel.cs", 40, "session file opened without FileShare", "yes"),
+                Found("codex", "src/Gate.cs", 12, "the retry loop never gives up", "yes")),
+            Run("local",
+                Found("local", "src/Panel.cs", 41, "the session file is opened without FileShare", "yes"),
+                Found("local", "src/Log.cs", 8, "this variable could be named better", "no"),
+                Found("local", "src/Log.cs", 60, "an off-by-one closes the file too early", "yes")),
+        ]);
+
+        var codex = overlaps.Single(o => o.Provider == "codex");
+        var local = overlaps.Single(o => o.Provider == "local");
+
+        codex.Only.Should().Be(1, "the retry loop");
+        codex.OnlyUseful.Should().Be(1);
+        local.Only.Should().Be(2, "the naming nit and the off-by-one");
+        local.OnlyUseful.Should().Be(1, "only the off-by-one was worth having");
+        local.Useful.Should().Be(2, "the shared one counts towards its hit rate, not towards its uniqueness");
+    }
+
+    [Fact]
+    public void OneProviderSayingTheSameThingInFourRunsSaidOneThing()
+    {
+        // Pooled across arms and repeats on purpose: a provider is measured on the union of its
+        // attempts. Four runs of one arm must not make one insight look like four.
+        var same = () => Found("codex", "src/Panel.cs", 40, "session file opened without FileShare");
+        var overlaps = Overlap.Across([Run("codex", same()), Run("codex,gemini", same()), Run("codex,local", same())]);
+
+        overlaps.Single(o => o.Provider == "codex").Raw.Should().Be(3);
+        overlaps.Single(o => o.Provider == "codex").Distinct.Should().Be(1);
+    }
+
+    [Fact]
+    public void FindingsAboutDifferentCasesNeverCluster()
+    {
+        var other = new Case("engine-lease", "research/PLAN_engine_lease.md");
+        var overlaps = Overlap.Across(
+        [
+            Run("codex", Found("codex", "src/Panel.cs", 40, "session file opened without FileShare")),
+            new RunRecord(other, "gemini", 1, 1)
+            {
+                Stages =
+                [
+                    new StageResult("CodeReview", 10.0)
+                    {
+                        Findings = [Found("gemini", "src/Panel.cs", 40, "session file opened without FileShare")],
+                    },
+                ],
+            },
+        ]);
+
+        overlaps.Should().OnlyContain(o => o.Only == 1, "two reviews of two different changes are not agreement");
+    }
+}

--- a/src_bench/CoaiBench.Tests/OverlapTests.cs
+++ b/src_bench/CoaiBench.Tests/OverlapTests.cs
@@ -153,4 +153,33 @@ public sealed class OverlapTests
 
         overlaps.Should().OnlyContain(o => o.Only == 1, "two reviews of two different changes are not agreement");
     }
+
+    // ---------- the table the campaign report prints ----------
+
+    [Fact]
+    public void TheTableCarriesOneRowPerProvider_WithWhatItFoundAlone()
+    {
+        var overlaps = Overlap.Across(
+        [
+            Run("codex,gemini",
+                Found("codex", "src/Panel.cs", 40, "session file opened without FileShare", useful: "yes"),
+                Found("gemini", "src/Panel.cs", 41, "the session file is opened without FileShare"),
+                Found("codex", "src/Store.cs", 12, "the temp directory is never swept", useful: "yes")),
+        ]);
+        var table = Overlap.Table(overlaps);
+
+        table.Should().Contain("| provider |").And.Contain("found by it alone");
+        // codex wrote two, both distinct; one of them gemini also named, one it found alone - and
+        // that one was worth having. This is the number a second provider is bought on.
+        table.Should().Contain("| `codex` | 2 | 2 | 1 (50%) | 1 (50%) | **1** |");
+        table.Should().Contain("| `gemini` | 1 | 1 | 1 (100%) | 0 (0%) | **0** |");
+    }
+
+    [Fact]
+    public void AProviderThatWroteNothingIsAnEmDash_NotADivisionByZero()
+    {
+        var table = Overlap.Table([new ProviderOverlap("local", Raw: 0, Distinct: 0, Shared: 0, Only: 0, OnlyUseful: 0, Useful: 0)]);
+
+        table.Should().Contain("| `local` | 0 | 0 | — | — | **0** |");
+    }
 }

--- a/src_bench/CoaiBench/Judging/Judge.cs
+++ b/src_bench/CoaiBench/Judging/Judge.cs
@@ -120,6 +120,16 @@ public sealed class Judge(string executable, string model, string repo)
             ? (1, Math.Min(lines.Length, 2 * radius + 1))
             : (Math.Max(1, line - radius), Math.Min(lines.Length, line + radius));
 
+        // A reviewer may cite a line the file does not have - a stale number, a hallucinated one, a
+        // path that resolved to a different file than the one it was reading. Then `from` runs past
+        // `to`, the count below goes negative, and this threw - taking the whole judgement down with
+        // it on its fourteenth run of fourteen. There is simply nothing to show; the judge gets no
+        // window and reads the finding on its own words.
+        if (from > to)
+        {
+            return string.Empty;
+        }
+
         return string.Join("\n", Enumerable.Range(from, to - from + 1).Select(n => $"{n}: {lines[n - 1]}"));
     }
 

--- a/src_bench/CoaiBench/Judging/Judge.cs
+++ b/src_bench/CoaiBench/Judging/Judge.cs
@@ -58,7 +58,7 @@ public sealed class Judge(string executable, string model, string repo)
             stages.Add(stage with { Findings = findings });
         }
 
-        return run with { Stages = stages };
+        return run with { Stages = stages, JudgedBy = model };
     }
 
     private async Task<Finding> OneAsync(Case work, Finding finding, CancellationToken ct)

--- a/src_bench/CoaiBench/Judging/JudgePass.cs
+++ b/src_bench/CoaiBench/Judging/JudgePass.cs
@@ -1,0 +1,51 @@
+using CoaiBench.Model;
+
+namespace CoaiBench.Judging;
+
+/// <summary>
+/// A judgement that survives being interrupted.
+/// </summary>
+/// <remarks>
+/// <para>The first version judged every run and wrote the file once, at the end. On 2026-09-05 a
+/// judgement was stopped twelve runs in to change the model, and twelve runs of answers went with
+/// it — each of them a paid CLI turn per finding, none of them anywhere but in memory.</para>
+/// <para>Nothing about the pass needs that. Every run is judged independently, and the file it
+/// writes is the file it reads. So the answer lands on disk as soon as it exists, and a pass
+/// restarted over the same file judges only what THIS judge has not judged yet: the run carries the
+/// model that marked it, so an interrupted pass resumes, and a different model re-judges everything
+/// rather than leaving a file half in one opinion and half in another.</para>
+/// </remarks>
+public static class JudgePass
+{
+    public static async Task<IReadOnlyList<RunRecord>> RunAsync(
+        IReadOnlyList<RunRecord> runs,
+        string model,
+        Func<RunRecord, CancellationToken, Task<RunRecord>> judge,
+        Func<IReadOnlyList<RunRecord>, CancellationToken, Task> save,
+        Action<RunRecord, bool> report,
+        CancellationToken ct)
+    {
+        var judged = runs.ToList();
+        for (var index = 0; index < judged.Count; index++)
+        {
+            if (!NeedsJudging(judged[index], model))
+            {
+                report(judged[index], false);
+                continue;
+            }
+
+            judged[index] = await judge(judged[index], ct);
+
+            // Before the next one starts, not after the last one finishes. The whole file is
+            // rewritten each time: it is a few hundred kilobytes against a CLI turn per finding,
+            // and it means the file on disk is never a partial record of a run.
+            await save(judged, ct);
+            report(judged[index], true);
+        }
+
+        return judged;
+    }
+
+    /// <summary>Whether this judge has an opinion on this run yet.</summary>
+    public static bool NeedsJudging(RunRecord run, string model) => run.JudgedBy != model;
+}

--- a/src_bench/CoaiBench/Judging/JudgePass.cs
+++ b/src_bench/CoaiBench/Judging/JudgePass.cs
@@ -46,6 +46,23 @@ public static class JudgePass
         return judged;
     }
 
+    /// <summary>
+    /// The one line a run gets as the pass walks the file.
+    /// </summary>
+    /// <remarks>
+    /// Here rather than at the call site because it is the only thing a person watching a judgement
+    /// actually reads, and because a pass that skips a run has to SAY so - a silent skip and a fast
+    /// judgement look identical from the outside, and the difference is whether anything was paid for.
+    /// </remarks>
+    public static string Line(RunRecord run, bool judgedNow)
+    {
+        var counted = run.Stages.SelectMany(stage => stage.Findings).ToList();
+
+        return $"{run.Arm,-22} {run.Case.Name,-34} #{run.Repeat} "
+            + $"{counted.Count(finding => finding.Useful == "yes")}/{counted.Count} worth having"
+            + (judgedNow ? "" : "   (kept - already judged)");
+    }
+
     /// <summary>Whether this judge has an opinion on this run yet.</summary>
     public static bool NeedsJudging(RunRecord run, string model) => run.JudgedBy != model;
 }

--- a/src_bench/CoaiBench/Judging/Overlap.cs
+++ b/src_bench/CoaiBench/Judging/Overlap.cs
@@ -1,0 +1,181 @@
+using System.Globalization;
+using System.Text;
+using CoaiBench.Model;
+
+namespace CoaiBench.Judging;
+
+/// <summary>What one provider found that no other provider found.</summary>
+/// <param name="Provider">codex, gemini, local.</param>
+/// <param name="Raw">Every finding it wrote, duplicates and repeats included.</param>
+/// <param name="Distinct">How many distinct things those were.</param>
+/// <param name="Shared">How many of them another provider also named.</param>
+/// <param name="Only">How many nobody else named.</param>
+/// <param name="OnlyUseful">Of those, how many the judge thought worth having.</param>
+/// <param name="Useful">How many of its distinct findings the judge thought worth having at all.</param>
+public sealed record ProviderOverlap(
+    string Provider, int Raw, int Distinct, int Shared, int Only, int OnlyUseful, int Useful);
+
+/// <summary>
+/// Who found what, and who found it alone.
+/// </summary>
+/// <remarks>
+/// <para>The per-arm table answers "how much of this provider's output was worth having". It cannot
+/// answer the question that decides whether to PAY for a second provider: <b>did it find anything
+/// the others did not?</b> A model with a fine hit-rate that only ever repeats what codex already
+/// said is worth nothing on top of codex, and the counts alone make it look valuable.</para>
+/// <para>The server does not merge across providers — every recorded finding carries exactly one —
+/// so the matching is done here, and deliberately GENEROUSLY: when two findings are close enough to
+/// argue about, they are counted as one. Erring the other way inflates "only I found this", which is
+/// precisely the number a second provider gets bought on.</para>
+/// <para>Findings are pooled per case and stage across every arm and repeat, so each provider is
+/// judged on the union of its attempts — its best showing, not its unluckiest run.</para>
+/// </remarks>
+public static class Overlap
+{
+    /// <summary>How far apart two citations of the same thing may be.</summary>
+    private const int Nearby = 10;
+
+    private static readonly string[] Ignored =
+    [
+        "the", "and", "for", "with", "that", "this", "from", "when", "not", "into", "are", "its",
+        "but", "can", "has", "have", "was", "will", "may", "does", "than", "then", "there",
+    ];
+
+    public static IReadOnlyList<ProviderOverlap> Across(IReadOnlyList<RunRecord> runs)
+    {
+        var clusters = new List<List<Finding>>();
+        var raw = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var one in runs.SelectMany(Findings))
+        {
+            raw[ProviderOf(one.Finding)] = raw.GetValueOrDefault(ProviderOf(one.Finding)) + 1;
+            Place(clusters, one.Finding, one.Group);
+        }
+
+        return
+        [
+            .. raw.Keys
+                .Select(p => Count(p, clusters, raw[p]))
+                .OrderByDescending(o => o.OnlyUseful)
+                .ThenByDescending(o => o.Only),
+        ];
+    }
+
+    /// <summary>Every finding in the campaign, each tagged with the group it may be compared inside.</summary>
+    private static IEnumerable<(Finding Finding, string Group)> Findings(RunRecord run) =>
+        run.Stages.SelectMany(s => s.Findings.Select(f => (f, $"{run.Case.Name}|{s.Stage}")));
+
+    /// <summary>The cluster a finding joins, or a new one. Single linkage: close to any member is close.</summary>
+    private static void Place(List<List<Finding>> clusters, Finding finding, string group)
+    {
+        var home = clusters.FirstOrDefault(c => Group(c) == group && c.Exists(other => SameThing(other, finding)));
+        if (home is null)
+        {
+            clusters.Add([Tagged(finding, group)]);
+
+            return;
+        }
+
+        home.Add(Tagged(finding, group));
+    }
+
+    // The comparison group rides on Role, which the clustering does not otherwise use: one case's
+    // findings must never cluster with another case's, and a parallel list of keys would be one more
+    // thing to keep in step with the clusters.
+    private static Finding Tagged(Finding finding, string group) => finding with { Role = group };
+
+    private static string Group(List<Finding> cluster) => cluster[0].Role;
+
+    private static ProviderOverlap Count(string provider, List<List<Finding>> clusters, int raw)
+    {
+        var mine = clusters.Where(c => c.Exists(f => Is(f, provider))).ToList();
+        var alone = mine.Where(c => c.TrueForAll(f => Is(f, provider))).ToList();
+
+        return new ProviderOverlap(
+            provider,
+            raw,
+            mine.Count,
+            mine.Count - alone.Count,
+            alone.Count,
+            alone.Count(Worthwhile),
+            mine.Count(c => c.Where(f => Is(f, provider)).Any(f => f.Useful == "yes")));
+    }
+
+    private static bool Worthwhile(List<Finding> cluster) => cluster.Exists(f => f.Useful == "yes");
+
+    private static bool Is(Finding finding, string provider) =>
+        string.Equals(ProviderOf(finding), provider, StringComparison.OrdinalIgnoreCase);
+
+    private static string ProviderOf(Finding finding) =>
+        finding.Providers is { Count: > 0 } list ? list[0] : "unattributed";
+
+    /// <summary>
+    /// Whether two findings are the same finding.
+    /// </summary>
+    /// <remarks>
+    /// The same place, and something in common in what they say. Place first because it is cheap and
+    /// decisive: two findings about different files are never the same finding, whatever the words.
+    /// Findings that name no file at all are matched on wording alone, and are held to a higher bar
+    /// for it.
+    /// </remarks>
+    internal static bool SameThing(Finding a, Finding b)
+    {
+        var (left, right) = (Normalise(a.File), Normalise(b.File));
+
+        return left.Length == 0 || right.Length == 0
+            ? left.Length == right.Length && Alike(a.Title, b.Title, 0.5)
+            : left == right && Near(a.Line, b.Line) && Alike(a.Title, b.Title, 0.25);
+    }
+
+    /// <summary>A cited line of 0 is "no line", which cannot disagree with anything.</summary>
+    private static bool Near(int a, int b) => a == 0 || b == 0 || Math.Abs(a - b) <= Nearby;
+
+    private static string Normalise(string file) =>
+        file.Replace('\\', '/').TrimStart('.', '/').ToLowerInvariant();
+
+    /// <summary>Jaccard over the words that carry meaning, so the wording may differ and the subject may not.</summary>
+    internal static bool Alike(string a, string b, double bar)
+    {
+        var (left, right) = (Words(a), Words(b));
+        if (left.Count == 0 || right.Count == 0)
+        {
+            return false;
+        }
+
+        var shared = left.Intersect(right, StringComparer.Ordinal).Count();
+
+        return (double)shared / left.Union(right, StringComparer.Ordinal).Count() >= bar;
+    }
+
+    private static HashSet<string> Words(string text) =>
+    [
+        .. new string([.. text.Select(c => char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : ' ')])
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(w => w.Length >= 4 && !Ignored.Contains(w, StringComparer.Ordinal)),
+    ];
+
+    public static string Table(IReadOnlyList<ProviderOverlap> overlaps)
+    {
+        var table = new StringBuilder()
+            .AppendLine("| provider | findings written | distinct | also found by another | found by it alone | of those, worth having |")
+            .AppendLine("|---|---|---|---|---|---|");
+
+        foreach (var one in overlaps)
+        {
+            table.AppendLine(string.Join(" | ",
+            [
+                $"| `{one.Provider}`",
+                one.Raw.ToString(CultureInfo.InvariantCulture),
+                one.Distinct.ToString(CultureInfo.InvariantCulture),
+                Share(one.Shared, one.Distinct),
+                Share(one.Only, one.Distinct),
+                $"**{one.OnlyUseful}** |",
+            ]));
+        }
+
+        return table.ToString();
+    }
+
+    private static string Share(int part, int whole) =>
+        whole == 0 ? "—" : $"{part} ({100.0 * part / whole:0}%)";
+}

--- a/src_bench/CoaiBench/Model/BenchRun.cs
+++ b/src_bench/CoaiBench/Model/BenchRun.cs
@@ -127,4 +127,14 @@ public sealed record RunRecord(Case Case, string Arm, int Repeat, int Lane)
 
     /// <summary>Whether the settings this run ASKED for are the ones it actually got.</summary>
     public Running.SettingsApplied? Settings { get; init; }
+
+    /// <summary>
+    /// Which judge model has an opinion on this run. Empty until one does.
+    /// </summary>
+    /// <remarks>
+    /// It is what makes a judgement resumable: a pass restarted over the same file skips the runs
+    /// this judge already answered, and a DIFFERENT judge re-judges all of them rather than leaving
+    /// the file half in one model's opinion and half in another.
+    /// </remarks>
+    public string JudgedBy { get; init; } = string.Empty;
 }

--- a/src_bench/CoaiBench/Program.cs
+++ b/src_bench/CoaiBench/Program.cs
@@ -211,20 +211,27 @@ public static class Program
 
         var runs = await RunStore.LoadAsync(options.RunsFile, ct);
         var judge = new Judge("claude", options.Judge, options.Repo);
-        var judged = new List<RunRecord>();
-        foreach (var run in runs)
-        {
-            judged.Add(await judge.JudgeAsync(run, ct));
-            var counted = judged[^1].Stages.SelectMany(s => s.Findings).ToList();
-            Console.WriteLine(
-                $"{run.Arm,-22} {run.Case.Name,-34} #{run.Repeat} "
-                + $"{counted.Count(f => f.Useful == "yes")}/{counted.Count} worth having");
-        }
+        var judged = await JudgePass.RunAsync(
+            runs,
+            options.Judge,
+            judge.JudgeAsync,
+            (all, token) => RunStore.SaveAsync(options.RunsFile, all, token),
+            Announce,
+            ct);
 
-        await RunStore.SaveAsync(options.RunsFile, judged, ct);
         Report(judged, Path.GetDirectoryName(options.RunsFile) ?? ".");
 
         return 0;
+    }
+
+    /// <summary>One line per run as the judgement walks the file, saying which ones it paid for.</summary>
+    private static void Announce(RunRecord run, bool judgedNow)
+    {
+        var counted = run.Stages.SelectMany(s => s.Findings).ToList();
+        Console.WriteLine(
+            $"{run.Arm,-22} {run.Case.Name,-34} #{run.Repeat} "
+            + $"{counted.Count(f => f.Useful == "yes")}/{counted.Count} worth having"
+            + (judgedNow ? "" : "   (kept - already judged)"));
     }
 
     private static async Task<int> TableAsync(Options options, CancellationToken ct)
@@ -244,10 +251,15 @@ public static class Program
     {
         var perArm = Tables.PerArm(runs);
         var perRun = Tables.PerRun(runs);
-        Console.WriteLine($"\n{perArm}\n{perRun}");
+
+        // Who found it ALONE. The per-arm table cannot answer that: a provider whose every finding
+        // repeats another's scores exactly as well there as one that found things by itself, and the
+        // second is the only thing a second provider is worth paying for.
+        var overlap = Overlap.Table(Overlap.Across(runs));
+        Console.WriteLine($"\n{perArm}\n{overlap}\n{perRun}");
         Directory.CreateDirectory(outDir);
         File.WriteAllText(
             Path.Combine(outDir, "tables.md"),
-            $"# Bench\n\n## Per arm\n\n{perArm}\n## Per run\n\n{perRun}");
+            $"# Bench\n\n## Per arm\n\n{perArm}\n## Who found it alone\n\n{overlap}\n## Per run\n\n{perRun}");
     }
 }

--- a/src_bench/CoaiBench/Program.cs
+++ b/src_bench/CoaiBench/Program.cs
@@ -225,14 +225,7 @@ public static class Program
     }
 
     /// <summary>One line per run as the judgement walks the file, saying which ones it paid for.</summary>
-    private static void Announce(RunRecord run, bool judgedNow)
-    {
-        var counted = run.Stages.SelectMany(s => s.Findings).ToList();
-        Console.WriteLine(
-            $"{run.Arm,-22} {run.Case.Name,-34} #{run.Repeat} "
-            + $"{counted.Count(f => f.Useful == "yes")}/{counted.Count} worth having"
-            + (judgedNow ? "" : "   (kept - already judged)"));
-    }
+    private static void Announce(RunRecord run, bool judgedNow) => Console.WriteLine(JudgePass.Line(run, judgedNow));
 
     private static async Task<int> TableAsync(Options options, CancellationToken ct)
     {

--- a/src_bench/CoaiBench/Store/RunStore.cs
+++ b/src_bench/CoaiBench/Store/RunStore.cs
@@ -20,11 +20,22 @@ internal sealed partial class BenchJson : JsonSerializerContext;
 /// </remarks>
 public static class RunStore
 {
+    /// <summary>
+    /// The whole file, replaced in one step.
+    /// </summary>
+    /// <remarks>
+    /// Written beside the file and moved over it, because a judgement now saves after every run and
+    /// a reader — the table verb, a person watching a campaign — that arrives mid-write would
+    /// otherwise read half a JSON array and call the file corrupt. A move is one operation; a write
+    /// of six hundred kilobytes is not.
+    /// </remarks>
     public static async Task SaveAsync(string file, IReadOnlyList<RunRecord> runs, CancellationToken ct)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(file) ?? ".");
+        var beside = file + ".writing";
         await File.WriteAllTextAsync(
-            file, JsonSerializer.Serialize(runs.ToList(), BenchJson.Default.ListRunRecord), ct);
+            beside, JsonSerializer.Serialize(runs.ToList(), BenchJson.Default.ListRunRecord), ct);
+        File.Move(beside, file, overwrite: true);
     }
 
     public static async Task<IReadOnlyList<RunRecord>> LoadAsync(string file, CancellationToken ct) =>


### PR DESCRIPTION
Two fixes that were made in a throwaway checkout this morning and never carried here — which is the whole defect, because the instrument **in the repository** is the one everybody runs.

## A judgement saved once, after the loop

Stopping it to change the model this morning lost **twelve judged runs**, roughly a hundred paid CLI turns. The same trap was still armed tonight, with fourteen runs in flight over the 0.18.0 matrix.

The pass now writes after **every** run, and a restart over the same file skips what this judge already answered: each run carries the model that marked it, so an interrupted pass resumes where it stopped and a *different* judge re-judges everything rather than leaving the file half in one model's opinion and half in another.

The file is written beside itself and moved over, because a reader arriving mid-write would otherwise read half a JSON array and call it corrupt — and with a save per run there is now a reader arriving mid-write.

## And the table the per-arm one cannot produce: who found it ALONE

A provider whose every finding repeats another's scores exactly as well in the per-arm table as one that found things by itself — and the second is the only thing a second provider is worth paying for. The overlap pass clusters findings per case and stage across every arm and repeat, and reports, per vendor: what it wrote, how many distinct things those were, how many another vendor also named, how many nobody else did, and how many of *those* the judge thought worth having.

Matching is deliberately generous: when two findings are close enough to argue about they are counted as one. Erring the other way inflates "only I found this", which is precisely the number a second provider gets bought on.

## Verified

**103 tests pass**, twelve of them ported with the code — nine on what counts as the same finding, three on surviving a stop.

Teeth checked: with the save moved back to the end of the loop, the first goes red with `Expected saves to contain 2 item(s) ... but found 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
