### PR TITLE
fix(panel): the Team-server sign-in sends its token where the server reads it

### DIFF
--- a/research/module_team_server.md
+++ b/research/module_team_server.md
@@ -57,8 +57,11 @@ sequenceDiagram
 | `DELETE /api/reviews/{id}` | owner | `204` |
 | `GET /api/usage?window=&scope=` | any / **admins for `company`** | per-vendor totals for the caller, or for everyone plus per person · `400` unknown window · `403` company as a non-admin |
 
-**Every route reads its credential from `Authorization: Bearer …` and from nowhere else** —
-`Auth.Bearer` looks at that header, and no handler here reads a token out of a request body.
+**Every route that has a caller reads its credential from `Authorization: Bearer …` and from
+nowhere else** — `Auth.Bearer` looks at that header, and no handler here reads a token out of a
+request body. The two anonymous routes above (`/api/health`, `/api/client-config`) have no
+credential to read at all, deliberately: a client that has not signed in yet must be able to ask
+this server what it wants.
 `POST /api/session` is the one people expect to be different, because it is where a session begins;
 it is not.
 

--- a/research/module_team_server.md
+++ b/research/module_team_server.md
@@ -57,6 +57,21 @@ sequenceDiagram
 | `DELETE /api/reviews/{id}` | owner | `204` |
 | `GET /api/usage?window=&scope=` | any / **admins for `company`** | per-vendor totals for the caller, or for everyone plus per person · `400` unknown window · `403` company as a non-admin |
 
+**Every route reads its credential from `Authorization: Bearer …` and from nowhere else** —
+`Auth.Bearer` looks at that header, and no handler here reads a token out of a request body.
+`POST /api/session` is the one people expect to be different, because it is where a session begins;
+it is not.
+
+> **How that was learned, 2026-09-07.** Extension 0.31.1 posted the Microsoft token as
+> `{ token }` in the body of `POST /api/session`. `RequireCaller` then found no identity and
+> answered **401 — before any JWT scheme ran**, which makes this failure hard to read from either
+> end: the panel can only say *the server answered 401*, because the challenge carries no body, and
+> the journal shows `401 0 null 0.68ms` with **no `JwtBearerHandler` line at all**. The absence of
+> that line is the diagnostic: a token that is examined and rejected always logs `IDX…`, and takes
+> milliseconds rather than fractions of one. Both halves of the contract had passing tests — the
+> server's posting a header and a null body, the extension's asserting the token was in the body —
+> and nothing crossed between them.
+
 ## Core entities
 
 | Type | File | Role |

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Extension 0.31.2 — 2026-09-07
+
+**Signing in to a Team server works.** It could not in 0.31.1, for anybody: the extension sent your
+Microsoft token in the request *body*, and the server reads it from the `Authorization` header and
+nowhere else. So the server answered `401` before it had looked at the token at all — which is why
+the panel could only say *the server answered 401*, with no reason attached. The token now travels
+in the header, which is where every other call already put it.
+
+Nothing else changed, and no configuration needs changing: this was one line on the client side of
+a contract whose two halves were each tested on their own.
+
 ## Extension 0.31.1 — 2026-09-06
 
 **Team servers.** A company buys ONE subscription per vendor, installs the CLIs on ONE machine, and

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it \u2014 the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {

--- a/src_vs_code/src/teamServerApi.ts
+++ b/src_vs_code/src/teamServerApi.ts
@@ -225,7 +225,16 @@ export function isHttpsOrLoopback(url: string): boolean {
   }
 }
 
-/** Trade an identity-provider token for a session on this server. */
+/**
+ * Trade an identity-provider token for a session on this server.
+ *
+ * <p><b>The token travels in the Authorization header, and only there.</b> This route is
+ * authorised like every other one: the server resolves the caller from
+ * `Request.Headers.Authorization` before the handler runs, and reads nothing out of the request
+ * body. Posting the token as `{ token }` instead — which is what 0.31.1 shipped — is answered
+ * `401` with an empty body before any JWT scheme is even attempted, so the failure names neither
+ * the token nor the reason.</p>
+ */
 export function createSession(
   url: string,
   idpToken: string,
@@ -233,7 +242,7 @@ export function createSession(
 ): Promise<ServerResult<Session>> {
   return ask<Session>(url, 'api/session', {
     method: 'POST',
-    body: { token: idpToken },
+    token: idpToken,
     fetchImpl,
   });
 }

--- a/src_vs_code/src/test/teamServerApi.test.ts
+++ b/src_vs_code/src/test/teamServerApi.test.ts
@@ -171,8 +171,42 @@ test('a session is created by POST and given up by DELETE', async () => {
   await deleteSession('https://s', 't', fetchImpl);
 
   assert.strictEqual(fetchImpl.seen[0]?.init.method, 'POST');
-  assert.strictEqual(String(fetchImpl.seen[0]?.init.body).includes('idp-token'), true);
   assert.strictEqual(fetchImpl.seen[1]?.init.method, 'DELETE');
+});
+
+/**
+ * The seam that shipped broken in 0.31.1, and the reason this assertion is here rather than one
+ * about the body.
+ *
+ * <p>The extension posted the identity token as `{ token }` in the BODY. The server authorises
+ * `/api/session` from the Authorization header ALONE — `Auth.Bearer` reads
+ * `Request.Headers.Authorization` and nothing on that server ever reads the body — so every
+ * sign-in was answered `401` with an empty body in half a millisecond, without the JWT handler
+ * running at all. Observed on `coai.remsoft.dev`: a 2114-byte JSON body, no
+ * `JwtBearerHandler` line, `401 0 null 0.6838ms`.</p>
+ *
+ * <p>Both halves had tests. The server's posts a header and a null body; this file's asserted the
+ * token was in the body. Two green suites, contradictory expectations, and nothing crossing
+ * between them.</p>
+ */
+test('the identity token is minted through the Authorization header, which is the only place the server reads it', async () => {
+  const fetchImpl = stub(() => ({
+    status: 200,
+    body: JSON.stringify({ token: 't', expiresUtc: '2026-10-01T00:00:00Z', email: 'a@b.c' }),
+  }));
+
+  await createSession('https://s', 'idp-token', fetchImpl);
+
+  const sent = fetchImpl.seen[0];
+  assert.strictEqual(
+    (sent?.init.headers as Record<string, string>)['Authorization'],
+    'Bearer idp-token',
+  );
+  assert.strictEqual(
+    sent?.init.body,
+    undefined,
+    'the server reads no body on this route, and a bearer token in one is a bearer token in a log',
+  );
 });
 
 test('usage names its window and its scope on the wire', async () => {

--- a/src_vs_code/src/test/teamServerApi.test.ts
+++ b/src_vs_code/src/test/teamServerApi.test.ts
@@ -197,11 +197,13 @@ test('the identity token is minted through the Authorization header, which is th
 
   await createSession('https://s', 'idp-token', fetchImpl);
 
+  // `new Headers(...)` rather than `init.headers as Record<string, string>`: the doctrine's DoD
+  // forbids an `as` cast standing in for a real type, and `HeadersInit` is a union of three shapes
+  // — a cast to one of them is a promise about `ask`'s internals that would come due silently the
+  // day it passes a `Headers` instead. This reads whichever shape it is. (The neighbouring catalog
+  // test still casts; left as found rather than rewritten in a hotfix.)
   const sent = fetchImpl.seen[0];
-  assert.strictEqual(
-    (sent?.init.headers as Record<string, string>)['Authorization'],
-    'Bearer idp-token',
-  );
+  assert.strictEqual(new Headers(sent?.init.headers).get('Authorization'), 'Bearer idp-token');
   assert.strictEqual(
     sent?.init.body,
     undefined,

--- a/todo/PLAN_contract_across_the_seam.md
+++ b/todo/PLAN_contract_across_the_seam.md
@@ -1,0 +1,64 @@
+# PLAN — two green suites must not be able to disagree about one wire
+
+> Status: **plan only, nothing implemented yet.** Scope: the client/server seam of the Team server
+> — `src_vs_code/src/teamServerApi.ts`, `src_server/src/{Auth,SessionEndpoints}.cs`, and the test
+> projects on both sides.
+>
+> Related docs: [module_team_server.md](../research/module_team_server.md),
+> [PLAN_team_server.md](../research/PLAN_team_server.md).
+
+## The symptom this comes from
+
+Extension 0.31.1 shipped a sign-in that could not work for anybody. `createSession` posted the
+Microsoft token as `{ token }` in the request BODY; `POST /api/session` authorises from the
+`Authorization` header alone. Every sign-in was answered `401` before any JWT scheme ran.
+
+**Both halves had passing tests, and they expected opposite things.**
+`src_server/tests/SessionTests.cs:19` posts a header and `content: null`.
+`src_vs_code/src/test/teamServerApi.test.ts` asserted the token was in the body. Neither suite can
+observe the other, so nothing was red and the defect reached the Marketplace. Fixed on the client
+in `fix(panel): the Team-server sign-in sends its token where the server reads it` (0.31.2) — this
+plan is about the class, not that instance.
+
+It also took a server journal to diagnose, which is the second half of the problem: the failure was
+unreadable from both ends. `401` with an empty body, no `WWW-Authenticate`, and — because nothing
+authenticated — no `JwtBearerHandler` line either. The panel could only say *the server answered
+401*.
+
+## Accepted in the gate and deferred to here
+
+From the plan round of that fix (codex, gemini and the local reviewer each raised a form of it):
+
+1. **A cross-seam contract test.** A unit assertion at the client's `fetch` boundary proves what
+   the client SENDS; it cannot prove the server ACCEPTS it. Something must exercise one against the
+   other.
+2. **The single-auth-path rule is a convention, not an enforcement.** `Auth.Bearer` reading only
+   `Request.Headers.Authorization` is documented now
+   ([module_team_server.md](../research/module_team_server.md)) and true by inspection; nothing
+   fails when a future route reads a token from somewhere else.
+3. **The server's 401 says nothing.** A refusal that names no reason costs whoever meets it a
+   server-log session. The reason must reach the caller without becoming an oracle for guessing
+   tokens.
+
+## Open questions the plan must answer before it is built
+
+- **At which layer.** Three candidates, and they are not equivalent:
+  a hand-written `.http`/smoke suite run against a started server (the shape `ClaudeRag` already
+  uses, `tools/http-smoke`); a shared fixture describing each route's wire format that BOTH suites
+  assert against; or a test that boots the real server in-process and drives the extension's own
+  `ask` at it. The third is the only one that can catch this exact defect without anyone writing
+  the expectation down twice — and it is the most expensive.
+- **What the 401 may safely say.** "No credential was presented" is safe. "Your token's audience is
+  wrong" is a hint to an attacker holding a token. The split has to be decided rather than assumed.
+- **Whether `Attempt.body` should stay.** After this fix no call in `teamServerApi.ts` sends a body,
+  though `POST /api/reviews` on the server takes one. Kept deliberately; revisit if it is still
+  unused when the review routes reach the panel.
+
+## Definition of Done
+
+- [ ] A test exists that fails when the client and the server disagree about `POST /api/session`'s
+      wire format — demonstrated by reverting the 0.31.2 fix and watching it go red.
+- [ ] The "credential comes from the Authorization header and nowhere else" rule is enforced by
+      something that fails, not only written down.
+- [ ] A caller refused by this server learns why, to the extent that saying so is safe.
+- [ ] `research/module_team_server.md` records what shipped.

--- a/todo/README.md
+++ b/todo/README.md
@@ -18,6 +18,7 @@ Convention: `.claude/rules/shared/common/planning-docs.md`.
 | [PLAN_provider_liveness.md](PLAN_provider_liveness.md) | `providers` still calls a vendor healthy on the strength of `--version`, which never reaches the vendor. Three states instead of two, established by a real round trip and cached. |
 | [PLAN_rule_formatting.md](PLAN_rule_formatting.md) | Every reviewer in an eight-cell measurement missed the one rule written as a table row. Whether rule FORMATTING changes what a reviewer can apply, measured. |
 | [PLAN_panel_probing_state.md](PLAN_panel_probing_state.md) | A render waits on its probes with nothing on screen saying so: press ⟳ where nothing answers and the old sentence sits unchanged for seconds. Extracted from the WSL plan's code round, where it was accepted as true and left as a tail. |
+| [PLAN_contract_across_the_seam.md](PLAN_contract_across_the_seam.md) | Two green suites disagreed about one wire format and shipped a sign-in nobody could use: the server's tests posted a header, the extension's asserted a body. A test that fails when the two halves disagree, an enforced "credential comes from the Authorization header only" rule, and a 401 that says why to the extent it safely can. Accepted in the 0.31.2 gate and deferred out of the hotfix. |
 
 Everything else planned so far shipped — the master plan, all six epics, the conventions pass, the
 per-role gate with dealt prompts, and the escalation tail are


### PR DESCRIPTION
## The defect

**Signing in to a Team server could not work in 0.31.1, for anybody.**

`createSession` posted the Microsoft token as `{ token }` in the request **body**. `POST /api/session` is authorised like every other route on that server: `Auth.Bearer` reads `Request.Headers.Authorization`, and nothing on that server reads a token out of a body. So `RequireCaller` found no identity and answered **401 — before any JWT scheme ran**.

## Found on the deployment, not inferred

The operator's own attempt, in the server journal:

```
POST /api/session - application/json 2114  ->  401 0 null 0.6838ms
```

2114 bytes is the real Microsoft token, in the body — and there is **no `JwtBearerHandler` line against that request at all**. The absence is the diagnostic: a token that is examined and rejected always logs an `IDX…` failure and costs milliseconds, not fractions of one.

Both directions were then reproduced against `coai.remsoft.dev`:

| request | result | handler ran? |
|---|---|---|
| POST `/api/session`, token in the body, no header | `401 0 null 0.3504ms` | **no** |
| POST `/api/session`, `Authorization: Bearer …`, no body | `401 0 null 2.5957ms`, `IDX10223: Lifetime validation failed` | **yes** |

The header path is the live one; the body path never reaches authentication.

## Why it was unreadable from both ends

The 401 challenge carries no body, and `said()` falls back to `the server answered ${status}` exactly when the response is empty. So the panel could only report *"RemSoftDev: the server answered 401"* — a sentence that names neither the token nor the reason. On the server side the refusal is silent by construction, because nothing was ever authenticated to fail.

Ruled out along the way, each with evidence rather than assumption: the Entra pre-authorisation (`aebc6443-…` is listed against `coai.access`), the audience shape (`Auth__Microsoft__Audiences` carries **both** `<client-id>` and `api://<client-id>`), the tenant, and the account (a wrong domain answers **403**, not 401 — `Auth.RequireCaller` separates the two).

## The fix

One line on the client side of the contract: the token goes in the header, where every other call on this API already puts it. The server is unchanged — its model is one authentication path, and a second one that reads bodies is the thing this codebase deliberately does not have.

## Tests

**606, 0 failing** (605 before; one added).

Red before green, per the repository rule. The new test failed against the unfixed code with `+ undefined  - 'Bearer idp-token'` — the defect itself, not a setup error.

The old assertion is the reason this shipped: `SessionTests` posts a header and `content: null`, while `teamServerApi.test.ts` asserted the token was **in the body**. Two green suites, contradictory expectations about one seam, and nothing crossing between them. That assertion is now the header, and the body is asserted **absent** — a bearer token in a request body is a bearer token in a log.

## Docs

`research/module_team_server.md` gains the rule (*every route reads its credential from `Authorization` and nowhere else*) and a note on how the failure presents, because a bodyless 401 with no handler line is hard to read from either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Team server sign-in failures by sending identity-provider tokens through the `Authorization` header.
  - Sign-in requests no longer include tokens in the request body, preventing premature `401 Unauthorized` responses.

- **Documentation**
  - Documented the authentication requirements and the sign-in compatibility issue.

- **Chores**
  - Updated the VS Code extension version to 0.31.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->