### PR TITLE
chore(release): extension 0.31.5, coai-mcp 0.18.8 — the Team-server reviewer runs

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Extension 0.31.5 — 2026-09-07
+
+**A reviewer you added from a Team server now actually reviews.** It did not, for anybody, since
+Team servers shipped: the row sat in *Reviewers* with both stage boxes ticked, and every round ran
+without it. Nothing said so — the panel called it configured, which was true, and the round reported
+"all 3 reviewers answered", which was true about what it asked.
+
+Two things were wrong, and both are fixed.
+
+The extension never sent the one field a Team server needs. A reviewer row is named
+`<server>-<vendor>` so two servers offering `codex` cannot collide, and the name the SERVER knows it
+by travels separately — that second name was missing from everything the extension wrote, so your
+server was asked for a vendor called `remsoftdev-claude` and answered, truthfully, that it offers no
+such thing.
+
+And a second VS Code window could undo your settings. Every window writes the file the server reads,
+including a window still running the build it was opened with — and an older build rewrites a
+reviewer type it does not recognise. Two windows, 0.4 seconds apart, and the newer one lost. The
+file now records which build wrote it, an older one stands down and tells you to reload that window,
+and the write happens under a lock and by rename, so a crash cannot leave half a file behind.
+
+**And when a reviewer cannot run, you are told.** Its card says so, with the reason — not signed in,
+no key, no such vendor — and a round that leaves one out names it in the log and in what it hands
+your AI. The reason comes from the server, so the panel never has a second opinion about it.
+
+Smaller: a Team-server card no longer claims its models come from the Codex CLI, and a refusal says
+which of the row's two names was tried instead of reading like a typo you never made.
+
 ## Extension 0.31.4 — 2026-09-07
 
 **The *Server* section is now *MCP server*, and it is about that.** It carried the Team server's

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it \u2014 the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The version bump and the changelog for the three epics of [`PLAN_team_server_reviewer_never_called.md`](research/PLAN_team_server_reviewer_never_called.md), merged as #84, #89 and #88.

Two files, no behaviour. The manifest version **is** the release version — the extension release job refuses a tag that disagrees with it — so this lands before the tags do.

## What is being released

**A reviewer added from a Team server has never actually reviewed.** It sat in *Reviewers* with both stage boxes ticked and every round ran without it, and nothing said so: the panel called it configured, which was true, and the round reported *"all 3 reviewers answered"*, which was true about what it asked.

- The extension never sent `remoteVendor`, the name a Team server knows its vendor by — deliberately not the row's id, because a row is `<server>-<vendor>` so two servers offering `codex` cannot collide. So the server was asked for `remsoftdev-claude` and answered, truthfully, that it offers no such thing. Both suites were green for three releases: each half was self-consistent, and nothing asserted the crossing.
- A second VS Code window could undo the settings. Every window writes the file the server reads, including one still running the build it was opened with, and an older build rewrites a runtime it does not recognise — two windows, 0.4 seconds apart, newer one loses.

**And the reporting that would have made either visible in a minute.** A round names the enabled reviewer it could not run, with the reason, in the log and in what it hands the calling AI; a card says when the server cannot run a reviewer; `coai-mcp --providers` is what both read.

## After this merges

Two tags: `extension-v0.31.5` and `mcp-v0.18.8`.

## Verification on `main`

MCP **1029**, server **171**, extension **642**, the live seam check green against the real binary, `plan-lifecycle` and `pin-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
