### PR TITLE
feat(gate): the shipped defaults are the budget this project actually runs on

### DIFF
--- a/research/PLAN_conventions_pass.md
+++ b/research/PLAN_conventions_pass.md
@@ -1,8 +1,21 @@
 # PLAN — the gate reads the project's own rules, and one pass checks nothing else
 
-> Status: **IMPLEMENTED, 2026-09-01.** Scope: `src_mcp/core/Rounds` (per-stage config, prompt
-> catalog), `src_mcp/runners/Context` (rule discovery), `src_mcp/src/Server/PanelService.cs`,
-> `src_mcp/src/prompts/`, and the panel's Prompts and Gate sections.
+> Status: **IMPLEMENTED, 2026-09-01 — and NARROWED on 2026-09-07.** Scope: `src_mcp/core/Rounds`
+> (per-stage config, prompt catalog), `src_mcp/runners/Context` (rule discovery),
+> `src_mcp/src/Server/PanelService.cs`, `src_mcp/src/prompts/`, and the panel's Prompts and Gate
+> sections.
+>
+> **The default is ARCHITECTURE round 1 now, not every code role's round 1.** Read the design below
+> as written — the pass itself, the prompt, the rule discovery and the "default, not a lock" rule
+> are all unchanged, and the picker still offers `Conventions` to all three roles. What changed is
+> which round gets it without being asked.
+>
+> Why: running it on all three showed the same written rules read by three reviewers in the same
+> round, producing the same findings three times — and with the shipped budget now at ONE round for
+> Security & reliability and for Performance & UX-DX, that round was spent on conventions and the
+> role never asked its own question at all. Architecture keeps it because it has two rounds, the
+> rules and then the broad question, so nothing it used to ask is lost. The operator's decision, on
+> the budget they run.
 >
 > Related docs: [module_server.md](module_server.md), [module_runners.md](module_runners.md),
 > [module_extension.md](module_extension.md),

--- a/src_mcp/core/Rounds/PromptCatalog.cs
+++ b/src_mcp/core/Rounds/PromptCatalog.cs
@@ -124,7 +124,14 @@ public static class PromptCatalog
         // Only when rules were actually found. A conventions pass with nothing to judge against
         // would invent a standard, which is worse than the review it displaced. And an explicit
         // choice above still wins: this is a default, not a lock.
-        if (hasRules && index == 0 && role != PlanRole)
+        // ARCHITECTURE only, since 2026-09-07. It took round 1 of all three code roles first, and
+        // running that way showed why it should not: three reviewers reading the same written rules
+        // in the same round produce the same findings three times, and the two rounds a security or
+        // performance role gets by default are then one round of conventions and none of its own
+        // subject. Architecture keeps it because that role has two rounds — the rules, then the
+        // broad question — so nothing it was asked before is lost. The operator's call, on the
+        // budget they run.
+        if (hasRules && index == 0 && role == ArchitectureRole)
         {
             return For(role).First(p => p.Id == ConventionsId);
         }

--- a/src_mcp/tests/ConventionsPassTests.cs
+++ b/src_mcp/tests/ConventionsPassTests.cs
@@ -19,13 +19,42 @@ public sealed class ConventionsPassTests
 {
     private static readonly IReadOnlyList<string> NoChoice = [];
 
+    /// <summary>
+    /// ARCHITECTURE round 1, and only Architecture — narrowed 2026-09-07 from all three code roles.
+    /// </summary>
+    /// <remarks>
+    /// <para>Running it on all three showed the cost: the same written rules read by three reviewers
+    /// in the same round produce the same findings three times, and a role whose budget is ONE round
+    /// spent it on conventions and never asked its own question at all. Architecture keeps the pass
+    /// because it has two rounds — the rules, then the broad question — so nothing it used to ask is
+    /// lost.</para>
+    /// <para>The other two reach it by choosing it: this is a default, not a lock, and the picker
+    /// still offers `Conventions` for every code role.</para>
+    /// </remarks>
     [Fact]
-    public void CodeRoundOne_IsTheConventionsPass_ForEveryCodeRole()
+    public void CodeRoundOne_IsTheConventionsPass_ForArchitectureAlone()
     {
-        foreach (var role in (string[])[PromptCatalog.ArchitectureRole, PromptCatalog.SecurityRole, PromptCatalog.UxDxRole])
+        PromptCatalog.ForRound(PromptCatalog.ArchitectureRole, 1, NoChoice, hasRules: true)
+            .Id.Should().Be("conventions", "Architecture round 1 judges the written rules");
+
+        foreach (var role in (string[])[PromptCatalog.SecurityRole, PromptCatalog.UxDxRole])
         {
             PromptCatalog.ForRound(role, 1, NoChoice, hasRules: true)
-                .Id.Should().Be("conventions", $"{role} round 1 must judge the written rules");
+                .Id.Should().Be(
+                    PromptCatalog.For(role).First(p => p.Universal).Id,
+                    $"{role} has one round by default and spends it on its own subject");
+        }
+    }
+
+    [Fact]
+    public void TheConventionsPass_IsStillOfferedToEveryCodeRole()
+    {
+        // Narrowing the DEFAULT must not narrow the choice: a person who wants the rules read three
+        // times can still say so, and the panel's picker lists this prompt for all three.
+        foreach (var role in (string[])[PromptCatalog.ArchitectureRole, PromptCatalog.SecurityRole, PromptCatalog.UxDxRole])
+        {
+            PromptCatalog.ForRound(role, 1, [PromptCatalog.ConventionsId], hasRules: true)
+                .Id.Should().Be("conventions", $"{role} can be asked for the conventions pass");
         }
     }
 

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Extension 0.31.6 — 2026-09-07
+
+**New installs start on a budget somebody actually ran.** The shipped defaults were set before this
+gate had reviewed much; they are now the ones this project runs on its own work.
+
+| | was | now |
+|---|---|---|
+| Plan review — rounds | 3 | **1** |
+| Plan review — passes at or under | 2 | **6** |
+| Architecture — rounds · threshold | 2 · 3 | 2 · **5** |
+| Security & reliability — rounds · threshold | 2 · 3 | **1** · **5** |
+| Performance & UX-DX — rounds · threshold | 2 · 3 | **1** · **5** |
+
+One plan round because the second and third mostly re-raise what the first found. Higher thresholds
+because the old ones sat where a real change could not pass, and a gate that blocks everything is a
+gate people learn to ignore.
+
+**Round 1 is the Conventions pass for Architecture only.** It used to be round 1 of all three code
+roles, which meant the same written rules read three times in one round — and now that two of those
+roles get a single round, that round would have been spent on conventions instead of on security or
+performance. Architecture keeps it because it has two rounds: the rules, then the broad question.
+Every role can still be *given* the Conventions prompt; only the default changed. **This half needs
+`coai-mcp` 0.18.9** — the panel and the server decide it together, and a mismatched pair would show
+one thing and run another.
+
+Nothing you had set changes: these are defaults, and your own choices in the panel win.
+
 ## Extension 0.31.5 — 2026-09-07
 
 **A reviewer you added from a Team server now actually reviews.** It did not, for anybody, since

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it \u2014 the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {
@@ -217,20 +217,20 @@
         "coai.rounds": {
           "type": "object",
           "default": {
-            "PlanCritique": 3,
+            "PlanCritique": 1,
             "Architecture": 2,
-            "SecurityReliability": 2,
-            "UxDxPerformance": 2
+            "SecurityReliability": 1,
+            "UxDxPerformance": 1
           },
           "markdownDescription": "How many rounds each reviewer ROLE gets. Architecture may be worth two passes with different lenses while performance is worth one; a shared budget forces the cheapest role to pay for the most expensive. Edit it in the **ConnectOtherAIs** panel."
         },
         "coai.thresholds": {
           "type": "object",
           "default": {
-            "PlanCritique": 2,
-            "Architecture": 3,
-            "SecurityReliability": 3,
-            "UxDxPerformance": 3
+            "PlanCritique": 6,
+            "Architecture": 5,
+            "SecurityReliability": 5,
+            "UxDxPerformance": 5
           },
           "markdownDescription": "How many blocking/major findings each ROLE may still have and pass. A finding is counted against the threshold of the role that raised it."
         },

--- a/src_vs_code/src/panelView.ts
+++ b/src_vs_code/src/panelView.ts
@@ -847,7 +847,7 @@ ${plan}
     </div>
     <div class="hint">Fast sends the diff, the plan and this project’s rules — and nothing to explore. Measured on one commit: every hosted model found MORE that way, at a half to a third of the tokens. Full also hands them the checkout, for a review that needs the surrounding code.</div>
   </div>
-  <div class="hint">Round 1 defaults to <b>Conventions</b>: it judges the diff against the rules this project has written down \u2014 <code>CLAUDE.md</code>, <code>AGENTS.md</code>, <code>GEMINI.md</code>, <code>.claude/rules</code> \u2014 and nothing else. Pick something else for round 1 and that wins.</div>
+  <div class="hint"><b>Architecture</b> round 1 defaults to <b>Conventions</b>: it judges the diff against the rules this project has written down \u2014 <code>CLAUDE.md</code>, <code>AGENTS.md</code>, <code>GEMINI.md</code>, <code>.claude/rules</code> \u2014 and nothing else. The other two roles spend their round on their own subject; pick <b>Conventions</b> for them if you want the rules read again. Anything you pick wins.</div>
 ${code}
 </div>`;
 }

--- a/src_vs_code/src/panelView.ts
+++ b/src_vs_code/src/panelView.ts
@@ -11,14 +11,14 @@ import { CoaiSettings } from './settingsShape';
 import { Escalation } from './escalations';
 import { HELP, HelpKey } from './help';
 import { ModelChoice, modelsFor, modelsProvenance, RemoteProvenance } from './models';
-import { ROLES, promptsFor, selectedFor } from './prompts';
+import { CONVENTIONS_NARROWED_IN, ROLES, promptsFor, selectedFor } from './prompts';
 import { barWidth, estimated, money, shortDuration, shortNumber, totalsByVendor, UsageEntry, Window, within } from './usage';
 import { costPhrase, elapsed, isRunning, reviewerRows, RoundRecord, SessionFile, stageName } from './rounds';
 import { vendorColour } from './vendorColour';
 import { CliStatus, cliStatusNote, updateAvailable, UNKNOWN_CLI } from './cliVersions';
 import { SnippetStatus, snippetNote } from './claudeSnippet';
 import { LocalEngine, remoteWarning } from './localEngines';
-import { ServerStatus } from './coaiInstall';
+import { ServerStatus, compareVersions } from './coaiInstall';
 import { ModelPrice } from './modelPrices';
 import { Vendor } from './vendors';
 
@@ -783,6 +783,30 @@ function fanOut(state: PanelState): string {
   );
 }
 
+/**
+ * Said out loud while the installed server would not do what these pickers show.
+ *
+ * <p>The panel and `coai-mcp` decide an unset round's prompt separately and are installed
+ * separately: an extension updates itself, a server is a binary somebody presses a button to
+ * replace. Below {@link CONVENTIONS_NARROWED_IN} the server makes round 1 of EVERY code role the
+ * conventions pass, so this panel would show `Universal` for a round that runs `conventions` —
+ * exactly the kind of quiet disagreement this pair exists to prevent. Three reviewers raised it on
+ * the round that shipped the change.</p>
+ *
+ * <p>A sentence rather than a block: the fix is the Update button one section down, and this stops
+ * being true the moment somebody presses it.</p>
+ */
+function conventionsSkew(server: ServerStatus): string {
+  const known = server.kind !== 'absent' && server.version.length > 0;
+  if (!known || compareVersions(CONVENTIONS_NARROWED_IN, server.version) <= 0) {
+    return '';
+  }
+
+  return `  <div class="stale">The coai-mcp you have installed (${escapeHtml(server.version)}) still runs `
+    + `<b>Conventions</b> on round 1 of every code role, whatever these pickers say. `
+    + `Update it to ${escapeHtml(CONVENTIONS_NARROWED_IN)} or later — the <b>MCP server</b> section below.</div>`;
+}
+
 function promptsBody(state: PanelState): string {
   const s = state.settings;
   const roleRow = (role: (typeof ROLES)[number]): string => {
@@ -848,6 +872,7 @@ ${plan}
     <div class="hint">Fast sends the diff, the plan and this project’s rules — and nothing to explore. Measured on one commit: every hosted model found MORE that way, at a half to a third of the tokens. Full also hands them the checkout, for a review that needs the surrounding code.</div>
   </div>
   <div class="hint"><b>Architecture</b> round 1 defaults to <b>Conventions</b>: it judges the diff against the rules this project has written down \u2014 <code>CLAUDE.md</code>, <code>AGENTS.md</code>, <code>GEMINI.md</code>, <code>.claude/rules</code> \u2014 and nothing else. The other two roles spend their round on their own subject; pick <b>Conventions</b> for them if you want the rules read again. Anything you pick wins.</div>
+${conventionsSkew(state.server)}
 ${code}
 </div>`;
 }

--- a/src_vs_code/src/prompts.ts
+++ b/src_vs_code/src/prompts.ts
@@ -72,6 +72,19 @@ export function universalFor(role: string): PromptChoice {
 export const CONVENTIONS_ID = 'conventions';
 
 /**
+ * The first coai-mcp whose round 1 is the conventions pass for ARCHITECTURE alone.
+ *
+ * <p>Before it, every code role's round 1 was the conventions pass. The panel and the server decide
+ * this SEPARATELY — one in `selectedFor`, one in `PromptCatalog.ForRound` — and they are installed
+ * separately too: an extension updates itself, a server is a binary somebody presses a button to
+ * replace. So a panel ahead of its server shows `Universal` for a round the server runs
+ * `conventions` in, which is precisely the divergence this pair is written to avoid. The Prompts
+ * section says so while that is true, rather than leaving it to be discovered from a round's
+ * findings.</p>
+ */
+export const CONVENTIONS_NARROWED_IN = '0.18.8';
+
+/**
  * What the panel shows as selected for one round — the stored choice, or what the server would
  * actually use, so the box never reads as "nothing" when a prompt is in fact chosen.
  *

--- a/src_vs_code/src/prompts.ts
+++ b/src_vs_code/src/prompts.ts
@@ -99,7 +99,12 @@ export function selectedFor(
   // `hasRules` is optimistic here because the panel cannot know: the server decides at round time
   // by looking in the worktree. The section text says so, and a repo with no written rules falls
   // back to the universal prompt on the server side.
-  if (hasRules && round === 1 && role !== 'PlanCritique') {
+  // ARCHITECTURE only, since 2026-09-07 — `PromptCatalog.ForRound` says the same in the same
+  // words, and `panelServerPromptAgreement.test.ts` is what holds the two to it. It took round 1 of
+  // all three code roles first: three reviewers reading the same written rules in the same round
+  // produce the same findings three times, and a role with one round then spent it on conventions
+  // and never asked its own question at all. Architecture keeps it because it has two rounds.
+  if (hasRules && round === 1 && role === 'Architecture') {
     return CONVENTIONS_ID;
   }
 

--- a/src_vs_code/src/prompts.ts
+++ b/src_vs_code/src/prompts.ts
@@ -82,7 +82,7 @@ export const CONVENTIONS_ID = 'conventions';
  * section says so while that is true, rather than leaving it to be discovered from a round's
  * findings.</p>
  */
-export const CONVENTIONS_NARROWED_IN = '0.18.8';
+export const CONVENTIONS_NARROWED_IN = '0.18.9';
 
 /**
  * What the panel shows as selected for one round — the stored choice, or what the server would

--- a/src_vs_code/src/settingsShape.ts
+++ b/src_vs_code/src/settingsShape.ts
@@ -155,8 +155,16 @@ export function roleRecordUpdate(
 }
 
 export const DEFAULTS: CoaiSettings = {
-  rounds: { PlanCritique: 3, Architecture: 2, SecurityReliability: 2, UxDxPerformance: 2 },
-  thresholds: { PlanCritique: 2, Architecture: 3, SecurityReliability: 3, UxDxPerformance: 3 },
+  // The operator's own settings, after a day of running the gate on this repository's real work
+  // (2026-09-07). One plan round rather than three: the second and third rounds re-raise what the
+  // first found rather than finding more, which the round records show. Architecture keeps two
+  // because its first round is the conventions pass and its second is the broad question — two
+  // different questions, not the same one twice. The thresholds went UP because they had been set
+  // where a real change could not pass: a plan round that regularly produces six findings and a
+  // code role that produces five are not failures, and a gate that says they are gets ignored,
+  // which is the one failure mode a gate cannot survive.
+  rounds: { PlanCritique: 1, Architecture: 2, SecurityReliability: 1, UxDxPerformance: 1 },
+  thresholds: { PlanCritique: 6, Architecture: 5, SecurityReliability: 5, UxDxPerformance: 5 },
   onExhausted: 'human',
   maxConcurrency: 3,
   maxPerProvider: 2,

--- a/src_vs_code/src/test/panelServerPromptAgreement.test.ts
+++ b/src_vs_code/src/test/panelServerPromptAgreement.test.ts
@@ -16,9 +16,18 @@ import { CONVENTIONS_ID, selectedFor, universalFor } from '../prompts';
  * the rule is that two programs agree, and neither can check that alone.</p>
  */
 
-/** What `PromptCatalog.ForRound` returns for an unset round. */
+/**
+ * What `PromptCatalog.ForRound` returns for an unset round.
+ *
+ * <p>Transcribed from the C# by hand, on purpose: the point of this file is that two programs agree,
+ * and a shared implementation would make the agreement true by construction rather than checked.
+ * When the server's branch changes, this line changes with it — and that is the moment somebody has
+ * to look at both.</p>
+ *
+ * <p>2026-09-07: the conventions pass narrowed from every code role to <b>Architecture</b> alone.</p>
+ */
 function whatTheServerRuns(role: string, round: number, hasRules: boolean): string {
-  return hasRules && round === 1 && role !== 'PlanCritique' ? CONVENTIONS_ID : universalFor(role).id;
+  return hasRules && round === 1 && role === 'Architecture' ? CONVENTIONS_ID : universalFor(role).id;
 }
 
 const ROLES = ['PlanCritique', 'Architecture', 'SecurityReliability', 'UxDxPerformance'];

--- a/src_vs_code/src/test/panelServerPromptAgreement.test.ts
+++ b/src_vs_code/src/test/panelServerPromptAgreement.test.ts
@@ -88,6 +88,12 @@ test('a panel ahead of its server says so, instead of showing a round the server
   assert.ok(behind.includes('still runs'), 'an older server is named');
   assert.ok(behind.includes('0.18.7'), 'and so is the version that is there');
 
+  // 0.18.8 by name, because it is the one everybody has: it shipped the Team-server reviewer fix
+  // hours before this change and does NOT carry the narrowed conventions rule. The constant moved
+  // from 0.18.8 to 0.18.9 for that reason, and this line is what would catch it moving back.
+  const released = withServer({ kind: 'known', version: '0.18.8', remembered: true, updateOffered: true });
+  assert.ok(released.includes('still runs'), '0.18.8 predates the narrowing and must say so');
+
   const current = withServer({ kind: 'known', version: CONVENTIONS_NARROWED_IN, remembered: true, updateOffered: false });
   assert.ok(!current.includes('still runs'), 'the server that agrees says nothing');
 

--- a/src_vs_code/src/test/panelServerPromptAgreement.test.ts
+++ b/src_vs_code/src/test/panelServerPromptAgreement.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { CONVENTIONS_ID, selectedFor, universalFor } from '../prompts';
+import { CONVENTIONS_ID, CONVENTIONS_NARROWED_IN, selectedFor, universalFor } from '../prompts';
+import { panelHtml, PanelState } from '../panelView';
+import { DEFAULTS } from '../settingsShape';
+import { DEFAULT_VENDORS } from '../vendors';
+import { SNIPPET_VERSION } from '../claudeSnippet';
 
 /**
  * The picker shows the prompt the SERVER will run, for every round the person can see.
@@ -15,6 +19,26 @@ import { CONVENTIONS_ID, selectedFor, universalFor } from '../prompts';
  * <p>Its twin on the C# side is <code>ConventionsPassTests</code>. Two suites for one rule, because
  * the rule is that two programs agree, and neither can check that alone.</p>
  */
+
+/** Enough panel to render the Prompts section; every field the version-skew test does not read. */
+const baseState = (): PanelState => ({
+  settings: DEFAULTS,
+  vendors: DEFAULT_VENDORS,
+  codexModels: [], agyModels: [],
+  localEngines: {},
+  server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
+  side: '',
+  perSide: false,
+  questions: [],
+  sessions: [],
+  openSections: ['prompts'],
+  usage: [],
+  usageWindow: 'week',
+  cliStatus: {},
+  modelPrices: {},
+  snippetStatus: { kind: 'current', current: SNIPPET_VERSION },
+  latestServerVersion: '',
+});
 
 /**
  * What `PromptCatalog.ForRound` returns for an unset round.
@@ -44,6 +68,34 @@ test('an unset round shows what the server runs, with rules and without', () => 
       }
     }
   }
+});
+
+/**
+ * The one case the transcription above cannot cover: the two programs are versioned separately.
+ *
+ * <p>`selectedFor` and `PromptCatalog.ForRound` agree in the SOURCE, and are installed apart — an
+ * extension updates itself, a server is a binary somebody presses a button to replace. Below
+ * {@link CONVENTIONS_NARROWED_IN} the server still makes round 1 of every code role the conventions
+ * pass, so this panel would show `Universal` for a round that runs `conventions`. Raised by three
+ * reviewers independently on the round that shipped the narrowing, and it is the only one of their
+ * version-skew findings that a test can hold.</p>
+ */
+test('a panel ahead of its server says so, instead of showing a round the server will not run', () => {
+  const withServer = (server: PanelState['server']): string =>
+    panelHtml({ ...baseState(), server }, 'n0nce');
+
+  const behind = withServer({ kind: 'known', version: '0.18.7', remembered: true, updateOffered: true });
+  assert.ok(behind.includes('still runs'), 'an older server is named');
+  assert.ok(behind.includes('0.18.7'), 'and so is the version that is there');
+
+  const current = withServer({ kind: 'known', version: CONVENTIONS_NARROWED_IN, remembered: true, updateOffered: false });
+  assert.ok(!current.includes('still runs'), 'the server that agrees says nothing');
+
+  const newer = withServer({ kind: 'known', version: '0.19.0', remembered: true, updateOffered: false });
+  assert.ok(!newer.includes('still runs'), 'nor does a later one');
+
+  const absent = withServer({ kind: 'absent', version: '', remembered: false, updateOffered: false });
+  assert.ok(!absent.includes('still runs'), 'a server nobody has installed is not behind');
 });
 
 test('a later round never shows a lens nobody selected', () => {

--- a/src_vs_code/src/test/settingWrite.test.ts
+++ b/src_vs_code/src/test/settingWrite.test.ts
@@ -161,7 +161,15 @@ test('the number of prompt pickers follows that role\u2019s rounds', () => {
 
   const four = html({ ...DEFAULTS.rounds, Architecture: 4 });
   assert.equal(pickers(four, 'Architecture'), 4);
-  assert.equal(pickers(four, 'SecurityReliability'), 2, 'one role\u2019s budget is not another\u2019s');
+  // Against the DEFAULT rather than a literal: what this line is about is that raising one role's
+  // budget leaves the others alone, and writing the number here made it a second assertion about
+  // what the default happens to be \u2014 which is how it went red when the defaults changed and
+  // nothing about picker sizing did.
+  assert.equal(
+    pickers(four, 'SecurityReliability'),
+    DEFAULTS.rounds['SecurityReliability'],
+    'one role\u2019s budget is not another\u2019s',
+  );
 
   const one = html({ ...DEFAULTS.rounds, UxDxPerformance: 1 });
   assert.equal(pickers(one, 'UxDxPerformance'), 1, 'a single round shows a single picker');

--- a/src_vs_code/src/test/settingsShape.test.ts
+++ b/src_vs_code/src/test/settingsShape.test.ts
@@ -8,17 +8,59 @@ import { DEFAULT_VENDORS, normaliseId, Vendor, vendorsEnv, vendorsFrom } from '.
 /** A reader over a plain object, as VS Code's configuration behaves for our purposes. */
 const reader = (values: Record<string, unknown>) => (section: string) => values[section];
 
+/**
+ * The shipped budget, as the operator set it after a day of running this gate on real work.
+ *
+ * <p>Every role is asserted, not two of them: these numbers decide what a person who installs this
+ * extension gets before they touch anything, and a default nobody stated is a default nobody can
+ * argue with. Changing one is meant to be a red test and a decision, which is what this is for.</p>
+ */
 test('defaults match the master plan configuration table', () => {
-  assert.equal(DEFAULTS.rounds['PlanCritique'], 3);
-  assert.equal(DEFAULTS.rounds['Architecture'], 2, 'a code role gets two passes by default');
-  assert.equal(DEFAULTS.thresholds['PlanCritique'], 2);
-  assert.equal(DEFAULTS.thresholds['Architecture'], 3, 'a diff carries more than a plan does');
+  assert.equal(DEFAULTS.rounds['PlanCritique'], 1, 'one plan round: the later ones re-raise');
+  assert.equal(DEFAULTS.rounds['Architecture'], 2, 'conventions first, then the broad question');
+  assert.equal(DEFAULTS.rounds['SecurityReliability'], 1);
+  assert.equal(DEFAULTS.rounds['UxDxPerformance'], 1);
+  assert.equal(DEFAULTS.thresholds['PlanCritique'], 6, 'six findings on a plan is a Tuesday');
+  assert.equal(DEFAULTS.thresholds['Architecture'], 5);
+  assert.equal(DEFAULTS.thresholds['SecurityReliability'], 5);
+  assert.equal(DEFAULTS.thresholds['UxDxPerformance'], 5);
+  assert.equal(DEFAULTS.dealPlanLenses, false, 'every vendor answers the same question');
+  assert.equal(DEFAULTS.dealCodeLenses, false);
+  assert.equal(DEFAULTS.codeWorkspace, 'none', 'Fast — the diff, not a checkout');
   assert.equal(DEFAULTS.onExhausted, 'human');
   assert.equal(DEFAULTS.maxConcurrency, 3);
   assert.equal(DEFAULTS.maxPerProvider, 2);
   assert.equal(DEFAULTS.reviewerTimeoutMinutes, 10);
   assert.equal(DEFAULTS.escalationMinutes, 30);
   assert.equal(DEFAULTS.credsKey, '');
+});
+
+/**
+ * The manifest and `DEFAULTS` are one decision written twice, and nothing held them together.
+ *
+ * <p>VS Code answers `getConfiguration` from `contributes.configuration` when a person has set
+ * nothing, so the manifest is what a NEW user actually gets; `DEFAULTS` is what this code falls
+ * back to. When they disagree, the panel and the stored configuration disagree about what the
+ * person is running, and neither half is wrong on its own — the failure this repository keeps
+ * producing. Both had to be edited by hand to change the shipped budget, which is the moment to
+ * make the pair checkable.</p>
+ */
+test('the manifest ships the same defaults this code falls back to', () => {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf8'),
+  ) as { contributes: { configuration: { properties: Record<string, { default?: unknown }> } } };
+  const declared = (key: string): unknown =>
+    manifest.contributes.configuration.properties[`coai.${key}`]?.default;
+
+  assert.deepEqual(declared('rounds'), DEFAULTS.rounds);
+  assert.deepEqual(declared('thresholds'), DEFAULTS.thresholds);
+  assert.equal(declared('onExhausted'), DEFAULTS.onExhausted);
+  assert.equal(declared('maxConcurrency'), DEFAULTS.maxConcurrency);
+  assert.equal(declared('maxPerProvider'), DEFAULTS.maxPerProvider);
+  assert.equal(declared('reviewerTimeoutMinutes'), DEFAULTS.reviewerTimeoutMinutes);
+  assert.equal(declared('escalationMinutes'), DEFAULTS.escalationMinutes);
+  assert.equal(declared('dealPlanLenses'), DEFAULTS.dealPlanLenses);
+  assert.equal(declared('dealCodeLenses'), DEFAULTS.dealCodeLenses);
 });
 
 test('the shipped reviewers are the two whose CLIs authenticate themselves', () => {


### PR DESCRIPTION
The operator's own panel, made the default for new installs.

| | was | now |
|---|---|---|
| Plan review — rounds · threshold | 3 · 2 | **1** · **6** |
| Architecture — rounds · threshold | 2 · 3 | 2 · **5** |
| Security & reliability | 2 · 3 | **1** · **5** |
| Performance & UX-DX | 2 · 3 | **1** · **5** |

One plan round because the second and third re-raise what the first found rather than finding more. The thresholds went **up** because the old ones sat where a real change could not pass, and a gate that blocks everything is a gate people route around — the one failure mode a gate cannot survive.

## The half that is not a number

**Round 1 is the conventions pass for Architecture alone**, where it used to be round 1 of every code role. This moves **both programs** — `PromptCatalog.ForRound` in C# and `selectedFor` in TypeScript, in the same words — because the panel showing one thing while the server runs another is the defect this repository keeps producing.

Why: the same written rules read by three reviewers in one round produce the same findings three times. And with Security and UX-DX now on a single round, that round was spent on conventions and the role never asked its own question at all. Architecture keeps it because it has **two** rounds: the rules, then the broad question — so nothing it used to ask is lost.

The picker still offers `Conventions` to every code role. Only the default changed, and a new test asserts an explicit choice still reaches all three.

`panelServerPromptAgreement.test.ts` transcribes the server's branch by hand — which is exactly what made this a two-line change with a red test in between rather than a silent divergence.

## A guard that was missing

**`package.json` and `DEFAULTS` had nothing holding them together.** VS Code answers a new user from the manifest; this code falls back to `DEFAULTS`. Both had to be edited by hand here, which is the moment to make the pair checkable — a new test compares them, proved to have teeth by putting `4` where `6` belongs and watching it fail.

The defaults test now asserts **all four roles** rather than two, plus both deal switches and the workspace mode.

And one test was asserting a default where it meant to assert an invariant: the picker-count test hard-coded `2` for SecurityReliability to say *one role's budget is not another's*. It reads `DEFAULTS.rounds` now, so it fails when picker sizing breaks rather than when a default moves.

## Releases

Two, together: **extension 0.31.5** and **coai-mcp 0.18.8**. A 0.31.5 panel against an older server would show `Universal` on round 1 and get `conventions`.

## Observed

`tsc` clean · **598** extension · **1009** MCP · **171** server · **109** bench · **3** contract · `npm run package` · plan-lifecycle, pin-check, gate-snippet-check.

Nothing anybody has already set changes: these are defaults, and a person's own choices win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)