### PR TITLE
feat(log): a round says whether anybody has decided about its findings

### DIFF
--- a/src_vs_code/src/roundsDb.ts
+++ b/src_vs_code/src/roundsDb.ts
@@ -155,3 +155,22 @@ export function findingsByRound(log: DbLog): Map<string, readonly DbFinding[]> {
 
   return byRound;
 }
+
+/**
+ * What each round's gate CLOSED at, by the same key.
+ *
+ * <p>Separate from the findings because it answers a different question: the findings say what was
+ * raised, and this says whether anybody has decided about them. The server writes -1 until a resolve
+ * lands, which is the only honest way to tell "nothing was accepted" from "nobody has said yet" —
+ * and the log page read neither, so a round with thirteen open findings displayed as `done`.</p>
+ */
+export function decisionsByRound(log: DbLog): Map<string, { accepted: number; rejected: number }> {
+  const byRound = new Map<string, { accepted: number; rejected: number }>();
+  for (const one of log.rounds) {
+    byRound.set(
+      roundKeyOf(one.sessionId, one.repoPath, one.branch, one.stage, one.number),
+      { accepted: one.accepted, rejected: one.rejected });
+  }
+
+  return byRound;
+}

--- a/src_vs_code/src/roundsLog.ts
+++ b/src_vs_code/src/roundsLog.ts
@@ -5,7 +5,7 @@ import { UsageEntry, Window, WINDOWS } from './usage';
 import { Vendor } from './vendors';
 import { MAX_PLAUSIBLE_SECONDS, reviewerLines, reviewerRows, RoundRecord, SessionFile, stageName } from './rounds';
 import { vendorColour } from './vendorColour';
-import { BlindSpot, DbFinding, DbLog, EMPTY_LOG, findingsByRound, roundKeyOf } from './roundsDb';
+import { BlindSpot, DbFinding, DbLog, decisionsByRound, EMPTY_LOG, findingsByRound, roundKeyOf } from './roundsDb';
 import { escapeHtml, jsonForScript } from './webviewHtml';
 
 /**
@@ -40,7 +40,17 @@ export interface LogRow {
   readonly stage: string;
   readonly number: number;
   readonly subject: string;
-  readonly status: 'running' | 'done' | 'interrupted';
+  /**
+   * `awaiting` is a finished round whose findings nobody has decided about yet — `done` is about the
+   * REVIEWERS having answered, and whether the gate was closed is a different fact.
+   */
+  readonly status: 'running' | 'done' | 'interrupted' | 'awaiting';
+
+  /**
+   * How the gate closed: accepted and rejected counts, or `null` for a round the database has never
+   * heard of. `-1` in either field is the server saying nobody has decided yet.
+   */
+  readonly decided: { readonly accepted: number; readonly rejected: number } | null;
   readonly verdict: string;
   readonly gating: number;
   /** The sum over its reviewers, or null when the file recorded none — absent is not zero. */
@@ -122,9 +132,11 @@ export function rowsFrom(
   log: DbLog = EMPTY_LOG,
 ): LogRow[] {
   const byRound = findingsByRound(log);
+  const decided = decisionsByRound(log);
 
   return sessions
-    .flatMap((session) => session.rounds.map((round) => rowFrom(session, round, nowMs, priceOf, usage, byRound)))
+    .flatMap((session) =>
+      session.rounds.map((round) => rowFrom(session, round, nowMs, priceOf, usage, byRound, decided)))
     .sort((a, b) => (b.startedUtc || b.completedUtc).localeCompare(a.startedUtc || a.completedUtc));
 }
 
@@ -135,9 +147,14 @@ function rowFrom(
   priceOf: PriceOfModel,
   usage: readonly UsageEntry[],
   byRound: Map<string, readonly DbFinding[]> = new Map(),
+  decidedBy: Map<string, { accepted: number; rejected: number }> = new Map(),
 ): LogRow {
   const cost = costOf(round, priceOf, usage, nowMs);
-  const status = round.status === 'running' ? 'running' : round.status === 'interrupted' ? 'interrupted' : 'done';
+  const key = roundKeyOf(
+    session.state.sessionId, session.state.repoPath, session.state.branch, round.stage, round.number);
+  const found = byRound.get(key) ?? [];
+  const decided = decidedBy.get(key) ?? null;
+  const status = statusOf(round, found, decided);
   const states = round.reviewerStates ?? [];
   const rows = reviewerRows(round);
 
@@ -152,6 +169,7 @@ function rowFrom(
     number: round.number,
     subject: round.subject ?? '',
     status,
+    decided,
     verdict: round.verdict,
     gating: round.gatingCount,
     findings: states.length === 0 ? null : states.reduce((sum, s) => sum + s.findings, 0),
@@ -164,9 +182,36 @@ function rowFrom(
     vendors: [...new Set(states.map((s) => s.provider))],
     reviewers: reviewerLines(round),
     reviewerColours: rows.map((r) => vendorColour(r.provider)),
-    found: byRound.get(roundKeyOf(
-      session.state.sessionId, session.state.repoPath, session.state.branch, round.stage, round.number)) ?? [],
+    found,
   };
+}
+
+/**
+ * What the row's Status column says.
+ *
+ * <p>`done` used to be everything that was not running or dead, and that read as finished while the
+ * gate was still open: a screenshot of a round with thirteen `open` findings showed Status `done`,
+ * Verdict `good_enough`. Both were true. Together they said the opposite of what was happening.</p>
+ *
+ * <p>So a fourth state, from the fact the server already records: `accepted` stays −1 until a
+ * resolve lands. A round that raised NOTHING is exempt — there is no resolve to make, so its −1
+ * never moves and it would sit in "awaiting" for ever. A round the database has never heard of is
+ * exempt too: an older server wrote no database, and accusing it of an unclosed gate invents a fact
+ * about a round nobody can resolve any more.</p>
+ */
+function statusOf(
+  round: RoundRecord,
+  found: readonly DbFinding[],
+  decided: { accepted: number; rejected: number } | null,
+): LogRow['status'] {
+  if (round.status === 'running') {
+    return 'running';
+  }
+  if (round.status === 'interrupted') {
+    return 'interrupted';
+  }
+
+  return decided !== null && decided.accepted < 0 && found.length > 0 ? 'awaiting' : 'done';
 }
 
 /**
@@ -671,6 +716,8 @@ export function roundsLogHtml(
   .badge.running { background: var(--vscode-charts-blue); color: var(--vscode-editor-background); }
   .badge.interrupted { background: var(--vscode-charts-orange); color: var(--vscode-editor-background); }
   .badge.done { background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); }
+  .badge.awaiting { background: var(--vscode-charts-purple); color: var(--vscode-editor-background); }
+  .decided { margin-left: 6px; opacity: .85; white-space: nowrap; }
   .empty { opacity: .75; padding: 24px 0; }
   .failed { border: 1px solid var(--vscode-inputValidation-errorBorder, #c33); background: var(--vscode-inputValidation-errorBackground, transparent); padding: 8px 12px; margin: 0 0 12px; white-space: pre-wrap; }
   .tabs { display: flex; gap: 6px; margin: 4px 0 10px; border-bottom: 1px solid var(--vscode-panel-border); }
@@ -789,7 +836,17 @@ export function roundsLogHtml(
   }
 
   function badge(status) {
-    return '<span class="badge ' + esc(status) + '">' + esc(status) + '</span>';
+    var said = status === 'awaiting' ? 'awaiting decisions' : status;
+    return '<span class="badge ' + esc(status) + '">' + esc(said) + '</span>';
+  }
+  function decided(row) {
+    // Nothing for a round the database never saw, and nothing while the gate is still open - the
+    // badge already says that. A closed gate shows what it closed AT, which is the whole reason
+    // these two numbers are recorded.
+    if (!row.decided || row.decided.accepted < 0) { return ''; }
+    var a = row.decided.accepted, r = row.decided.rejected;
+    return '<span class="decided" title="' + a + ' accepted, ' + r + ' rejected">'
+      + a + ' ✓ ' + r + ' ✗</span>';
   }
   function detail(row) {
     if (row.reviewers.length === 0) {
@@ -843,7 +900,7 @@ export function roundsLogHtml(
         + '<td>' + esc(r.stage) + '</td>'
         + '<td class="num">' + r.number + '</td>'
         + '<td class="what" title="' + esc(r.subject) + '">' + esc(r.subject) + '</td>'
-        + '<td>' + badge(r.status) + '</td>'
+        + '<td>' + badge(r.status) + decided(r) + '</td>'
         + '<td>' + esc(r.verdict) + '</td>'
         + '<td class="num">' + r.gating + '</td>'
         + '<td class="num">' + num(r.findings) + '</td>'

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -71,6 +71,21 @@ const USED = {
   stage: 'CodeReview', seconds: 23, tokensIn: 1_000_000, tokensOut: 200_000, costUsd: null, outcome: 'ok',
 };
 
+/** The same round as the database has it: a gate that was closed, nine accepted and four rejected. */
+const LOG = {
+  rounds: [{
+    repoPath: 'D:/repo', branch: 'main', stage: 'CodeReview', number: 1,
+    startedUtc: '2026-09-05T11:41:00.000Z', sessionId: 's1', accepted: 9, rejected: 4,
+    findings: [{
+      ordinal: 1, severity: 'Major', category: 'Reliability', file: 'src/Panel.cs', line: 40,
+      title: 'a finding', why: '', fix: '', role: 'Architecture', isGating: true,
+      providers: 'codex', resolution: 'accept', reason: '', reRaised: false,
+    }],
+  }],
+  blindSpots: [],
+  defended: [],
+};
+
 const PRICES = (model: string) =>
   model === 'gpt-5.6-sol' ? { inPerMillion: 2, outPerMillion: 10 } : undefined;
 
@@ -97,14 +112,14 @@ function bundledPage(): { html: string; script: string } {
   new Function('module', 'exports', bundle)(shim, shim.exports);
   const module_ = shim.exports as unknown as {
     roundsLogHtml: (rows: unknown[], questions: unknown[], nonce: string, usage?: string) => string;
-    rowsFrom: (sessions: unknown[], now: number, priceOf?: unknown, usage?: unknown[]) => unknown[];
+    rowsFrom: (sessions: unknown[], now: number, priceOf?: unknown, usage?: unknown[], log?: unknown) => unknown[];
   };
   // WITH a row, and a priced one. This helper used to render an empty page, and an empty page never
   // calls the functions that format a row — which is exactly how 0.29.12 shipped "R is not defined":
   // `cost3` is embedded by its source text and CALLED `money`, a module-level binding the minifier
   // had renamed to `R`. The page defines `money`, so nothing looked missing until a row asked for
   // its cost.
-  const html = module_.roundsLogHtml(module_.rowsFrom([SESSION], NOW, PRICES, [USED]), [], 'n0nce');
+  const html = module_.roundsLogHtml(module_.rowsFrom([SESSION], NOW, PRICES, [USED], LOG), [], 'n0nce');
   fs.rmSync(dir, { recursive: true, force: true });
 
   return { html, script: html.slice(html.indexOf('<script'), html.lastIndexOf('</script>')) };
@@ -152,6 +167,12 @@ test('the page script the bundle produces parses and runs', () => {
     seen['rows']?.innerHTML ?? '',
     /<tr/,
     'the page rendered no rows, so nothing that formats a row was ever called');
+  // And that the row went through the cell that reads the database's own counts: a page which
+  // rendered the badge but not this would look right and still hide whether the gate was closed.
+  assert.match(
+    seen['rows']?.innerHTML ?? '',
+    /9 ✓ 4 ✗/,
+    'the status cell did not render what the gate closed at');
 });
 
 test('a function embedded by its source calls nothing the minifier can rename', () => {

--- a/src_vs_code/src/test/roundsLog.test.ts
+++ b/src_vs_code/src/test/roundsLog.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../roundsLog';
 import { Escalation } from '../escalations';
 import { RoundRecord, SessionFile } from '../rounds';
+import { DbFinding, DbLog, DbRound } from '../roundsDb';
 
 /**
  * The rounds log: every round of every session, as rows a table can sort, filter and search.
@@ -226,4 +227,74 @@ test('the table offers every column the log has, each sortable, and a filter per
     assert.ok(html.includes(`data-filter="${facet}"`), `filter ${facet}`);
   }
   assert.ok(html.includes('id="search"'));
+});
+
+// ---------- whether anybody has decided yet ----------
+
+function dbFinding(over: Partial<DbFinding> = {}): DbFinding {
+  return {
+    ordinal: 1, severity: 'Major', category: 'Reliability', file: 'src/Panel.cs', line: 40,
+    title: 'the session file is opened without FileShare', why: '…', fix: '…',
+    role: 'Architecture', isGating: true, providers: 'codex', resolution: '', reason: '',
+    reRaised: false,
+    ...over,
+  };
+}
+
+function dbLog(over: Partial<DbRound> = {}): DbLog {
+  return {
+    rounds: [{
+      repoPath: 'D:/rsd/dew_flow_connect_other_ais', branch: 'feat/shared-gate-rule',
+      stage: 'CodeReview', number: 1, startedUtc: '2026-09-05T07:41:00.000Z',
+      sessionId: 'ba0c73a1', accepted: -1, rejected: -1, findings: [dbFinding()],
+      ...over,
+    }],
+    blindSpots: [],
+    defended: [],
+  };
+}
+
+test('a finished round whose findings nobody has decided says so, instead of done', () => {
+  // Asked for over a screenshot: the row read Status `done`, Verdict `good_enough`, and thirteen
+  // findings under it were still `open`. Both fields were true and together they read as finished.
+  // `done` is about the reviewers having answered; whether the gate was CLOSED is a different fact,
+  // and the server already records it — accepted stays -1 until a resolve lands.
+  const [row] = rowsFrom([session([round()])], NOW, () => undefined, [], dbLog()) as [LogRow];
+
+  assert.equal(row.status, 'awaiting');
+  assert.deepEqual(row.decided, { accepted: -1, rejected: -1 });
+});
+
+test('once the decisions are recorded the row shows the split', () => {
+  const [row] = rowsFrom(
+    [session([round()])], NOW, () => undefined, [],
+    dbLog({ accepted: 9, rejected: 4, findings: [dbFinding({ resolution: 'accept' })] })) as [LogRow];
+
+  assert.equal(row.status, 'done');
+  assert.deepEqual(row.decided, { accepted: 9, rejected: 4 });
+});
+
+test('a round that produced no findings has nothing to decide and stays done', () => {
+  // Otherwise every clean round would sit in "awaiting decisions" for ever: there is no resolve to
+  // make, so the server's -1 never moves.
+  const [row] = rowsFrom(
+    [session([round()])], NOW, () => undefined, [], dbLog({ findings: [] })) as [LogRow];
+
+  assert.equal(row.status, 'done');
+});
+
+test('a running round is running, whatever the database has not yet been told', () => {
+  const [row] = rowsFrom(
+    [session([round({ status: 'running', completedUtc: '' })])], NOW, () => undefined, [], dbLog()) as [LogRow];
+
+  assert.equal(row.status, 'running');
+});
+
+test('a round the database has never heard of is done, not awaiting', () => {
+  // An older server wrote no database at all, and a row that accused it of an unclosed gate would
+  // be inventing a fact about a round nobody can resolve any more.
+  const [row] = rowsFrom([session([round()])], NOW) as [LogRow];
+
+  assert.equal(row.status, 'done');
+  assert.equal(row.decided, null);
 });


### PR DESCRIPTION
Reported over a screenshot: the row read Status **`done`**, Verdict **`good_enough`** — and the thirteen findings under it were all `open`.

Both fields were true. Together they read as finished, while the gate was still open and what happens *after* the reviewers answer is the whole point of the gate.

`done` is about the REVIEWERS having answered. Whether the gate was **closed** is a different fact, and the server already records it: `accepted` stays `-1` until a `resolve` lands. Nothing read it.

## What the row says now

- **`awaiting decisions`** — a finished round whose findings nobody has decided about yet.
- **`9 ✓ 4 ✗`** beside the badge once they are in, with the words in the tooltip.

Two exemptions, both because the alternative invents a fact:

- A round that raised **nothing** has no resolve to make, so its `-1` never moves and it would sit in "awaiting" for ever.
- A round the **database has never heard of** was written by an older server that kept no database, and accusing it of an unclosed gate is an accusation nobody can answer.

## Verified

**458 tests pass**, six of them new: five on the row (awaiting, the split, the no-findings round, a running round, an unknown round) and one in the **page** — the bundled, minified page must actually RENDER the split. That last one goes red when the cell is left out, which matters: a page that shows the badge and not the counts looks right and still hides whether the gate was closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
