### PR TITLE
feat(rounds): the log names the model each reviewer was launched with

### DIFF
--- a/research/module_server.md
+++ b/research/module_server.md
@@ -440,6 +440,19 @@ was named for making them the ones that run. `panelServerDefaultsAgreement.test.
 constants out of `SessionState.cs` rather than transcribing them, and a second test asserts that a
 default panel writes no gate key at all.
 
+**A round writes down which MODEL each reviewer was launched with (2026-09-08).** `ReviewerState`
+carries it and the rounds log renders it beside the role — a round that named its vendor and its role
+but not its model could not answer the question people actually ask about a slow or a weak reviewer,
+which is how one came to be investigated by reading the spending ledger instead
+([RESULTS_reviewer_input_sizes.md](RESULTS_reviewer_input_sizes.md)). The field is trailing and
+defaulted, so sessions already on disk stay valid and simply name none.
+
+**It is what was ASKED for, not necessarily what answered.** A Team server picks the model for the
+account it claims and reports none back, and an escalation can run a stronger one. Closing that gap
+needs a field on `ReviewStatusDto` and is written up as
+[PLAN_the_log_names_the_model.md](../todo/PLAN_the_log_names_the_model.md); until then the log shows
+the client's side and the docstring says so rather than letting the number imply more than it knows.
+
 **The vendors are offered in a shuffled order (2026-09-08).** `BuildWork` builds a round
 vendor-major and the scheduler starts one task per row against one machine-wide semaphore, which
 hands slots out in the order they were asked for — so the list's order is the order reviewers reach

--- a/research/module_server.md
+++ b/research/module_server.md
@@ -444,7 +444,7 @@ default panel writes no gate key at all.
 carries it and the rounds log renders it beside the role — a round that named its vendor and its role
 but not its model could not answer the question people actually ask about a slow or a weak reviewer,
 which is how one came to be investigated by reading the spending ledger instead
-([RESULTS_reviewer_input_sizes.md](RESULTS_reviewer_input_sizes.md)). The field is trailing and
+(`RESULTS_reviewer_input_sizes.md`, which lands with the reviewer-deadline fix). The field is trailing and
 defaulted, so sessions already on disk stay valid and simply name none.
 
 **It is what was ASKED for, not necessarily what answered.** A Team server picks the model for the

--- a/research/module_server.md
+++ b/research/module_server.md
@@ -444,7 +444,7 @@ default panel writes no gate key at all.
 carries it and the rounds log renders it beside the role — a round that named its vendor and its role
 but not its model could not answer the question people actually ask about a slow or a weak reviewer,
 which is how one came to be investigated by reading the spending ledger instead
-(`RESULTS_reviewer_input_sizes.md`, which lands with the reviewer-deadline fix). The field is trailing and
+([RESULTS_reviewer_input_sizes.md](RESULTS_reviewer_input_sizes.md)). The field is trailing and
 defaulted, so sessions already on disk stay valid and simply name none.
 
 **It is what was ASKED for, not necessarily what answered.** A Team server picks the model for the

--- a/src_mcp/src/Server/LiveRound.cs
+++ b/src_mcp/src/Server/LiveRound.cs
@@ -39,18 +39,21 @@ public sealed class LiveRound
                 // The invocation has carried this since the adapters were written; the round simply
                 // never wrote it down, so the log could say WHO reviewed but not WITH WHAT.
                 //
-                // Trimmed, because a configured model of " " is not a model and the renderer's
-                // `s.model ? ...` would treat it as one — a separator with nothing after it. Raised
-                // twice on the plan round.
-                //
-                // The null coalesce is NOT belt-and-braces on a non-nullable string: an invocation
-                // that came back through JSON with `"model": null` is null at runtime whatever the
-                // annotation says, and `.Trim()` on it would throw before the round is persisted or
-                // any reviewer starts. Two reviewers on the code round, and the one place where a
-                // nullable-reference annotation is a claim rather than a guarantee.
-                Model: (w.Invocation.Model ?? string.Empty).Trim()));
+                Model: Normalise(w.Invocation.Model)));
         Persist();
     }
+
+    /// <summary>A model, or nothing — the two ways of having none, made one.</summary>
+    /// <remarks>
+    /// <para>Trimmed, because a configured model of " " is not a model and the renderer's truthiness
+    /// check would treat it as one: a separator with nothing after it.</para>
+    /// <para>The null coalesce is NOT belt-and-braces on a non-nullable string. An invocation that
+    /// came back through JSON with a null model IS null at runtime whatever the annotation says, and
+    /// `.Trim()` on it would throw before the round is persisted or any reviewer starts — the one
+    /// place in this file where a nullable-reference annotation is a claim rather than a
+    /// guarantee.</para>
+    /// </remarks>
+    private static string Normalise(string? model) => (model ?? string.Empty).Trim();
 
     /// <summary>One reviewer moved. Called from the fan-out's threads, hence the lock.</summary>
     public void Report(ReviewerProgress progress)

--- a/src_mcp/src/Server/LiveRound.cs
+++ b/src_mcp/src/Server/LiveRound.cs
@@ -32,7 +32,13 @@ public sealed class LiveRound
         _session = session;
         _states = work.ToDictionary(
             w => Key(w.Invocation.Provider, w.Invocation.Role.ToString()),
-            w => new ReviewerState(w.Invocation.Provider, w.Invocation.Role.ToString(), ReviewerState.Queued));
+            w => new ReviewerState(
+                w.Invocation.Provider,
+                w.Invocation.Role.ToString(),
+                ReviewerState.Queued,
+                // The invocation has carried this since the adapters were written; the round simply
+                // never wrote it down, so the log could say WHO reviewed but not WITH WHAT.
+                Model: w.Invocation.Model));
         Persist();
     }
 

--- a/src_mcp/src/Server/LiveRound.cs
+++ b/src_mcp/src/Server/LiveRound.cs
@@ -41,9 +41,14 @@ public sealed class LiveRound
                 //
                 // Trimmed, because a configured model of " " is not a model and the renderer's
                 // `s.model ? ...` would treat it as one — a separator with nothing after it. Raised
-                // twice on the plan round. It cannot be null: `ReviewerInvocation.Model` is a
-                // non-nullable string defaulting to empty.
-                Model: w.Invocation.Model.Trim()));
+                // twice on the plan round.
+                //
+                // The null coalesce is NOT belt-and-braces on a non-nullable string: an invocation
+                // that came back through JSON with `"model": null` is null at runtime whatever the
+                // annotation says, and `.Trim()` on it would throw before the round is persisted or
+                // any reviewer starts. Two reviewers on the code round, and the one place where a
+                // nullable-reference annotation is a claim rather than a guarantee.
+                Model: (w.Invocation.Model ?? string.Empty).Trim()));
         Persist();
     }
 

--- a/src_mcp/src/Server/LiveRound.cs
+++ b/src_mcp/src/Server/LiveRound.cs
@@ -38,7 +38,12 @@ public sealed class LiveRound
                 ReviewerState.Queued,
                 // The invocation has carried this since the adapters were written; the round simply
                 // never wrote it down, so the log could say WHO reviewed but not WITH WHAT.
-                Model: w.Invocation.Model));
+                //
+                // Trimmed, because a configured model of " " is not a model and the renderer's
+                // `s.model ? ...` would treat it as one — a separator with nothing after it. Raised
+                // twice on the plan round. It cannot be null: `ReviewerInvocation.Model` is a
+                // non-nullable string defaulting to empty.
+                Model: w.Invocation.Model.Trim()));
         Persist();
     }
 

--- a/src_mcp/src/Server/SessionStore.cs
+++ b/src_mcp/src/Server/SessionStore.cs
@@ -22,9 +22,9 @@ namespace CoaiMcp.Server;
 /// simply names no model, which is the truth about it.</para>
 /// <para><b>It is what was ASKED for, not necessarily what answered.</b> A Team server picks the
 /// model for the account it claims and reports none back, and an escalation can run a stronger one —
-/// so this is the client's side of the question until the server answers it too
-/// (`todo/PLAN_the_log_names_the_model.md`). Naming that limit here rather than letting the log
-/// imply more than it knows.</para>
+/// so this is the client's side of the question until the server answers it too — the plan named
+/// `PLAN_the_log_names_the_model` records what step 2 needs. Naming that limit here rather than
+/// letting the log imply more than it knows.</para>
 /// </remarks>
 public sealed record ReviewerState(
     string Provider,

--- a/src_mcp/src/Server/SessionStore.cs
+++ b/src_mcp/src/Server/SessionStore.cs
@@ -14,13 +14,26 @@ namespace CoaiMcp.Server;
 /// measures each reviewer anyway (<c>ReviewerProgress.Elapsed</c>) and was throwing the number away
 /// at this boundary.
 /// </remarks>
+/// <param name="Model">
+/// The model this reviewer was LAUNCHED with — what the panel is configured to ask for.
+/// </param>
+/// <remarks>
+/// <para>Trailing and defaulted, so every session file already on disk stays valid: an older round
+/// simply names no model, which is the truth about it.</para>
+/// <para><b>It is what was ASKED for, not necessarily what answered.</b> A Team server picks the
+/// model for the account it claims and reports none back, and an escalation can run a stronger one —
+/// so this is the client's side of the question until the server answers it too
+/// (`todo/PLAN_the_log_names_the_model.md`). Naming that limit here rather than letting the log
+/// imply more than it knows.</para>
+/// </remarks>
 public sealed record ReviewerState(
     string Provider,
     string Role,
     string Status,
     int Findings = 0,
     string Note = "",
-    double Seconds = 0)
+    double Seconds = 0,
+    string Model = "")
 {
     public const string Queued = "queued";
     public const string Running = "running";

--- a/src_mcp/tests/LiveRoundTests.cs
+++ b/src_mcp/tests/LiveRoundTests.cs
@@ -24,6 +24,39 @@ public sealed class LiveRoundTests
     private static ReviewerWork Work(string provider, ReviewRole role) =>
         new(new ReviewerInvocation(provider, role, new ProcessRequest("cli", [], ".")));
 
+    /// <summary>The same JSON with one property name removed, wherever it appears.</summary>
+    private static void WriteWithout(
+        System.Text.Json.JsonElement element,
+        string drop,
+        System.Text.Json.Utf8JsonWriter writer)
+    {
+        switch (element.ValueKind)
+        {
+            case System.Text.Json.JsonValueKind.Object:
+                writer.WriteStartObject();
+                foreach (var property in element.EnumerateObject().Where(p => p.Name != drop))
+                {
+                    writer.WritePropertyName(property.Name);
+                    WriteWithout(property.Value, drop, writer);
+                }
+
+                writer.WriteEndObject();
+                break;
+            case System.Text.Json.JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in element.EnumerateArray())
+                {
+                    WriteWithout(item, drop, writer);
+                }
+
+                writer.WriteEndArray();
+                break;
+            default:
+                element.WriteTo(writer);
+                break;
+        }
+    }
+
     private static NormalisedReview Review(int findings) =>
         new(
             [.. Enumerable.Range(0, findings).Select(i =>
@@ -63,6 +96,32 @@ public sealed class LiveRoundTests
     }
 
     [Fact]
+    public void ANullOrWhitespaceModel_IsRecordedAsNone()
+    {
+        // The two inputs the "launched without a model" test does NOT reach: it uses the invocation's
+        // own default, which is already empty, so neither the coalesce nor the trim ever runs. A
+        // reviewer on the code round asked for them by name.
+        //
+        // `null!` is the point rather than a shortcut: an invocation that came back through JSON with
+        // a null model IS null at runtime whatever the annotation says, and that is the case the
+        // coalesce exists for.
+        var store = new SessionStore(_dir);
+        var session = Session();
+        store.Save(session);
+
+        var codex = Work("codex", ReviewRole.Architecture);
+        var local = Work("local", ReviewRole.SecurityReliability);
+        _ = new LiveRound(store, session, [
+            codex with { Invocation = codex.Invocation with { Model = null! } },
+            local with { Invocation = local.Invocation with { Model = "   " } },
+        ]);
+
+        store.Load("D:/repo", "feature/x")!.Rounds.Single().ReviewerStates
+            .Should().OnlyContain(s => s.Model == string.Empty,
+                "a model that is null or only whitespace is no model, and neither may throw");
+    }
+
+    [Fact]
     public void ASessionFileWrittenBeforeTheModelField_StillLoads()
     {
         // The promise a trailing default makes, kept by reading a file that predates it.
@@ -71,10 +130,27 @@ public sealed class LiveRoundTests
         store.Save(session);
         _ = new LiveRound(store, session, [Work("codex", ReviewRole.Architecture)]);
 
+        // Removed STRUCTURALLY, not by string surgery. The first draft replaced `"model": "",`
+        // — and `Model` is the trailing property, so there is no comma after it, so the replacement
+        // matched nothing and this test reloaded a CURRENT-format file while claiming to prove
+        // something about an older one. Caught on the code round; it is the same vacuous shape as a
+        // test that compares a function with itself.
         var path = Directory.EnumerateFiles(Path.Combine(_dir, "sessions"), "session-*.json").Single();
-        var withoutModel = File.ReadAllText(path).Replace("\"model\": \"\",", string.Empty);
-        File.WriteAllText(path, withoutModel);
+        var legacy = File.ReadAllText(path);
+        legacy.Should().Contain("\"model\"", "the fixture must start from a file that HAS the field");
 
+        using (var document = System.Text.Json.JsonDocument.Parse(legacy))
+        {
+            using var buffer = new MemoryStream();
+            using (var writer = new System.Text.Json.Utf8JsonWriter(buffer))
+            {
+                WriteWithout(document.RootElement, "model", writer);
+            }
+
+            File.WriteAllBytes(path, buffer.ToArray());
+        }
+
+        File.ReadAllText(path).Should().NotContain("\"model\"", "the field really is gone now");
         store.Load("D:/repo", "feature/x")!.Rounds.Single().ReviewerStates
             .Single().Model.Should().BeEmpty();
     }

--- a/src_mcp/tests/LiveRoundTests.cs
+++ b/src_mcp/tests/LiveRoundTests.cs
@@ -30,6 +30,55 @@ public sealed class LiveRoundTests
                 new Finding(Severity.Major, Category.Security, "a.cs", i + 1, $"f{i}", "why", "fix", ["codex"]))],
             []);
 
+    /// <summary>
+    /// The round writes down WHICH MODEL each reviewer was launched with.
+    /// </summary>
+    /// <remarks>
+    /// <para>The invocation has carried the model since the adapters were written; the round simply
+    /// never wrote it down, so the log could say who reviewed and not with what. That is how a slow
+    /// claude reviewer came to be investigated by reading a spending ledger instead of the log
+    /// (`research/RESULTS_reviewer_input_sizes.md`).</para>
+    /// <para>The field is trailing and defaulted, so every session file already on disk stays valid:
+    /// an older round names no model, which is the truth about it rather than a gap.</para>
+    /// </remarks>
+    [Fact]
+    public void EachReviewerRecordsTheModelItWasLaunchedWith()
+    {
+        var store = new SessionStore(_dir);
+        var session = Session();
+        store.Save(session);
+
+        _ = new LiveRound(store, session, [
+            Work("codex", ReviewRole.Architecture) with
+            {
+                Invocation = Work("codex", ReviewRole.Architecture).Invocation with { Model = "gpt-5-codex" },
+            },
+            Work("local", ReviewRole.SecurityReliability),
+        ]);
+
+        var states = store.Load("D:/repo", "feature/x")!.Rounds.Single().ReviewerStates;
+        states.Single(s => s.Provider == "codex").Model.Should().Be("gpt-5-codex");
+        states.Single(s => s.Provider == "local").Model.Should().BeEmpty(
+            "a reviewer launched without a model names none rather than inventing one");
+    }
+
+    [Fact]
+    public void ASessionFileWrittenBeforeTheModelField_StillLoads()
+    {
+        // The promise a trailing default makes, kept by reading a file that predates it.
+        var store = new SessionStore(_dir);
+        var session = Session();
+        store.Save(session);
+        _ = new LiveRound(store, session, [Work("codex", ReviewRole.Architecture)]);
+
+        var path = Directory.EnumerateFiles(Path.Combine(_dir, "sessions"), "session-*.json").Single();
+        var withoutModel = File.ReadAllText(path).Replace("\"model\": \"\",", string.Empty);
+        File.WriteAllText(path, withoutModel);
+
+        store.Load("D:/repo", "feature/x")!.Rounds.Single().ReviewerStates
+            .Single().Model.Should().BeEmpty();
+    }
+
     [Fact]
     public void TheRoundIsOnDisk_BeforeAnyReviewerHasAnswered()
     {

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+**The rounds log names the model.** Every reviewer row now reads
+`remsoftdev-claude/Architecture · claude-haiku-4-5 — done (3 findings)` instead of stopping at the
+role. It is also searchable: the log page's filter reads these rows, so typing a model name finds
+the rounds that used it.
+
+**Read it as the model that was ASKED for.** For a local CLI that is the model that ran. For a Team
+server it is what your panel requested — the server picks the account, and it does not yet report
+back which model answered, so an escalation or a server-side substitution is not visible here. That
+gap is the next piece of work, and this entry exists so the number is not read as more than it is.
+
+Rounds recorded before this release name no model, which is the truth about them.
+
 ## Extension 0.31.7 — 2026-09-08
 
 **Conventions is its own reviewer now.** There is a fourth box in the code stage, above

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-**The rounds log names the model.** Every reviewer row now reads
+**The rounds log names the model.** A reviewer row that has one now reads
 `remsoftdev-claude/Architecture · claude-haiku-4-5 — done (3 findings)` instead of stopping at the
-role. It is also searchable: the log page's filter reads these rows, so typing a model name finds
+role. A reviewer launched without a model — a local engine with none configured — reads exactly as
+it did. It is also searchable: the log page's filter reads these rows, so typing a model name finds
 the rounds that used it.
 
 **Read it as the model that was ASKED for.** For a local CLI that is the model that ran. For a Team

--- a/src_vs_code/src/rounds.ts
+++ b/src_vs_code/src/rounds.ts
@@ -166,7 +166,12 @@ export function reviewerRows(round: RoundRecord): readonly ReviewerRow[] {
       // The model rides with the ROLE rather than in the detail list: it is what the reviewer IS,
       // like its vendor and its role, not something it did. An older round carries none and reads
       // exactly as it did.
-      rest: `/${s.role}${s.model ? ` · ${s.model}` : ''} — ${s.status}`
+      //
+      // TRIMMED here as well as where it is written. The writer trims because a configured model of
+      // " " is not a model; this side does not trust that, because a state can arrive from an older
+      // server or a hand-edited file — and a bare truthiness check turned "   " into a separator
+      // with nothing after it, which is what the test below caught.
+      rest: `/${s.role}${s.model?.trim() ? ` · ${s.model.trim()}` : ''} — ${s.status}`
         + `${detail.length > 0 ? ` (${detail.join(', ')})` : ''}`,
     };
   });

--- a/src_vs_code/src/rounds.ts
+++ b/src_vs_code/src/rounds.ts
@@ -23,6 +23,15 @@ export interface ReviewerState {
   /** What this reviewer read and wrote, when the server recorded it per reviewer. */
   readonly tokensIn?: number;
   readonly tokensOut?: number;
+  /**
+   * The model it was LAUNCHED with — absent in rounds written before 0.18.11.
+   *
+   * <p>What was asked for, not necessarily what answered: a Team server chooses the model for the
+   * account it claims and reports none back. The log shows this because a round that names its
+   * vendor and not its model cannot answer the question people actually ask about a slow or a weak
+   * reviewer.</p>
+   */
+  readonly model?: string;
 }
 
 export interface RoundRecord {
@@ -154,7 +163,11 @@ export function reviewerRows(round: RoundRecord): readonly ReviewerRow[] {
 
     return {
       provider: s.provider,
-      rest: `/${s.role} — ${s.status}${detail.length > 0 ? ` (${detail.join(', ')})` : ''}`,
+      // The model rides with the ROLE rather than in the detail list: it is what the reviewer IS,
+      // like its vendor and its role, not something it did. An older round carries none and reads
+      // exactly as it did.
+      rest: `/${s.role}${s.model ? ` · ${s.model}` : ''} — ${s.status}`
+        + `${detail.length > 0 ? ` (${detail.join(', ')})` : ''}`,
     };
   });
 }

--- a/src_vs_code/src/rounds.ts
+++ b/src_vs_code/src/rounds.ts
@@ -148,6 +148,11 @@ export function reviewerLines(round: RoundRecord): readonly string[] {
   return reviewerRows(round).map((row) => `${row.provider}${row.rest}`);
 }
 
+/** The model this state names, or empty — anything that is not a usable string is absent. */
+function modelOf(state: ReviewerState): string {
+  return typeof state.model === 'string' ? state.model.trim() : '';
+}
+
 export function reviewerRows(round: RoundRecord): readonly ReviewerRow[] {
   return (round.reviewerStates ?? []).map((s) => {
     const detail = [
@@ -167,11 +172,16 @@ export function reviewerRows(round: RoundRecord): readonly ReviewerRow[] {
       // like its vendor and its role, not something it did. An older round carries none and reads
       // exactly as it did.
       //
-      // TRIMMED here as well as where it is written. The writer trims because a configured model of
-      // " " is not a model; this side does not trust that, because a state can arrive from an older
-      // server or a hand-edited file — and a bare truthiness check turned "   " into a separator
-      // with nothing after it, which is what the test below caught.
-      rest: `/${s.role}${s.model?.trim() ? ` · ${s.model.trim()}` : ''} — ${s.status}`
+      // NORMALISED here as well as where it is written. The writer trims because a configured model
+      // of " " is not a model; this side does not trust that, because a state can arrive from an
+      // older server or a hand-edited file — and a bare truthiness check turned "   " into a
+      // separator with nothing after it, which is what the test below caught.
+      //
+      // The TYPE check is the same distrust one step further: an interface is not runtime
+      // validation, and a session carrying `model: 42` would reach `.trim()` and throw while the
+      // log was being built — blanking a page to render one row. Anything that is not a string is
+      // absent. Raised on the code round.
+      rest: `/${s.role}${modelOf(s) ? ` · ${modelOf(s)}` : ''} — ${s.status}`
         + `${detail.length > 0 ? ` (${detail.join(', ')})` : ''}`,
     };
   });

--- a/src_vs_code/src/rounds.ts
+++ b/src_vs_code/src/rounds.ts
@@ -148,6 +148,20 @@ export function reviewerLines(round: RoundRecord): readonly string[] {
   return reviewerRows(round).map((row) => `${row.provider}${row.rest}`);
 }
 
+/**
+ * Everything after the provider: the role, the model when there is one, the status, the detail.
+ *
+ * <p>A function rather than one template because it was three nested ones, which Sonar flags and
+ * which had genuinely stopped being readable — the model's separator and the detail's brackets were
+ * both conditional inside a literal that was itself inside a literal.</p>
+ */
+function restOf(state: ReviewerState, model: string, detail: readonly string[]): string {
+  const named = model ? ` · ${model}` : '';
+  const said = detail.length > 0 ? ` (${detail.join(', ')})` : '';
+
+  return `/${state.role}${named} — ${state.status}${said}`;
+}
+
 /** The model this state names, or empty — anything that is not a usable string is absent. */
 function modelOf(state: ReviewerState): string {
   return typeof state.model === 'string' ? state.model.trim() : '';
@@ -181,8 +195,7 @@ export function reviewerRows(round: RoundRecord): readonly ReviewerRow[] {
       // validation, and a session carrying `model: 42` would reach `.trim()` and throw while the
       // log was being built — blanking a page to render one row. Anything that is not a string is
       // absent. Raised on the code round.
-      rest: `/${s.role}${modelOf(s) ? ` · ${modelOf(s)}` : ''} — ${s.status}`
-        + `${detail.length > 0 ? ` (${detail.join(', ')})` : ''}`,
+      rest: restOf(s, modelOf(s), detail),
     };
   });
 }

--- a/src_vs_code/src/test/rounds.test.ts
+++ b/src_vs_code/src/test/rounds.test.ts
@@ -83,6 +83,20 @@ test('a reviewer launched without a model gets no separator, not an empty one', 
   ]);
 });
 
+test('a session carrying a model that is not a string renders as if it had none', () => {
+  // An interface is not runtime validation. A hand-edited or foreign session file reaches the
+  // renderer as-is, and `.trim()` on a number would throw while the log was being built — blanking
+  // a whole page to render one row. Raised on the code round; the cast is the only way to express
+  // "this file is not what the type says", which is the situation being tested.
+  const nonsense = round({
+    reviewerStates: [
+      { provider: 'local', role: 'Architecture', status: 'done', findings: 0, note: '', model: 42 as unknown as string },
+    ],
+  });
+
+  assert.deepEqual(reviewerLines(nonsense), ['local/Architecture — done (0 findings)']);
+});
+
 test('a round from before the field reads exactly as it did', () => {
   const older = round({
     reviewerStates: [{ provider: 'codex', role: 'Architecture', status: 'done', findings: 1, note: '' }],

--- a/src_vs_code/src/test/rounds.test.ts
+++ b/src_vs_code/src/test/rounds.test.ts
@@ -66,6 +66,23 @@ test('a reviewer row names the model it was launched with', () => {
   ]);
 });
 
+test('a reviewer launched without a model gets no separator, not an empty one', () => {
+  // The case the "older round" test below does NOT cover, and a reviewer on the plan round was
+  // right to separate them: an old file has no field at all, while a CURRENT round can carry an
+  // empty string — a local engine with no model configured. Both must read the same.
+  const noModel = round({
+    reviewerStates: [
+      { provider: 'local', role: 'Architecture', status: 'done', findings: 0, note: '', model: '' },
+      { provider: 'local', role: 'SecurityReliability', status: 'done', findings: 0, note: '', model: '   ' },
+    ],
+  });
+
+  assert.deepEqual(reviewerLines(noModel), [
+    'local/Architecture — done (0 findings)',
+    'local/SecurityReliability — done (0 findings)',
+  ]);
+});
+
 test('a round from before the field reads exactly as it did', () => {
   const older = round({
     reviewerStates: [{ provider: 'codex', role: 'Architecture', status: 'done', findings: 1, note: '' }],

--- a/src_vs_code/src/test/rounds.test.ts
+++ b/src_vs_code/src/test/rounds.test.ts
@@ -42,3 +42,34 @@ test('a start date from an older server does not render as a billion minutes', (
   // .NET's default date is year ONE, and the subtraction produced "1065396701m 44s" in the panel.
   assert.equal(elapsed(round({ startedUtc: '0001-01-01T00:00:00' }), Date.parse('2026-09-01T09:00:00Z')), '');
 });
+
+/**
+ * The log names the model, and says nothing where it does not know one.
+ *
+ * <p>A round that names its vendor and its role but not its model cannot answer the question people
+ * actually ask about a slow or a weak reviewer — which is how the claude row came to be investigated
+ * by reading a spending ledger instead of the log
+ * (`research/RESULTS_reviewer_input_sizes.md`).</p>
+ *
+ * <p>The absent case matters as much: every round written before this field exists has none, and
+ * must read exactly as it did rather than growing an empty separator.</p>
+ */
+test('a reviewer row names the model it was launched with', () => {
+  const withModel = round({
+    reviewerStates: [
+      { provider: 'remsoftdev-claude', role: 'Architecture', status: 'done', findings: 3, note: '', model: 'claude-haiku-4-5' },
+    ],
+  });
+
+  assert.deepEqual(reviewerLines(withModel), [
+    'remsoftdev-claude/Architecture · claude-haiku-4-5 — done (3 findings)',
+  ]);
+});
+
+test('a round from before the field reads exactly as it did', () => {
+  const older = round({
+    reviewerStates: [{ provider: 'codex', role: 'Architecture', status: 'done', findings: 1, note: '' }],
+  });
+
+  assert.deepEqual(reviewerLines(older), ['codex/Architecture — done (1 finding)']);
+});

--- a/todo/PLAN_the_log_names_the_model.md
+++ b/todo/PLAN_the_log_names_the_model.md
@@ -76,7 +76,11 @@ skew scare (2026-09-08) is the reason to state explicitly rather than assume.
 
 1. RED: a reviewer state carries the model it was launched with; the log renders it.
 2. RED: a persisted session written before this field still loads (the defaulted-parameter promise).
-3. Implement 1, ship it — the local case is complete and correct at this point.
+3. Implement 1, ship it — the local case is complete and correct at this point. **The
+   documentation step is part of that, not after it**: `module_server.md` says where the value
+   comes from, and the CHANGELOG says the same thing in the place a USER reads, because a caveat
+   that lives only in a docstring is a caveat nobody affected by it will see. A code round pointed
+   out that the Definition of Done named the documentation while the build order did not.
 4. RED, on the server: a finished job reports the model that ran, and it is the account's resolved
    model rather than the request's.
 5. RED, on the client: a non-empty model from the server WINS over the configured one; an empty one
@@ -90,6 +94,7 @@ skew scare (2026-09-08) is the reason to state explicitly rather than assume.
 | The state carries the launched model | `src_mcp/tests` | step 1 |
 | An old session file without the field loads | `src_mcp/tests` | nothing on disk is invalidated |
 | The rounds log shows the model | `src_vs_code/src/test` | the surface the task is about |
+| A reviewer with an EMPTY or whitespace model gets no separator | `src_vs_code/src/test` | the case an "older file" test does not cover — a current round can carry `""` |
 | A finished job reports its resolved model | `src_server/tests` | step 2 |
 | A server's model overrides the configured one; empty does not | `src_mcp/tests` | the trap above |
 

--- a/todo/PLAN_the_log_names_the_model.md
+++ b/todo/PLAN_the_log_names_the_model.md
@@ -1,6 +1,6 @@
 # PLAN — the rounds log names the model, and the one that actually ran
 
-> Status: **plan only, nothing implemented yet.** Scope: `ReviewerState` and the panel's rounds
+> Status: **step 1 IMPLEMENTED 2026-09-08; steps 2 and 3 are open.** Scope: `ReviewerState` and the panel's rounds
 > log, `ReviewStatusDto` on the Team server, and the client that reads it.
 >
 > Related docs: [module_server.md](../research/module_server.md),
@@ -100,9 +100,19 @@ skew scare (2026-09-08) is the reason to state explicitly rather than assume.
 
 ## Definition of Done
 
-- [ ] The rounds log names a model for every reviewer.
+**Step 1, done 2026-09-08:**
+
+- [x] The rounds log names the model a reviewer was LAUNCHED with, where there is one. Deliberately
+      not "for every reviewer", which the first draft of this line said: a local engine with no
+      model configured has none, and inventing a name for it would be worse than the blank. A code
+      round pointed out that the wording and the behaviour disagreed.
+- [x] Sessions written before the field still load — proved by removing the property structurally
+      from a real file, not by string surgery that turned out to match nothing.
+- [x] Module docs and the CHANGELOG describe where the model comes from and why it is not the whole
+      answer, the CHANGELOG because that is where a user reads.
+
+**Steps 2 and 3, open:**
+
 - [ ] A Team-server run shows the model the SERVER ran, not the one the client asked for.
 - [ ] An older server, which reports none, leaves the configured name in place and fails nothing.
 - [ ] The usage ledger and the log agree, because they read the same value.
-- [ ] Sessions written before the field still load.
-- [ ] Module docs describe where the model comes from and why the configured one is not trusted.


### PR DESCRIPTION
## The gap

A round said **who** reviewed and never **with what**. That is the question people actually ask about a slow or a weak reviewer — and its absence is why the claude row was investigated by reading a spending ledger rather than the log it should have been visible in ([RESULTS_reviewer_input_sizes.md](https://github.com/oleksandrdubyna88/dew_flow_connect_other_ais/blob/main/research/RESULTS_reviewer_input_sizes.md)).

## The change

The invocation has carried the model since the adapters were written; the round simply never wrote it down. `ReviewerState` carries it now, and the one renderer both surfaces share puts it beside the role:

```
remsoftdev-claude/Architecture · claude-haiku-4-5 — done (3 findings)
```

## What it does not claim

**It is what was ASKED for, not necessarily what answered**, and the docstrings say so rather than letting the log imply more than it knows: a Team server picks the model for the account it claims and reports none back, and an escalation can run a stronger one. Closing that needs a field on the server's `ReviewStatusDto` and is step 2 of `todo/PLAN_the_log_names_the_model.md` — this is step 1, which is useful on its own.

## Compatibility

The field is trailing and defaulted, so every session file already on disk stays valid and an older round names no model — the truth about it rather than a gap. Asserted by reading a file with the field stripped back out, and on the rendering side by a round from before it reading exactly as it did, with no empty separator where a model would go.

## Test plan

- [x] 1061 MCP, 181 server, 653 extension, 0 failing
- [x] plan-lifecycle clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reviewer rows in the rounds log now display the requested model alongside the reviewer role and status.
  - Log filtering includes displayed model names.

- **Bug Fixes**
  - Older session files remain compatible and display no model when model information is unavailable.
  - Blank or invalid model values no longer add unnecessary separators or disrupt log rendering.

- **Documentation**
  - Documented that displayed models represent requested models and may differ from the model that ultimately responds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->