### PR TITLE
chore(deps): stop proposing @types/vscode minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,14 @@ updates:
       npm-minor-and-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    # @types/vscode is pinned by hand to the engine the extension declares, so MINOR bumps are
+    # ignored as well as major ones. vsce refuses to package when the types run ahead of it —
+    # "@types/vscode ^1.136.0 greater than engines.vscode ^1.85.0" — so 1.134 -> 1.136 is a red
+    # build, and the only ways out are to raise engines, which drops every user below that VS Code
+    # build, or to leave the types alone. PR #77, 2026-09-07.
+    ignore:
+      - dependency-name: "@types/vscode"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     labels: ["dependencies", "npm"]
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
Dependabot proposes `@types/vscode` 1.134.0 → 1.136.0 inside the weekly npm group every Monday, and it fails `extension · typecheck · test · package` every time — not in typecheck, in packaging:

```
@types/vscode ^1.136.0 greater than engines.vscode ^1.85.0.
Either upgrade engines.vscode or use an older @types/vscode version
```

`vsce` refuses to package an extension whose VS Code types run ahead of the engine it declares. That is a real check, not a flake, and it has exactly two resolutions:

- **raise `engines.vscode`** — which drops every user on a VS Code older than that build. A product decision with its own review, not a dependency update;
- **leave the types where the engine is** — free.

The npm ecosystem had no `ignore` list in this repository at all, so this adds one covering `@types/vscode` for major *and* minor. The sibling repository `dew_flow_creds_for_devs` already ignored the majors on the same reasoning it records for TypeScript and `@types/node` (the toolchain is chosen by hand with the engine version); it is being widened to minor in the same task. Both extensions declare `^1.85.0`.

PR #77 is closed as part of this — it cannot go green as proposed.

## Test plan

- [x] The file parses as YAML
- [x] No source, manifest or workflow touched — only the bot's proposal policy
- [ ] Next Monday's run no longer proposes an `@types/vscode` minor bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to limit major and minor updates for the VS Code type definitions package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->