### PR TITLE
fix(ci): main is red on two counts — a stale conventions pin and a test that was green for one day

### DIFF
--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -26,7 +26,33 @@ const ROOT = process.cwd();
 /** Every function the page embeds by its SOURCE TEXT, and therefore every one this file guards. */
 const EMBEDDED = ['compareRows', 'rowMatches', 'money', 'cost3', 'costTitle', 'asInstant'];
 
-const NOW = Date.parse('2026-09-05T08:00:00.000Z');
+/**
+ * The fixture's day is TODAY, taken from the real clock, and that is load-bearing rather than lazy.
+ *
+ * <p>The page opens on today's range — `setToday()` reads `new Date()`, because the question
+ * somebody has when they open it is almost always "what happened today". A fixture pinned to a
+ * literal date therefore renders rows on exactly ONE day and an empty table on every day after it,
+ * which is what this file did: written on 2026-09-05, green that afternoon, red from the next
+ * morning onwards with "the page rendered no rows" — a failure that says nothing about the page and
+ * everything about the calendar.</p>
+ *
+ * <p>Local NOON, not midnight and not a UTC literal: the page's range is built from the LOCAL day
+ * while a round's stamp is UTC, so an instant near either edge lands on the neighbouring local day
+ * under some offsets and the bomb comes back wearing a timezone. Noon is the only hour no offset on
+ * earth can move out of its own day.</p>
+ */
+function todayAtLocal(hours: number, minutes: number, seconds = 0): Date {
+  const day = new Date();
+  day.setHours(hours, minutes, seconds, 0);
+
+  return day;
+}
+
+const STARTED = todayAtLocal(12, 0);
+const COMPLETED = todayAtLocal(12, 2, 10);
+const PRICED = todayAtLocal(12, 1);
+/** After the round finished, so the row has an age — and still the same local day. */
+const NOW = todayAtLocal(12, 17).getTime();
 
 /** One finished round, priced from one ledger line — enough to exercise every cell of a row. */
 const SESSION = {
@@ -34,14 +60,14 @@ const SESSION = {
   rounds: [{
     stage: 'CodeReview', number: 1, verdict: 'proceed', gatingCount: 1,
     reviewers: 'all 2 reviewers answered', status: 'done',
-    startedUtc: '2026-09-05T07:41:00.000Z', completedUtc: '2026-09-05T07:43:10.000Z',
+    startedUtc: STARTED.toISOString(), completedUtc: COMPLETED.toISOString(),
     subject: 'SCOPE - something', tokensIn: 1_000_000, tokensOut: 200_000,
     reviewerStates: [{ provider: 'codex', role: 'Architecture', status: 'done', findings: 1, note: '', seconds: 23 }],
   }],
 };
 
 const USED = {
-  utc: '2026-09-05T07:42:00.000Z', provider: 'codex', model: 'gpt-5.6-sol', role: 'Architecture',
+  utc: PRICED.toISOString(), provider: 'codex', model: 'gpt-5.6-sol', role: 'Architecture',
   stage: 'CodeReview', seconds: 23, tokensIn: 1_000_000, tokensOut: 200_000, costUsd: null, outcome: 'ok',
 };
 
@@ -175,3 +201,19 @@ function strangers(body: string, name: string): string[] {
       .map((m) => m[1] as string)
       .filter((called) => !mine.has(called)))];
 }
+
+test('the fixture lands on the local day the page opens on', () => {
+  // The dependency the file used to carry silently, stated as a check. The two tests above assert
+  // on RENDERED rows, so anything that puts the fixture outside the page's opening range empties
+  // the table and they fail claiming the page formats no rows - a sentence that sends the next
+  // reader into the bundler. This one fails first and names the calendar instead.
+  const localDay = (at: Date) =>
+    `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, '0')}-${String(at.getDate()).padStart(2, '0')}`;
+  const today = localDay(new Date());
+
+  for (const [what, when] of [['started', STARTED], ['completed', COMPLETED], ['priced', PRICED]] as const) {
+    assert.equal(
+      localDay(when), today,
+      `the fixture's ${what} stamp is not on today's local day, so the page opens with it filtered out`);
+  }
+});


### PR DESCRIPTION
`main` is red, and every PR opened against it inherits both failures. Two independent root causes; neither PR could go green alone, so they land together.

## 1 · The bundled-page test was green for exactly one day

```
✖ the page script the bundle produces parses and runs
  AssertionError: the page rendered no rows, so nothing that formats a row was ever called
```

That sentence sends the reader into the bundler. The defect is the calendar.

The rounds page **opens on today's range** — `setToday()` in [roundsLog.ts:930](src_vs_code/src/roundsLog.ts#L930) reads `new Date()`, because the question somebody has when they open the log is almost always "what happened today". The fixture was pinned to `2026-09-05T07:43:10Z`. It rendered its row on the afternoon it was written and an empty table every morning after — the test could only ever have been green on **one day**, and 2026-09-05 was it.

The fix makes the fixture's stamps relative to the real clock at **local noon** — noon rather than a UTC literal because the page's range is built from the LOCAL day while a round's stamp is UTC, so an instant near either edge lands on the neighbouring local day under some offsets and the bomb comes back wearing a timezone. Noon is the only hour no offset on earth can move out of its own day.

A new test states the dependency the file used to carry silently. Without it, anything that moves the fixture out of range fails the two *render* tests with a sentence about formatting rows, which is the wrong place to look.

No production code changed, and no assertion was weakened — the render assertions are byte-identical.

## 2 · The conventions pin was never cascaded

```
pin-check: STALE .claude/rules/shared
  pinned cef6e53…   remote c5a6019…
```

`dew_flow_conventions` moved to `c5a6019` and **no consumer was bumped**. Audited:

| repository | pinned at | |
|---|---|---|
| `dew_flow_connect_other_ais` | `cef6e53` | **this PR** |
| `dew_flow_creds_for_devs` | `cef6e53` | stale |
| `dew_flow_mcp` · `dew_flow_rag_qln` · `dew_flow_benchmark` · `dew_flow_sidecar_rust` | `4dbead4` | stale, two behind |

`pin-check` compares against the remote tip, so **every repository in the family is red on this check right now**. This fixes one of six; the other five need the same bump, with `dew_flow_rag_qln` last because bumping `mcp` and `benchmark` moves the tips it pins in turn. That is a family-wide task and it is not this PR.

**What adopting `c5a6019` costs:** it adds `common/scenario-tests.md` (every repository owns a scenario harness, recorded in `research/module_tests.md`), the paragraphs pointing at it, and the plan for the check that will enforce it. It adds **no tool**, so this bump turns nothing else red today — and the rule's own *Adoption* section says a repository without a harness starts by writing the catalogue, not the tests. That catalogue is deliberately not in this PR: a one-line fix for a red `main` is not the place to bury an unreviewed 40-flow inventory.

## Why one PR

`SonarCloud Scan` runs the extension suite for coverage, so the clock bomb fails it too. With only the pin bumped, `extension` and `SonarCloud` stay red; with only the test fixed, `family checks` stays red. Merging one at a time green-lights nothing, so they are stacked here and #52 is closed in favour of this.

## Test plan

- [x] **RED first, on pristine `origin/main`**: reproduced with the real symptom before touching anything — `pass 437, fail 1`, `the page rendered no rows`.
- [x] **GREEN after**: `tests 440, pass 439, skipped 1, fail 0`.
- [x] **The guard has teeth**: `STARTED` pinned back to a literal date fails it with *"the fixture's started stamp is not on today's local day, so the page opens with it filtered out"*, and the render test fails beside it — the exact pair the guard exists to disambiguate.
- [x] `tsc -p ./ --noEmit` clean.
- [x] `pin-check.mjs` → `OK — 1 pin(s) at their remote tips`, run **after** committing: it reads the pin from HEAD, so a staged bump still reports STALE and reads as a second failure.
- [x] `plan-lifecycle.mjs`, `gate-snippet-check.mjs` → OK.
