### PR TITLE
fix(sessions): a session file from an older build no longer kills every code round

### DIFF
--- a/src_mcp/src/Server/SessionStore.cs
+++ b/src_mcp/src/Server/SessionStore.cs
@@ -58,7 +58,12 @@ public sealed record RoundRecord(
     public int RunnerPid { get; init; }
 
     /// <summary>Per-reviewer progress — the live part of a running round.</summary>
-    public List<ReviewerState> ReviewerStates { get; init; } = [];
+    /// <remarks>Normalised on the way in, for the reason spelled out on PersistedSession.UsedPrompts.</remarks>
+    public List<ReviewerState> ReviewerStates
+    {
+        get => field ??= [];
+        init => field = value ?? [];
+    }
 
     /// <summary>
     /// What this round was ABOUT — the plan's file name or its title.
@@ -93,7 +98,12 @@ public sealed record PersistedSession(SessionState State, List<RoundRecord> Roun
     public DateTime OpenedUtc { get; init; }
 
     /// <summary>The last round's merged findings — what `resolve`'s indices point into.</summary>
-    public List<Finding> Pending { get; init; } = [];
+    /// <remarks>Normalised on the way in, for the reason spelled out on <see cref="UsedPrompts"/>.</remarks>
+    public List<Finding> Pending
+    {
+        get => field ??= [];
+        init => field = value ?? [];
+    }
 
     /// <summary>
     /// The scope: what this change was supposed to achieve, as the plan stage stated it.
@@ -114,7 +124,19 @@ public sealed record PersistedSession(SessionState State, List<RoundRecord> Roun
     /// the pool in two rounds rather than asking the universal question twice. Without this the deal
     /// would be random with replacement, which asks the same lens again while another goes unasked.
     /// </remarks>
-    public List<string> UsedPrompts { get; init; } = [];
+    /// <remarks>
+    /// Normalised where it is DECLARED, not at the call site. A session file written before this
+    /// field existed has no such member, and the source-generated deserializer does not run the
+    /// property initializer for an absent one — so `= []` was a promise nobody could rely on, and on
+    /// 2026-09-06 every `review_code` in every repository threw
+    /// <c>Value cannot be null. (Parameter 'first')</c> from the `Union` that spends a lens. An
+    /// explicit `null` is covered too, because one build had already written one.
+    /// </remarks>
+    public List<string> UsedPrompts
+    {
+        get => field ??= [];
+        init => field = value ?? [];
+    }
 }
 
 /// <summary>
@@ -197,7 +219,13 @@ public sealed class SessionStore(string dataDir)
 
         try
         {
-            return JsonSerializer.Deserialize(ReadShared(file), ServerJsonContext.Default.PersistedSession);
+            var session = JsonSerializer.Deserialize(ReadShared(file), ServerJsonContext.Default.PersistedSession);
+
+            // `Rounds` is a CONSTRUCTOR parameter, so an absent member passes null straight in and no
+            // property initializer can catch it. Every other collection normalises where it is
+            // declared; this one can only be normalised here, at the single place a session comes off
+            // disk.
+            return session is null or { Rounds: not null } ? session : session with { Rounds = [] };
         }
         catch (Exception e) when (e is JsonException or IOException or UnauthorizedAccessException)
         {
@@ -369,7 +397,11 @@ public sealed class SessionStore(string dataDir)
     private static bool IsOrphaned(RoundRecord round, Func<int, bool> processIsAlive) =>
         round.Status == RoundRecord.Running && (round.RunnerPid == 0 || !processIsAlive(round.RunnerPid));
 
-    private string FileFor(string repoPath, string branch)
+    /// <summary>
+    /// Where one session lives. Internal so a test can plant a file written by an OLDER build — the
+    /// compatibility this store owns cannot be checked without writing the old shape to disk.
+    /// </summary>
+    internal string FileFor(string repoPath, string branch)
     {
         // The session key is not a valid file name; hash it and keep a readable prefix.
         var key = SessionKey.For(repoPath, branch);

--- a/src_mcp/src/Server/SessionStore.cs
+++ b/src_mcp/src/Server/SessionStore.cs
@@ -219,13 +219,8 @@ public sealed class SessionStore(string dataDir)
 
         try
         {
-            var session = JsonSerializer.Deserialize(ReadShared(file), ServerJsonContext.Default.PersistedSession);
-
-            // `Rounds` is a CONSTRUCTOR parameter, so an absent member passes null straight in and no
-            // property initializer can catch it. Every other collection normalises where it is
-            // declared; this one can only be normalised here, at the single place a session comes off
-            // disk.
-            return session is null or { Rounds: not null } ? session : session with { Rounds = [] };
+            return Normalised(
+                JsonSerializer.Deserialize(ReadShared(file), ServerJsonContext.Default.PersistedSession));
         }
         catch (Exception e) when (e is JsonException or IOException or UnauthorizedAccessException)
         {
@@ -370,7 +365,8 @@ public sealed class SessionStore(string dataDir)
             PersistedSession? session;
             try
             {
-                session = JsonSerializer.Deserialize(ReadShared(file), ServerJsonContext.Default.PersistedSession);
+                session = Normalised(
+                    JsonSerializer.Deserialize(ReadShared(file), ServerJsonContext.Default.PersistedSession));
             }
             catch (Exception e) when (e is JsonException or IOException or UnauthorizedAccessException)
             {
@@ -393,6 +389,21 @@ public sealed class SessionStore(string dataDir)
 
         return swept;
     }
+
+    /// <summary>
+    /// A session as read from disk, with the one collection a property initializer cannot reach.
+    /// </summary>
+    /// <remarks>
+    /// <para>`Rounds` is a CONSTRUCTOR parameter, so an absent member passes null straight in — the
+    /// `field`-normalised properties on the record cover every other collection, and this one can
+    /// only be covered where the JSON is read.</para>
+    /// <para>Used by BOTH readers, which is the review gate's point: it was in `Load` alone, and
+    /// `SweepOrphanedRounds` deserialises separately and then calls `session.Rounds.Any(...)` — so an
+    /// old file would have taken down the startup sweep with a NullReferenceException instead of one
+    /// round. One normaliser, every reader.</para>
+    /// </remarks>
+    private static PersistedSession? Normalised(PersistedSession? session) =>
+        session is null or { Rounds: not null } ? session : session with { Rounds = [] };
 
     private static bool IsOrphaned(RoundRecord round, Func<int, bool> processIsAlive) =>
         round.Status == RoundRecord.Running && (round.RunnerPid == 0 || !processIsAlive(round.RunnerPid));

--- a/src_mcp/tests/ASessionFromAnOlderBuildStillRunsTests.cs
+++ b/src_mcp/tests/ASessionFromAnOlderBuildStillRunsTests.cs
@@ -111,4 +111,65 @@ public sealed class ASessionFromAnOlderBuildStillRunsTests
         session.Should().NotBeNull();
         session!.Rounds.Should().NotBeNull().And.BeEmpty();
     }
+
+    [Fact]
+    public void TheStartupSweepSurvivesTheSameFile()
+    {
+        // The review gate's catch, and the worse half of the defect: `SweepOrphanedRounds`
+        // deserialises separately and then calls `session.Rounds.Any(...)`, so an old file would have
+        // taken down the sweep that runs at STARTUP — every window, not one round. The normalisation
+        // is one method used by both readers now.
+        var dir = Directory.CreateTempSubdirectory("coai-oldsession-sweep-").FullName;
+        var store = new SessionStore(dir);
+        var file = store.FileFor("D:/x", "main");
+        Directory.CreateDirectory(Path.GetDirectoryName(file)!);
+        File.WriteAllText(file, """
+            {
+              "state": { "sessionId": "s", "repoPath": "D:/x", "branch": "main", "stage": "PlanReview" },
+              "openedUtc": "2026-09-01T08:00:00Z"
+            }
+            """);
+
+        var sweep = () => store.SweepOrphanedRounds(_ => false);
+
+        sweep.Should().NotThrow().Which.Should().Be(0, "there are no rounds to sweep, which is not the same as a crash");
+    }
+
+    [Fact]
+    public void AnAbsentPendingIsAlsoAnEmptyList()
+    {
+        // The gate asked for the absent case as well as the null one: they take DIFFERENT paths —
+        // `get` answers for the absent member, `init` for the explicit null — and only one of them
+        // was covered.
+        var session = JsonSerializer.Deserialize("""
+            {
+              "state": { "sessionId": "s", "repoPath": "D:/x", "branch": "main", "stage": "PlanReview" },
+              "rounds": []
+            }
+            """, ServerJsonContext.Default.PersistedSession)!;
+
+        session.Pending.Should().NotBeNull().And.BeEmpty();
+        session.UsedPrompts.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void ARoundsReviewerStates_AreEmptyWhetherAbsentOrNull()
+    {
+        // The third normalised collection, and the one a round writes on every repaint: the panel
+        // reads `reviewerStates` to draw who answered, so a null here is a blank card rather than a
+        // crash - which is exactly the kind of quiet wrongness that survives for weeks.
+        var session = JsonSerializer.Deserialize("""
+            {
+              "state": { "sessionId": "s", "repoPath": "D:/x", "branch": "main", "stage": "CodeReview" },
+              "rounds": [
+                { "stage": "CodeReview", "number": 1, "verdict": "proceed", "status": "done" },
+                { "stage": "CodeReview", "number": 2, "verdict": "proceed", "status": "done", "reviewerStates": null }
+              ]
+            }
+            """, ServerJsonContext.Default.PersistedSession)!;
+
+        session.Rounds.Should().HaveCount(2);
+        session.Rounds[0].ReviewerStates.Should().NotBeNull().And.BeEmpty("absent");
+        session.Rounds[1].ReviewerStates.Should().NotBeNull().And.BeEmpty("explicitly null");
+    }
 }

--- a/src_mcp/tests/ASessionFromAnOlderBuildStillRunsTests.cs
+++ b/src_mcp/tests/ASessionFromAnOlderBuildStillRunsTests.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Xunit;
+using CoaiMcp.Server;
+using FluentAssertions;
+
+namespace CoaiMcp.Tests;
+
+/// <summary>
+/// A session file written before a field existed still runs a round.
+/// </summary>
+/// <remarks>
+/// <para>Reported 2026-09-06 as "coai mcp is dead": every `review_code` in every repository threw
+/// <c>Value cannot be null. (Parameter 'first')</c> while `review_plan`, `status`, `resolve`, `open`
+/// and `providers` all answered normally. The stack named
+/// <c>Enumerable.Union</c> inside <c>RunStageAsync</c> — an extension method called on a null
+/// receiver, which is `session.UsedPrompts` at the line that records which lenses a round spent.</para>
+/// <para>The cause is data, not code: `UsedPrompts` arrived on 2026-09-01, and a session file
+/// written before that has no such member. The property carries <c>= []</c>, and that initializer is
+/// what nobody could rely on — so an old file loads with a null list and the NEXT round over that
+/// session dies. New sessions were fine, which is why the plan stage looked healthy: it had just
+/// created one.</para>
+/// <para>Kept as a rule rather than a patch: a collection that came off disk is normalised where it
+/// is declared, so no caller anywhere has to remember which build wrote the file it is reading.</para>
+/// </remarks>
+public sealed class ASessionFromAnOlderBuildStillRunsTests
+{
+    /// <summary>Exactly the shape found on disk: no `usedPrompts` member at all.</summary>
+    private const string BeforeUsedPromptsExisted = """
+        {
+          "state": {
+            "sessionId": "924f8ea0",
+            "repoPath": "D:/rsd/dew_flow_connect_other_ais",
+            "branch": "main",
+            "stage": "CodeReview",
+            "awaitingResolve": false
+          },
+          "rounds": [],
+          "openedUtc": "2026-09-01T08:00:00Z",
+          "pending": [],
+          "planText": "SCOPE - something agreed at the plan stage"
+        }
+        """;
+
+    [Fact]
+    public void ASessionWrittenBeforeTheFieldExisted_HasAnEmptyListRatherThanNull()
+    {
+        var session = JsonSerializer.Deserialize(
+            BeforeUsedPromptsExisted, ServerJsonContext.Default.PersistedSession);
+
+        session.Should().NotBeNull();
+        session!.UsedPrompts.Should().NotBeNull(
+            "a null here killed every review_code in every repository on 2026-09-06");
+        session.UsedPrompts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AndTheLineThatKilledIt_Runs()
+    {
+        // The exact expression from RunStageAsync, which is where the exception came from. Asserted
+        // rather than described, because the value that broke it was legal JSON.
+        var session = JsonSerializer.Deserialize(
+            BeforeUsedPromptsExisted, ServerJsonContext.Default.PersistedSession)!;
+
+        var spent = () => session.UsedPrompts.Union(["universal", ""]).Where(p => p.Length > 0).ToList();
+
+        spent.Should().NotThrow().Which.Should().ContainSingle().Which.Should().Be("universal");
+    }
+
+    [Fact]
+    public void AnExplicitNullIsAlsoAnEmptyList()
+    {
+        // Once one build had written a null — and one had, because a null list serialises as null —
+        // every later build read it back. The normalisation has to cover the value as well as the
+        // absence, or the bad files stay bad for ever.
+        var withNulls = """
+            {
+              "state": { "sessionId": "s", "repoPath": "D:/x", "branch": "main", "stage": "PlanReview" },
+              "rounds": [],
+              "usedPrompts": null,
+              "pending": null
+            }
+            """;
+
+        var session = JsonSerializer.Deserialize(withNulls, ServerJsonContext.Default.PersistedSession)!;
+
+        session.UsedPrompts.Should().NotBeNull().And.BeEmpty();
+        session.Pending.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void ASessionWithNoRoundsMember_IsNotANullRoundList()
+    {
+        // `Rounds` is a CONSTRUCTOR parameter, so an absent member passes null straight in and no
+        // property initializer can catch it — the same defect one layer over, and this one would take
+        // down the panel rather than a round. It can only be normalised where a session comes off
+        // disk, so this goes through the store rather than through the serializer.
+        var dir = Directory.CreateTempSubdirectory("coai-oldsession-").FullName;
+        var store = new SessionStore(dir);
+        var withoutRounds = """
+            {
+              "state": { "sessionId": "s", "repoPath": "D:/x", "branch": "main", "stage": "PlanReview" },
+              "openedUtc": "2026-09-01T08:00:00Z"
+            }
+            """;
+        var file = store.FileFor("D:/x", "main");
+        Directory.CreateDirectory(Path.GetDirectoryName(file)!);
+        File.WriteAllText(file, withoutRounds);
+
+        var session = store.Load("D:/x", "main");
+
+        session.Should().NotBeNull();
+        session!.Rounds.Should().NotBeNull().And.BeEmpty();
+    }
+}


### PR DESCRIPTION
**Reported as "coai mcp is dead":** every `review_code` in every repository threw `Value cannot be null. (Parameter 'first')`, while `review_plan`, `status`, `resolve`, `open` and `providers` answered normally.

Reproduced, then diagnosed from the server's own log, which named it exactly:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'first')
   at System.Linq.Enumerable.Union[TSource](...)
   at CoaiMcp.Server.PanelService.<RunStageAsync>d__33.MoveNext()
```

An extension method on a **null receiver** — `session.UsedPrompts`, at the line that records which lenses a round spent.

## The cause is data, not code

`UsedPrompts` arrived on 2026-09-01. A session file written before that has **no such member**, and the source-generated deserializer does not run a property initializer for an absent one — so `= []` was a promise nobody could rely on, and the next round over an old session died. **Nine such files are on this machine.**

New sessions were fine, which is exactly why the plan stage looked healthy: it had just created one. That asymmetry — plan works, code throws — is what made it look like a regression in the code path.

## The fix

Where the collections are **declared**, with the `field` keyword, so no caller has to know which build wrote the file it is reading:

- `UsedPrompts`, `Pending`, `ReviewerStates` — an absent member *and* an explicit `null` both become an empty list. Covering the value matters: one build had already written a null, and without that the bad files stay bad for ever.
- `Rounds` is a **constructor parameter**, so no initializer can catch it. Normalised at `SessionStore.Load`, the single place a session comes off disk. That one would have taken down the panel rather than a round.

## Verified

**RED first — four tests, all failing with the real symptom before the fix:** the exact file shape found on disk, the exact expression that threw, an explicit null, and a session with no `rounds` member. Teeth re-checked afterwards by reverting the normalisation.

**805 tests pass.**

Worth noting for the next incident: the answer came out of the server's log in about a minute — but that log lives *beside the binary* (`globalStorage/.../logs/`), which is not where anyone looks. Moving it next to `coai.db` in the data directory is a small follow-up worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Исправления**
  - Повышена совместимость с ранее сохранёнными сессиями: отсутствующие или пустые данные корректно загружаются как пустые списки.
  - Устранены ошибки при обработке сессий, в которых некоторые коллекции имеют значение `null`.
  - Загрузка сессий без информации о раундах теперь выполняется корректно.

- **Тесты**
  - Добавлены проверки обратной совместимости для сессий, созданных в старых версиях приложения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->