### PR TITLE
fix(ci): make .coderabbit.yaml parse again

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -47,7 +47,7 @@ reviews:
           how many models. A number without its sample is an advertisement. Bought on 2026-09-06,
           when a fast-mode measurement of one commit was nearly published as a general claim.
           Not applicable to a version number, a line number, a test count, or a size in bytes.
-      - name: "A release-only check has a test that runs on every push"
+      - name: "A release-only check is tested on every push"
         mode: "warning"
         instructions: |
           Pass/fail criteria: if the diff adds or changes logic that executes ONLY while a release is
@@ -56,7 +56,7 @@ reviews:
           logic in the ordinary suite. Bought on 2026-09-06: an archive check written to protect the
           release passed on `tar` output and failed on `7z` output, and would have broken both Windows
           builds at the last step of the release. Its only execution was the release itself.
-      - name: "A bug fix carries a test that reproduces the defect"
+      - name: "A bug fix carries a reproducing test"
         mode: "warning"
         instructions: |
           Pass/fail criteria: if the pull request describes fixing a defect — wrong output, a crash, a


### PR DESCRIPTION
CodeRabbit has been reviewing this repository on **default settings**, not on the configuration in the repo. Every review carries the warning, collapsed at the top where it is easy to miss, and it names the fault precisely:

```
Validation error: Check name must be under 50 characters at
"reviews.pre_merge_checks.custom_checks[1].name";
Check name must be under 50 characters at "reviews.pre_merge_checks.custom_checks[2].name"
```

Two of the five custom-check names were 55 and 51 characters:

| was | chars | now | chars |
|---|---|---|---|
| A release-only check has a test that runs on every push | 55 | A release-only check is tested on every push | 44 |
| A bug fix carries a test that reproduces the defect | 51 | A bug fix carries a reproducing test | 36 |

**One invalid field discards the whole file.** So the path instructions, the language setting and the other three checks — `No dotnet test`, the sample-size check, the wall-clock check — were being ignored along with the two long names. The reviews that have run since these checks landed did not apply any of them.

No instruction text, `mode` or check was changed, so what the reviewer is asked to look for is identical. The `yaml-language-server` schema comment at the top of the file was already present and did not catch this — the published schema does not encode the length bound.

Found while merging #79: the warning was sitting in CodeRabbit's review comment on that pull request.

## Test plan

- [x] The file parses as YAML and still yields 5 custom checks
- [x] Every remaining check name is within 50 characters (asserted, not eyeballed)
- [ ] CodeRabbit's review on this pull request no longer reports a parsing error — the check that matters, and it runs here

🤖 Generated with [Claude Code](https://claude.com/claude-code)