### PR TITLE
fix(install): the copied block is a path, so the panel stops being overruled

### DIFF
--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -10,8 +10,8 @@ import { showHelp } from './helpPanel';
 import { parseSession, SessionFile } from './rounds';
 import { blindSpotsHtml, rowsFrom } from './roundsLog';
 import { RoundsLogPanel } from './roundsLogPanel';
-import { envBlock, settingsFrom } from './settingsShape';
 import { ServerSettingsSync } from './serverSettingsSync';
+import { settingsFrom } from './settingsShape';
 import { vendorsFrom } from './vendors';
 
 /**
@@ -165,10 +165,6 @@ async function answerQuestion(watcher: EscalationWatcher): Promise<void> {
   }
 }
 
-function settings(): ReturnType<typeof settingsFrom> {
-  const config = vscode.workspace.getConfiguration('coai');
-  return settingsFrom((section) => config.get(section));
-}
 
 /** One install at a time: the panel button and the ⋯ menu are two doors to the same work. */
 const installing = new SingleFlight<void>();
@@ -183,7 +179,7 @@ async function install(context: vscode.ExtensionContext): Promise<void> {
       { location: vscode.ProgressLocation.Notification, title: 'Installing coai-mcp…' },
       () => installLatest(context.globalStorageUri, context.globalState),
     );
-    await vscode.env.clipboard.writeText(mcpServerBlock(target.fsPath, envBlock(settings())));
+    await vscode.env.clipboard.writeText(mcpServerBlock(target.fsPath));
     const targets = clientTargetsLine(CLIENT_TARGETS);
     void vscode.window.showInformationMessage(`${installedMessage(target.fsPath)} Paste it into: ${targets}`);
   } catch (error) {
@@ -206,7 +202,7 @@ async function copyConfigBlock(context: vscode.ExtensionContext): Promise<void> 
   // that did not exist and called it installed. `stat` answers it; asking for the full status would
   // launch a `--version` process to learn something the stat already knew.
   const installed = await serverExists(context.globalStorageUri);
-  await vscode.env.clipboard.writeText(mcpServerBlock(path.fsPath, envBlock(settings())));
+  await vscode.env.clipboard.writeText(mcpServerBlock(path.fsPath));
   void vscode.window.showInformationMessage(
     installed
       ? 'The MCP config block is on your clipboard — paste it into your client and restart it.'

--- a/src_vs_code/src/mcpBlock.ts
+++ b/src_vs_code/src/mcpBlock.ts
@@ -40,7 +40,24 @@ export function clientTargetsLine(targets: readonly { label: string; path: strin
  * `mcp__coai__…`, which is why it is short. `env` is omitted when empty: a field that does
  * nothing invites the question of what it is for.
  */
-export function mcpServerBlock(binaryPath: string, env: Readonly<Record<string, string>>): string {
+/**
+ * The block a person pastes into their MCP client: a path to a binary, and nothing else.
+ *
+ * <p>It used to carry every setting that differed from the defaults — sixteen keys at full stretch —
+ * and that was right when the env block was the ONLY channel to the server. Then the settings moved
+ * into a file in the data directory that the server re-reads live, and nobody trimmed the block.</p>
+ *
+ * <p><b>What that cost.</b> A variable in the client's config beats the file, key by key and on
+ * purpose (`SettingsFile.Layer`: a variable is more specific than a file any window may rewrite,
+ * and it is what a scripted run has). So every key a person had pasted was FROZEN at its pasted
+ * value: change it in the panel, the panel saves it, the panel shows the new number — and the server
+ * keeps using the old one, silently. Reported on 2026-09-06 as "we fixed the settings applying
+ * immediately several times", which was true, and true only for the keys nobody had pasted.</p>
+ *
+ * <p>An `env` argument is still accepted, because a containerised or scripted run has no panel and
+ * no data directory to share — that caller passes what it needs. The panel passes nothing.</p>
+ */
+export function mcpServerBlock(binaryPath: string, env: Readonly<Record<string, string>> = {}): string {
   const server =
     Object.keys(env).length === 0 ? { command: binaryPath } : { command: binaryPath, env };
   return JSON.stringify({ mcpServers: { coai: server } }, null, 2);

--- a/src_vs_code/src/test/install.test.ts
+++ b/src_vs_code/src/test/install.test.ts
@@ -467,3 +467,45 @@ test('the install record and the settings overlay never share a key', () => {
   assert.notEqual(overlayKey(side), installedKey(side));
   assert.ok(overlayKey(side).endsWith(sideKey(side)) && installedKey(side).endsWith(sideKey(side)));
 });
+
+test('the block the panel copies is a path and nothing else, whatever the settings say', () => {
+  // Reported on 2026-09-06 as "we fixed the settings applying immediately several times" — and that
+  // was true, and true only for the keys nobody had pasted. The block used to carry every setting
+  // that differed from the defaults, sixteen keys at full stretch, and a variable in the client's
+  // config beats the settings file KEY BY KEY and on purpose. So each pasted key was frozen at its
+  // pasted value: change it in the panel, the panel saves it and shows the new number, and the
+  // server keeps using the old one without a word.
+  //
+  // The env block predates the settings file. Nobody trimmed it when the file landed.
+  const parsed = JSON.parse(mcpServerBlock('/home/ada/.local/coai-mcp')) as {
+    mcpServers: { coai: Record<string, unknown> };
+  };
+
+  assert.deepEqual(Object.keys(parsed.mcpServers.coai), ['command'],
+    'anything else in here freezes that setting for this client, silently');
+});
+
+test('a scripted run can still be handed environment variables', () => {
+  // The channel is not removed, only unused by the panel: a containerised or CI run has no panel
+  // and no shared data directory, and env is the only way to configure it.
+  const parsed = JSON.parse(mcpServerBlock('/bin/coai-mcp', { COAI_ON_EXHAUSTED: 'good_enough' })) as {
+    mcpServers: { coai: { env?: Record<string, string> } };
+  };
+
+  assert.equal(parsed.mcpServers.coai.env?.['COAI_ON_EXHAUSTED'], 'good_enough');
+});
+
+test('and the extension passes it nothing — the call site, not just the default', () => {
+  // The first version of this guard asserted the FUNCTION's default and let the call site do as it
+  // pleased: putting the env back in extension.ts left every test green. The call site lives behind
+  // `vscode`, which this suite cannot import, so the source is what it reads — and it asserts it
+  // FOUND the calls, because a structural test that matches nothing passes for ever.
+  const source = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'extension.ts'), 'utf8');
+  const calls = [...source.matchAll(/mcpServerBlock\(([^)]*)\)/g)].map((m) => m[1]!.trim());
+
+  assert.ok(calls.length >= 2, `expected the two clipboard writes, found ${calls.length}`);
+  for (const args of calls) {
+    assert.doesNotMatch(args, /,/,
+      `mcpServerBlock(${args}) passes an env: every key in it freezes that setting for the client`);
+  }
+});


### PR DESCRIPTION
> "We fixed the settings applying immediately several times."

True — and true only for the keys nobody had pasted.

## What was actually happening

The block the panel copies carried **every setting that differed from the defaults** — sixteen keys at full stretch. And a variable in the client's config beats the settings file **key by key**, deliberately:

```csharp
// SettingsFile.Layer
return name => environment(name) is { Length: > 0 } fromEnv ? fromEnv : fromFile.GetValueOrDefault(name);
```

That precedence is right: a variable is more specific than a file any window may rewrite, and it is what a scripted or containerised run has.

The consequence was not right. Every key somebody had pasted was **frozen at its pasted value**: change it in the panel, the panel saves it and shows the new number, and the server keeps using the old one — silently, with nothing anywhere saying so. One person's block pinned thirteen keys, including all the rounds, all the thresholds, the prompts and the exhaustion policy.

**The env block predates the settings file.** Nobody trimmed it when the file landed, so the fix that made settings live could not reach the settings anybody had already pasted.

## What ships

The copied block is now a path and nothing else:

```json
{ "mcpServers": { "coai": { "command": "…/coai-mcp.exe" } } }
```

The env channel stays open for callers that have no panel and no shared data directory — a containerised or scripted run passes what it needs.

**Anyone with an old block should re-copy it** (⋯ → *Copy the config block*) and replace what they pasted; until then their thirteen keys stay pinned.

## Verified

Three tests — and the third exists because the first two were not enough. They assert the **function's** default, and putting the env back at the call site left every one of them green. The call site lives behind `vscode`, which this suite cannot import, so the guard reads `extension.ts` as source and asserts it **found** the calls, because a structural test that matches nothing passes for ever.

Checked by putting an env back at the call site: it goes red naming the key. **482 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
