### PR TITLE
chore(release): extension 0.31.1 — Team servers

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Extension 0.31.1 — 2026-09-06
+
+**Team servers.** A company buys ONE subscription per vendor, installs the CLIs on ONE machine, and
+everybody reviews through it with their work account. Nobody needs codex, claude or agy installed,
+and nobody needs their own subscription.
+
+The panel gains a **Team servers** section: add a server by name and address, sign in with Microsoft,
+and it shows the account you signed in as, the server's version, and — per vendor — how many accounts
+are free. That last line distinguishes the two states that need different people: *all signed out*
+is the operator's job, *all rate-limited* comes back by itself.
+
+**＋ Add a reviewer** then offers each signed-in server, and picking one lists the vendors that server
+actually has, with their free accounts beside them. The models offered are the ones that server
+allows — discovered from it, never a list shipped in this extension — and a model it stops allowing
+is kept and marked rather than silently swapped. A Team-server row asks for no endpoint, no CLI path
+and no price: all three are decided on the server.
+
+Your spending page gains a block per server, beside this machine's own totals rather than added to
+them — the two ledgers are separate and a combined figure would be a number neither of them holds.
+An admin additionally sees the whole company's.
+
+**Where your code goes is said on every row.** Being the company's own server makes it no less true
+that the plan, the diffs and the file contents around them leave this machine, so the same disclosure
+a remote local engine gets is shown here too.
+
+The sign-in is your work Microsoft account, restricted to the domain the server allows; an account
+outside it is told that, rather than told to try again. The session renews itself before it expires,
+without asking. The token is kept in a file only you can read — never in `settings.json`, never in a
+command line, never in a log.
+
+*Requires a Team server: `coai-server`, deployed by whoever runs your company's subscriptions.*
+
 ## Server 0.18.4 — 2026-09-06
 
 **Every `review_code` in every repository was failing.** It threw

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it \u2014 the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Why

Epics 1–4 are merged and **none of the Team-servers UI is in a published build.** `extension-v0.31.0` was cut before that merge — `teamServerView.ts` is not in the released tag, so the *Team servers* section exists in no installed extension today.

The release workflow refuses a tag that disagrees with `package.json`, so this bumps the manifest to `0.31.1` and writes the changelog entry.

## What ships in it

The panel gains **Team servers**: add a server, sign in with your work Microsoft account, and see the account, the server's version, and per vendor how many accounts are free — distinguishing *all signed out* (the operator must act) from *all rate-limited* (comes back by itself).

**＋ Add a reviewer** offers each signed-in server and lists what that server actually has. Models come from the server's own allowlist, never a list shipped in the extension; one it stops allowing is kept and marked rather than silently swapped. The spending page gains a block per server, beside this machine's totals rather than added to them.

Where your code goes is said on every row — being the company's own server makes it no less true that the plan and diffs leave this machine.

## Verified

- **567 extension tests** pass, 0 failed, 1 skipped.
- `vsce package` produces a 201 KB .vsix.
- **The bundle was checked, not the source**: minified `dist/extension.js` carries `signInTeamServer`, `addTeamServer`, `teamUsageScope`, `coai.access` and `Team servers`. (This repository has shipped a minifier-renamed binding twice; the source compiling is not evidence.)

## After the merge

`extension-v0.31.1` cut on `main`, per the release rule. The server side is already deployed — `https://coai.remsoft.dev/api/health` answers `{"ok":true,"version":"0.5.2"}`.

**One thing I cannot verify from here**, and it is the step that is silently forgotten: in the Entra app registration, *Expose an API → Add a client application* must list `aebc6443-996d-45c2-90f0-388ff96faa56` (Visual Studio Code) against the `coai.access` scope. Without it the extension can only obtain a Graph token, which no server can accept — sign-in returns 401 with everything else correct. The server is advertising the right scope; only the portal shows whether that client is authorised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
