### PR TITLE
feat(panel): an admin is shown what is published, and cannot press anything about it

### DIFF
--- a/research/module_team_server.md
+++ b/research/module_team_server.md
@@ -75,6 +75,19 @@ it is not.
 > server's posting a header and a null body, the extension's asserting the token was in the body —
 > and nothing crossed between them.
 
+**An admin is shown the release line, and cannot act on it from here.** The *Team servers* row
+carries one more sentence for a caller the catalog marks `isAdmin`: what the newest published
+`server-v*` release is, with a `⬆` when it is newer than the version this server reports. Read-only
+on purpose — a Team server is DEPLOYED rather than downloaded, so an Update button would mean this
+panel touching somebody else's machine, and the request was to show it.
+
+Silent in three states, each of which would otherwise be a sentence teaching nothing: the caller is
+not an admin, the server has not said its version yet, or no `server-v*` release exists — which is
+the ordinary state today, since the deployment was made by hand and the release line has never been
+cut. `latestTeamServerVersion` and the coai-mcp lookup share one tag list, one half-hour clock and
+one comparator; the tag PREFIX is the only difference, and it is a parameter rather than a second
+copy of the filter.
+
 **The `Local` scheme and a real provider cannot both be configured.** `Startup.Guard` refuses to
 start when `Auth:Local:SigningKey` is set alongside a Microsoft tenant or Google: that scheme signs
 identities with a shared secret, so beside a real provider it is an identity bypass — anyone with

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Extension 0.31.7 — 2026-09-07
+
+**If you are an admin on a Team server, its row now tells you what is published.** One line under
+the status: the newest released `coai-server` version, and a `⬆` when it is newer than the one your
+server is running.
+
+Nothing to press. A Team server is deployed rather than downloaded, so updating it is somebody
+going to that machine — this only tells you there is a reason to. Everybody who is not an admin
+sees nothing new, and so does an admin whose server has no published release to compare against.
+
 ## Extension 0.31.6 — 2026-09-07
 
 **New installs start on a budget somebody actually ran.** The shipped defaults were set before this

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it \u2014 the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.6",
+  "version": "0.31.7",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {

--- a/src_vs_code/src/coaiInstall.ts
+++ b/src_vs_code/src/coaiInstall.ts
@@ -178,10 +178,18 @@ export function sqliteNameFor(rid: CoaiRid): string {
   return rid.startsWith('osx-') ? 'libe_sqlite3.dylib' : 'libe_sqlite3.so';
 }
 
-/** `mcp-v0.1.0` → `0.1.0`; any other tag line yields nothing rather than a wrong version. */
-export function versionFromTag(tag: string): string | undefined {
-  return tag.startsWith(TAG_PREFIX) && tag.length > TAG_PREFIX.length
-    ? tag.slice(TAG_PREFIX.length)
+/**
+ * `mcp-v0.1.0` → `0.1.0`; any other tag line yields nothing rather than a wrong version.
+ *
+ * <p><b>The prefix is a parameter</b> because this repository publishes three release lines from
+ * one tag list — `mcp-v*`, `extension-v*` and `server-v*` — and each reader wants exactly one of
+ * them. Answering with the newest tag of ANY shape is the defect this whole pair exists to prevent
+ * (see {@link newestServerTag}); a second copy of the same filter for the Team server would be the
+ * same defect written twice.</p>
+ */
+export function versionFromTag(tag: string, prefix: string = TAG_PREFIX): string | undefined {
+  return tag.startsWith(prefix) && tag.length > prefix.length
+    ? tag.slice(prefix.length)
     : undefined;
 }
 
@@ -215,11 +223,17 @@ export function updateAvailable(installed: string | undefined, publishedTag: str
  * extension release therefore answered the question "is there a newer server", produced a tag
  * that is not a server version, and the check quietly concluded no. It never fired once.</p>
  */
-export function newestServerTag(tags: readonly string[]): string | undefined {
+export function newestServerTag(
+  tags: readonly string[],
+  prefix: string = TAG_PREFIX,
+): string | undefined {
   return tags
-    .filter((t) => versionFromTag(t) !== undefined)
-    .sort((a, b) => compareVersions(versionFromTag(b)!, versionFromTag(a)!))[0];
+    .filter((t) => versionFromTag(t, prefix) !== undefined)
+    .sort((a, b) => compareVersions(versionFromTag(b, prefix)!, versionFromTag(a, prefix)!))[0];
 }
+
+/** The Team server's own release line. Deployed rather than downloaded — the tag is all we read. */
+export const TEAM_SERVER_TAG_PREFIX = 'server-v';
 
 /**
  * What to DO about an install that failed, when the failure is one we recognise.

--- a/src_vs_code/src/installer.ts
+++ b/src_vs_code/src/installer.ts
@@ -16,6 +16,8 @@ import {
   installedKey,
   ridFor,
   newestServerTag,
+  TEAM_SERVER_TAG_PREFIX,
+  TAG_PREFIX,
   serverStatus,
   versionFromTag,
 } from './coaiInstall';
@@ -230,7 +232,26 @@ export async function latestServerVersion(): Promise<string | undefined> {
   }
 }
 
-async function latestTag(): Promise<string> {
+/**
+ * The newest published TEAM server version, or undefined when there is none or GitHub is away.
+ *
+ * <p>Read-only, and shown to admins only. A Team server is DEPLOYED rather than downloaded — there
+ * is no button here and there could not be one, because updating it means touching somebody's
+ * machine. The panel's job is to say that a newer one exists, which is the whole request.</p>
+ *
+ * <p>`undefined` covers two different states on purpose: no `server-v*` release has been cut yet,
+ * and GitHub could not be reached. Neither is worth a sentence in a panel — an admin who sees
+ * nothing here learns nothing false.</p>
+ */
+export async function latestTeamServerVersion(): Promise<string | undefined> {
+  try {
+    return versionFromTag(await latestTag(TEAM_SERVER_TAG_PREFIX), TEAM_SERVER_TAG_PREFIX);
+  } catch {
+    return undefined;
+  }
+}
+
+async function latestTag(prefix: string = TAG_PREFIX): Promise<string> {
   const response = await fetch(`https://api.github.com/repos/${RELEASES_REPO}/releases?per_page=30`, {
     headers: { accept: 'application/vnd.github+json' },
   });
@@ -241,7 +262,7 @@ async function latestTag(): Promise<string> {
   const tags = Array.isArray(body)
     ? body.map((r) => r.tag_name).filter((t): t is string => typeof t === 'string')
     : [];
-  const newest = newestServerTag(tags);
+  const newest = newestServerTag(tags, prefix);
   if (newest === undefined) {
     throw new Error('no server release is published yet');
   }

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -25,7 +25,7 @@ import {
 import { askVersion, capture } from './versionProbe';
 import { readOverlay, seedIfEmpty, writeOverlay } from './sideSettings';
 import { thisSide } from './installer';
-import { latestServerVersion, serverOnThisSide, serverPath } from './installer';
+import { latestServerVersion, latestTeamServerVersion, serverOnThisSide, serverPath } from './installer';
 import { DbLog, EMPTY_LOG } from './roundsDb';
 import { ProvidersAnswer } from './providers';
 import { readProviders } from './providersProbe';
@@ -188,6 +188,8 @@ export class PanelProvider implements vscode.WebviewViewProvider {
   }> = {};
   /** The newest published server version, and when GitHub last answered. */
   private latestServer = '';
+  /** The newest published Team-server version, shown to admins only. Read-only: it is deployed. */
+  private latestTeamServer = '';
   private latestCheckedAt = 0;
   /** Each vendor's installed and published CLI version, and when they were last read. */
   private cliStatus: Record<string, CliStatus> = {};
@@ -438,6 +440,7 @@ export class PanelProvider implements vscode.WebviewViewProvider {
       usage: this.remembered(await this.readUsage()),
       usageWindow: this.usageWindow,
       latestServerVersion: published,
+      latestTeamServerVersion: this.latestTeamServer,
       cliStatus: await this.vendorCliStatus(vendors),
       modelPrices: await this.modelPrices(vendors),
       snippetStatus: await pastedSnippetStatus(),
@@ -1918,6 +1921,9 @@ export class PanelProvider implements vscode.WebviewViewProvider {
     }
     this.latestCheckedAt = Date.now();
     this.latestServer = (await latestServerVersion()) ?? '';
+    // The Team server's line, on the same clock and in the same breath: two release lines read from
+    // one tag list, and a second timer would mean two rate limits and two answers about one moment.
+    this.latestTeamServer = (await latestTeamServerVersion()) ?? '';
     return this.latestServer;
   }
 

--- a/src_vs_code/src/panelView.ts
+++ b/src_vs_code/src/panelView.ts
@@ -109,6 +109,8 @@ export interface PanelState {
   readonly usageWindow: Window;
   /** The newest published server version, or empty while it is unknown or unreachable. */
   readonly latestServerVersion: string;
+  /** The newest published Team-server version, or empty. Admins see it; nobody can act on it here. */
+  readonly latestTeamServerVersion?: string | undefined;
   /**
    * The local model engine on this machine, probed at repaint.
    *
@@ -165,7 +167,7 @@ export function panelHtml(state: PanelState, nonce: string, nowMs: number = Date
     section('gate', 'The gate', open, gateBody(state.settings)),
     section('limits', 'Limits', open, limitsBody(state.settings)),
     section('keys', 'Vendor keys', open, keysBody(state)),
-    section('teamServers', 'Team servers', open, teamServersBody(state.teamServers ?? [])),
+    section('teamServers', 'Team servers', open, teamServersBody(state.teamServers ?? [], state.latestTeamServerVersion ?? '')),
     section('side', 'This side', open, sideBody(state)),
     section('server', 'MCP server', open, serverBody(state)),
     section('rounds', 'Active rounds', open, `<div id="live-rounds">${roundsBody(state.sessions, nowMs)}</div>`),

--- a/src_vs_code/src/teamServerView.ts
+++ b/src_vs_code/src/teamServerView.ts
@@ -1,5 +1,8 @@
 import { Catalog, CatalogVendor, SlotSummary, Usage } from './teamServerApi';
 import { TeamServer, canonicalTeamServerUrl } from './teamServers';
+// The same comparator the coai-mcp update check uses. Two version comparisons in one panel that
+// disagreed about what "newer" means is a defect waiting for a version like 0.10.0.
+import { compareVersions } from './coaiInstall';
 // The ONE escaper, imported rather than copied. A private second copy is the anti-pattern the
 // security rule names by example — "three byte-identical private copies | hardening one left the
 // other two behind" — and byte-identical is exactly what this one was. Caught on the code round.
@@ -213,14 +216,38 @@ function notSignedInHere(state: TeamServerState): string {
       + `itself in: ${state.problem}`;
 }
 
+/**
+ * What the release line has, for the person who could act on it.
+ *
+ * <p><b>Admins only, and read-only on purpose.</b> A Team server is DEPLOYED, not downloaded —
+ * there is no Update button here and there could not be one, because updating it means touching a
+ * machine this panel has no business touching. The request was to SHOW it, and that is all this
+ * does.</p>
+ *
+ * <p>Silent in three states, each of which would otherwise be a sentence that teaches nothing: the
+ * caller is not an admin; the server has not said its version yet; or no `server-v*` release has
+ * been published (the Team server is deployed by hand, so that is the ordinary state today).</p>
+ */
+export function publishedNote(state: TeamServerState, published: string): string {
+  const running = state.catalog?.serverVersion ?? '';
+  if (state.catalog?.isAdmin !== true || running.length === 0 || published.length === 0) {
+    return '';
+  }
+
+  return compareVersions(published, running) > 0
+    ? `⬆ ${published} is published — this one runs ${running}.`
+    : `${published} is the newest published — this one is up to date.`;
+}
+
 /** One server's rows. */
-export function teamServerRow(state: TeamServerState): string {
+export function teamServerRow(state: TeamServerState, published = ''): string {
   const signedIn = state.email.length > 0;
   const id = escape(state.server.id);
   // A button that cannot help while something is already in flight is disabled rather than left
   // pressable — pressing it again is what a person does when nothing appears to be happening.
   const stop = (state.busy ?? '').length > 0 ? ' disabled' : '';
   const slots = (state.catalog?.vendors ?? []).map((v) => escape(slotSentence(v))).join('; ');
+  const release = publishedNote(state, published);
 
   return `<div class="ts-row" data-server="${id}">
   <div class="ts-head">
@@ -229,6 +256,7 @@ export function teamServerRow(state: TeamServerState): string {
   </div>
   <div class="ts-acct">${accountGlyph(signedIn)} ${escape(signedIn ? state.email : 'no account')}</div>
   <div class="hint">${escape(statusSentence(state))}</div>
+  ${release.length > 0 ? `<div class="hint ts-release">${escape(release)}</div>` : ''}
   ${slots.length > 0 ? `<div class="ts-slots">${slots}</div>` : ''}
   <div class="hint ts-warn">${escape(disclosure(state.server.url))}</div>
   <div class="ts-buttons">
@@ -241,7 +269,7 @@ export function teamServerRow(state: TeamServerState): string {
 }
 
 /** The whole section body. */
-export function teamServersBody(states: readonly TeamServerState[]): string {
+export function teamServersBody(states: readonly TeamServerState[], published = ''): string {
   const add = `<button class="add" data-command="addTeamServer">＋&nbsp; Add a Team server</button>`;
   if (states.length === 0) {
     return `<div class="hint"><b>Nothing here yet.</b> A Team server runs the vendor CLIs on one `
@@ -250,6 +278,6 @@ export function teamServersBody(states: readonly TeamServerState[]): string {
 ${add}`;
   }
 
-  return `${states.map(teamServerRow).join('\n')}
+  return `${states.map((s) => teamServerRow(s, published)).join('\n')}
 ${add}`;
 }

--- a/src_vs_code/src/test/teamServerView.test.ts
+++ b/src_vs_code/src/test/teamServerView.test.ts
@@ -6,6 +6,7 @@ import {
   TeamServerState,
   disclosure,
   slotSentence,
+  publishedNote,
   statusSentence,
   teamServerRow,
   teamServersBody,
@@ -128,7 +129,45 @@ test('a server that has not answered yet says it is asking, not that it is broke
 });
 
 /**
- * The address and the account, which now appear in this section and nowhere else.
+ * What the release line has, for the person who could act on it — and silence for everybody else.
+ *
+ * <p>Read-only by design: a Team server is deployed rather than downloaded, so there is no button
+ * and there could not be one. The operator asked to be SHOWN it, with an arrow when a newer
+ * release exists, and nothing more.</p>
+ */
+test('an admin is told what is published, and told when it is newer', () => {
+  const admin = (serverVersion: string): TeamServerState =>
+    state({ email: 'a@b.c', catalog: { serverVersion, isAdmin: true, vendors: [], error: '' } });
+
+  assert.ok(publishedNote(admin('0.5.2'), '0.5.3').startsWith('⬆'), 'a newer release leads with the arrow');
+  assert.ok(publishedNote(admin('0.5.2'), '0.5.3').includes('0.5.3'), 'and names it');
+  assert.ok(publishedNote(admin('0.5.2'), '0.5.3').includes('0.5.2'), 'beside what is running');
+
+  assert.ok(!publishedNote(admin('0.5.3'), '0.5.3').startsWith('⬆'), 'the same version is not an update');
+  assert.ok(publishedNote(admin('0.5.3'), '0.5.3').includes('up to date'));
+
+  // 0.10.0 against 0.9.9 is the case a string comparison gets wrong, which is why this shares the
+  // comparator with the coai-mcp update check rather than having one of its own.
+  assert.ok(publishedNote(admin('0.9.9'), '0.10.0').startsWith('⬆'), '0.10.0 is newer than 0.9.9');
+});
+
+test('everybody who is not an admin is told nothing about the release line', () => {
+  const notAdmin = state({
+    email: 'a@b.c',
+    catalog: { serverVersion: '0.5.2', isAdmin: false, vendors: [], error: '' },
+  });
+  assert.strictEqual(publishedNote(notAdmin, '0.5.3'), '');
+
+  // Two more silences, each of which would otherwise be a sentence that teaches nothing: a server
+  // that has not said its version yet, and a release line with nothing published in it — which is
+  // the ordinary state today, since the Team server is deployed by hand and has no `server-v*` tag.
+  const admin = { ...notAdmin, catalog: { ...notAdmin.catalog!, isAdmin: true } };
+  assert.strictEqual(publishedNote({ ...admin, catalog: undefined }, '0.5.3'), '');
+  assert.strictEqual(publishedNote(admin, ''), '');
+});
+
+/**
+ * The address and the account, which appear in this section and nowhere else.
  *
  * <p>Asserted here for the same reason: until 0.31.4 they were also in the *Server* section, so a
  * regression that dropped them from the row would still have shown them somewhere. Nothing is


### PR DESCRIPTION
## What was asked

> и для админа — показывай еще какая версия последняя в релизах. в релизах более свежая — должен будет показ иконку(обновить). просто показываем. не нужно никаких действий

## What it does

A Team server row gains one line for a caller the catalog marks `isAdmin`: the newest published `server-v*` release, with a **⬆** when it is ahead of the version that server reports.

**Read-only by construction, not by omission.** A Team server is *deployed*, not downloaded — an Update button here would mean this panel touching a machine it has no business touching. It says there is a reason to go and update it; going is a person's job.

## Silent in three states

Each of which would otherwise be a sentence that teaches nothing:

- the caller is not an admin;
- the server has not said its version yet;
- **no `server-v*` release exists at all** — which is today's state, because the deployment was made by hand and that release line has never been cut. So this ships correct and invisible until somebody cuts one.

## Widened rather than copied

`versionFromTag`, `newestServerTag` and `latestTag` take the tag prefix as a parameter now. The Team server's lookup is the **same fetch, the same half-hour clock and the same comparator** — `server-v` against `mcp-v` is the whole difference.

A second copy of that filter would have been the exact defect its own comment warns about: asking GitHub for *"the latest release"* and getting the newest tag of any shape, which is how the coai-mcp update check silently never fired for months.

The comparator is shared for the same reason — two version comparisons in one panel that disagreed about "newer" is a defect waiting for `0.10.0`, and the test names that case.

## Observed

`tsc` clean · **647** extension tests, 0 failing · `npm run package` · plan-lifecycle, pin-check clean.

## Not in this PR

Adding `oleksandr.dubyna@remsoft.dev` to `Coai__Admins` on the deployment — that is a config change on the VM, and the vault prompt for it is still waiting to be approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Team server admins can see the latest published server version in each Team server row.
  - An ⬆ marker indicates when a newer version is available; current or unavailable version information is handled silently.
  - Non-admin views remain unchanged.

- **Documentation**
  - Added documentation and changelog coverage for Team server release indicators.

- **Tests**
  - Added coverage for update notifications, current versions, semantic version ordering, and visibility rules.

- **Chores**
  - Updated the extension version to 0.31.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->