### PR TITLE
fix(remote): the job claim is written where a kill cannot truncate it

### DIFF
--- a/src_mcp/runners/Reviewers/RemoteRuntime.cs
+++ b/src_mcp/runners/Reviewers/RemoteRuntime.cs
@@ -293,7 +293,14 @@ public sealed class RemoteRuntime(string id, string serverUrl, string vendorOnSe
     {
         // Beside the destination, never in the temp directory: a move across volumes is a copy, and a
         // copy is the non-atomic write this exists to avoid.
-        var pending = jobFile + ".writing-" + Guid.NewGuid().ToString("N")[..8];
+        //
+        // The name is DERIVED, not random. A random one cannot be cleaned up after the very failure
+        // this function is about — a process killed between creating the sibling and renaming it runs
+        // no `finally`, and nothing would ever know the orphan's name. Derived from the job file,
+        // which is itself unique per invocation, the next attempt simply writes over it. Raised by
+        // two reviewers, who also pointed out that "cleaned up on the failure path" cannot be true
+        // for a kill.
+        var pending = jobFile + ".writing";
         try
         {
             File.WriteAllText(
@@ -301,7 +308,7 @@ public sealed class RemoteRuntime(string id, string serverUrl, string vendorOnSe
                 JsonSerializer.Serialize(
                     new RemoteClaim(TeamServerAuth.Normalise(serverUrl), jobId, tokenFile),
                     RemoteClaimContext.Default.RemoteClaim));
-            File.Move(pending, jobFile, overwrite: true);
+            Replace(pending, jobFile);
 
             return string.Empty;
         }
@@ -309,6 +316,34 @@ public sealed class RemoteRuntime(string id, string serverUrl, string vendorOnSe
         {
             Forget(pending);
             return e.Message;
+        }
+    }
+
+    /// <summary>Rename over the destination, retrying the refusals Windows hands out transiently.</summary>
+    /// <remarks>
+    /// <para>Copied in shape from <c>SessionStore</c>, which learned it the expensive way and left the
+    /// measurement in a comment: on Windows a rename over an open file needs that file's handle to
+    /// permit deletion, and a reader that is not this code — an antivirus scanner, an indexer, the
+    /// parent reading a claim at the moment a retry writes one — can refuse it for an instant.</para>
+    /// <para>Fewer attempts and a shorter step than the session store's, because the contention here
+    /// is nothing like the same: a claim is written once per shim, to a path unique to that
+    /// invocation. A reviewer asked why this fix omitted the retry its own cited prior art needed.
+    /// It no longer does.</para>
+    /// </remarks>
+    private static void Replace(string pending, string jobFile)
+    {
+        const int attempts = 5;
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            try
+            {
+                File.Move(pending, jobFile, overwrite: true);
+                return;
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException && attempt < attempts)
+            {
+                Thread.Sleep(Random.Shared.Next(5, 15) * attempt);
+            }
         }
     }
 

--- a/src_mcp/runners/Reviewers/RemoteRuntime.cs
+++ b/src_mcp/runners/Reviewers/RemoteRuntime.cs
@@ -332,20 +332,37 @@ public sealed class RemoteRuntime(string id, string serverUrl, string vendorOnSe
     /// </remarks>
     private static void Replace(string pending, string jobFile)
     {
-        const int attempts = 5;
-        for (var attempt = 1; attempt <= attempts; attempt++)
+        for (var attempt = 1; attempt <= ReplaceAttempts; attempt++)
         {
             try
             {
                 File.Move(pending, jobFile, overwrite: true);
                 return;
             }
-            catch (Exception e) when (e is IOException or UnauthorizedAccessException && attempt < attempts)
+            catch (Exception e) when (WorthRetrying(e, attempt))
             {
-                Thread.Sleep(Random.Shared.Next(5, 15) * attempt);
+                // Jittered, because several writers backing off in lock-step retry in lock-step.
+                Thread.Sleep(Random.Shared.Next(MinBackoffMs, MaxBackoffMs) * attempt);
             }
         }
     }
+
+    /// <summary>A transient refusal with an attempt left, rather than a failure to report.</summary>
+    /// <remarks>
+    /// A predicate rather than a compound `when` clause: the loop it guards was over the doctrine's
+    /// complexity ceiling with the filter inline, and this is the clause that reads as a sentence.
+    /// </remarks>
+    private static bool WorthRetrying(Exception e, int attempt) =>
+        e is IOException or UnauthorizedAccessException && attempt < ReplaceAttempts;
+
+    /// <summary>Five, because the contention is one reader at most — not the session store's crowd.</summary>
+    private const int ReplaceAttempts = 5;
+
+    /// <inheritdoc cref="ReplaceAttempts"/>
+    private const int MinBackoffMs = 5;
+
+    /// <inheritdoc cref="ReplaceAttempts"/>
+    private const int MaxBackoffMs = 15;
 
     /// <summary>The job reached a terminal state by itself; there is nothing to cancel.</summary>
     public static void Forget(string jobFile)

--- a/src_mcp/runners/Reviewers/RemoteRuntime.cs
+++ b/src_mcp/runners/Reviewers/RemoteRuntime.cs
@@ -274,25 +274,40 @@ public sealed class RemoteRuntime(string id, string serverUrl, string vendorOnSe
     /// </summary>
     /// <returns>Empty when the claim was written; otherwise why it could not be.</returns>
     /// <remarks>
-    /// The failure is RETURNED rather than swallowed. Losing the claim costs a cancellation, not a
-    /// review — the server's queue deadline still ends the job eventually — so this must not fail the
-    /// review; but a silent loss means a person is later billed for work nobody can explain, with
-    /// nothing anywhere saying why. The shim prints it. Raised twice on the code round.
+    /// <para>The failure is RETURNED rather than swallowed. Losing the claim costs a cancellation, not
+    /// a review — the server's queue deadline still ends the job eventually — so this must not fail
+    /// the review; but a silent loss means a person is later billed for work nobody can explain, with
+    /// nothing anywhere saying why. The shim prints it. Raised twice on the code round.</para>
+    /// <para><b>Written to a sibling and MOVED over, because the point of this file is that it
+    /// survives a kill.</b> `File.WriteAllText` truncates first and writes second, so a process killed
+    /// between those two steps left a file that exists and names nothing — `ReadClaim` returns
+    /// `None`, `CancelAbandonedAsync` gives up, and the job keeps costing money until the server's own
+    /// deadline. That is precisely the silent loss the paragraph above says must not happen, in the
+    /// one function written to prevent it.</para>
+    /// <para>A same-directory move is atomic on both platforms this ships to, so a reader sees the old
+    /// claim or the new one and never half of either. Found by a release runner: the killed-shim test
+    /// failed on win-x64 and nowhere else, expecting a job id and reading an empty string, because a
+    /// slower machine killed the shim inside the write.</para>
     /// </remarks>
     public static string Claim(string jobFile, string serverUrl, string jobId, string tokenFile)
     {
+        // Beside the destination, never in the temp directory: a move across volumes is a copy, and a
+        // copy is the non-atomic write this exists to avoid.
+        var pending = jobFile + ".writing-" + Guid.NewGuid().ToString("N")[..8];
         try
         {
             File.WriteAllText(
-                jobFile,
+                pending,
                 JsonSerializer.Serialize(
                     new RemoteClaim(TeamServerAuth.Normalise(serverUrl), jobId, tokenFile),
                     RemoteClaimContext.Default.RemoteClaim));
+            File.Move(pending, jobFile, overwrite: true);
 
             return string.Empty;
         }
         catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
+            Forget(pending);
             return e.Message;
         }
     }

--- a/src_mcp/tests/ClaimIsWrittenAtomicallyTests.cs
+++ b/src_mcp/tests/ClaimIsWrittenAtomicallyTests.cs
@@ -98,6 +98,39 @@ public sealed class ClaimIsWrittenAtomicallyTests
         File.Delete(jobFile);
     }
 
+    /// <summary>
+    /// A destination nothing can replace is REPORTED, after the retries have been spent on it.
+    /// </summary>
+    /// <remarks>
+    /// <para>The retry loop exists because a rename over an open file can be refused for an instant
+    /// by a scanner, an indexer, or a reader that is not this code — the lesson `SessionStore` paid
+    /// for and left a measurement about. A handle held for the whole call is the deterministic
+    /// version of that refusal: every attempt fails, the last one is caught, and `Claim` returns the
+    /// reason rather than throwing, which is the contract the shim prints.</para>
+    /// <para>It also leaves nothing behind. The sibling is removed on the way out, so a destination
+    /// somebody else has locked costs one message and no litter.</para>
+    /// </remarks>
+    [Fact]
+    public void ADestinationHeldOpen_IsReportedRatherThanThrown_AndLeavesNoSibling()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"coai-locked-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var jobFile = Path.Combine(dir, "job.json");
+        RemoteRuntime.Claim(jobFile, "https://coai.example.com", "job-1", "t.json").Should().BeEmpty();
+
+        string failure;
+        using (var _ = new FileStream(jobFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            failure = RemoteRuntime.Claim(jobFile, "https://coai.example.com", "job-2", "t.json");
+        }
+
+        failure.Should().NotBeEmpty("a destination that cannot be replaced is the shim's to report");
+        RemoteRuntime.ReadClaim(jobFile).JobId.Should().Be("job-1",
+            "the claim that was already there survives a write that could not land");
+        Directory.EnumerateFiles(dir).Should().Equal([jobFile], "the sibling is cleaned up");
+        Directory.Delete(dir, recursive: true);
+    }
+
     [Fact]
     public void AClaimIntoAMissingDirectory_ReportsWhyRatherThanThrowing()
     {

--- a/src_mcp/tests/ClaimIsWrittenAtomicallyTests.cs
+++ b/src_mcp/tests/ClaimIsWrittenAtomicallyTests.cs
@@ -104,30 +104,27 @@ public sealed class ClaimIsWrittenAtomicallyTests
     /// <remarks>
     /// <para>The retry loop exists because a rename over an open file can be refused for an instant
     /// by a scanner, an indexer, or a reader that is not this code — the lesson `SessionStore` paid
-    /// for and left a measurement about. A handle held for the whole call is the deterministic
-    /// version of that refusal: every attempt fails, the last one is caught, and `Claim` returns the
-    /// reason rather than throwing, which is the contract the shim prints.</para>
-    /// <para>It also leaves nothing behind. The sibling is removed on the way out, so a destination
-    /// somebody else has locked costs one message and no litter.</para>
+    /// for and left a measurement about. This is the deterministic version of that refusal: every
+    /// attempt fails, the last one is caught, and `Claim` returns the reason rather than throwing,
+    /// which is the contract the shim prints. It also leaves nothing behind.</para>
+    /// <para><b>The destination is a DIRECTORY, and the first draft of this test held a file open
+    /// instead.</b> That works on Windows and not on Linux, where a rename does not care who has the
+    /// file open — so it passed here and failed in CI, which is the same portability mistake this
+    /// repository keeps catching. A directory refuses a rename on both.</para>
     /// </remarks>
     [Fact]
-    public void ADestinationHeldOpen_IsReportedRatherThanThrown_AndLeavesNoSibling()
+    public void ADestinationThatCannotBeReplaced_IsReportedRatherThanThrown_AndLeavesNoSibling()
     {
         var dir = Path.Combine(Path.GetTempPath(), $"coai-locked-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dir);
         var jobFile = Path.Combine(dir, "job.json");
-        RemoteRuntime.Claim(jobFile, "https://coai.example.com", "job-1", "t.json").Should().BeEmpty();
+        Directory.CreateDirectory(jobFile);
 
-        string failure;
-        using (var _ = new FileStream(jobFile, FileMode.Open, FileAccess.Read, FileShare.None))
-        {
-            failure = RemoteRuntime.Claim(jobFile, "https://coai.example.com", "job-2", "t.json");
-        }
+        var failure = RemoteRuntime.Claim(jobFile, "https://coai.example.com", "job-2", "t.json");
 
         failure.Should().NotBeEmpty("a destination that cannot be replaced is the shim's to report");
-        RemoteRuntime.ReadClaim(jobFile).JobId.Should().Be("job-1",
-            "the claim that was already there survives a write that could not land");
-        Directory.EnumerateFiles(dir).Should().Equal([jobFile], "the sibling is cleaned up");
+        Directory.EnumerateFiles(dir).Should().BeEmpty(
+            "the sibling is cleaned up, so a destination somebody else holds costs one message and no litter");
         Directory.Delete(dir, recursive: true);
     }
 

--- a/src_mcp/tests/ClaimIsWrittenAtomicallyTests.cs
+++ b/src_mcp/tests/ClaimIsWrittenAtomicallyTests.cs
@@ -20,7 +20,7 @@ namespace CoaiMcp.Tests;
 /// for the file to EXIST and then killed the shim, which on a slower machine is a kill inside the
 /// write. The flake and the defect are the same fact.</para>
 /// </remarks>
-public class ClaimIsWrittenAtomicallyTests
+public sealed class ClaimIsWrittenAtomicallyTests
 {
     private static string TempFile() =>
         Path.Combine(Path.GetTempPath(), $"coai-claim-{Guid.NewGuid():N}.json");
@@ -47,6 +47,39 @@ public class ClaimIsWrittenAtomicallyTests
 
         Directory.EnumerateFiles(dir).Should().Equal([jobFile]);
         RemoteRuntime.ReadClaim(jobFile).JobId.Should().Be("job-4");
+        Directory.Delete(dir, recursive: true);
+    }
+
+    /// <summary>
+    /// The write goes THROUGH the sibling — asserted deterministically, with no seam in the product.
+    /// </summary>
+    /// <remarks>
+    /// <para>The gate asked for this twice and was right both times: the kill test reproduces the CI
+    /// failure but cannot be made to fail on a fast machine, so a return to a direct
+    /// `File.WriteAllText` could have slipped past every other test here. A synchronisation point
+    /// injected into the shim would have proved it, at the cost of test-only machinery on a path that
+    /// runs in production.</para>
+    /// <para>The filesystem is the seam instead. Block the SIBLING's path — put a directory where the
+    /// `.writing` file must go — and the two implementations answer differently and deterministically:
+    /// a create-then-rename writer cannot write and reports why, while a direct writer neither needs
+    /// the sibling nor notices it and publishes the claim happily. Verified by reverting the fix: this
+    /// test goes red with `Claim` returning empty and a claim on disk.</para>
+    /// </remarks>
+    [Fact]
+    public void WithTheSiblingsPathBlocked_NoClaimIsPublished()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"coai-blocked-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var jobFile = Path.Combine(dir, "job.json");
+        // A directory cannot be opened for writing, so the sibling write is refused.
+        Directory.CreateDirectory(jobFile + ".writing");
+
+        var failure = RemoteRuntime.Claim(jobFile, "https://coai.example.com", "job-77", "t.json");
+
+        failure.Should().NotBeEmpty("the write could not reach its sibling and must say so");
+        File.Exists(jobFile).Should().BeFalse(
+            "a claim that never went through the sibling was written straight at the destination, "
+            + "which is the truncate-then-write this whole change removed");
         Directory.Delete(dir, recursive: true);
     }
 

--- a/src_mcp/tests/ClaimIsWrittenAtomicallyTests.cs
+++ b/src_mcp/tests/ClaimIsWrittenAtomicallyTests.cs
@@ -1,0 +1,76 @@
+using CoaiMcp.Runners.Reviewers;
+using FluentAssertions;
+using Xunit;
+
+namespace CoaiMcp.Tests;
+
+/// <summary>
+/// A reader of the job claim sees a whole claim or no file — never an empty one.
+/// </summary>
+/// <remarks>
+/// <para><b>What this is for.</b> The claim file is the ONLY thing that survives a killed shim, and
+/// the parent reads it to cancel a job that is still costing money on a Team server. `Claim` wrote
+/// it with `File.WriteAllText`, which truncates first and writes second: a process killed between
+/// those two steps leaves a file that exists and names nothing. `ReadClaim` then returns
+/// `RemoteClaim.None`, `CancelAbandonedAsync` gives up, and the job runs to its queue deadline while
+/// somebody is billed for a review nobody can explain — the exact loss `Claim`'s own docstring says
+/// must not happen silently.</para>
+/// <para><b>How it was found.</b> Not by reading: `AKilledShimLEAVESAClaimTheParentCanActOn` failed
+/// on a win-x64 release runner and nowhere else, expecting `job-77` and getting `""`. The test waited
+/// for the file to EXIST and then killed the shim, which on a slower machine is a kill inside the
+/// write. The flake and the defect are the same fact.</para>
+/// </remarks>
+public class ClaimIsWrittenAtomicallyTests
+{
+    private static string TempFile() =>
+        Path.Combine(Path.GetTempPath(), $"coai-claim-{Guid.NewGuid():N}.json");
+
+    /// <summary>
+    /// The write leaves nothing beside the claim, whatever happened.
+    /// </summary>
+    /// <remarks>
+    /// A create-then-rename writer earns its atomicity by leaving a sibling around for an instant,
+    /// and the failure mode of that shape is litter: one abandoned `.writing-` file per crashed
+    /// shim, in a directory nobody sweeps.
+    /// </remarks>
+    [Fact]
+    public void TheWriteLeavesNoTemporaryFileBehind()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"coai-claimdir-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var jobFile = Path.Combine(dir, "job.json");
+
+        for (var i = 0; i < 5; i++)
+        {
+            RemoteRuntime.Claim(jobFile, "https://coai.example.com", $"job-{i}", "t.json").Should().BeEmpty();
+        }
+
+        Directory.EnumerateFiles(dir).Should().Equal([jobFile]);
+        RemoteRuntime.ReadClaim(jobFile).JobId.Should().Be("job-4");
+        Directory.Delete(dir, recursive: true);
+    }
+
+    [Fact]
+    public void AClaimSurvivesARoundTrip()
+    {
+        // The guard on the other side: making the write atomic must not change what it writes.
+        var jobFile = TempFile();
+
+        RemoteRuntime.Claim(jobFile, "https://coai.remsoft.dev/", "job-77", "t.json").Should().BeEmpty();
+
+        var claim = RemoteRuntime.ReadClaim(jobFile);
+        claim.JobId.Should().Be("job-77");
+        claim.TokenFile.Should().Be("t.json");
+        claim.Server.Should().Be(TeamServerAuth.Normalise("https://coai.remsoft.dev/"));
+        File.Delete(jobFile);
+    }
+
+    [Fact]
+    public void AClaimIntoAMissingDirectory_ReportsWhyRatherThanThrowing()
+    {
+        var nowhere = Path.Combine(Path.GetTempPath(), $"coai-absent-{Guid.NewGuid():N}", "deeper", "job.json");
+
+        RemoteRuntime.Claim(nowhere, "https://coai.example.com", "job-1", "t.json")
+            .Should().NotBeEmpty("losing the claim costs a cancellation, so it is returned rather than swallowed");
+    }
+}

--- a/src_mcp/tests/RemoteShimScenarioTests.cs
+++ b/src_mcp/tests/RemoteShimScenarioTests.cs
@@ -316,6 +316,73 @@ public sealed class RemoteShimScenarioTests : IAsyncLifetime
         }
     }
 
+    /// <summary>
+    /// Killed as early as the kill can be arranged: whatever the parent finds, it is never HALF a
+    /// claim.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>This is the regression test, and the test above is not.</b> That one waits for a
+    /// readable claim before killing, which is what makes it deterministic — and a reviewer pointed
+    /// out that determinism removed the exact window that found the defect. Both are needed: one
+    /// asserts the parent can cancel a claim that exists, and this one asserts nothing can be left in
+    /// between.</para>
+    /// <para>The assertion is what makes it stable rather than a race dressed up as a test. Two
+    /// outcomes are correct — the shim died before publishing anything, or a whole claim is there —
+    /// and only the third is a failure: a file that exists and names nothing, which is what a
+    /// truncate-then-write leaves and what `CancelAbandonedAsync` cannot act on. Reintroducing a
+    /// direct `File.WriteAllText` brings that third state back and this goes red; every other test in
+    /// the suite would stay green, which was the finding.</para>
+    /// <para><b>What this test cannot claim.</b> It was NOT observed to go red against the old
+    /// truncate-then-write on this machine: reverting the fix and running it twice left it green,
+    /// because the window between creating the file and filling it is microseconds here and killing a
+    /// process takes longer than that. That is not a weakness of the test — it is the reason the
+    /// defect survived every local run and was found by a loaded CI runner instead. The test
+    /// reproduces the CI failure by construction (kill on the first sign of the file, assert the
+    /// parent never sees half a claim) and cannot fail falsely, because two of the three outcomes are
+    /// accepted.</para>
+    /// <para>The `.writing` sibling may exist after a kill — no `finally` runs for one — which is why
+    /// its name is derived from the job file rather than random: the next attempt writes over it
+    /// instead of leaving an orphan nobody can name.</para>
+    /// </remarks>
+    [Fact]
+    public async Task AShimKilledMidClaim_LeavesEitherNothingOrAWholeClaim_NeverHalf()
+    {
+        SignIn();
+        _answer = context => context.Request.HttpMethod == "POST"
+            ? (202, """{"id":"job-77","position":1}""")
+            : (200, """{"id":"job-77","status":"queued","position":1}""");
+
+        for (var attempt = 0; attempt < 6; attempt++)
+        {
+            var invocation = new RemoteRuntime("codex", _prefix).Build(
+                ReviewRole.Architecture, "review this", _outputDir,
+                Path.Combine(_outputDir, "schema.json"), _outputDir,
+                new ReviewerSettings("codex") { Model = "m", DataDir = _dataDir, Timeout = TimeSpan.FromMinutes(5) });
+
+            var info = new ProcessStartInfo(ShimExe) { RedirectStandardError = true, UseShellExecute = false };
+            foreach (var argument in invocation.Request.Arguments.SkipWhile(a => a != "--ask-remote"))
+            {
+                info.ArgumentList.Add(argument);
+            }
+
+            using var process = Process.Start(info)!;
+            // As early as this can be arranged: the instant ANYTHING appears under the claim's name,
+            // including the sibling being written. On a slow machine that lands inside the write.
+            await WaitForAsync(
+                () => File.Exists(invocation.JobFile) || File.Exists(invocation.JobFile + ".writing"),
+                TimeSpan.FromSeconds(30));
+            process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync();
+
+            if (File.Exists(invocation.JobFile))
+            {
+                RemoteRuntime.ReadClaim(invocation.JobFile).JobId.Should().Be("job-77",
+                    "a claim file that exists must name its job — a parent holding half of one cannot "
+                    + "cancel, and the review keeps costing money until the server's own deadline");
+            }
+        }
+    }
+
     private static async Task WaitForAsync(Func<bool> condition, TimeSpan limit)
     {
         var clock = Stopwatch.StartNew();

--- a/src_mcp/tests/RemoteShimScenarioTests.cs
+++ b/src_mcp/tests/RemoteShimScenarioTests.cs
@@ -292,7 +292,14 @@ public sealed class RemoteShimScenarioTests : IAsyncLifetime
         }
 
         using var process = Process.Start(info)!;
-        await WaitForAsync(() => File.Exists(invocation.JobFile), TimeSpan.FromSeconds(30));
+        // Waits for a READABLE claim, not for the file to appear. Waiting on File.Exists killed the
+        // shim in the window between creating the file and writing it, which is a real window and a
+        // real defect — it left a claim naming no job, and the parent could not cancel. It is fixed
+        // (the write goes to a sibling and moves over), and this waits for the thing it actually
+        // needs so the test cannot depend on how fast the machine is. It failed on a win-x64 release
+        // runner and nowhere else: `Expected string to be "job-77" ... but "" has a length of 0`.
+        await WaitForAsync(
+            () => RemoteRuntime.ReadClaim(invocation.JobFile).JobId.Length > 0, TimeSpan.FromSeconds(30));
         process.Kill(entireProcessTree: true);
         await process.WaitForExitAsync();
 


### PR DESCRIPTION
## Found by a release runner

`AKilledShimLEAVESAClaimTheParentCanActOn` failed on **win-x64 and nowhere else** during the `mcp-v0.18.10` release — `Expected string to be "job-77" ... but "" has a length of 0`. The flake and a real defect turned out to be the same fact.

## The defect

The claim file is the **only** thing that survives a killed shim: the parent reads it to cancel a review still running on a Team server's subscription.

`Claim` wrote it with `File.WriteAllText`, which creates-and-truncates first and writes second. A process killed between those two steps leaves a file that **exists and names nothing** — `ReadClaim` returns `None`, `CancelAbandonedAsync` gives up, and the job runs to the server's queue deadline while somebody is billed for a review nobody can explain.

That is precisely the silent loss `Claim`'s own docstring says must not happen, in the one function written to prevent it. The test hit the window because it waited for the file to **exist** — true at create, before the content — and then killed immediately.

## The fix

Write to a sibling, move over. **Three other writers in this repository already do exactly that, for exactly this reason** — `SessionStore`, `Escalations` and the server's `JsonFileStore` — and the file whose whole purpose is surviving a kill was the one that did not.

## On the evidence, stated honestly

The mechanism is create-then-rename and a same-directory rename is atomic on both platforms this ships to; the CI failure is the observed symptom. I could **not** pin the atomicity itself with a deterministic test: a 120-byte payload's truncate-to-write window is too narrow to catch by racing a reader, and the first draft of the test caught something else entirely — a concurrent reader being refused the file for an instant during the replace, which `ReadClaim` folds into the same empty answer. That is not the defect, and a test that cannot tell the two apart is evidence for nothing. It was deleted rather than kept as decoration.

What **is** asserted: the claim round-trips, a write into a missing directory reports why instead of throwing, and five writes leave exactly one file behind — the litter a create-then-rename writer produces when its cleanup is wrong.

The scenario test now waits for a **readable claim** instead of for the file to appear, so it stops depending on how fast the machine is.

## Test plan

- [x] 1038 MCP, 0 failing
- [x] 171 server, 0 failing
- [x] the previously flaky scenario test passes on its own and in the full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)