### PR TITLE
fix(prompts): the repair launch is told the truth too, and an overridden prompt cannot carry the old claim

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,7 +141,13 @@ The prompt is told which of the two it got, and this is not decoration. Eighteen
 prompt files used to open by claiming a read-only checkout was present — in Fast, the default, it was
 not, and an agentic CLI that goes looking for one runs headless with nobody to grant it permission:
 it refuses itself and returns nothing at all. Measured 2026-09-06 over 71 antigravity reviewer runs,
-15 of them — 21 % — died exactly there. The sentence now comes from `PanelService`, which is the only
+15 of them — 21 % — died exactly there. The one repair launch a reviewer is allowed is composed the
+same way but always as no-checkout, because it always runs in an empty temp directory whatever the
+review was given — promising it a tree was the same defect one layer down. And a prompt somebody
+overrode in the catalog before this changed has the old sentence stripped as it is composed: their own
+copy cannot know the mode either, and two opposite sentences in one prompt is worse than either.
+
+The sentence comes from `PanelService`, which is the only
 code that knows the mode — and the plan stage counts as no-checkout too, because its working
 directory is an empty scratch. Both no-checkout cases say outright that there is no tool to call.
 

--- a/src_mcp/src/Server/PanelService.cs
+++ b/src_mcp/src/Server/PanelService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Text.RegularExpressions;
 using System.Text.Json;
 using CoaiMcp.Core.Context;
 using CoaiMcp.Core.Findings;
@@ -16,7 +17,7 @@ namespace CoaiMcp.Server;
 /// this class carries data between the wire, the runners and the state machine — and answers
 /// every failure as a sentence in JSON, never as an exception up the stdio stack.
 /// </summary>
-public sealed class PanelService
+public sealed partial class PanelService
 {
     private readonly PanelSettings _settings;
     private readonly VaultKeys _keys;
@@ -870,10 +871,18 @@ public sealed class PanelService
                 MaxTokens = _settings.LocalMaxTokens,
             };
             var prompt = ComposePrompt(choice, context, hasCheckout);
-            // The repair is built before anybody knows which way the first attempt failed, so it
-            // covers both. The second sentence exists because a refused tool produces NO answer at
-            // all, and telling that model its JSON was malformed describes a failure it did not have.
-            var repairPrompt = prompt +
+            // The repair is composed with hasCheckout: FALSE always, because the repair launch always
+            // runs in repairDir — an empty temp directory, whatever the review was given (see above).
+            // Composing it with the REVIEW's mode is what shipped on 2026-09-06: in worktree mode the
+            // repair opened by promising a read-only checkout and closed by saying there were no
+            // tools, in one prompt, to the reviewer that had already failed once. Found by codex at
+            // that change's own code round — which diagnosed it the other way round, as a repair that
+            // should promise the tree. The code says otherwise: the repair never has one.
+            //
+            // The paragraph itself is built before anybody knows which way the first attempt failed,
+            // so it covers both. Its second sentence exists because a refused tool produces NO answer
+            // at all, and telling that model its JSON was malformed describes a failure it never had.
+            var repairPrompt = ComposePrompt(choice, context, hasCheckout: false) +
                 "\n\nYOUR PREVIOUS ATTEMPT DID NOT PRODUCE A USABLE ANSWER."
                 + " If it returned text that was not the schema's JSON: return ONLY the JSON object — no fences, no prose."
                 + " If it returned nothing because a command or a file read was refused: there are no tools here"
@@ -908,7 +917,7 @@ public sealed class PanelService
         CallerIdentity.Current() is { Length: > 0 } id ? id : $"repo:{session.State.RepoPath}";
 
     private string ComposePrompt(PromptChoice choice, string context, bool hasCheckout) =>
-        $"{_prompts.ForChoice(choice)}\n\n{WhatYouHave(hasCheckout)}\n\n## The finding contract\n\nReturn ONLY a JSON object matching this schema — no fences, no prose:\n\n{FindingSchema.Json}\n\n{context}";
+        $"{WithoutTheStaleClaim(_prompts.ForChoice(choice))}\n\n{WhatYouHave(hasCheckout)}\n\n## The finding contract\n\nReturn ONLY a JSON object matching this schema — no fences, no prose:\n\n{FindingSchema.Json}\n\n{context}";
 
     /// <summary>
     /// What the reviewer actually has — said once, by the only code that knows which it is.
@@ -925,6 +934,27 @@ public sealed class PanelService
     /// of the two truths — and a prompt somebody has overridden in the catalog needs the sentence
     /// just as much as a shipped one, which is the second reason it is here.</para>
     /// </remarks>
+    /// <summary>
+    /// The old claim, removed from a prompt that still carries it.
+    /// </summary>
+    /// <remarks>
+    /// <para>The prompt catalog is EDITABLE: a prompt somebody overrode before 2026-09-06 sits in
+    /// their own data directory still opening with "You have the checkout read-only and the diff
+    /// below", and no edit to the shipped files can reach it. Composing the true sentence underneath
+    /// it hands the model two opposite instructions in one prompt — which is worse than either
+    /// sentence alone, and is the shape that made a headless CLI go looking for a tool in the first
+    /// place. Raised by gemini at the plan gate of the change that removed the claim, and again by
+    /// the local reviewer at its code gate.</para>
+    /// <para>Only that one sentence is removed. A person's own prompt is theirs; this strips the
+    /// line the product used to put in it and nothing else.</para>
+    /// </remarks>
+    internal static string WithoutTheStaleClaim(string prompt) => StaleClaim().Replace(prompt, string.Empty);
+
+    [GeneratedRegex(
+        @"\s*You\s+have\s+the\s+(?:repository\s+)?checkout\s+read-only\s+and\s+the\s+diff\s+below\.",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex StaleClaim();
+
     internal static string WhatYouHave(bool hasCheckout) =>
         hasCheckout
             ? "## What you have\n\nA READ-ONLY checkout of the repository in your working "

--- a/src_mcp/tests/CodeWorkspaceTests.cs
+++ b/src_mcp/tests/CodeWorkspaceTests.cs
@@ -62,11 +62,11 @@ public class CodeWorkspaceTests
             .Unrecognised.Should().BeEmpty();
     }
 
-    private static PanelService Service(string workspace)
+    private static PanelService Service(string workspace, string dataDir = "")
     {
         var settings = new PanelSettings
         {
-            DataDir = Path.Combine(Path.GetTempPath(), $"coai-ws-{Guid.NewGuid():N}"),
+            DataDir = dataDir.Length > 0 ? dataDir : Path.Combine(Path.GetTempPath(), $"coai-ws-{Guid.NewGuid():N}"),
             CodeWorkspace = workspace,
             Providers = [new ProviderSettings("local") { Enabled = true, Runtime = "local", Model = "m" }],
         };
@@ -109,6 +109,68 @@ public class CodeWorkspaceTests
         var work = Service("worktree").BuildWork([ReviewRole.Architecture], worktree, "ctx", round: 1, isPlanStage: false);
 
         work[0].Invocation.Request.WorkingDirectory.Should().Be(worktree);
+    }
+
+    [Fact]
+    public void TheRepairLaunch_IsToldItHasNoCheckout_EvenWhenTheReviewWasGivenOne()
+    {
+        // The repair launch has ALWAYS run in an empty directory, and the remark beside it says why:
+        // it is not asking for a better review, it is asking for the answer in the schema, and an
+        // agentic CLI handed a checkout goes exploring instead. Its PROMPT, though, was composed for
+        // the review's mode — so in worktree mode it opened by telling the model it had a read-only
+        // checkout and then told it there were no tools. One prompt, two contradictory sentences,
+        // sent to the reviewer that had already failed once. Found by codex at this change's own
+        // code round; its diagnosis was that the repair should promise the checkout, and reading the
+        // code says the opposite: the repair never has one.
+        var worktree = Worktree();
+
+        var work = Service("worktree").BuildWork([ReviewRole.Architecture], worktree, "ctx", round: 1, isPlanStage: false);
+
+        Sent(work[0].Repair!).Should().Contain("no tool you can call",
+            "the repair launch runs in an empty temp directory whatever the review got");
+        Sent(work[0].Repair!).Should().NotContain("READ-ONLY checkout");
+        Sent(work[0].Invocation).Should().Contain("READ-ONLY checkout",
+            "the REVIEW launch really was given the tree, and must still be told so");
+    }
+
+    [Fact]
+    public void APromptSomebodyOverrodeBeforeTheClaimWasRemoved_DoesNotArriveWithBothSentences()
+    {
+        // The catalog is editable, and an override written before 2026-09-06 still opens with "You
+        // have the checkout read-only and the diff below." Composing the true sentence underneath it
+        // hands the model two opposite instructions in one prompt — raised by gemini at the plan gate
+        // and again at the code gate. Editing the shipped files cannot reach a person's own copy.
+        var dataDir = Path.Combine(Path.GetTempPath(), $"coai-override-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(dataDir, "prompts"));
+        File.WriteAllText(
+            Path.Combine(dataDir, "prompts", "architecture.md"),
+            "You are an independent ARCHITECTURE reviewer of a change written by another AI. You have the\n"
+            + "repository checkout read-only and the diff below. Review the change, not the whole codebase.\n");
+
+        var work = Service("none", dataDir)
+            .BuildWork([ReviewRole.Architecture], Worktree(), "ctx", round: 1, isPlanStage: false);
+
+        Sent(work[0].Invocation).Should().NotContain("checkout read-only",
+            "a person's own copy of a prompt cannot know which mode is running either");
+        Sent(work[0].Invocation).Should().Contain("no tool you can call");
+        Sent(work[0].Invocation).Should().Contain("independent ARCHITECTURE reviewer",
+            "only the false sentence is removed, never the person's prompt");
+    }
+
+    /// <summary>
+    /// Everything the child is actually given, by whichever door this runtime uses: a vendor CLI
+    /// takes the prompt on stdin (cmd.exe truncates an argument at its first newline), and the local
+    /// engine takes a --prompt-file. Reading only stdin made both tests here fail against correct
+    /// code, which is the cheapest possible reminder to assert on what is SENT, not on where.
+    /// </summary>
+    private static string Sent(ReviewerInvocation invocation)
+    {
+        var args = invocation.Request.Arguments;
+        var at = args.ToList().IndexOf("--prompt-file");
+        var file = at >= 0 && at + 1 < args.Count && File.Exists(args[at + 1])
+            ? File.ReadAllText(args[at + 1])
+            : string.Empty;
+        return string.Join("\n", [invocation.Request.StdIn, file, string.Join(" ", args)]);
     }
 
     [Fact]

--- a/src_mcp/tests/ThePromptSaysWhatTheReviewerHasTests.cs
+++ b/src_mcp/tests/ThePromptSaysWhatTheReviewerHasTests.cs
@@ -28,10 +28,7 @@ public sealed class ThePromptSaysWhatTheReviewerHasTests
     public void NoShippedPrompt_ClaimsACheckoutItCannotKnowIsThere()
     {
         var prompts = new RolePrompts(Path.GetTempPath());
-        var claiming = PromptCatalog.All
-            .Where(c => prompts.ForChoice(c).Contains("checkout", StringComparison.OrdinalIgnoreCase))
-            .Select(c => c.Id)
-            .ToList();
+        var claiming = PromptCatalog.All.Where(c => Claims(prompts.ForChoice(c))).Select(c => c.Id).ToList();
 
         // The guard on the guard: a typo in the catalog would make the query above pass by finding
         // nothing at all, which is how a test of an emptied collection stays green for ever.
@@ -39,6 +36,28 @@ public sealed class ThePromptSaysWhatTheReviewerHasTests
         claiming.Should().BeEmpty(
             "a prompt file cannot know whether a checkout was mounted — only PanelService does");
     }
+
+    [Fact]
+    public void TheScanItself_StillFindsTheClaimWhenItIsThere()
+    {
+        // The companion the project's own rule demands for a structural scan: a prohibition that
+        // would pass over EMPTY text proves nothing, and the catalog above is loaded through a call
+        // that could start returning empty strings without failing anything else. So this asserts
+        // the two things that would make the scan vacuous — that the search matches the sentence it
+        // forbids, and that every prompt it searched is real text.
+        Claims("You have the checkout read-only and the diff below.").Should().BeTrue(
+            "the search used by the prohibition must actually match the sentence it forbids");
+
+        var prompts = new RolePrompts(Path.GetTempPath());
+        foreach (var choice in PromptCatalog.All)
+        {
+            prompts.ForChoice(choice).Length.Should().BeGreaterThan(200,
+                $"{choice.Id} must be real text, or the scan over it means nothing");
+        }
+    }
+
+    /// <summary>The one search, used by the prohibition and by its own control.</summary>
+    private static bool Claims(string text) => text.Contains("checkout", StringComparison.OrdinalIgnoreCase);
 
     [Fact]
     public void InFastMode_TheReviewerIsToldThereIsNothingToLookAt()

--- a/todo/PLAN_panel_probing_state.md
+++ b/todo/PLAN_panel_probing_state.md
@@ -64,16 +64,46 @@ starting a process each, and a probe's outcome — failure included — is cache
   Whatever shape this takes should be able to say which of them is outstanding, or deliberately say
   nothing about the others — but that choice should be made, not fallen into.
 
+## What the gate found, 2026-09-06 (all three reviewers answered; four findings taken)
+
+1. **The test plan contradicted requirement 3.** Requirement 3 says the probing state can never
+   outlive its probe; the test plan then asserted "a render whose probe never resolves publishes the
+   probing state and no final state" — a test FOR the permanent spinner requirement 3 forbids, and a
+   promise that never settles never reaches the `finally` either. The probe needs its own deadline
+   that resolves to a diagnosis. Found independently by codex and gemini, both Blocking.
+2. **A generation token per render.** Press reprobe while a probe is in flight and the older render's
+   `finally` can clear the NEWER probing state, or publish its stale diagnosis over it. Nothing in the
+   plan knew which render was current.
+3. **Every awaited source, named.** The constraints say the choice about `cliVersions`, the price
+   tables and the GitHub check "should be made, not fallen into" — and then the build order and the
+   tests covered only the local-engine probe. This change was given ownership of every probe when the
+   server-version round rejected the same finding, so each needs a timeout and a failure state, or
+   the scope has to be narrowed out loud.
+4. **Publishing `probing` before the await is not enough.** The awaited work is still inside `render`,
+   so a settings edit arriving mid-probe waits behind the same timeout. Painting the settings
+   immediately and letting the probe dispatch its own update when it finishes is a different shape
+   from step 2 below, and it is the shape this needs.
+
 ## Build order
 
-1. The state itself in `PanelState`, with `staticKey`/`liveRegions` deciding repaint-or-patch.
-2. `render()` publishing it before the await and clearing it in a `finally`.
-3. The markup, and a test that the state is reachable and always cleared.
+1. The state itself in `PanelState`, with `staticKey`/`liveRegions` deciding repaint-or-patch, plus a
+   generation token so only the current render may publish or clear it (finding 2).
+2. `render()` paints immediately and never awaits a probe: each probe runs behind its own bounded
+   deadline and dispatches its result back, so a settings edit is never queued behind a wedged binary
+   (finding 4). A deadline that expires publishes a diagnosis, not a cleared spinner (finding 1).
+3. The awaited sources this covers, each with its deadline: the local-engine probe, the server
+   `--version`, the vendor CLI versions, the GitHub check (finding 3).
+4. The markup, and a test that the state is reachable and always cleared.
 
 ## Test plan
 
-- A render whose probe never resolves publishes the probing state and no final state.
+- A probe that never resolves publishes the probing state and then, at its deadline, a TIMEOUT
+  diagnosis — never a spinner that outlives it. (The earlier version of this line asserted the
+  opposite and was the gate's Blocking finding.)
 - A probe that fails clears it and publishes the failure diagnosis.
+- Reprobe pressed while a probe is in flight: the older render neither clears the newer probing state
+  nor publishes its own result.
+- A settings change made during a probe is visible before the probe's deadline.
 - `staticKey` does not change between probing and settled, so the transition is a patch and not a
   full repaint.
 

--- a/todo/PLAN_provider_liveness.md
+++ b/todo/PLAN_provider_liveness.md
@@ -43,17 +43,62 @@ The panel shows `installed` as a distinct, non-green state rather than folding i
    handling — it must NOT be a second launcher (`reuse-first.md`).
 2. Cache the result per vendor in the server's data directory with a timestamp. A liveness probe
    costs real tokens, so it runs at most once an hour per vendor and on explicit request.
-3. `ProbeAsync` consults, in order: the diagnosis table (free, certain), then the cache, then
-   `--version`. It never launches a live probe on the `providers` path itself unless asked —
-   `providers` is called before every round and must stay fast.
-4. A `refresh` argument on the `providers` tool that forces the live probe.
+3. `ProbeAsync` answers from the cache first, then from `--version`, and treats the diagnosis table
+   as a HINT that any live answer overrules (finding 1). `providers` is called before every round and
+   must stay fast, so it never WAITS for a probe — but a cache miss STARTS one in the background
+   (finding 2), and the answer lands in the cache for the next call or is superseded by the round
+   itself (finding 3).
+4. A `refresh` argument on the `providers` tool that forces the live probe, single-flight per vendor
+   and rate-limited so the hourly ceiling is enforced in code rather than promised (finding 7). A
+   remediation from the panel evicts that vendor's entry (finding 6).
 5. The panel's Reviewers rows show the three states with their own wording, and the vendor row's ▶
    button stays the way to fix a `Refused`.
+
+## What the gate found, 2026-09-06 (all three reviewers answered; nine findings taken)
+
+The plan went through the review gate before a line of it was built, and it came back with a
+contradiction inside itself plus eight things it had not said. They are folded into the build order
+above; recorded here because the reasoning is the valuable part.
+
+1. **The diagnosis table cannot come first.** Step 3 consulted the table before anything else, and
+   that table lists `gemini` as retired — while gemini answered **nine reviewers out of nine** on this
+   machine the same afternoon. As written, the plan would have reported a working vendor
+   `unavailable` for ever and never probed it. The table is a HINT that a live answer overrules, not a
+   verdict ahead of the measurement. (codex, Blocking.)
+2. **Step 3 contradicted the RED test.** With an empty cache and a `--version` that exits 0, a probe
+   the plan forbids on the `providers` path leaves the answer `installed` — while the test demands
+   `unavailable` for exactly that machine. So a cache MISS has to start the probe (asynchronously, so
+   `providers` stays fast) and the first answer arrives from the round or the next call. (gemini,
+   Blocking — the sharpest finding of the round.)
+3. **A completed reviewer round is liveness evidence**, and the cheapest kind: it has already been
+   paid for. A vendor that just answered a real round must not still read `installed`.
+4. **The cache key is the effective runtime**, not the vendor name — executable, version, model,
+   account. An hour is long enough to change any of them, and a stale entry would vouch for a runtime
+   that no longer exists.
+5. **Serve the stale entry while a refresh runs behind it.** A hard hourly expiry drops every healthy
+   vendor back to `installed` once an hour and leaves it there until somebody asks.
+6. **A refusal gets a shorter life than an answer, and remediation evicts it.** The play button is
+   named as the cure; caching the refusal for an hour tells the person their fix did not work.
+7. **`refresh` needs single-flight and a rate limit.** Two panels open, or one that polls, would
+   launch several paid probes inside the hour the plan promises as a ceiling — a guarantee has to be
+   enforced in code, not stated in a document.
+8. **Name the probe's timeout** beside the sentence that depends on it: this is the one path that
+   talks to a vendor daemon that can hang.
+9. **A per-row verify**, because `refresh` is otherwise all-or-nothing: somebody who has just
+   installed one CLI should not have to re-probe every vendor.
+
+Rejected, with reasons recorded in the gate: defining exit-code semantics for a CLI we do not ship
+(that `--version` cannot distinguish installed from authenticated is the reason this plan exists), and
+a hypothetical "refresh might be ignored" that the plan's own test already covers.
 
 ## Test plan
 
 - RED first, per `testing.md`: a fake launcher whose `--version` exits 0 and whose answer path
-  refuses must produce `unavailable`, not `own auth`. That is today's defect, in a test.
+  refuses must produce `unavailable`, not `own auth`. That is today's defect, in a test — and per
+  finding 2 above it only passes if a cache MISS starts the probe, so this test is also the one that
+  pins that decision.
+- A vendor the diagnosis table calls retired, which then ANSWERS, is reported `answered` — the case
+  that would have kept today's working gemini dark for ever.
 - A vendor that answers is `answered`; one that has only ever been version-checked is `installed`.
 - The cache is honoured: a second `providers` inside the hour launches nothing (assert on the fake
   launcher's call count).
@@ -63,6 +108,7 @@ The panel shows `installed` as a distinct, non-green state rather than folding i
 ## Definition of Done
 
 - [ ] `providers` never reports a vendor as authenticated on the strength of `--version` alone.
+- [ ] A live answer overrules the diagnosis table, and a refusal never outlives its remediation.
 - [ ] The three states are distinct in the tool's JSON and in the panel.
 - [ ] A liveness probe costs at most one small round trip per vendor per hour.
 - [ ] Tests above pass; each was watched fail first.


### PR DESCRIPTION
Two defects the review gate found in yesterday's fix — both of them mine, both real, both now with a test that was watched red first.

## The repair launch was promised a tree it never has

The one repair launch a reviewer is allowed has **always** run in an empty temp directory (`repairDir`), and the remark beside it says why: it is not asking for a better review, it is asking for the answer in the schema, and an agentic CLI handed a checkout goes exploring instead.

Its **prompt**, though, was composed with the *review's* mode. So in `worktree` mode the repair prompt opened by promising a read-only checkout and closed by saying there were no tools — one prompt, two contradictory sentences, sent to the reviewer that had already failed once.

`codex` found it and diagnosed it the **other way round**: make the repair promise the checkout. Reading the code says the opposite — the repair never has one — so it is now composed with `hasCheckout: false`, always. Recording that here because the finding was right about the defect and wrong about the cure, and the difference came from reading `repairDir` at line 780 rather than the diff hunk.

## A prompt somebody overrode still carries the old claim

The catalog is editable. An override written before yesterday sits in that person's data directory still opening with *"You have the checkout read-only and the diff below"* — and no edit to the shipped files can reach it. Composing the true sentence underneath it hands the model two opposite instructions, which is the exact shape that sent a headless CLI looking for a tool in the first place.

The composer now strips that one sentence — a source-generated regex, AOT-safe, tolerant of the line wrap — and nothing else of the person's prompt. Raised by `gemini` at the plan gate and independently by the local reviewer at the code gate.

## The scan test had no positive control

The prohibition over all 25 prompts would have passed over **empty** text, and the catalog is loaded through a call that could start returning empty without failing anything else. The project's own rule asks for a companion assertion that the search still finds a known instance — added, plus a length floor on every prompt.

## From the two plan rounds run through the gate today

- **`todo/PLAN_provider_liveness.md`** — nine findings taken. One would have kept a *working* vendor dark for ever: the plan consults the diagnosis table first, and that table lists `gemini` as retired, while `gemini` answered **9 reviewers out of 9** on this machine the same afternoon. Another named a contradiction between step 3 and the plan's own RED test. Steps 3 and 4 are rewritten, not merely annotated.
- **`todo/PLAN_panel_probing_state.md`** — its test plan asserted the permanent spinner that its own requirement 3 forbids, found independently by two vendors. Rewritten with the generation token and the render/probe decoupling the gate named.

## Tests

**820 server · 482 extension, all green.** Three new, each watched red against the real symptom:

| defect put back | what the test said |
|---|---|
| repair composed with the review's mode | the repair prompt contained `READ-ONLY checkout` |
| the strip removed from the composer | the override's `checkout read-only` reached the prompt (`CodeWorkspaceTests.cs:153`) |

One of those first reds was **my own test's fault**, not the code's: it read `StdIn` while the local engine takes a `--prompt-file`. Fixed before it could pass for the wrong reason — a test that fails for a setup reason proves nothing, and it nearly proved nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
