### PR TITLE
docs(changelog): 0.31.3 is released, so it is dated

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## Extension 0.31.3 — unreleased
+## Extension 0.31.3 — 2026-09-07
 
-**No behaviour changed.** This entry exists because the version string must not: 0.31.2 is published
-to the Marketplace, and the code behind it has since gained one field — a successful server result
-now carries the HTTP status it came back with, so a caller can tell `201 Created` from any other
-success. Two different builds answering to one version string is how "fixed in 0.31.2" and "still
-broken in 0.31.2" become both true.
+**Nothing you can see changed.** Install it or don't; the panel behaves exactly as 0.31.2 did.
+This release exists because the version string had to move: 0.31.2 is published, and the code
+behind it has since gained one field — a successful server result now carries the HTTP status it
+came back with, so a caller can tell `201 Created` from any other success. Two different builds
+answering to one version string is how "fixed in 0.31.2" and "still broken in 0.31.2" become both
+true.
 
 Behind it: one test suite that drives this extension's real client against a real `coai-server` and
 fails when the two disagree about a wire format — which is what shipped a sign-in nobody could use


### PR DESCRIPTION
The 0.31.3 entry was written as `unreleased` in the same breath as the manifest bump, because at that point there was nothing to install for. There is now — `extension-v0.31.3` goes out as soon as this lands.

The reason for the entry is unchanged and still the interesting part: **0.31.2 is published and the code behind it moved**, so the string had to. `teamServerApi.ts` gained a `status` field on a successful result; nothing a person can see behaves differently.

The wording now says that out loud — *"Nothing you can see changed. Install it or don't"* — which is the honest thing to put in front of somebody deciding whether to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)