### PR TITLE
fix(logging): the log lives where a person is told to look

### DIFF
--- a/src_mcp/service_defaults/CoaiLogPath.cs
+++ b/src_mcp/service_defaults/CoaiLogPath.cs
@@ -14,6 +14,19 @@ namespace CoaiMcp.ServiceDefaults;
 /// </remarks>
 public static class CoaiLogPath
 {
+    /// <summary>
+    /// Where a host's logs live: <c>logs/</c> under the directory it already keeps its data in.
+    /// </summary>
+    /// <remarks>
+    /// It used to be <c>logs/</c> beside the BINARY, and for an installed VS Code extension that is
+    /// <c>…/globalStorage/&lt;publisher&gt;.&lt;extension&gt;/logs</c> — a path nobody would think to
+    /// open. On 2026-09-06 a reported "the MCP server is dead" took a quarter of an hour to answer,
+    /// and the answer was one line in a log file found by guessing where a Native-AOT binary puts its
+    /// working directory. The data directory is the one place a person is TOLD about: the sessions,
+    /// the settings file and <c>coai.db</c> are already there.
+    /// </remarks>
+    public static string RootFor(string dataDir) => Path.Combine(dataDir, "logs");
+
     public static string For(string logsRoot, string appName, DateTime utcNow, int pid) =>
         Path.Combine(
             logsRoot,

--- a/src_mcp/src/Program.cs
+++ b/src_mcp/src/Program.cs
@@ -385,7 +385,13 @@ internal static class Program
     private static async Task<int> ServeAsync()
     {
         // stdio host → the console sink goes to stderr (logging-serilog.md, stdio hosts).
-        using var log = ServiceDefaults.CoaiLogging.CreateDewFlowLogger(AppName, consoleToStdErr: true);
+        using var log = ServiceDefaults.CoaiLogging.CreateDewFlowLogger(
+            AppName,
+            consoleToStdErr: true,
+            // Beside the sessions and the database, not beside the binary: the data directory is the
+            // one place a person is told about, and the binary's is inside the extension's storage.
+            logsRoot: ServiceDefaults.CoaiLogPath.RootFor(
+                SettingsFile.DataDirFrom(Environment.GetEnvironmentVariable)));
         try
         {
             // The file the extension writes is the base; the client config env overrides it — a

--- a/src_mcp/tests/LogPathTests.cs
+++ b/src_mcp/tests/LogPathTests.cs
@@ -22,4 +22,19 @@ public sealed class LogPathTests
 
         CoaiLogPath.For("logs", "a", now, 1).Should().NotBe(CoaiLogPath.For("logs", "a", now, 2));
     }
+
+    [Fact]
+    public void TheLogLivesUnderTheDataDirectory_NotBesideTheBinary()
+    {
+        // Reported on 2026-09-06 as "the MCP server is dead". Answering it took a quarter of an hour,
+        // and the answer was one line in a log file whose location had to be GUESSED: `logs/` beside
+        // the binary, which for an installed extension is
+        // …/globalStorage/<publisher>.<extension>/logs. The data directory is the one place a person
+        // is told about - the sessions, settings.json and coai.db are already there.
+        var root = CoaiLogPath.RootFor(Path.Combine("C:", "Users", "ada", "AppData", "Local", "coai-mcp"));
+
+        root.Should().Be(Path.Combine("C:", "Users", "ada", "AppData", "Local", "coai-mcp", "logs"));
+        CoaiLogPath.For(root, "coai-mcp", new DateTime(2026, 9, 6, 11, 48, 18, DateTimeKind.Utc), 18756)
+            .Should().EndWith(Path.Combine("coai-mcp", "logs", "2026-09-06", "coai-mcp-11-48-18-18756.log"));
+    }
 }


### PR DESCRIPTION
Reported today as **"the MCP server is dead"**. Answering it took a quarter of an hour, and the answer was one line in a log file whose location had to be *guessed*.

The logs went to `logs/` beside the **binary** — which for an installed extension is `…/globalStorage/<publisher>.<extension>/logs`, a path nobody would think to open. I looked in the data directory first, like anybody would, and found logs three days stale.

## What changes

The log joins the things a person is actually told about: the sessions, `settings.json` and `coai.db` are already in the data directory. `COAI_DATA_DIR` now moves all four together.

The path shape is untouched — `logs/{yyyy-MM-dd}/{app}-{HH-mm-ss}-{pid}.log`, per the family rule, which governs the shape and not the root. `logsRoot` stays injectable, so a host with no data directory keeps the old behaviour by passing one.

## Verified

On the real binary, not only in a test: run with a fresh `COAI_DATA_DIR`, and the day's folder appears under it. **810 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
