### PR TITLE
fix(log): the exception chain reality produces, not the one the test invented

### DIFF
--- a/src_mcp/src/Program.cs
+++ b/src_mcp/src/Program.cs
@@ -164,9 +164,8 @@ internal static class Program
     /// find out what happened must not be the one that dies.
     /// </remarks>
     internal static bool Unreadable(Exception e) =>
-        e is Microsoft.Data.Sqlite.SqliteException or IOException or UnauthorizedAccessException
-            or DllNotFoundException
-        || (e is TypeInitializationException { InnerException: { } inner } && Unreadable(inner));
+        Chain(e).Any(one => one is Microsoft.Data.Sqlite.SqliteException or IOException
+            or UnauthorizedAccessException or DllNotFoundException);
 
     /// <summary>What to say about it — and, for the missing library, what to do about it.</summary>
     internal static string WhyUnreadable(Exception e) =>
@@ -176,12 +175,27 @@ internal static class Program
             : $"the rounds database could not be read: {e.Message}";
 
     /// <summary>The name the loader could not find, or nothing when this is a different fault.</summary>
-    private static string? Missing(Exception e) => e switch
+    private static string? Missing(Exception e) =>
+        Chain(e).Any(one => one is DllNotFoundException) ? "e_sqlite3" : null;
+
+    /// <summary>
+    /// An exception and every one it wraps.
+    /// </summary>
+    /// <remarks>
+    /// The WHOLE chain, because the interesting fault is never on top and the layers between are not
+    /// ours to predict. Measured on the published 0.18.2 binary with its library removed:
+    /// <c>TypeInitializationException</c> wraps <c>TargetInvocationException</c> wraps
+    /// <c>DllNotFoundException</c> - and the first version of this code knew only the first and the
+    /// last, so it recursed into a type it did not recognise, stopped, and let the crash through. The
+    /// test that was supposed to prove otherwise had built the chain by hand without the middle layer.
+    /// </remarks>
+    private static IEnumerable<Exception> Chain(Exception e)
     {
-        DllNotFoundException => "e_sqlite3",
-        TypeInitializationException { InnerException: { } inner } => Missing(inner),
-        _ => null,
-    };
+        for (var one = e; one is not null; one = one.InnerException)
+        {
+            yield return one;
+        }
+    }
 
     /// <summary>`--log --limit 50`, or the default. A number nobody can read is the default too.</summary>
     internal static int Limit(string[] args)

--- a/src_mcp/tests/RoundsQueryTests.cs
+++ b/src_mcp/tests/RoundsQueryTests.cs
@@ -227,8 +227,16 @@ public sealed class RoundsQueryTests : IDisposable
         // TypeInitializationException wrapping DllNotFoundException - from the type initializer, so
         // the handler's filter (SqliteException, IOException, UnauthorizedAccessException) never saw
         // it. The one command a person runs to find out what happened was the one that crashed.
+        // The REAL chain, taken from the published 0.18.2 binary with its library removed. The first
+        // version of this test built it by hand as TypeInitializationException wrapping
+        // DllNotFoundException, and the fix then agreed with the fixture rather than with reality:
+        // the runtime puts a TargetInvocationException between them, the recursion stopped at a type
+        // it did not know, and the shipped binary crashed exactly as before. A fixture the code
+        // accepts proves nothing about the fault it was written for.
         var missing = new TypeInitializationException(
-            "SQLitePCL.raw", new DllNotFoundException("Unable to load DLL 'e_sqlite3'"));
+            "SQLitePCL.raw",
+            new System.Reflection.TargetInvocationException(
+                new DllNotFoundException("Unable to load DLL 'e_sqlite3' or one of its dependencies")));
 
         Program.Unreadable(missing).Should().BeTrue("an empty log beats a stack trace");
         Program.WhyUnreadable(missing).Should().Contain("e_sqlite3")


### PR DESCRIPTION
**The fix that shipped in 0.18.2 did nothing.** Found by verifying the release the honest way — download the published archive, delete the library, run it — and it crashed exactly as 0.18.1 did.

The chain has a layer I did not know about:

```
TypeInitializationException → TargetInvocationException → DllNotFoundException
```

The first version knew the first type and the last one, and recursed only through `TypeInitializationException`. It met `TargetInvocationException`, did not recognise it, stopped, and let the crash through.

**And the test that was supposed to prove otherwise had built the chain by hand, without the middle layer.** So the code agreed with the fixture, and the fixture was wrong — the trap `testing.md` names as *"a fixture the code accepts proves nothing about the fault it was written for"*. The new test carries the chain taken from the published binary, with a comment saying where it came from.

The whole chain is walked now, through any wrapper, because the interesting fault is never on top and the layers between are not ours to predict.

## Verified on the fault path, not on a fixture

With the native library moved aside:

```
[coai-mcp] the SQLite library (e_sqlite3) is not beside the executable, so no round can be
read or recorded. Reinstall the server from the panel; a release archive carries it.
{ "rounds": [], "blindSpots": [], "defended": [] }
```

The published 0.18.2 prints a stack trace at the same point.

**791 tests pass.** Also confirmed on the published 0.18.2 archive: it *does* now carry `e_sqlite3.dll` beside the binary (1.9 MB, all six platforms), and with the library present it opens a database and answers — so the release did fix the silent-data-loss defect it was cut for. This PR fixes only the explanation for the case where the library is absent anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
