### PR TITLE
fix(reviewers): an empty answer carries the CLI's own sentence

### DIFF
--- a/src_mcp/runners/Reviewers/ReviewerExecutor.cs
+++ b/src_mcp/runners/Reviewers/ReviewerExecutor.cs
@@ -213,7 +213,7 @@ public sealed class ReviewerExecutor(IProcessLauncher launcher, string? keepUnpa
         if (repair is null)
         {
             return new ReviewerOutcome.Unparseable(
-                Because(Said(answer), "and no repair was configured", Keep(invocation, evidence)), usage);
+                Because(Said(answer, evidence), "and no repair was configured", Keep(invocation, evidence)), usage);
         }
 
         var (repairOutcome, repaired, repairUsage, repairAnswer, repairEvidence) = await RunOnceAsync(repair, ct);
@@ -226,7 +226,10 @@ public sealed class ReviewerExecutor(IProcessLauncher launcher, string? keepUnpa
                    // empty: a vendor whose envelope broke leaves nothing to read, and the
                    // evidence file was landing at zero bytes exactly when it was most needed.
                    : new ReviewerOutcome.Unparseable(
-                       Because(Said(repairAnswer ?? answer), "after one repair attempt", Keep(repair, Longer(evidence, repairEvidence))),
+                       Because(
+                           Said(repairAnswer ?? answer, Longer(evidence, repairEvidence)),
+                           "after one repair attempt",
+                           Keep(repair, Longer(evidence, repairEvidence))),
                        usage.Add(repairUsage)));
     }
 
@@ -251,10 +254,45 @@ public sealed class ReviewerExecutor(IProcessLauncher launcher, string? keepUnpa
     /// vendor had returned NOTHING — an empty envelope — and the sentence sent the reader looking
     /// for malformed JSON that did not exist.
     /// </remarks>
-    private static string Said(string? raw) =>
+    private static string Said(string? raw, string? evidence) =>
         string.IsNullOrWhiteSpace(raw)
-            ? "the vendor returned an empty answer"
+            ? Explained("the vendor returned an empty answer", Complaint(evidence))
             : "the answer was not the schema's JSON";
+
+    /// <summary>
+    /// The CLI's own sentence, when it produced nothing and said why.
+    /// </summary>
+    /// <remarks>
+    /// Measured on a real round, 2026-09-06: three antigravity reviewers reported "the vendor
+    /// returned an empty answer" and the panel showed nothing more, while the CLI's stderr said
+    /// exactly what happened — a tool wanted the "command" permission, headless mode cannot prompt
+    /// for one, so it auto-denied itself and printed nothing. That sentence was only in the kept
+    /// evidence file, which nobody knows to open; finding it took a quarter of an hour, and reading
+    /// the note should have taken seconds. The transcript is already here — this reads the stderr
+    /// half of it.
+    /// </remarks>
+    private static string Complaint(string? evidence)
+    {
+        const string marker = "--- stderr ---";
+        var at = evidence?.LastIndexOf(marker, StringComparison.Ordinal) ?? -1;
+        if (at < 0)
+        {
+            return string.Empty;
+        }
+
+        var said = evidence![(at + marker.Length)..]
+            .Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault(line => line.Length > 0) ?? string.Empty;
+
+        // One line, capped: a note is read in a table cell, and a vendor's stack trace is not the
+        // sentence a person needs.
+        return said.Length <= ComplaintCap ? said : said[..ComplaintCap] + "…";
+    }
+
+    private static string Explained(string what, string why) =>
+        why.Length == 0 ? what : $"{what} — it said: {why}";
+
+    private const int ComplaintCap = 240;
 
     /// <summary>The launch that actually said something — the repair is often the empty one.</summary>
     private static string? Longer(string? first, string? second) =>

--- a/src_mcp/tests/ReviewerExecutorTests.cs
+++ b/src_mcp/tests/ReviewerExecutorTests.cs
@@ -139,6 +139,31 @@ public sealed class ReviewerExecutorTests
     }
 
     [Fact]
+    public async Task AnEmptyAnswerCarriesTheCliOwnSentence_NotJustTheWordEmpty()
+    {
+        // Measured on a real round, 2026-09-06: three antigravity reviewers in one round reported
+        // "the vendor returned an empty answer" and the panel showed nothing else. The CLI had said
+        // exactly why on stderr - a tool wanted the "command" permission, headless mode cannot
+        // prompt for one, so it auto-denied and produced nothing - and that sentence was only in the
+        // kept evidence file, which nobody knows to open. Finding it took a quarter of an hour; it
+        // should have taken reading the note.
+        var launcher = new CountingLauncher(new ProcessResult(
+            ExitCode: 0,
+            StdOut: string.Empty,
+            StdErr: "jetski: no output produced - a tool required the \"command\" permission that "
+                + "headless mode cannot prompt for, so it was auto-denied.",
+            TimedOut: false));
+        var executor = new ReviewerExecutor(launcher);
+
+        var outcome = await executor.RunAsync(
+            FakeCliInvocations.Invoke("gemini", ["emit", ""]), ct: TestContext.Current.CancellationToken);
+
+        outcome.Should().BeOfType<ReviewerOutcome.Unparseable>()
+            .Which.Reason.Should().Contain("empty answer")
+            .And.Contain("auto-denied", "the CLI explained itself and the note must carry that");
+    }
+
+    [Fact]
     public async Task ExitZeroButNoOutputFile_IsUnparseable_NotOk()
     {
         var outcome = await _executor.RunAsync(


### PR DESCRIPTION
Three antigravity reviewers failed in one round today with **"the vendor returned an empty answer"**, and the panel said nothing more.

The CLI had explained itself precisely, on stderr:

```
jetski: no output produced — a tool required the "command" permission that headless mode
cannot prompt for, so it was auto-denied.
```

That sentence was only in the kept evidence file, which nobody knows to open. Finding it took a quarter of an hour of reading a saved transcript — and the transcript was already in hand at the moment the note was written.

## What changes

An empty answer now says what the vendor said: the first line of its stderr, capped at 240 characters, because a note is read in a table cell and a stack trace is not the sentence a person needs. Everything else about the failure is unchanged — the evidence file is still kept, the round still completes with the reviewer marked failed.

Before: `unparseable: the vendor returned an empty answer after one repair attempt`
After: `unparseable: the vendor returned an empty answer — it said: jetski: no output produced — a tool required the "command" permission… after one repair attempt`

## Verified

**RED first.** The test builds exactly today's failure — exit 0, no stdout, that stderr — and failed with `Expected … to contain "auto-denied"`. **809 tests pass.**

## The vendor behaviour itself is a separate question

At `gemini-3.8-flash-low` the model reaches for a shell command instead of answering, and headless mode has nobody to ask for permission. A higher-effort model does not do this — that is the workaround until the launch flags are measured rather than guessed. The CLI offers `--dangerously-skip-permissions` and `--sandbox`; which of them a reviewer should get is a question with a measurable answer, and it is not this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
