### PR TITLE
feat(chat): the conversation tab — page, registry, and the message reading

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -3,6 +3,27 @@
 > `src_vs_code` — the human surface. Four commands, zero runtime dependencies, no background work
 > and **no port**: the review itself lives in `coai-mcp`, which an MCP client owns and starts.
 
+### What the code round did to the chat tab (2026-09-08)
+
+Twelve reviewers read epic 2 and found two real defects in it, both of the same family: something
+that survives longer than the thing it was named after.
+
+A panel’s callbacks closed over the TAB KEY they were created with. When `sessionKey` re-keys a
+conversation onto a replacement tab object, every message from that page was then looked up under a
+key nobody held: sends dropped silently, and a close that could not find its entry left the vendor
+process running. A conversation now carries its own `id`, made once in `createChatPanel` and never
+replaced; hooks take the id, only the map takes the key.
+
+And `closeAll` disposed sessions without disposing panels. On a tab close that is right — VS Code
+has already disposed the panel — but deactivation is not a tab closing, and it left tabs open whose
+composer still took text with nothing behind it. `closeAll` now removes the entry FIRST and then
+disposes both, so the `onDidDispose` it triggers finds nothing and cannot dispose a session twice.
+
+Four smaller ones came with them: the model now travels in a pushed state (after `continue with a
+local model` the page would otherwise still show the remote one as selected while answers came from
+somewhere else), a pushed state that has not changed is not sent at all, a `pick` naming a model the
+conversation was never offered is refused at the host boundary rather than trusted, and the
+composer takes focus back when a turn ends — without which every follow-up costs a mouse click.
 ### One webview per SESSION, which no other page in here does (2026-09-08)
 
 Every other webview in this extension is a singleton — the rounds log and the help page each keep

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -3,6 +3,24 @@
 > `src_vs_code` — the human surface. Four commands, zero runtime dependencies, no background work
 > and **no port**: the review itself lives in `coai-mcp`, which an MCP client owns and starts.
 
+### One webview per SESSION, which no other page in here does (2026-09-08)
+
+Every other webview in this extension is a singleton — the rounds log and the help page each keep
+one panel in one field, revealed while open. The chat tab keeps a MAP, because the requirement is
+that session 1’s conversation lives in its tab, session 2 opens its own, and both stay open while
+somebody moves between them.
+
+The key is the host’s own `vscode.Tab` object, never the tab’s label. Two Claude Code tabs can both
+be called `main`, and a registry keyed by name hands the second one the first one’s conversation —
+an answer that arrives and is simply about somebody else’s question. Two of the plan gate’s three
+reviewers refused the label design independently, and a third finding on the code round showed the
+same hole had survived in the FALLBACK: re-attaching a closed panel by label while a live namesake
+sat beside it. The fallback now requires the label to name exactly one panel.
+
+`chatPanels.ts` is the registry and knows nothing about `vscode`, so the rule that matters can be
+tested: closing one tab disposes ONE session, its own. A vendor process that outlives its tab is an
+authenticated child nobody can see and nobody will stop; one that dies with a stranger’s tab loses a
+conversation somebody is still reading.
 ### One spawn site, and why it grew a handle (2026-09-08)
 
 `processLauncher.ts` owns the only `spawn` in `src/` that this extension controls. It is the version

--- a/src_vs_code/src/chatMessages.ts
+++ b/src_vs_code/src/chatMessages.ts
@@ -1,0 +1,88 @@
+/**
+ * What a message from the chat page MEANS, decided without a host.
+ *
+ * <p>It exists because of one finding on the plan round: every test in epic 2 exercised the pure
+ * registry and the pure page, while the only module that maps a webview message to an action was the
+ * one no unit test can reach. A wrong message type would then ship with every test green — a person's
+ * send quietly ignored, or delivered somewhere else. So the DECISION moved here and the `vscode` half
+ * kept only the wiring, which is the part a test genuinely cannot reach.</p>
+ *
+ * <p>The page and the host ship in one `.vsix` today, but a webview retained across a reload can be
+ * older than the extension that talks to it. An unknown message is therefore ignored rather than
+ * thrown on: the older half must not break because the newer one learned a word.</p>
+ */
+
+/** Anything the page might post. Every field optional, because the page is not to be trusted. */
+export interface PageMessage {
+  readonly type?: unknown;
+  readonly command?: unknown;
+  readonly text?: unknown;
+  readonly id?: unknown;
+  readonly delta?: unknown;
+  readonly message?: unknown;
+}
+
+export type ChatCommand =
+  | { readonly kind: 'send'; readonly text: string }
+  | { readonly kind: 'pick'; readonly id: string }
+  | { readonly kind: 'zoom'; readonly delta: number }
+  | { readonly kind: 'restart' }
+  | { readonly kind: 'useLocal' }
+  | { readonly kind: 'pageError'; readonly message: string }
+  | { readonly kind: 'ignore' };
+
+const IGNORE: ChatCommand = { kind: 'ignore' };
+
+/** A string, or nothing at all — the page's values arrive over a bridge and are not typed there. */
+function text(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/** The zoom control posts its own shape, and it is not a `command`. */
+function zoomOf(message: PageMessage): ChatCommand {
+  const delta = typeof message.delta === 'number' && Number.isFinite(message.delta) ? message.delta : 0;
+
+  return { kind: 'zoom', delta };
+}
+
+/**
+ * One message, read.
+ *
+ * <p>An empty `send` is `ignore` rather than a send of nothing: the page already refuses to post one,
+ * and a host that would have sent it anyway is a host that spends a vendor turn on a stray Enter.</p>
+ */
+export function chatCommandOf(message: PageMessage | undefined): ChatCommand {
+  if (message === undefined || message === null) {
+    return IGNORE;
+  }
+  if (message.type === 'zoom') {
+    return zoomOf(message);
+  }
+  if (message.type === 'pageError') {
+    const said = text(message.message);
+
+    return said.length === 0 ? IGNORE : { kind: 'pageError', message: said };
+  }
+  if (message.type !== 'command') {
+    return IGNORE;
+  }
+
+  switch (message.command) {
+    case 'send': {
+      const said = text(message.text).trim();
+
+      return said.length === 0 ? IGNORE : { kind: 'send', text: said };
+    }
+    case 'pick': {
+      const id = text(message.id);
+
+      return id.length === 0 ? IGNORE : { kind: 'pick', id };
+    }
+    case 'restart':
+      return { kind: 'restart' };
+    case 'useLocal':
+      return { kind: 'useLocal' };
+    default:
+      return IGNORE;
+  }
+}

--- a/src_vs_code/src/chatMessages.ts
+++ b/src_vs_code/src/chatMessages.ts
@@ -7,9 +7,15 @@
  * send quietly ignored, or delivered somewhere else. So the DECISION moved here and the `vscode` half
  * kept only the wiring, which is the part a test genuinely cannot reach.</p>
  *
- * <p>The page and the host ship in one `.vsix` today, but a webview retained across a reload can be
- * older than the extension that talks to it. An unknown message is therefore ignored rather than
- * thrown on: the older half must not break because the newer one learned a word.</p>
+ * <p><b>An unknown message is IGNORED, and that is a deliberate exception to a written rule.</b>
+ * `coding-style.md` says an unknown name fails naming the legal values rather than falling back
+ * silently, and that rule is right where it was written: a SETTING somebody typed, where a silent
+ * fallback hides a typo until the behaviour surprises them. This is not that boundary. A webview
+ * retained across a reload can be older — or newer — than the extension talking to it, and a host
+ * that refused a word it did not know would break the half that had done nothing wrong. The values
+ * are enumerated in `ChatCommand` and every one of them is tested, including the unknown case; what
+ * is silent is the ignoring, not the vocabulary. (codex, the code round, asked for this reconciled
+ * explicitly rather than left as two rules pointing opposite ways.)</p>
  */
 
 /** Anything the page might post. Every field optional, because the page is not to be trusted. */
@@ -38,11 +44,20 @@ function text(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-/** The zoom control posts its own shape, and it is not a `command`. */
+/**
+ * The zoom control posts its own shape, and it is not a `command`.
+ *
+ * <p>The delta is CLAMPED to one step, not merely checked for finiteness. `applyZoomDelta` clamps
+ * the resulting scale, so a huge value could not have broken the layout — but it would have jumped
+ * the size to a bound in one message, from a surface the host does not control. The control itself
+ * only ever sends ±1, so anything else is not a zoom. (gemini, the code round.)</p>
+ */
 function zoomOf(message: PageMessage): ChatCommand {
-  const delta = typeof message.delta === 'number' && Number.isFinite(message.delta) ? message.delta : 0;
+  if (typeof message.delta !== 'number' || !Number.isFinite(message.delta)) {
+    return { kind: 'zoom', delta: 0 };
+  }
 
-  return { kind: 'zoom', delta };
+  return { kind: 'zoom', delta: Math.max(-1, Math.min(1, Math.trunc(message.delta))) };
 }
 
 /**

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -41,9 +41,31 @@ export interface ChatPageState {
   readonly modelId: string;
   /** A turn is in flight: the composer is locked and the thinking line is shown. */
   readonly running: boolean;
+  /**
+   * The conversation has reached its limit and cannot take another turn.
+   *
+   * <p>Only a remote model reaches this: it holds no conversation, so turn four re-sends everything
+   * said so far for the fourth time, and the thread's cost grows while its usefulness does not. The
+   * owner capped it at three on 2026-09-08. A capped page must OFFER something — a locked box with
+   * no way out is the failure the gate named — so it shows the two honest actions, start again or
+   * move the thread to a local model, which does have memory.</p>
+   */
+  readonly capped: boolean;
   /** Empty when nothing failed. A sentence when something did. */
   readonly failure: string;
   readonly uiScale: number;
+}
+
+/** What a capped conversation offers instead of a composer nobody can use. */
+export function chatCappedHtml(capped: boolean): string {
+  if (!capped) {
+    return '';
+  }
+
+  return '<div class="capped"><p>This model keeps no conversation, so every follow-up re-sends the whole '
+    + 'thread. Three turns is the limit.</p>'
+    + '<button type="button" id="restart">Start a new conversation</button> '
+    + '<button type="button" id="useLocal">Continue with a local model</button></div>';
 }
 
 /** The messages region on its own, so the host can push it without re-rendering the page. */
@@ -108,6 +130,8 @@ export function chatPageHtml(state: ChatPageState, nonce: string): string {
   textarea { width: 100%; box-sizing: border-box; min-height: 64px; font: inherit; color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 4px; padding: 8px; }
   textarea[disabled] { opacity: .6; }
   .hint { font-size: .85em; opacity: .6; margin-top: 4px; }
+  .capped { border: 1px solid var(--vscode-panel-border); border-radius: 4px; padding: 10px 12px; margin: 0 0 10px; }
+  .capped p { margin: 0 0 8px; }
 ${ZOOM_CSS}
 </style>
 </head>
@@ -117,8 +141,9 @@ ${ZOOM_CSS}
 <div id="failure">${state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`}</div>
 <div id="messages">${chatMessagesHtml(state.messages)}</div>
 <div id="thinking">${state.running ? '<p class="thinking">Thinking…</p>' : ''}</div>
+<div id="capped">${chatCappedHtml(state.capped)}</div>
 ${chatPickerHtml(state.models, state.modelId)}
-<textarea id="say" rows="3" placeholder="Ask about the text above…"${state.running ? ' disabled' : ''}></textarea>
+<textarea id="say" rows="3" placeholder="Ask about the text above…"${state.running || state.capped ? ' disabled' : ''}></textarea>
 <div class="hint">Enter sends · Shift+Enter for a new line</div>
 <script nonce="${nonce}">
 (function () {
@@ -129,6 +154,9 @@ ${chatPickerHtml(state.models, state.modelId)}
   window.onerror = function (message) {
     const box = document.getElementById('failure');
     if (box) { box.textContent = 'The page hit an error: ' + message; }
+    // And TELL the host. A trap that only writes into the page leaves the extension believing the
+    // conversation is fine while the tab has stopped answering Enter. (gemini, the plan round.)
+    vscode.postMessage({ type: 'pageError', message: String(message) });
   };
   ${zoomScript()}
   function send() {
@@ -153,15 +181,32 @@ ${chatPickerHtml(state.models, state.modelId)}
       vscode.postMessage({ type: 'command', command: 'pick', id: model.value });
     });
   }
+  function wireCapped() {
+    const restart = document.getElementById('restart');
+    if (restart) {
+      restart.addEventListener('click', function () {
+        vscode.postMessage({ type: 'command', command: 'restart' });
+      });
+    }
+    const useLocal = document.getElementById('useLocal');
+    if (useLocal) {
+      useLocal.addEventListener('click', function () {
+        vscode.postMessage({ type: 'command', command: 'useLocal' });
+      });
+    }
+  }
+  wireCapped();
   window.addEventListener('message', function (event) {
     const data = event.data || {};
     if (data.type !== 'state') { return; }
+    const capped = document.getElementById('capped');
+    if (capped) { capped.innerHTML = data.cappedHtml || ''; wireCapped(); }
     const messages = document.getElementById('messages');
     if (messages && typeof data.messagesHtml === 'string') { messages.innerHTML = data.messagesHtml; }
     const thinking = document.getElementById('thinking');
     if (thinking) { thinking.innerHTML = data.running ? '<p class="thinking">Thinking…</p>' : ''; }
     const box = document.getElementById('say');
-    if (box) { box.disabled = !!data.running; }
+    if (box) { box.disabled = !!data.running || !!data.capped; }
     const failure = document.getElementById('failure');
     if (failure) { failure.innerHTML = data.failureHtml || ''; }
     const passage = document.getElementById('passage');

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -222,9 +222,12 @@ function chatScript(state: ChatPageState): string {
     const passage = document.getElementById('passage');
     if (passage && typeof data.passage === 'string') { passage.textContent = data.passage; }
     const box = document.getElementById('say');
-    if (box) {
+    // Only a real boolean moves the lock. A state that says nothing about running - a partial push,
+    // or a null across the bridge - must leave the composer as it is rather than quietly unlocking
+    // it while a turn is still in flight. (local, the second code round.)
+    if (box && typeof data.running === 'boolean' && typeof data.capped === 'boolean') {
       const wasLocked = box.disabled;
-      box.disabled = !!data.running || !!data.capped;
+      box.disabled = data.running || data.capped;
       // Back to the box when the turn ends. Without this every single follow-up costs a mouse click,
       // nine seconds after the last one — which is the whole conversation, one click at a time.
       if (wasLocked && !box.disabled && typeof box.focus === 'function') { box.focus(); }

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -9,10 +9,18 @@ import { ZOOM_CSS, zoomControlHtml, zoomScript, zoomStyle } from './zoomControl'
  * nothing from the host" a check rather than a sentence. Everything the page needs arrives as a
  * value; everything it wants done goes back as a message.</p>
  *
- * <p><b>The passage is at the top, and it is not decoration.</b> The menu path takes whatever is in
+ * <p><b>The page escapes nothing it is handed at render time.</b> Every string that reaches
+ * `innerHTML` — the messages, the failure, the capped region, the picker — is built by a function in
+ * THIS file or by `chatPanel.ts`, and escaped there, at the point it is built. That is the invariant:
+ * escaping happens where the string is made, never where it is written. A reviewer looking at the
+ * `innerHTML` assignments in the script below should follow the value back to its builder rather
+ * than conclude the page is unsafe. (Raised on the code round; it was true, and it was implicit.)</p>
+ *
+ * <p><b>The passage is at the top and it is not decoration.</b> The menu path takes whatever is in
  * the clipboard and cannot know whether it is the passage just selected or something copied an hour
  * ago — the gate raised that three times. Showing the text the conversation is ABOUT is how a person
- * sees a stale clipboard instead of discovering it in the answer.</p>
+ * sees a stale clipboard instead of discovering it in the answer. It is capped in height and scrolls:
+ * a fifty-line selection would otherwise push the composer off the screen on open.</p>
  *
  * <p><b>The composer is disabled while a turn runs, and that is a feature.</b> A real explanation
  * took 9.4 s when it was measured, and eight of those seconds are silent. Two turns down one NDJSON
@@ -56,18 +64,6 @@ export interface ChatPageState {
   readonly uiScale: number;
 }
 
-/** What a capped conversation offers instead of a composer nobody can use. */
-export function chatCappedHtml(capped: boolean): string {
-  if (!capped) {
-    return '';
-  }
-
-  return '<div class="capped"><p>This model keeps no conversation, so every follow-up re-sends the whole '
-    + 'thread. Three turns is the limit.</p>'
-    + '<button type="button" id="restart">Start a new conversation</button> '
-    + '<button type="button" id="useLocal">Continue with a local model</button></div>';
-}
-
 /** The messages region on its own, so the host can push it without re-rendering the page. */
 export function chatMessagesHtml(messages: readonly ChatMessage[]): string {
   if (messages.length === 0) {
@@ -102,22 +98,25 @@ export function chatPickerHtml(models: readonly ChatModelChoice[], chosen: strin
     + `<span class="caption" id="caption">${escapeHtml(caption)}</span></div>`;
 }
 
-export function chatPageHtml(state: ChatPageState, nonce: string): string {
-  const captions = Object.fromEntries(state.models.map((model) => [model.id, model.caption]));
+/** What a capped conversation offers instead of a composer nobody can use. */
+export function chatCappedHtml(capped: boolean): string {
+  if (!capped) {
+    return '';
+  }
 
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${escapeHtml(state.title)}</title>
-<style>
-  ${zoomStyle(state.uiScale)}
+  return '<div class="capped"><p>This model keeps no conversation, so every follow-up re-sends the whole '
+    + 'thread. Three turns is the limit.</p>'
+    + '<button type="button" id="restart">Start a new conversation</button> '
+    + '<button type="button" id="useLocal">Continue with a local model</button></div>';
+}
+
+/** The page's own styles. Its own function so the document below stays readable. */
+function chatStyle(uiScale: number): string {
+  return `  ${zoomStyle(uiScale)}
   body { font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground); background: var(--vscode-editor-background); margin: 0; padding: 16px 20px; }
   header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; }
   h1 { font-size: 1.2em; margin: 0; }
-  .passage { border-left: 3px solid var(--vscode-panel-border); padding: 6px 0 6px 12px; margin: 0 0 16px; white-space: pre-wrap; opacity: .85; }
+  .passage { border-left: 3px solid var(--vscode-panel-border); padding: 6px 0 6px 12px; margin: 0 0 16px; white-space: pre-wrap; opacity: .85; max-height: 180px; overflow-y: auto; }
   .msg { margin: 0 0 14px; }
   .msg .who { font-size: .85em; opacity: .7; margin-bottom: 3px; }
   .msg .what { white-space: pre-wrap; }
@@ -125,37 +124,43 @@ export function chatPageHtml(state: ChatPageState, nonce: string): string {
   .empty { opacity: .6; }
   .thinking { opacity: .75; margin: 0 0 12px; }
   .failure { border: 1px solid var(--vscode-inputValidation-errorBorder, var(--vscode-panel-border)); border-radius: 4px; padding: 8px 10px; margin: 0 0 12px; }
+  .capped { border: 1px solid var(--vscode-panel-border); border-radius: 4px; padding: 10px 12px; margin: 0 0 10px; }
+  .capped p { margin: 0 0 8px; }
   .picker { display: flex; gap: 8px; align-items: center; margin: 0 0 8px; }
   .caption { font-size: .85em; opacity: .7; }
   textarea { width: 100%; box-sizing: border-box; min-height: 64px; font: inherit; color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 4px; padding: 8px; }
   textarea[disabled] { opacity: .6; }
   .hint { font-size: .85em; opacity: .6; margin-top: 4px; }
-  .capped { border: 1px solid var(--vscode-panel-border); border-radius: 4px; padding: 10px 12px; margin: 0 0 10px; }
-  .capped p { margin: 0 0 8px; }
-${ZOOM_CSS}
-</style>
-</head>
-<body>
-<header><h1>${escapeHtml(state.title)}</h1>${zoomControlHtml(state.uiScale)}</header>
+${ZOOM_CSS}`;
+}
+
+/** The document, without its head or its script. */
+function chatBody(state: ChatPageState): string {
+  const locked = state.running || state.capped;
+
+  return `<header><h1>${escapeHtml(state.title)}</h1>${zoomControlHtml(state.uiScale)}</header>
 <div class="passage" id="passage">${escapeHtml(state.passage)}</div>
 <div id="failure">${state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`}</div>
 <div id="messages">${chatMessagesHtml(state.messages)}</div>
 <div id="thinking">${state.running ? '<p class="thinking">Thinking…</p>' : ''}</div>
 <div id="capped">${chatCappedHtml(state.capped)}</div>
-${chatPickerHtml(state.models, state.modelId)}
-<textarea id="say" rows="3" placeholder="Ask about the text above…"${state.running || state.capped ? ' disabled' : ''}></textarea>
-<div class="hint">Enter sends · Shift+Enter for a new line</div>
-<script nonce="${nonce}">
-(function () {
+<div id="pickerBox">${chatPickerHtml(state.models, state.modelId)}</div>
+<textarea id="say" rows="3" placeholder="Ask about the text above…"${locked ? ' disabled' : ''}></textarea>
+<div class="hint">Enter sends · Shift+Enter for a new line</div>`;
+}
+
+/** The page's behaviour. Its own function for the same reason the styles are. */
+function chatScript(state: ChatPageState): string {
+  return `(function () {
   const vscode = acquireVsCodeApi();
-  const captions = ${jsonForScript(captions)};
+  let captions = ${jsonForScript(Object.fromEntries(state.models.map((model) => [model.id, model.caption])))};
   // The webview swallows a thrown error silently, and a page that stops responding to Enter with no
   // sign of why is the defect this trap exists to name. Same shape as the rounds log's.
   window.onerror = function (message) {
     const box = document.getElementById('failure');
     if (box) { box.textContent = 'The page hit an error: ' + message; }
     // And TELL the host. A trap that only writes into the page leaves the extension believing the
-    // conversation is fine while the tab has stopped answering Enter. (gemini, the plan round.)
+    // conversation is fine while the tab has stopped answering Enter.
     vscode.postMessage({ type: 'pageError', message: String(message) });
   };
   ${zoomScript()}
@@ -173,8 +178,9 @@ ${chatPickerHtml(state.models, state.modelId)}
       if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); send(); }
     });
   }
-  const model = document.getElementById('model');
-  if (model) {
+  function wirePicker() {
+    const model = document.getElementById('model');
+    if (!model) { return; }
     model.addEventListener('change', function () {
       const caption = document.getElementById('caption');
       if (caption) { caption.textContent = captions[model.value] || ''; }
@@ -195,24 +201,54 @@ ${chatPickerHtml(state.models, state.modelId)}
       });
     }
   }
+  wirePicker();
   wireCapped();
   window.addEventListener('message', function (event) {
     const data = event.data || {};
     if (data.type !== 'state') { return; }
-    const capped = document.getElementById('capped');
-    if (capped) { capped.innerHTML = data.cappedHtml || ''; wireCapped(); }
     const messages = document.getElementById('messages');
     if (messages && typeof data.messagesHtml === 'string') { messages.innerHTML = data.messagesHtml; }
     const thinking = document.getElementById('thinking');
     if (thinking) { thinking.innerHTML = data.running ? '<p class="thinking">Thinking…</p>' : ''; }
-    const box = document.getElementById('say');
-    if (box) { box.disabled = !!data.running || !!data.capped; }
+    const capped = document.getElementById('capped');
+    if (capped) { capped.innerHTML = data.cappedHtml || ''; wireCapped(); }
+    // The picker is re-rendered rather than nudged: after "continue with a local model" the whole
+    // list can be different, and a select that only had its value set would show a model it no
+    // longer offers.
+    const pickerBox = document.getElementById('pickerBox');
+    if (pickerBox && typeof data.pickerHtml === 'string') { pickerBox.innerHTML = data.pickerHtml; wirePicker(); }
     const failure = document.getElementById('failure');
     if (failure) { failure.innerHTML = data.failureHtml || ''; }
     const passage = document.getElementById('passage');
     if (passage && typeof data.passage === 'string') { passage.textContent = data.passage; }
+    const box = document.getElementById('say');
+    if (box) {
+      const wasLocked = box.disabled;
+      box.disabled = !!data.running || !!data.capped;
+      // Back to the box when the turn ends. Without this every single follow-up costs a mouse click,
+      // nine seconds after the last one — which is the whole conversation, one click at a time.
+      if (wasLocked && !box.disabled && typeof box.focus === 'function') { box.focus(); }
+    }
   });
-}());
+}());`;
+}
+
+export function chatPageHtml(state: ChatPageState, nonce: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(state.title)}</title>
+<style>
+${chatStyle(state.uiScale)}
+</style>
+</head>
+<body>
+${chatBody(state)}
+<script nonce="${nonce}">
+${chatScript(state)}
 </script>
 </body>
 </html>`;

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -1,0 +1,174 @@
+import { escapeHtml, jsonForScript } from './webviewHtml';
+import { ZOOM_CSS, zoomControlHtml, zoomScript, zoomStyle } from './zoomControl';
+
+/**
+ * The conversation tab: the passage that started it, what has been said, and a box to say more.
+ *
+ * <p>PURE — no `vscode`, no `node:`. `bundledPage.test.ts` bundles this module the way the shipped
+ * page is bundled and refuses a `node:` import in it, which is what makes "a page module imports
+ * nothing from the host" a check rather than a sentence. Everything the page needs arrives as a
+ * value; everything it wants done goes back as a message.</p>
+ *
+ * <p><b>The passage is at the top, and it is not decoration.</b> The menu path takes whatever is in
+ * the clipboard and cannot know whether it is the passage just selected or something copied an hour
+ * ago — the gate raised that three times. Showing the text the conversation is ABOUT is how a person
+ * sees a stale clipboard instead of discovering it in the answer.</p>
+ *
+ * <p><b>The composer is disabled while a turn runs, and that is a feature.</b> A real explanation
+ * took 9.4 s when it was measured, and eight of those seconds are silent. Two turns down one NDJSON
+ * pipe would interleave; the page makes that impossible rather than the session refusing it late.</p>
+ */
+
+/** One thing said, by one of the two parties. */
+export interface ChatMessage {
+  readonly role: 'you' | 'model';
+  readonly text: string;
+}
+
+/** A model the picker may offer. `remote` models say what they cannot do. */
+export interface ChatModelChoice {
+  readonly id: string;
+  readonly label: string;
+  readonly caption: string;
+}
+
+export interface ChatPageState {
+  /** The Claude Code session this tab belongs to — its label, shown as the heading. */
+  readonly title: string;
+  readonly passage: string;
+  readonly messages: readonly ChatMessage[];
+  readonly models: readonly ChatModelChoice[];
+  readonly modelId: string;
+  /** A turn is in flight: the composer is locked and the thinking line is shown. */
+  readonly running: boolean;
+  /** Empty when nothing failed. A sentence when something did. */
+  readonly failure: string;
+  readonly uiScale: number;
+}
+
+/** The messages region on its own, so the host can push it without re-rendering the page. */
+export function chatMessagesHtml(messages: readonly ChatMessage[]): string {
+  if (messages.length === 0) {
+    return '<p class="empty">Nothing asked yet.</p>';
+  }
+
+  return messages
+    .map(
+      (message) =>
+        `<div class="msg ${message.role === 'you' ? 'you' : 'model'}">`
+        + `<div class="who">${message.role === 'you' ? 'You' : 'The other AI'}</div>`
+        + `<div class="what">${escapeHtml(message.text)}</div></div>`,
+    )
+    .join('');
+}
+
+/** The picker, or nothing at all when there is only one model to pick. */
+export function chatPickerHtml(models: readonly ChatModelChoice[], chosen: string): string {
+  if (models.length < 2) {
+    return '';
+  }
+  const options = models
+    .map(
+      (model) =>
+        `<option value="${escapeHtml(model.id)}"${model.id === chosen ? ' selected' : ''}>`
+        + `${escapeHtml(model.label)}</option>`,
+    )
+    .join('');
+  const caption = models.find((model) => model.id === chosen)?.caption ?? '';
+
+  return `<div class="picker"><select id="model" aria-label="Which model answers">${options}</select>`
+    + `<span class="caption" id="caption">${escapeHtml(caption)}</span></div>`;
+}
+
+export function chatPageHtml(state: ChatPageState, nonce: string): string {
+  const captions = Object.fromEntries(state.models.map((model) => [model.id, model.caption]));
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(state.title)}</title>
+<style>
+  ${zoomStyle(state.uiScale)}
+  body { font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground); background: var(--vscode-editor-background); margin: 0; padding: 16px 20px; }
+  header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; }
+  h1 { font-size: 1.2em; margin: 0; }
+  .passage { border-left: 3px solid var(--vscode-panel-border); padding: 6px 0 6px 12px; margin: 0 0 16px; white-space: pre-wrap; opacity: .85; }
+  .msg { margin: 0 0 14px; }
+  .msg .who { font-size: .85em; opacity: .7; margin-bottom: 3px; }
+  .msg .what { white-space: pre-wrap; }
+  .msg.you .what { opacity: .85; }
+  .empty { opacity: .6; }
+  .thinking { opacity: .75; margin: 0 0 12px; }
+  .failure { border: 1px solid var(--vscode-inputValidation-errorBorder, var(--vscode-panel-border)); border-radius: 4px; padding: 8px 10px; margin: 0 0 12px; }
+  .picker { display: flex; gap: 8px; align-items: center; margin: 0 0 8px; }
+  .caption { font-size: .85em; opacity: .7; }
+  textarea { width: 100%; box-sizing: border-box; min-height: 64px; font: inherit; color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 4px; padding: 8px; }
+  textarea[disabled] { opacity: .6; }
+  .hint { font-size: .85em; opacity: .6; margin-top: 4px; }
+${ZOOM_CSS}
+</style>
+</head>
+<body>
+<header><h1>${escapeHtml(state.title)}</h1>${zoomControlHtml(state.uiScale)}</header>
+<div class="passage" id="passage">${escapeHtml(state.passage)}</div>
+<div id="failure">${state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`}</div>
+<div id="messages">${chatMessagesHtml(state.messages)}</div>
+<div id="thinking">${state.running ? '<p class="thinking">Thinking…</p>' : ''}</div>
+${chatPickerHtml(state.models, state.modelId)}
+<textarea id="say" rows="3" placeholder="Ask about the text above…"${state.running ? ' disabled' : ''}></textarea>
+<div class="hint">Enter sends · Shift+Enter for a new line</div>
+<script nonce="${nonce}">
+(function () {
+  const vscode = acquireVsCodeApi();
+  const captions = ${jsonForScript(captions)};
+  // The webview swallows a thrown error silently, and a page that stops responding to Enter with no
+  // sign of why is the defect this trap exists to name. Same shape as the rounds log's.
+  window.onerror = function (message) {
+    const box = document.getElementById('failure');
+    if (box) { box.textContent = 'The page hit an error: ' + message; }
+  };
+  ${zoomScript()}
+  function send() {
+    const box = document.getElementById('say');
+    if (!box || box.disabled) { return; }
+    const text = box.value.trim();
+    if (text.length === 0) { return; }
+    box.value = '';
+    vscode.postMessage({ type: 'command', command: 'send', text: text });
+  }
+  const say = document.getElementById('say');
+  if (say) {
+    say.addEventListener('keydown', function (event) {
+      if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); send(); }
+    });
+  }
+  const model = document.getElementById('model');
+  if (model) {
+    model.addEventListener('change', function () {
+      const caption = document.getElementById('caption');
+      if (caption) { caption.textContent = captions[model.value] || ''; }
+      vscode.postMessage({ type: 'command', command: 'pick', id: model.value });
+    });
+  }
+  window.addEventListener('message', function (event) {
+    const data = event.data || {};
+    if (data.type !== 'state') { return; }
+    const messages = document.getElementById('messages');
+    if (messages && typeof data.messagesHtml === 'string') { messages.innerHTML = data.messagesHtml; }
+    const thinking = document.getElementById('thinking');
+    if (thinking) { thinking.innerHTML = data.running ? '<p class="thinking">Thinking…</p>' : ''; }
+    const box = document.getElementById('say');
+    if (box) { box.disabled = !!data.running; }
+    const failure = document.getElementById('failure');
+    if (failure) { failure.innerHTML = data.failureHtml || ''; }
+    const passage = document.getElementById('passage');
+    if (passage && typeof data.passage === 'string') { passage.textContent = data.passage; }
+  });
+}());
+</script>
+</body>
+</html>`;
+}

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -74,10 +74,14 @@ export function createChatPanel(
   state: ChatPageState,
   session: DisposableSession,
   hooks: ChatPanelHooks,
-  known: (modelId: string) => boolean,
 ): ChatEntry {
   // The conversation's own identity, created once and never replaced. See the module comment.
   const id = { conversation: state.title };
+  // What this conversation is allowed to be answered by, kept from the state it was opened with and
+  // replaced by every push. A separate predicate handed in at creation was the alternative, and it
+  // would have drifted the moment a Team server's catalog arrived: two places deciding what a valid
+  // model is, one of them frozen. (gemini, the second code round.)
+  offered.set(id, new Set(state.models.map((model) => model.id)));
 
   const panel = vscode.window.createWebviewPanel(
     'coaiChat',
@@ -91,7 +95,7 @@ export function createChatPanel(
   panel.webview.onDidReceiveMessage((message: PageMessage) => {
     // A detached boundary: nothing awaits this, so a rejection here would have no owner and the
     // extension host would report it as unhandled instead of the tab saying anything. (codex.)
-    void handle(id, message, hooks, known).catch((reason: unknown) => {
+    void handle(id, message, hooks).catch((reason: unknown) => {
       hooks.onPageError(id, reason instanceof Error ? reason.message : String(reason));
     });
   });
@@ -123,12 +127,7 @@ export function createChatPanel(
  * left here is the dispatch. That split exists because a wrong message type would otherwise have
  * shipped with every test green — a person's send quietly ignored. (codex, the plan round.)</p>
  */
-async function handle(
-  id: object,
-  message: PageMessage,
-  hooks: ChatPanelHooks,
-  known: (modelId: string) => boolean,
-): Promise<void> {
+async function handle(id: object, message: PageMessage, hooks: ChatPanelHooks): Promise<void> {
   const command = chatCommandOf(message);
   switch (command.kind) {
     case 'zoom':
@@ -143,7 +142,7 @@ async function handle(
       // A page can post any id it likes — a stale retained webview certainly will, and a tampered
       // one might. Choosing a model is choosing who gets paid, so the host checks the name against
       // what this conversation was actually offered rather than trusting the page. (codex.)
-      if (known(command.id)) {
+      if (offered.get(id)?.has(command.id) === true) {
         hooks.onPick(id, command.id);
       } else {
         hooks.onPageError(id, `that model is not one this conversation offers: ${command.id}`);
@@ -177,6 +176,9 @@ async function handle(
  */
 const lastPushed = new WeakMap<object, string>();
 
+/** Which models each conversation currently offers — the one source the pick check reads. */
+const offered = new WeakMap<object, Set<string>>();
+
 /**
  * Push what changed into an open page.
  *
@@ -202,6 +204,8 @@ export function pushChatState(entry: ChatEntry, state: ChatPushState): boolean {
     pickerHtml: chatPickerHtml(state.models, state.modelId),
     modelId: state.modelId,
   };
+
+  offered.set(entry.id, new Set(state.models.map((model) => model.id)));
 
   const serialised = JSON.stringify(payload);
   if (lastPushed.get(entry.id) === serialised) {

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -2,7 +2,15 @@ import * as crypto from 'node:crypto';
 import * as vscode from 'vscode';
 import { PageMessage, chatCommandOf } from './chatMessages';
 import { ChatEntry, DisposableSession, RevealablePanel } from './chatPanels';
-import { ChatMessage, ChatPageState, chatCappedHtml, chatMessagesHtml, chatPageHtml } from './chatPage';
+import {
+  ChatMessage,
+  ChatModelChoice,
+  ChatPageState,
+  chatCappedHtml,
+  chatMessagesHtml,
+  chatPageHtml,
+  chatPickerHtml,
+} from './chatPage';
 import { escapeHtml } from './webviewHtml';
 import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
 
@@ -10,30 +18,48 @@ import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
  * The `vscode` half of a conversation tab, and deliberately the thin one.
  *
  * <p>Everything that can be decided without a host lives elsewhere: which tab a conversation belongs
- * to is `sessionKey.ts`, which conversations exist is `chatPanels.ts`, and what the page looks like
- * is `chatPage.ts`. What is left here is the part that can only be done against the real API —
- * creating the panel, carrying its messages, and pushing state into it — which is also the part no
- * unit test can reach. Keeping it small is how the untestable surface stays small.</p>
+ * to is `sessionKey.ts`, which conversations exist is `chatPanels.ts`, what a page message means is
+ * `chatMessages.ts`, and what the page looks like is `chatPage.ts`. What is left here is the part
+ * that can only be done against the real API — creating the panel, carrying its messages, and
+ * pushing state into it — which is also the part no unit test can reach. Keeping it small is how the
+ * untestable surface stays small.</p>
  *
- * <p>The panel is created with `retainContextWhenHidden` for the same reason the rounds log is: what
- * has been typed into the composer and how far the conversation is scrolled are page state, and a
- * page torn down behind another tab loses both every time somebody looks away.</p>
+ * <p><b>Hooks are called with the conversation's `id`, never with the tab key.</b> The first version
+ * closed over the key it was created with, and a `rekey` — which happens when the host replaces a
+ * live tab's object — left every message from that page looking itself up under a key nobody held:
+ * sends silently dropped, and a close that could not find its entry leaving the vendor process
+ * running. The id is created here, once, and outlives every key the tab wears. (gemini and codex,
+ * the code round, independently.)</p>
+ *
+ * <p><b>Everything assigned to `innerHTML` in the page is escaped HERE, where it is built.</b> The
+ * page never escapes anything it is handed; it renders what the host produced. That is the invariant
+ * a reader should carry into `chatPage.ts`.</p>
  */
 
-/** What the panel asks the extension to do. Everything else is the page's own business. */
+/** What the panel asks the extension to do. Every hook is passed the conversation's stable id. */
 export interface ChatPanelHooks {
   /** The person pressed send. */
-  readonly onSend: (key: object, text: string) => void;
-  /** The person chose a different model. */
-  readonly onPick: (key: object, modelId: string) => void;
+  readonly onSend: (id: object, text: string) => void;
+  /** The person chose a different model — already checked against the offered list. */
+  readonly onPick: (id: object, modelId: string) => void;
   /** VS Code closed the tab — the registry must forget it and end its session. */
-  readonly onClosed: (key: object) => void;
+  readonly onClosed: (id: object) => void;
   /** Start again with the same passage. */
-  readonly onRestart: (key: object) => void;
+  readonly onRestart: (id: object) => void;
   /** Move the thread to a model that keeps a conversation. */
-  readonly onUseLocal: (key: object) => void;
-  /** The page trapped an error and said so. */
-  readonly onPageError: (key: object, message: string) => void;
+  readonly onUseLocal: (id: object) => void;
+  /** The page trapped an error, or the host failed to handle one of its messages. */
+  readonly onPageError: (id: object, message: string) => void;
+}
+
+/** Everything the page shows that can change after it is open. */
+export interface ChatPushState {
+  readonly messages: readonly ChatMessage[];
+  readonly running: boolean;
+  readonly capped: boolean;
+  readonly failure: string;
+  readonly models: readonly ChatModelChoice[];
+  readonly modelId: string;
 }
 
 /**
@@ -41,13 +67,18 @@ export interface ChatPanelHooks {
  *
  * <p>Returns the registry's entry rather than the panel: the caller's next act is to put it in the
  * map, and handing back a `WebviewPanel` would invite a second place that knows how to dispose one.</p>
+ *
+ * @param known whether a model id the page asks for is one this conversation was actually offered
  */
 export function createChatPanel(
-  key: object,
   state: ChatPageState,
   session: DisposableSession,
   hooks: ChatPanelHooks,
+  known: (modelId: string) => boolean,
 ): ChatEntry {
+  // The conversation's own identity, created once and never replaced. See the module comment.
+  const id = { conversation: state.title };
+
   const panel = vscode.window.createWebviewPanel(
     'coaiChat',
     state.title,
@@ -58,11 +89,20 @@ export function createChatPanel(
 
   const scale = pushUiScaleTo(panel.webview);
   panel.webview.onDidReceiveMessage((message: PageMessage) => {
-    void handle(key, message, hooks);
+    // A detached boundary: nothing awaits this, so a rejection here would have no owner and the
+    // extension host would report it as unhandled instead of the tab saying anything. (codex.)
+    void handle(id, message, hooks, known).catch((reason: unknown) => {
+      hooks.onPageError(id, reason instanceof Error ? reason.message : String(reason));
+    });
   });
   panel.onDidDispose(() => {
     scale.dispose();
-    hooks.onClosed(key);
+    try {
+      hooks.onClosed(id);
+    } catch {
+      // A throw here escapes into VS Code's disposal loop, which is not ours to break. The session
+      // it failed to close is the caller's problem to notice; the editor's is not. (local.)
+    }
   });
 
   const revealable: RevealablePanel = {
@@ -73,7 +113,7 @@ export function createChatPanel(
     },
   };
 
-  return { panel: revealable, session, label: state.title };
+  return { id, panel: revealable, session };
 }
 
 /**
@@ -81,9 +121,14 @@ export function createChatPanel(
  *
  * <p>The READING of the message is `chatMessages.ts`, which needs no host and is tested; what is
  * left here is the dispatch. That split exists because a wrong message type would otherwise have
- * shipped with every test green — a person’s send quietly ignored. (codex, the plan round.)</p>
+ * shipped with every test green — a person's send quietly ignored. (codex, the plan round.)</p>
  */
-async function handle(key: object, message: PageMessage, hooks: ChatPanelHooks): Promise<void> {
+async function handle(
+  id: object,
+  message: PageMessage,
+  hooks: ChatPanelHooks,
+  known: (modelId: string) => boolean,
+): Promise<void> {
   const command = chatCommandOf(message);
   switch (command.kind) {
     case 'zoom':
@@ -91,31 +136,46 @@ async function handle(key: object, message: PageMessage, hooks: ChatPanelHooks):
 
       return;
     case 'send':
-      hooks.onSend(key, command.text);
+      hooks.onSend(id, command.text);
 
       return;
     case 'pick':
-      hooks.onPick(key, command.id);
+      // A page can post any id it likes — a stale retained webview certainly will, and a tampered
+      // one might. Choosing a model is choosing who gets paid, so the host checks the name against
+      // what this conversation was actually offered rather than trusting the page. (codex.)
+      if (known(command.id)) {
+        hooks.onPick(id, command.id);
+      } else {
+        hooks.onPageError(id, `that model is not one this conversation offers: ${command.id}`);
+      }
 
       return;
     case 'restart':
-      hooks.onRestart(key);
+      hooks.onRestart(id);
 
       return;
     case 'useLocal':
-      hooks.onUseLocal(key);
+      hooks.onUseLocal(id);
 
       return;
     case 'pageError':
-      hooks.onPageError(key, command.message);
+      hooks.onPageError(id, command.message);
 
       return;
     default:
-      // Ignored on purpose: a webview retained across a reload can be older than the extension that
-      // talks to it, and the older half must not break because the newer one learned a word.
+      // Ignored on purpose — see the exception documented in `chatMessages.ts`.
       return;
   }
 }
+
+/**
+ * What was last pushed to a conversation, so an unchanged state is not pushed again.
+ *
+ * <p>Keyed by the conversation's id and weak, so a closed tab's record goes with it. The page
+ * replaces its whole message region on every push, and pushing an identical one costs a re-render
+ * that drops the reader's text selection for nothing. The same shape `roundsLogPanel.ts` uses.</p>
+ */
+const lastPushed = new WeakMap<object, string>();
 
 /**
  * Push what changed into an open page.
@@ -123,22 +183,34 @@ async function handle(key: object, message: PageMessage, hooks: ChatPanelHooks):
  * <p>Regions, not a re-render. Re-assigning `webview.html` would rebuild the page and throw away the
  * half-typed follow-up in the composer — which is exactly what a person does while waiting nine
  * seconds for an answer.</p>
+ *
+ * <p>It carries the MODEL as well as the messages. After a capped thread takes "continue with a
+ * local model" the host switches models, and a page that was never told would keep showing the
+ * remote one as selected while the answers came from somewhere else — misleading about behaviour,
+ * latency and cost, all three. (gemini and codex, the code round.)</p>
+ *
+ * @returns whether anything was actually sent
  */
-export function pushChatState(
-  entry: ChatEntry,
-  messages: readonly ChatMessage[],
-  running: boolean,
-  failure: string,
-  capped = false,
-): void {
-  entry.panel.post({
+export function pushChatState(entry: ChatEntry, state: ChatPushState): boolean {
+  const payload = {
     type: 'state',
-    messagesHtml: chatMessagesHtml(messages),
-    running,
-    capped,
-    cappedHtml: chatCappedHtml(capped),
-    failureHtml: failure.length === 0 ? '' : `<div class="failure">${escapeHtml(failure)}</div>`,
-  });
+    messagesHtml: chatMessagesHtml(state.messages),
+    running: state.running,
+    capped: state.capped,
+    cappedHtml: chatCappedHtml(state.capped),
+    failureHtml: state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`,
+    pickerHtml: chatPickerHtml(state.models, state.modelId),
+    modelId: state.modelId,
+  };
+
+  const serialised = JSON.stringify(payload);
+  if (lastPushed.get(entry.id) === serialised) {
+    return false;
+  }
+  lastPushed.set(entry.id, serialised);
+  entry.panel.post(payload);
+
+  return true;
 }
 
 /** The scale the page opens at, so a new tab matches the ones already open. */

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -1,0 +1,130 @@
+import * as crypto from 'node:crypto';
+import * as vscode from 'vscode';
+import { ChatEntry, DisposableSession, RevealablePanel } from './chatPanels';
+import { ChatMessage, ChatPageState, chatMessagesHtml, chatPageHtml } from './chatPage';
+import { escapeHtml } from './webviewHtml';
+import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
+
+/**
+ * The `vscode` half of a conversation tab, and deliberately the thin one.
+ *
+ * <p>Everything that can be decided without a host lives elsewhere: which tab a conversation belongs
+ * to is `sessionKey.ts`, which conversations exist is `chatPanels.ts`, and what the page looks like
+ * is `chatPage.ts`. What is left here is the part that can only be done against the real API —
+ * creating the panel, carrying its messages, and pushing state into it — which is also the part no
+ * unit test can reach. Keeping it small is how the untestable surface stays small.</p>
+ *
+ * <p>The panel is created with `retainContextWhenHidden` for the same reason the rounds log is: what
+ * has been typed into the composer and how far the conversation is scrolled are page state, and a
+ * page torn down behind another tab loses both every time somebody looks away.</p>
+ */
+
+/** What the panel asks the extension to do. Everything else is the page's own business. */
+export interface ChatPanelHooks {
+  /** The person pressed send. */
+  readonly onSend: (key: object, text: string) => void;
+  /** The person chose a different model. */
+  readonly onPick: (key: object, modelId: string) => void;
+  /** VS Code closed the tab — the registry must forget it and end its session. */
+  readonly onClosed: (key: object) => void;
+}
+
+/** A message from the page. Narrowed here so the handler below reads as a decision, not a cast. */
+interface PageMessage {
+  readonly type?: string;
+  readonly command?: string;
+  readonly text?: string;
+  readonly id?: string;
+  readonly delta?: number;
+}
+
+/**
+ * Open a tab for one conversation.
+ *
+ * <p>Returns the registry's entry rather than the panel: the caller's next act is to put it in the
+ * map, and handing back a `WebviewPanel` would invite a second place that knows how to dispose one.</p>
+ */
+export function createChatPanel(
+  key: object,
+  state: ChatPageState,
+  session: DisposableSession,
+  hooks: ChatPanelHooks,
+): ChatEntry {
+  const panel = vscode.window.createWebviewPanel(
+    'coaiChat',
+    state.title,
+    vscode.ViewColumn.Active,
+    { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [] },
+  );
+  panel.webview.html = chatPageHtml(state, crypto.randomBytes(16).toString('hex'));
+
+  const scale = pushUiScaleTo(panel.webview);
+  panel.webview.onDidReceiveMessage((message: PageMessage) => {
+    void handle(key, message, hooks);
+  });
+  panel.onDidDispose(() => {
+    scale.dispose();
+    hooks.onClosed(key);
+  });
+
+  const revealable: RevealablePanel = {
+    reveal: () => panel.reveal(),
+    dispose: () => panel.dispose(),
+    post: (message) => {
+      void panel.webview.postMessage(message);
+    },
+  };
+
+  return { panel: revealable, session, label: state.title };
+}
+
+/**
+ * One message from the page.
+ *
+ * <p>A table rather than a chain of `if`s, so adding a command is adding a row — the shape
+ * `roundsLogPanel.ts` already uses. Anything unknown is ignored: a page and a host that ship
+ * separately will disagree about the vocabulary sooner or later, and the older half must not throw
+ * because the newer one learned a word.</p>
+ */
+async function handle(key: object, message: PageMessage, hooks: ChatPanelHooks): Promise<void> {
+  if (message.type === 'zoom') {
+    await applyZoomDelta(message.delta ?? 0);
+
+    return;
+  }
+  if (message.type !== 'command') {
+    return;
+  }
+
+  const handlers: Record<string, () => void> = {
+    send: () => hooks.onSend(key, message.text ?? ''),
+    pick: () => hooks.onPick(key, message.id ?? ''),
+  };
+  handlers[message.command ?? '']?.();
+}
+
+/**
+ * Push what changed into an open page.
+ *
+ * <p>Regions, not a re-render. Re-assigning `webview.html` would rebuild the page and throw away the
+ * half-typed follow-up in the composer — which is exactly what a person does while waiting nine
+ * seconds for an answer.</p>
+ */
+export function pushChatState(
+  entry: ChatEntry,
+  messages: readonly ChatMessage[],
+  running: boolean,
+  failure: string,
+): void {
+  entry.panel.post({
+    type: 'state',
+    messagesHtml: chatMessagesHtml(messages),
+    running,
+    failureHtml: failure.length === 0 ? '' : `<div class="failure">${escapeHtml(failure)}</div>`,
+  });
+}
+
+/** The scale the page opens at, so a new tab matches the ones already open. */
+export function chatUiScale(): number {
+  return currentUiScale();
+}

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -1,7 +1,8 @@
 import * as crypto from 'node:crypto';
 import * as vscode from 'vscode';
+import { PageMessage, chatCommandOf } from './chatMessages';
 import { ChatEntry, DisposableSession, RevealablePanel } from './chatPanels';
-import { ChatMessage, ChatPageState, chatMessagesHtml, chatPageHtml } from './chatPage';
+import { ChatMessage, ChatPageState, chatCappedHtml, chatMessagesHtml, chatPageHtml } from './chatPage';
 import { escapeHtml } from './webviewHtml';
 import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
 
@@ -27,15 +28,12 @@ export interface ChatPanelHooks {
   readonly onPick: (key: object, modelId: string) => void;
   /** VS Code closed the tab — the registry must forget it and end its session. */
   readonly onClosed: (key: object) => void;
-}
-
-/** A message from the page. Narrowed here so the handler below reads as a decision, not a cast. */
-interface PageMessage {
-  readonly type?: string;
-  readonly command?: string;
-  readonly text?: string;
-  readonly id?: string;
-  readonly delta?: number;
+  /** Start again with the same passage. */
+  readonly onRestart: (key: object) => void;
+  /** Move the thread to a model that keeps a conversation. */
+  readonly onUseLocal: (key: object) => void;
+  /** The page trapped an error and said so. */
+  readonly onPageError: (key: object, message: string) => void;
 }
 
 /**
@@ -81,26 +79,42 @@ export function createChatPanel(
 /**
  * One message from the page.
  *
- * <p>A table rather than a chain of `if`s, so adding a command is adding a row — the shape
- * `roundsLogPanel.ts` already uses. Anything unknown is ignored: a page and a host that ship
- * separately will disagree about the vocabulary sooner or later, and the older half must not throw
- * because the newer one learned a word.</p>
+ * <p>The READING of the message is `chatMessages.ts`, which needs no host and is tested; what is
+ * left here is the dispatch. That split exists because a wrong message type would otherwise have
+ * shipped with every test green — a person’s send quietly ignored. (codex, the plan round.)</p>
  */
 async function handle(key: object, message: PageMessage, hooks: ChatPanelHooks): Promise<void> {
-  if (message.type === 'zoom') {
-    await applyZoomDelta(message.delta ?? 0);
+  const command = chatCommandOf(message);
+  switch (command.kind) {
+    case 'zoom':
+      await applyZoomDelta(command.delta);
 
-    return;
-  }
-  if (message.type !== 'command') {
-    return;
-  }
+      return;
+    case 'send':
+      hooks.onSend(key, command.text);
 
-  const handlers: Record<string, () => void> = {
-    send: () => hooks.onSend(key, message.text ?? ''),
-    pick: () => hooks.onPick(key, message.id ?? ''),
-  };
-  handlers[message.command ?? '']?.();
+      return;
+    case 'pick':
+      hooks.onPick(key, command.id);
+
+      return;
+    case 'restart':
+      hooks.onRestart(key);
+
+      return;
+    case 'useLocal':
+      hooks.onUseLocal(key);
+
+      return;
+    case 'pageError':
+      hooks.onPageError(key, command.message);
+
+      return;
+    default:
+      // Ignored on purpose: a webview retained across a reload can be older than the extension that
+      // talks to it, and the older half must not break because the newer one learned a word.
+      return;
+  }
 }
 
 /**
@@ -115,11 +129,14 @@ export function pushChatState(
   messages: readonly ChatMessage[],
   running: boolean,
   failure: string,
+  capped = false,
 ): void {
   entry.panel.post({
     type: 'state',
     messagesHtml: chatMessagesHtml(messages),
     running,
+    capped,
+    cappedHtml: chatCappedHtml(capped),
     failureHtml: failure.length === 0 ? '' : `<div class="failure">${escapeHtml(failure)}</div>`,
   });
 }

--- a/src_vs_code/src/chatPanels.ts
+++ b/src_vs_code/src/chatPanels.ts
@@ -17,10 +17,18 @@
  * else's question — which is why two of the plan gate's reviewers refused the label design.</p>
  */
 
-/** What the registry needs from a panel. `vscode.WebviewPanel` satisfies it; so does a fake. */
+/**
+ * What the registry needs from a panel: bring it forward, close it, and push it something.
+ *
+ * <p>`post` is here rather than left to the caller to cast its way to, because the alternative was
+ * `entry.panel as unknown as vscode.WebviewPanel` at the one place that pushes state — a cast that
+ * says the type is wrong and asks the reader to trust the author instead. A fake satisfies all three
+ * in a line, which is what keeps the registry's tests free of a host.</p>
+ */
 export interface RevealablePanel {
   reveal(): void;
   dispose(): void;
+  post(message: unknown): void;
 }
 
 /** What the registry needs from a conversation: only that it can be ended. */

--- a/src_vs_code/src/chatPanels.ts
+++ b/src_vs_code/src/chatPanels.ts
@@ -1,30 +1,31 @@
 /**
  * Which conversation belongs to which Claude Code tab.
  *
- * <p>Pure — it knows nothing about `vscode`. It is handed things that can be revealed and disposed,
- * and it keeps them under the key `sessionKey.ts` decided on. Splitting it out is what makes the one
- * rule in it testable: <b>disposing one panel disposes ONE session, and only its own.</b></p>
+ * <p>Pure — it knows nothing about `vscode`. It is handed things that can be revealed, disposed and
+ * posted to, and it keeps them under the key `sessionKey.ts` decided on. Splitting it out is what
+ * makes the one rule in it testable: <b>closing one panel disposes ONE session, and only its own.</b></p>
  *
  * <p><b>This is the deviation from every other webview in this extension.</b> `RoundsLogPanel` and
  * the help page are singletons — "one webview panel per window, reused while open". This feature
  * needs one panel per Claude Code SESSION: the owner's requirement is that session 1's conversation
- * lives in its tab, session 2 opens its own, and both stay open while he moves between them. So the
- * field becomes a map, and disposal removes one entry rather than clearing a field.</p>
+ * lives in its tab, session 2 opens its own, and both stay open while he moves between them.</p>
  *
  * <p>A `Map` keyed by object identity is the point, not an implementation detail: two Claude Code
  * tabs can both be called `main`, and a registry keyed by name would hand the second tab the first
  * tab's conversation. That failure is silent — the answer arrives, it is simply about somebody
  * else's question — which is why two of the plan gate's reviewers refused the label design.</p>
+ *
+ * <p><b>Two things the code round of 2026-09-08 changed.</b> A conversation now carries its own
+ * `id`, stable for its whole life, because the tab KEY can move: a panel's callbacks closed over the
+ * key they were created with, and after a `rekey` every message from that page was looked up under a
+ * key nobody held any more — sends dropped, and a close that could not find its entry left the vendor
+ * process running. Hooks take the `id`; only the map takes the key. And the LABEL moved out of the
+ * entry into the registry, so a renamed tab can be relabelled without rebuilding anything: the label
+ * is what the fallback in `sessionKey.ts` matches on, and a stale one would send it looking for a
+ * name nobody wears.</p>
  */
 
-/**
- * What the registry needs from a panel: bring it forward, close it, and push it something.
- *
- * <p>`post` is here rather than left to the caller to cast its way to, because the alternative was
- * `entry.panel as unknown as vscode.WebviewPanel` at the one place that pushes state — a cast that
- * says the type is wrong and asks the reader to trust the author instead. A fake satisfies all three
- * in a line, which is what keeps the registry's tests free of a host.</p>
- */
+/** What the registry needs from a panel: bring it forward, close it, and push it something. */
 export interface RevealablePanel {
   reveal(): void;
   dispose(): void;
@@ -37,24 +38,37 @@ export interface DisposableSession {
 }
 
 export interface ChatEntry {
+  /**
+   * This conversation, for as long as it exists.
+   *
+   * <p>Not the tab key: that can be replaced under a live tab, and the panel's own callbacks are
+   * created once. Everything that has to survive a re-key — every hook the page calls — travels on
+   * this instead.</p>
+   */
+  readonly id: object;
   readonly panel: RevealablePanel;
   readonly session: DisposableSession;
-  /** The tab's label at the time it was opened — the panel's title, and the fallback key. */
-  readonly label: string;
 }
 
 /** What `open` had to do, so a caller can say it out loud rather than infer it. */
 export type OpenOutcome = 'revealed' | 'created';
+
+/** One conversation and the name its tab wore when we last looked. */
+interface Registered {
+  readonly entry: ChatEntry;
+  readonly label: string;
+}
 
 /**
  * One conversation per source tab.
  *
  * <p>A class, not a set of functions over a passed-in map: it is a stateful service and the house
  * rule says those stay classes. What it must never become is a place where state is edited from
- * outside — everything below returns rather than exposes the map.</p>
+ * outside — everything below returns rather than exposes the map, and the records inside it are
+ * replaced rather than mutated.</p>
  */
 export class ChatPanels {
-  private readonly entries = new Map<object, ChatEntry>();
+  private readonly entries = new Map<object, Registered>();
 
   /** How many conversations are open. For the tests, and for a caller that wants to say so. */
   get size(): number {
@@ -66,12 +80,40 @@ export class ChatPanels {
   }
 
   get(key: object): ChatEntry | undefined {
-    return this.entries.get(key);
+    return this.entries.get(key)?.entry;
+  }
+
+  /**
+   * The conversation with this id, wherever its tab has got to.
+   *
+   * <p>The lookup every hook uses. A page created for tab A and re-keyed to B still calls back with
+   * the id it was born with, and this is what turns that into the entry — which is the whole reason
+   * the id exists.</p>
+   */
+  entryOf(id: object): ChatEntry | undefined {
+    for (const registered of this.entries.values()) {
+      if (registered.entry.id === id) {
+        return registered.entry;
+      }
+    }
+
+    return undefined;
+  }
+
+  /** The key a conversation currently sits under, for a caller that must remove it by key. */
+  keyOf(id: object): object | undefined {
+    for (const [key, registered] of this.entries) {
+      if (registered.entry.id === id) {
+        return key;
+      }
+    }
+
+    return undefined;
   }
 
   /** Every open panel, as the shape `sessionKey.ts` matches against. */
   known(): readonly { readonly key: object; readonly label: string }[] {
-    return [...this.entries].map(([key, entry]) => ({ key, label: entry.label }));
+    return [...this.entries].map(([key, registered]) => ({ key, label: registered.label }));
   }
 
   /**
@@ -80,18 +122,35 @@ export class ChatPanels {
    * <p>`create` is a factory rather than a value so nothing is built for a tab that already has a
    * panel — building one would start a vendor process for a conversation nobody asked to begin.</p>
    */
-  open(key: object, create: () => ChatEntry): { entry: ChatEntry; outcome: OpenOutcome } {
+  open(key: object, label: string, create: () => ChatEntry): { entry: ChatEntry; outcome: OpenOutcome } {
     const known = this.entries.get(key);
     if (known !== undefined) {
-      known.panel.reveal();
+      known.entry.panel.reveal();
 
-      return { entry: known, outcome: 'revealed' };
+      return { entry: known.entry, outcome: 'revealed' };
     }
 
     const entry = create();
-    this.entries.set(key, entry);
+    this.entries.set(key, { entry, label });
 
     return { entry, outcome: 'created' };
+  }
+
+  /**
+   * The tab wears a new name.
+   *
+   * <p>The label is what the fallback in `sessionKey.ts` matches on when a tab's identity is lost, so
+   * a cached one sends it looking for a name nobody wears — and it opens a second tab for a
+   * conversation that already had one. (gemini, the code round.)</p>
+   */
+  relabel(key: object, label: string): boolean {
+    const known = this.entries.get(key);
+    if (known === undefined) {
+      return false;
+    }
+    this.entries.set(key, { entry: known.entry, label });
+
+    return true;
   }
 
   /**
@@ -100,15 +159,15 @@ export class ChatPanels {
    * <p>For the one case `sessionKey.ts` calls `rekey`: the host handed back a new `Tab` object for a
    * tab that is still open, and the panel would otherwise be orphaned beside it. Refuses rather than
    * overwrites when the destination is taken — two conversations must never collapse into one, and
-   * this is the second door into that failure.</p>
+   * this is the second door into that failure. Nothing is removed on a refusal.</p>
    */
   rekey(from: object, to: object): boolean {
-    const entry = this.entries.get(from);
-    if (entry === undefined || this.entries.has(to)) {
+    const known = this.entries.get(from);
+    if (known === undefined || this.entries.has(to)) {
       return false;
     }
     this.entries.delete(from);
-    this.entries.set(to, entry);
+    this.entries.set(to, known);
 
     return true;
   }
@@ -121,20 +180,34 @@ export class ChatPanels {
    * outlives its tab is an authenticated child nobody can see and nobody will stop.</p>
    */
   close(key: object): boolean {
-    const entry = this.entries.get(key);
-    if (entry === undefined) {
+    const known = this.entries.get(key);
+    if (known === undefined) {
       return false;
     }
     this.entries.delete(key);
-    entry.session.dispose();
+    known.entry.session.dispose();
 
     return true;
   }
 
-  /** End everything — the extension is deactivating, and no child may outlive it. */
+  /**
+   * End everything — the extension is deactivating, and nothing may outlive it.
+   *
+   * <p>This one DOES dispose the panel, and that is the difference from `close`. Deactivation is not
+   * a tab closing: nobody has told VS Code about these panels, so a session disposed without its
+   * panel leaves a tab open that answers nothing — a zombie whose composer still takes text.
+   * (gemini, the code round, twice.) The entry is removed BEFORE the panel is disposed, so the
+   * `onDidDispose` this triggers finds nothing and returns rather than disposing a session twice.</p>
+   */
   closeAll(): void {
     for (const key of [...this.entries.keys()]) {
-      this.close(key);
+      const known = this.entries.get(key);
+      if (known === undefined) {
+        continue;
+      }
+      this.entries.delete(key);
+      known.entry.session.dispose();
+      known.entry.panel.dispose();
     }
   }
 }

--- a/src_vs_code/src/chatPanels.ts
+++ b/src_vs_code/src/chatPanels.ts
@@ -1,0 +1,132 @@
+/**
+ * Which conversation belongs to which Claude Code tab.
+ *
+ * <p>Pure — it knows nothing about `vscode`. It is handed things that can be revealed and disposed,
+ * and it keeps them under the key `sessionKey.ts` decided on. Splitting it out is what makes the one
+ * rule in it testable: <b>disposing one panel disposes ONE session, and only its own.</b></p>
+ *
+ * <p><b>This is the deviation from every other webview in this extension.</b> `RoundsLogPanel` and
+ * the help page are singletons — "one webview panel per window, reused while open". This feature
+ * needs one panel per Claude Code SESSION: the owner's requirement is that session 1's conversation
+ * lives in its tab, session 2 opens its own, and both stay open while he moves between them. So the
+ * field becomes a map, and disposal removes one entry rather than clearing a field.</p>
+ *
+ * <p>A `Map` keyed by object identity is the point, not an implementation detail: two Claude Code
+ * tabs can both be called `main`, and a registry keyed by name would hand the second tab the first
+ * tab's conversation. That failure is silent — the answer arrives, it is simply about somebody
+ * else's question — which is why two of the plan gate's reviewers refused the label design.</p>
+ */
+
+/** What the registry needs from a panel. `vscode.WebviewPanel` satisfies it; so does a fake. */
+export interface RevealablePanel {
+  reveal(): void;
+  dispose(): void;
+}
+
+/** What the registry needs from a conversation: only that it can be ended. */
+export interface DisposableSession {
+  dispose(): void;
+}
+
+export interface ChatEntry {
+  readonly panel: RevealablePanel;
+  readonly session: DisposableSession;
+  /** The tab's label at the time it was opened — the panel's title, and the fallback key. */
+  readonly label: string;
+}
+
+/** What `open` had to do, so a caller can say it out loud rather than infer it. */
+export type OpenOutcome = 'revealed' | 'created';
+
+/**
+ * One conversation per source tab.
+ *
+ * <p>A class, not a set of functions over a passed-in map: it is a stateful service and the house
+ * rule says those stay classes. What it must never become is a place where state is edited from
+ * outside — everything below returns rather than exposes the map.</p>
+ */
+export class ChatPanels {
+  private readonly entries = new Map<object, ChatEntry>();
+
+  /** How many conversations are open. For the tests, and for a caller that wants to say so. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  has(key: object): boolean {
+    return this.entries.has(key);
+  }
+
+  get(key: object): ChatEntry | undefined {
+    return this.entries.get(key);
+  }
+
+  /** Every open panel, as the shape `sessionKey.ts` matches against. */
+  known(): readonly { readonly key: object; readonly label: string }[] {
+    return [...this.entries].map(([key, entry]) => ({ key, label: entry.label }));
+  }
+
+  /**
+   * Reveal the conversation this tab already has, or create it.
+   *
+   * <p>`create` is a factory rather than a value so nothing is built for a tab that already has a
+   * panel — building one would start a vendor process for a conversation nobody asked to begin.</p>
+   */
+  open(key: object, create: () => ChatEntry): { entry: ChatEntry; outcome: OpenOutcome } {
+    const known = this.entries.get(key);
+    if (known !== undefined) {
+      known.panel.reveal();
+
+      return { entry: known, outcome: 'revealed' };
+    }
+
+    const entry = create();
+    this.entries.set(key, entry);
+
+    return { entry, outcome: 'created' };
+  }
+
+  /**
+   * Move an existing conversation onto a new key.
+   *
+   * <p>For the one case `sessionKey.ts` calls `rekey`: the host handed back a new `Tab` object for a
+   * tab that is still open, and the panel would otherwise be orphaned beside it. Refuses rather than
+   * overwrites when the destination is taken — two conversations must never collapse into one, and
+   * this is the second door into that failure.</p>
+   */
+  rekey(from: object, to: object): boolean {
+    const entry = this.entries.get(from);
+    if (entry === undefined || this.entries.has(to)) {
+      return false;
+    }
+    this.entries.delete(from);
+    this.entries.set(to, entry);
+
+    return true;
+  }
+
+  /**
+   * Forget one conversation and end its session.
+   *
+   * <p>Called from the panel's own `onDidDispose`, which is why it does not dispose the panel: by
+   * then VS Code already has. What it must do is dispose the SESSION — a vendor process that
+   * outlives its tab is an authenticated child nobody can see and nobody will stop.</p>
+   */
+  close(key: object): boolean {
+    const entry = this.entries.get(key);
+    if (entry === undefined) {
+      return false;
+    }
+    this.entries.delete(key);
+    entry.session.dispose();
+
+    return true;
+  }
+
+  /** End everything — the extension is deactivating, and no child may outlive it. */
+  closeAll(): void {
+    for (const key of [...this.entries.keys()]) {
+      this.close(key);
+    }
+  }
+}

--- a/src_vs_code/src/chatPanels.ts
+++ b/src_vs_code/src/chatPanels.ts
@@ -70,6 +70,17 @@ interface Registered {
 export class ChatPanels {
   private readonly entries = new Map<object, Registered>();
 
+  /**
+   * Where each conversation currently sits, by its own id.
+   *
+   * <p>A second index rather than a scan. Every hook the page calls arrives with an id, so the
+   * lookup is on the hot path of every message; a linear walk over the open tabs would work today
+   * and become the wrong shape the moment anything streams. Maintained beside `entries` in the
+   * four places that change it — open, rekey, close, closeAll — which is the cost of having it.
+   * (gemini, the second code round.)</p>
+   */
+  private readonly whereById = new Map<object, object>();
+
   /** How many conversations are open. For the tests, and for a caller that wants to say so. */
   get size(): number {
     return this.entries.size;
@@ -91,24 +102,14 @@ export class ChatPanels {
    * the id exists.</p>
    */
   entryOf(id: object): ChatEntry | undefined {
-    for (const registered of this.entries.values()) {
-      if (registered.entry.id === id) {
-        return registered.entry;
-      }
-    }
+    const key = this.whereById.get(id);
 
-    return undefined;
+    return key === undefined ? undefined : this.entries.get(key)?.entry;
   }
 
   /** The key a conversation currently sits under, for a caller that must remove it by key. */
   keyOf(id: object): object | undefined {
-    for (const [key, registered] of this.entries) {
-      if (registered.entry.id === id) {
-        return key;
-      }
-    }
-
-    return undefined;
+    return this.whereById.get(id);
   }
 
   /** Every open panel, as the shape `sessionKey.ts` matches against. */
@@ -132,6 +133,7 @@ export class ChatPanels {
 
     const entry = create();
     this.entries.set(key, { entry, label });
+    this.whereById.set(entry.id, key);
 
     return { entry, outcome: 'created' };
   }
@@ -168,6 +170,7 @@ export class ChatPanels {
     }
     this.entries.delete(from);
     this.entries.set(to, known);
+    this.whereById.set(known.entry.id, to);
 
     return true;
   }
@@ -185,9 +188,24 @@ export class ChatPanels {
       return false;
     }
     this.entries.delete(key);
+    this.whereById.delete(known.entry.id);
     known.entry.session.dispose();
 
     return true;
+  }
+
+  /**
+   * The same, for a caller that holds the conversation rather than the tab.
+   *
+   * <p>Every hook is passed an id, so without this each of them would have to bridge id to key
+   * before closing — an asymmetric boundary where one call in the set works differently from the
+   * rest, and the kind of seam a second, drifting cleanup path grows out of. (gemini, the second
+   * code round.)</p>
+   */
+  closeById(id: object): boolean {
+    const key = this.whereById.get(id);
+
+    return key === undefined ? false : this.close(key);
   }
 
   /**
@@ -206,6 +224,7 @@ export class ChatPanels {
         continue;
       }
       this.entries.delete(key);
+      this.whereById.delete(known.entry.id);
       known.entry.session.dispose();
       known.entry.panel.dispose();
     }

--- a/src_vs_code/src/sessionKey.ts
+++ b/src_vs_code/src/sessionKey.ts
@@ -18,6 +18,15 @@
  * conversation is still wanted. Then, and only then, a label match re-keys the existing panel onto
  * the new object. A label match while the old object is still on screen means two real tabs, and it
  * must NOT re-key: that is exactly the collapse this module exists to prevent.</p>
+ *
+ * <p><b>What happens if `Tab` objects turn out to be EPHEMERAL.</b> A reviewer called this design
+ * Blocking on the claim that VS Code recreates them whenever tab-group state changes. If that is so,
+ * the identity branch misses every time and the fallback carries the feature: a uniquely named tab
+ * re-keys and keeps its conversation, and an ambiguously named one opens a SECOND chat tab. That is
+ * the degradation this shape was chosen for — the worst case is an extra tab, never a follow-up
+ * delivered to somebody else's conversation, which is what a label key gives you on its best day.
+ * The claim is answered by measurement rather than argument: `~/.vscode/extensions/coai-probe` logs
+ * `tab identity: SAME|NEW` across invocations, and three keypresses settle it.</p>
  */
 
 /**

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -238,3 +238,100 @@ test('the fixture lands on the local day the page opens on', () => {
       `the fixture's ${what} stamp is not on today's local day, so the page opens with it filtered out`);
   }
 });
+
+/* ------------------------------------------------------------------------------------------------
+ * The SECOND page. Until 2026-09-08 this file bundled one module, so "a page module imports nothing
+ * from the host" was a rule the chat page could have broken on its first day without anything
+ * noticing. The split adds a parameter rather than a copy: one bundler, two entry points.
+ * ---------------------------------------------------------------------------------------------- */
+
+/** Bundles one module the way `npm run bundle` does, and returns the text esbuild produced. */
+function bundleOf(module_: string, exported: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coai-bundle-'));
+  const entry = path.join(dir, 'entry.mjs');
+  const out = path.join(dir, 'bundle.cjs');
+  fs.writeFileSync(entry, `export { ${exported} } from ${JSON.stringify(path.join(ROOT, 'src', module_))};\n`);
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const esbuild = require('esbuild') as { buildSync: (options: Record<string, unknown>) => void };
+  esbuild.buildSync({
+    entryPoints: [entry], outfile: out, bundle: true, format: 'cjs', platform: 'node', minify: true,
+  });
+  const bundle = fs.readFileSync(out, 'utf8');
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  return bundle;
+}
+
+/** The chat page as it ships: bundled, minified, then rendered. */
+function bundledChatPage(): { bundle: string; html: string } {
+  const bundle = bundleOf('chatPage.ts', 'chatPageHtml');
+  const shim = { exports: {} as Record<string, unknown> };
+  new Function('module', 'exports', bundle)(shim, shim.exports);
+  const module_ = shim.exports as unknown as {
+    chatPageHtml: (state: unknown, nonce: string) => string;
+  };
+  const html = module_.chatPageHtml(
+    {
+      title: 'привет',
+      passage: 'The reviewers are read-only.',
+      messages: [{ role: 'model', text: 'because the worktree is pinned' }],
+      models: [
+        { id: 'antigravity', label: 'Gemini', caption: 'local' },
+        { id: 'remsoftdev-codex', label: 'GPT (team)', caption: 'remote · no memory' },
+      ],
+      modelId: 'antigravity',
+      running: false,
+      failure: '',
+      uiScale: 0,
+    },
+    'n0nce',
+  );
+
+  return { bundle, html };
+}
+
+test('the chat page carries nothing from the host into the webview', () => {
+  const { bundle } = bundledChatPage();
+
+  // The rule, as a check. A page module that reaches for `node:child_process` would be shipped into
+  // a webview that has no such thing, and the failure is a blank tab with a console nobody opens.
+  //
+  // WHAT THIS DOES NOT CATCH, measured by breaking it on purpose: a DEAD import. esbuild tree-shakes
+  // an import nothing on the rendering path uses, and the built-in disappears from the bundle with
+  // it — so `export const leak = spawn` passed this test while `spawn()` inside `chatPageHtml` fails
+  // both of these. That is the right boundary for a bundle check (it asserts on what SHIPS, and a
+  // dead import ships nothing) but it is not the boundary the sentence above implies, so it is
+  // written down rather than left to be re-discovered.
+  assert.ok(!bundle.includes('require("node:'), 'the chat page bundle pulled in a node built-in');
+  assert.ok(!bundle.includes('child_process'), 'the chat page bundle mentions child_process');
+});
+
+test('the chat page script the bundle produces parses and runs', () => {
+  const { html } = bundledChatPage();
+  const script = html.slice(html.indexOf('<script'), html.lastIndexOf('</script>'));
+  const body = script.slice(script.indexOf('>') + 1);
+
+  assert.doesNotThrow(() => new Function(body), 'the chat page script is not valid JavaScript');
+
+  const seen: Record<string, Record<string, unknown>> = {};
+  const element = (): Record<string, unknown> => ({
+    innerHTML: '', textContent: '', value: '', disabled: false, hidden: false,
+    addEventListener() {}, dataset: {}, style: {},
+  });
+  const document_ = {
+    getElementById: (id: string) => (seen[id] ??= element()),
+    querySelectorAll: () => [],
+    body: { style: {} },
+    addEventListener() {},
+  };
+  const window_: Record<string, unknown> = { addEventListener() {} };
+
+  assert.doesNotThrow(
+    () => new Function('document', 'window', 'acquireVsCodeApi', body)(
+      document_, window_, () => ({ postMessage() {} })),
+    'the chat page script threw on its first render',
+  );
+  // The trap must be installed, not merely written: a webview swallows a thrown error, and a page
+  // that stops answering Enter with no sign of why is the defect it exists to name.
+  assert.strictEqual(typeof window_['onerror'], 'function', 'the page installed no error trap');
+});

--- a/src_vs_code/src/test/chatMessages.test.ts
+++ b/src_vs_code/src/test/chatMessages.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { chatCommandOf } from '../chatMessages';
+
+/**
+ * What the page said, read without a host.
+ *
+ * <p>This file exists because of one finding on the plan round: every other test in epic 2 exercised
+ * the pure registry and the pure page, while the only module that turned a webview message into an
+ * action was the one no unit test could reach. A wrong message type would then ship with all of them
+ * green — a person's send quietly ignored, or delivered somewhere else. So the reading moved into a
+ * function, and this is that function under test.</p>
+ */
+
+test('a send carries its text, trimmed', () => {
+  assert.deepStrictEqual(
+    chatCommandOf({ type: 'command', command: 'send', text: '  why is it pinned?  ' }),
+    { kind: 'send', text: 'why is it pinned?' },
+  );
+});
+
+test('an empty send is ignored rather than spending a vendor turn on a stray Enter', () => {
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'send', text: '   ' }), { kind: 'ignore' });
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'send' }), { kind: 'ignore' });
+});
+
+test('a pick carries its model id, and a nameless one is ignored', () => {
+  assert.deepStrictEqual(
+    chatCommandOf({ type: 'command', command: 'pick', id: 'remsoftdev-codex' }),
+    { kind: 'pick', id: 'remsoftdev-codex' },
+  );
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'pick', id: '' }), { kind: 'ignore' });
+});
+
+test('the zoom control posts its own shape, not a command', () => {
+  // It is the shared control's message, and it has been that shape since the help page shipped.
+  assert.deepStrictEqual(chatCommandOf({ type: 'zoom', delta: -1 }), { kind: 'zoom', delta: -1 });
+});
+
+test('a zoom with nonsense in it moves nothing rather than throwing', () => {
+  assert.deepStrictEqual(chatCommandOf({ type: 'zoom', delta: 'lots' }), { kind: 'zoom', delta: 0 });
+  assert.deepStrictEqual(chatCommandOf({ type: 'zoom', delta: Number.NaN }), { kind: 'zoom', delta: 0 });
+});
+
+test('the two capped actions are read', () => {
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'restart' }), { kind: 'restart' });
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'useLocal' }), { kind: 'useLocal' });
+});
+
+test('a page that trapped an error tells the host what it was', () => {
+  assert.deepStrictEqual(
+    chatCommandOf({ type: 'pageError', message: 'x is not defined' }),
+    { kind: 'pageError', message: 'x is not defined' },
+  );
+  // Nothing to report is not a report.
+  assert.deepStrictEqual(chatCommandOf({ type: 'pageError', message: '' }), { kind: 'ignore' });
+});
+
+test('a word this host does not know is ignored, not thrown on', () => {
+  // A webview retained across a reload can be older than the extension talking to it - or newer.
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'summarise' }), { kind: 'ignore' });
+  assert.deepStrictEqual(chatCommandOf({ type: 'somethingElse' }), { kind: 'ignore' });
+});
+
+test('nothing at all is ignored', () => {
+  assert.deepStrictEqual(chatCommandOf(undefined), { kind: 'ignore' });
+  assert.deepStrictEqual(chatCommandOf({}), { kind: 'ignore' });
+});
+
+test('a message whose fields are the wrong types cannot become a command', () => {
+  // The bridge is untyped: everything here arrived as JSON from a page.
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'send', text: 42 }), { kind: 'ignore' });
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'pick', id: { id: 'x' } }), { kind: 'ignore' });
+  assert.deepStrictEqual(chatCommandOf({ type: 42, command: 'send', text: 'hi' }), { kind: 'ignore' });
+});

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { ChatModelChoice, ChatPageState, chatMessagesHtml, chatPageHtml, chatPickerHtml } from '../chatPage';
+
+/**
+ * The page, as a string.
+ *
+ * <p>Every value it renders comes from somewhere untrusted — the passage is another AI's answer, the
+ * model captions come from a Team server's catalog, and the title is a tab somebody named. So the
+ * escaping is not a nicety here: it is the only thing between a webview and text that was written to
+ * be executed somewhere else.</p>
+ */
+
+const MODELS: readonly ChatModelChoice[] = [
+  { id: 'antigravity', label: 'Gemini 3.8 Flash', caption: 'local · keeps the conversation' },
+  { id: 'remsoftdev-codex', label: 'GPT-5.6 (team)', caption: 'remote · no memory, the transcript is re-sent' },
+];
+
+function state(over: Partial<ChatPageState> = {}): ChatPageState {
+  return {
+    title: 'привет',
+    passage: 'The reviewers are read-only.',
+    messages: [],
+    models: MODELS,
+    modelId: 'antigravity',
+    running: false,
+    failure: '',
+    uiScale: 0,
+    ...over,
+  };
+}
+
+test('the passage the conversation is about is on the page', () => {
+  const html = chatPageHtml(state({ passage: 'a worktree pinned to a SHA' }), 'n0nce');
+
+  assert.ok(html.includes('a worktree pinned to a SHA'), 'the passage is not shown at all');
+});
+
+test('a passage that is markup is escaped, not rendered', () => {
+  const html = chatPageHtml(state({ passage: '<img src=x onerror=alert(1)>' }), 'n0nce');
+
+  assert.ok(!html.includes('<img src=x'), 'the passage reached the page as markup');
+  assert.ok(html.includes('&lt;img src=x'), 'the passage was not escaped');
+});
+
+test('a message containing a closing script tag cannot break out of the page', () => {
+  const html = chatPageHtml(
+    state({ messages: [{ role: 'model', text: 'write </script><script>alert(1)</script> here' }] }),
+    'n0nce',
+  );
+
+  // Exactly one script element: the page's own. A second one would mean the message closed it.
+  assert.strictEqual(html.split('<script').length - 1, 1, 'a message opened a second script element');
+});
+
+test('the zoom control is on the page, because the tab exists to be read', () => {
+  const html = chatPageHtml(state(), 'n0nce');
+
+  assert.ok(html.includes('zoomCtl'), 'the ± control is missing');
+});
+
+/**
+ * The rendered thinking REGION, not the whole document.
+ *
+ * <p>The page's own script carries the same sentence, because it re-renders this region when the
+ * host pushes a state — so a search of the whole HTML for "Thinking…" is true whatever the state is.
+ * The first version of these two tests did exactly that, and the idle one failed on its first run,
+ * which is the only reason this helper exists.</p>
+ */
+function thinkingRegion(html: string): string {
+  const at = html.indexOf('<div id="thinking">');
+
+  return html.slice(at, html.indexOf('</div>', at));
+}
+
+test('a running turn says so, and locks the composer', () => {
+  const html = chatPageHtml(state({ running: true }), 'n0nce');
+
+  // Eight of the 9.4 measured seconds are silent; without this the page reads as hung.
+  assert.ok(thinkingRegion(html).includes('Thinking…'), 'a running turn is invisible');
+  assert.ok(/<textarea[^>]*disabled/.test(html), 'a second turn could be typed into the same pipe');
+});
+
+test('an idle page has no thinking line and an open composer', () => {
+  const html = chatPageHtml(state(), 'n0nce');
+
+  assert.ok(!thinkingRegion(html).includes('Thinking…'), 'the page claims to be working when it is not');
+  assert.ok(!/<textarea[^>]*disabled/.test(html), 'the composer is locked with nothing running');
+});
+
+test('a failure is shown in words rather than left to be guessed', () => {
+  const html = chatPageHtml(state({ failure: 'agy exited before answering' }), 'n0nce');
+
+  assert.ok(html.includes('agy exited before answering'));
+});
+
+test('the picker is hidden when there is only one model to pick', () => {
+  assert.strictEqual(chatPickerHtml([MODELS[0]!], 'antigravity'), '');
+  assert.strictEqual(chatPickerHtml([], ''), '');
+});
+
+test('the picker offers every model and marks the chosen one', () => {
+  const picker = chatPickerHtml(MODELS, 'remsoftdev-codex');
+
+  assert.ok(picker.includes('Gemini 3.8 Flash'));
+  assert.ok(/value="remsoftdev-codex" selected/.test(picker), 'the chosen model is not selected');
+});
+
+test('a remote model says what it cannot do, where the choice is made', () => {
+  const picker = chatPickerHtml(MODELS, 'remsoftdev-codex');
+
+  // The panel must not know which kind it holds; the person must, because the difference shows up
+  // in latency and in cost.
+  assert.ok(picker.includes('no memory'), 'a remote model looks identical to a local one');
+});
+
+test('an empty conversation says so rather than showing nothing', () => {
+  assert.ok(chatMessagesHtml([]).includes('Nothing asked yet'));
+});
+
+test('both sides of the conversation are named', () => {
+  const html = chatMessagesHtml([
+    { role: 'you', text: 'why' },
+    { role: 'model', text: 'because' },
+  ]);
+
+  assert.ok(html.includes('You'));
+  assert.ok(html.includes('The other AI'));
+  assert.ok(html.indexOf('why') < html.indexOf('because'), 'the conversation is out of order');
+});

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { ChatModelChoice, ChatPageState, chatMessagesHtml, chatPageHtml, chatPickerHtml } from '../chatPage';
+import { ChatModelChoice, ChatPageState, chatCappedHtml, chatMessagesHtml, chatPageHtml, chatPickerHtml } from '../chatPage';
 
 /**
  * The page, as a string.
@@ -24,6 +24,7 @@ function state(over: Partial<ChatPageState> = {}): ChatPageState {
     models: MODELS,
     modelId: 'antigravity',
     running: false,
+    capped: false,
     failure: '',
     uiScale: 0,
     ...over,
@@ -127,4 +128,30 @@ test('both sides of the conversation are named', () => {
   assert.ok(html.includes('You'));
   assert.ok(html.includes('The other AI'));
   assert.ok(html.indexOf('why') < html.indexOf('because'), 'the conversation is out of order');
+});
+
+test('a capped conversation offers a way out rather than a locked box', () => {
+  const html = chatPageHtml(state({ capped: true }), 'n0nce');
+
+  // The owner capped remote threads at three turns. A page that only disabled the composer would
+  // leave somebody with a conversation they cannot continue and no idea what to do next - which is
+  // the failure the plan round named. (gemini and codex, independently.)
+  assert.ok(html.includes('Start a new conversation'), 'the capped page offers no restart');
+  assert.ok(html.includes('Continue with a local model'), 'the capped page does not name the way out');
+  assert.ok(/<textarea[^>]*disabled/.test(html), 'a fourth turn could still be typed');
+});
+
+test('an uncapped conversation says nothing about a limit', () => {
+  const html = chatPageHtml(state(), 'n0nce');
+
+  assert.strictEqual(chatCappedHtml(false), '');
+  assert.ok(!html.includes('Start a new conversation'), 'a limit was announced before it was reached');
+});
+
+test('the page tells the host when it traps an error, not only itself', () => {
+  const html = chatPageHtml(state(), 'n0nce');
+
+  // A trap that only writes into the page leaves the extension believing the conversation is fine
+  // while the tab has stopped answering Enter.
+  assert.match(html, /postMessage\(\{ type: 'pageError'/, 'the error trap reports to nobody');
 });

--- a/src_vs_code/src/test/chatPanel.test.ts
+++ b/src_vs_code/src/test/chatPanel.test.ts
@@ -10,18 +10,29 @@ import { ChatEntry, ChatPanels } from '../chatPanels';
  * hold — a correct key handed to a registry that merged on label would fail just as silently.</p>
  */
 
-function fakes(label: string): { entry: ChatEntry; revealed: () => number; disposed: () => number } {
+function fakes(label: string): {
+  entry: ChatEntry;
+  revealed: () => number;
+  disposed: () => number;
+  posted: () => readonly unknown[];
+} {
   let reveals = 0;
   let disposals = 0;
+  const messages: unknown[] = [];
 
   return {
     entry: {
       label,
-      panel: { reveal: () => { reveals += 1; }, dispose: () => undefined },
+      panel: {
+        reveal: () => { reveals += 1; },
+        dispose: () => undefined,
+        post: (message: unknown) => { messages.push(message); },
+      },
       session: { dispose: () => { disposals += 1; } },
     },
     revealed: () => reveals,
     disposed: () => disposals,
+    posted: () => messages,
   };
 }
 
@@ -127,6 +138,23 @@ test('a re-key never overwrites a conversation that is already there', () => {
   assert.strictEqual(panels.rekey(from, to), false, 'the re-key ate an open conversation');
   assert.strictEqual(panels.get(to), sitting.entry);
   assert.strictEqual(panels.size, 2);
+});
+
+test('a state pushed to one conversation is not seen by the other', () => {
+  const panels = new ChatPanels();
+  const keyA = {};
+  const keyB = {};
+  const a = fakes('a');
+  const b = fakes('b');
+  panels.open(keyA, () => a.entry);
+  panels.open(keyB, () => b.entry);
+
+  panels.get(keyA)?.panel.post({ type: 'state', running: true });
+
+  // An answer that lands in the wrong tab is the same silent failure as a follow-up asked of the
+  // wrong conversation, arriving from the other direction.
+  assert.deepStrictEqual(a.posted(), [{ type: 'state', running: true }]);
+  assert.deepStrictEqual(b.posted(), []);
 });
 
 test('the registry can describe itself to the key resolver', () => {

--- a/src_vs_code/src/test/chatPanel.test.ts
+++ b/src_vs_code/src/test/chatPanel.test.ts
@@ -238,3 +238,52 @@ test('the registry can describe itself to the key resolver', () => {
 
   assert.deepStrictEqual(panels.known(), [{ key, label: 'привет' }]);
 });
+
+test('a conversation can be closed by its own id, from the hook that holds one', () => {
+  const panels = new ChatPanels();
+  const from = {};
+  const to = {};
+  const only = fakes();
+  panels.open(from, 'привет', () => only.entry);
+  panels.rekey(from, to);
+
+  // Every hook is passed an id, so without this each of them would have to bridge id to key before
+  // closing - an asymmetric boundary, and where a second cleanup path grows. (gemini, round 2.)
+  assert.strictEqual(panels.closeById(only.entry.id), true);
+  assert.strictEqual(panels.size, 0);
+  assert.strictEqual(only.sessionDisposed(), 1);
+});
+
+test('closing by an id nobody holds says so rather than closing somebody else', () => {
+  const panels = new ChatPanels();
+  const only = fakes();
+  panels.open({}, 'привет', () => only.entry);
+
+  assert.strictEqual(panels.closeById({}), false);
+  assert.strictEqual(panels.size, 1);
+  assert.strictEqual(only.sessionDisposed(), 0);
+});
+
+test('the id index does not survive its conversation', () => {
+  const panels = new ChatPanels();
+  const key = {};
+  const only = fakes();
+  panels.open(key, 'привет', () => only.entry);
+
+  panels.close(key);
+
+  // A stale index entry would resolve an id to a key whose conversation is gone, and the next look
+  // would hand back undefined from a map that still claimed to know it.
+  assert.strictEqual(panels.entryOf(only.entry.id), undefined);
+  assert.strictEqual(panels.keyOf(only.entry.id), undefined);
+});
+
+test('deactivation clears the id index too', () => {
+  const panels = new ChatPanels();
+  const only = fakes();
+  panels.open({}, 'привет', () => only.entry);
+
+  panels.closeAll();
+
+  assert.strictEqual(panels.entryOf(only.entry.id), undefined);
+});

--- a/src_vs_code/src/test/chatPanel.test.ts
+++ b/src_vs_code/src/test/chatPanel.test.ts
@@ -8,39 +8,47 @@ import { ChatEntry, ChatPanels } from '../chatPanels';
  * <p>The two-tabs-one-label case is here again, from the other side: `sessionKey.ts` decides that
  * they are two keys, and this file proves the registry then keeps them apart. Both halves have to
  * hold — a correct key handed to a registry that merged on label would fail just as silently.</p>
+ *
+ * <p>The rest of this file is what the code round of 2026-09-08 added: an identity that survives a
+ * re-key, a label that can be corrected, and a deactivation that closes the tab as well as the
+ * conversation behind it.</p>
  */
 
-function fakes(label: string): {
-  entry: ChatEntry;
-  revealed: () => number;
-  disposed: () => number;
-  posted: () => readonly unknown[];
-} {
+interface Fake {
+  readonly entry: ChatEntry;
+  revealed(): number;
+  sessionDisposed(): number;
+  panelDisposed(): number;
+  posted(): readonly unknown[];
+}
+
+function fakes(): Fake {
   let reveals = 0;
-  let disposals = 0;
+  let sessionDisposals = 0;
+  let panelDisposals = 0;
   const messages: unknown[] = [];
 
   return {
     entry: {
-      label,
+      id: {},
       panel: {
         reveal: () => { reveals += 1; },
-        dispose: () => undefined,
+        dispose: () => { panelDisposals += 1; },
         post: (message: unknown) => { messages.push(message); },
       },
-      session: { dispose: () => { disposals += 1; } },
+      session: { dispose: () => { sessionDisposals += 1; } },
     },
     revealed: () => reveals,
-    disposed: () => disposals,
+    sessionDisposed: () => sessionDisposals,
+    panelDisposed: () => panelDisposals,
     posted: () => messages,
   };
 }
 
 test('a tab with no conversation gets one', () => {
   const panels = new ChatPanels();
-  const first = fakes('привет');
 
-  const opened = panels.open({}, () => first.entry);
+  const opened = panels.open({}, 'привет', () => fakes().entry);
 
   assert.strictEqual(opened.outcome, 'created');
   assert.strictEqual(panels.size, 1);
@@ -49,14 +57,14 @@ test('a tab with no conversation gets one', () => {
 test('the same tab reveals what it already has, and builds nothing', () => {
   const panels = new ChatPanels();
   const key = {};
-  const first = fakes('привет');
-  panels.open(key, () => first.entry);
+  const first = fakes();
+  panels.open(key, 'привет', () => first.entry);
 
   let built = 0;
-  const again = panels.open(key, () => {
+  const again = panels.open(key, 'привет', () => {
     built += 1;
 
-    return fakes('привет').entry;
+    return fakes().entry;
   });
 
   assert.strictEqual(again.outcome, 'revealed');
@@ -67,11 +75,9 @@ test('the same tab reveals what it already has, and builds nothing', () => {
 
 test('two tabs sharing a label are two conversations', () => {
   const panels = new ChatPanels();
-  const one = fakes('main');
-  const two = fakes('main');
 
-  panels.open({}, () => one.entry);
-  panels.open({}, () => two.entry);
+  panels.open({}, 'main', () => fakes().entry);
+  panels.open({}, 'main', () => fakes().entry);
 
   assert.strictEqual(panels.size, 2, 'a namesake collapsed two conversations into one');
 });
@@ -80,18 +86,29 @@ test('closing one panel ends its own session and nobody else’s', () => {
   const panels = new ChatPanels();
   const keyA = {};
   const keyB = {};
-  const a = fakes('a');
-  const b = fakes('b');
-  panels.open(keyA, () => a.entry);
-  panels.open(keyB, () => b.entry);
+  const a = fakes();
+  const b = fakes();
+  panels.open(keyA, 'a', () => a.entry);
+  panels.open(keyB, 'b', () => b.entry);
 
   panels.close(keyA);
 
   // A vendor process that outlives its tab is an authenticated child nobody can see and nobody will
   // stop; one that dies with a stranger's tab loses a conversation somebody is still reading.
-  assert.strictEqual(a.disposed(), 1, 'the closed tab’s session was left running');
-  assert.strictEqual(b.disposed(), 0, 'closing one tab ended another tab’s session');
+  assert.strictEqual(a.sessionDisposed(), 1, 'the closed tab’s session was left running');
+  assert.strictEqual(b.sessionDisposed(), 0, 'closing one tab ended another tab’s session');
   assert.strictEqual(panels.size, 1);
+});
+
+test('closing from the tab does NOT dispose the panel, because VS Code already has', () => {
+  const panels = new ChatPanels();
+  const key = {};
+  const only = fakes();
+  panels.open(key, 'привет', () => only.entry);
+
+  panels.close(key);
+
+  assert.strictEqual(only.panelDisposed(), 0, 'the panel was disposed twice over');
 });
 
 test('closing a tab that has nothing says so rather than throwing', () => {
@@ -100,26 +117,44 @@ test('closing a tab that has nothing says so rather than throwing', () => {
   assert.strictEqual(panels.close({}), false);
 });
 
-test('deactivating ends every session', () => {
+test('deactivating closes the tab as well as the conversation behind it', () => {
   const panels = new ChatPanels();
-  const a = fakes('a');
-  const b = fakes('b');
-  panels.open({}, () => a.entry);
-  panels.open({}, () => b.entry);
+  const a = fakes();
+  const b = fakes();
+  panels.open({}, 'a', () => a.entry);
+  panels.open({}, 'b', () => b.entry);
 
   panels.closeAll();
 
-  assert.strictEqual(a.disposed(), 1);
-  assert.strictEqual(b.disposed(), 1);
+  // Nobody has told VS Code about these panels, so a session disposed without its panel leaves a tab
+  // open that answers nothing — a zombie whose composer still takes text. (gemini, the code round.)
+  assert.strictEqual(a.sessionDisposed(), 1);
+  assert.strictEqual(a.panelDisposed(), 1, 'a tab was left open with no conversation behind it');
+  assert.strictEqual(b.sessionDisposed(), 1);
+  assert.strictEqual(b.panelDisposed(), 1);
   assert.strictEqual(panels.size, 0);
+});
+
+test('the disposal a deactivation triggers finds nothing left to close', () => {
+  // closeAll removes the entry BEFORE disposing the panel, so the onDidDispose it causes cannot
+  // dispose the same session a second time. This asserts the order, not the intention.
+  const panels = new ChatPanels();
+  const key = {};
+  const only = fakes();
+  panels.open(key, 'привет', () => only.entry);
+
+  panels.closeAll();
+
+  assert.strictEqual(panels.close(key), false, 'the entry was still there when the panel closed');
+  assert.strictEqual(only.sessionDisposed(), 1, 'the session was disposed twice');
 });
 
 test('a conversation can move onto a new tab object', () => {
   const panels = new ChatPanels();
   const from = {};
   const to = {};
-  const only = fakes('привет');
-  panels.open(from, () => only.entry);
+  const only = fakes();
+  panels.open(from, 'привет', () => only.entry);
 
   assert.strictEqual(panels.rekey(from, to), true);
   assert.strictEqual(panels.has(from), false);
@@ -130,24 +165,63 @@ test('a re-key never overwrites a conversation that is already there', () => {
   const panels = new ChatPanels();
   const from = {};
   const to = {};
-  const moving = fakes('a');
-  const sitting = fakes('b');
-  panels.open(from, () => moving.entry);
-  panels.open(to, () => sitting.entry);
+  const moving = fakes();
+  const sitting = fakes();
+  panels.open(from, 'a', () => moving.entry);
+  panels.open(to, 'b', () => sitting.entry);
 
   assert.strictEqual(panels.rekey(from, to), false, 'the re-key ate an open conversation');
   assert.strictEqual(panels.get(to), sitting.entry);
+  assert.strictEqual(panels.get(from), moving.entry, 'the refused move removed the source anyway');
   assert.strictEqual(panels.size, 2);
+});
+
+test('a conversation is found by its own id, whatever key its tab has moved to', () => {
+  const panels = new ChatPanels();
+  const from = {};
+  const to = {};
+  const only = fakes();
+  panels.open(from, 'привет', () => only.entry);
+  panels.rekey(from, to);
+
+  // This is the whole reason the id exists: a panel's callbacks were created once, with the key the
+  // tab had then. Looking up by that key after a re-key found nothing — sends dropped, and a close
+  // that could not find its entry left the vendor process running. (gemini and codex.)
+  assert.strictEqual(panels.entryOf(only.entry.id), only.entry);
+  assert.strictEqual(panels.keyOf(only.entry.id), to);
+});
+
+test('an id nobody holds resolves to nothing rather than to somebody else', () => {
+  const panels = new ChatPanels();
+  panels.open({}, 'привет', () => fakes().entry);
+
+  assert.strictEqual(panels.entryOf({}), undefined);
+  assert.strictEqual(panels.keyOf({}), undefined);
+});
+
+test('a renamed tab can be relabelled, so the fallback still recognises it', () => {
+  const panels = new ChatPanels();
+  const key = {};
+  panels.open(key, 'old name', () => fakes().entry);
+
+  assert.strictEqual(panels.relabel(key, 'new name'), true);
+  assert.deepStrictEqual(panels.known(), [{ key, label: 'new name' }]);
+});
+
+test('relabelling a tab that has no conversation says so', () => {
+  const panels = new ChatPanels();
+
+  assert.strictEqual(panels.relabel({}, 'anything'), false);
 });
 
 test('a state pushed to one conversation is not seen by the other', () => {
   const panels = new ChatPanels();
   const keyA = {};
   const keyB = {};
-  const a = fakes('a');
-  const b = fakes('b');
-  panels.open(keyA, () => a.entry);
-  panels.open(keyB, () => b.entry);
+  const a = fakes();
+  const b = fakes();
+  panels.open(keyA, 'a', () => a.entry);
+  panels.open(keyB, 'b', () => b.entry);
 
   panels.get(keyA)?.panel.post({ type: 'state', running: true });
 
@@ -160,7 +234,7 @@ test('a state pushed to one conversation is not seen by the other', () => {
 test('the registry can describe itself to the key resolver', () => {
   const panels = new ChatPanels();
   const key = {};
-  panels.open(key, () => fakes('привет').entry);
+  panels.open(key, 'привет', () => fakes().entry);
 
   assert.deepStrictEqual(panels.known(), [{ key, label: 'привет' }]);
 });

--- a/src_vs_code/src/test/chatPanel.test.ts
+++ b/src_vs_code/src/test/chatPanel.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { ChatEntry, ChatPanels } from '../chatPanels';
+
+/**
+ * One conversation per tab, and disposal that reaches exactly one session.
+ *
+ * <p>The two-tabs-one-label case is here again, from the other side: `sessionKey.ts` decides that
+ * they are two keys, and this file proves the registry then keeps them apart. Both halves have to
+ * hold — a correct key handed to a registry that merged on label would fail just as silently.</p>
+ */
+
+function fakes(label: string): { entry: ChatEntry; revealed: () => number; disposed: () => number } {
+  let reveals = 0;
+  let disposals = 0;
+
+  return {
+    entry: {
+      label,
+      panel: { reveal: () => { reveals += 1; }, dispose: () => undefined },
+      session: { dispose: () => { disposals += 1; } },
+    },
+    revealed: () => reveals,
+    disposed: () => disposals,
+  };
+}
+
+test('a tab with no conversation gets one', () => {
+  const panels = new ChatPanels();
+  const first = fakes('привет');
+
+  const opened = panels.open({}, () => first.entry);
+
+  assert.strictEqual(opened.outcome, 'created');
+  assert.strictEqual(panels.size, 1);
+});
+
+test('the same tab reveals what it already has, and builds nothing', () => {
+  const panels = new ChatPanels();
+  const key = {};
+  const first = fakes('привет');
+  panels.open(key, () => first.entry);
+
+  let built = 0;
+  const again = panels.open(key, () => {
+    built += 1;
+
+    return fakes('привет').entry;
+  });
+
+  assert.strictEqual(again.outcome, 'revealed');
+  assert.strictEqual(built, 0, 'a second vendor process was started for a tab that had one');
+  assert.strictEqual(first.revealed(), 1, 'the existing panel was not brought forward');
+  assert.strictEqual(panels.size, 1);
+});
+
+test('two tabs sharing a label are two conversations', () => {
+  const panels = new ChatPanels();
+  const one = fakes('main');
+  const two = fakes('main');
+
+  panels.open({}, () => one.entry);
+  panels.open({}, () => two.entry);
+
+  assert.strictEqual(panels.size, 2, 'a namesake collapsed two conversations into one');
+});
+
+test('closing one panel ends its own session and nobody else’s', () => {
+  const panels = new ChatPanels();
+  const keyA = {};
+  const keyB = {};
+  const a = fakes('a');
+  const b = fakes('b');
+  panels.open(keyA, () => a.entry);
+  panels.open(keyB, () => b.entry);
+
+  panels.close(keyA);
+
+  // A vendor process that outlives its tab is an authenticated child nobody can see and nobody will
+  // stop; one that dies with a stranger's tab loses a conversation somebody is still reading.
+  assert.strictEqual(a.disposed(), 1, 'the closed tab’s session was left running');
+  assert.strictEqual(b.disposed(), 0, 'closing one tab ended another tab’s session');
+  assert.strictEqual(panels.size, 1);
+});
+
+test('closing a tab that has nothing says so rather than throwing', () => {
+  const panels = new ChatPanels();
+
+  assert.strictEqual(panels.close({}), false);
+});
+
+test('deactivating ends every session', () => {
+  const panels = new ChatPanels();
+  const a = fakes('a');
+  const b = fakes('b');
+  panels.open({}, () => a.entry);
+  panels.open({}, () => b.entry);
+
+  panels.closeAll();
+
+  assert.strictEqual(a.disposed(), 1);
+  assert.strictEqual(b.disposed(), 1);
+  assert.strictEqual(panels.size, 0);
+});
+
+test('a conversation can move onto a new tab object', () => {
+  const panels = new ChatPanels();
+  const from = {};
+  const to = {};
+  const only = fakes('привет');
+  panels.open(from, () => only.entry);
+
+  assert.strictEqual(panels.rekey(from, to), true);
+  assert.strictEqual(panels.has(from), false);
+  assert.strictEqual(panels.get(to), only.entry);
+});
+
+test('a re-key never overwrites a conversation that is already there', () => {
+  const panels = new ChatPanels();
+  const from = {};
+  const to = {};
+  const moving = fakes('a');
+  const sitting = fakes('b');
+  panels.open(from, () => moving.entry);
+  panels.open(to, () => sitting.entry);
+
+  assert.strictEqual(panels.rekey(from, to), false, 'the re-key ate an open conversation');
+  assert.strictEqual(panels.get(to), sitting.entry);
+  assert.strictEqual(panels.size, 2);
+});
+
+test('the registry can describe itself to the key resolver', () => {
+  const panels = new ChatPanels();
+  const key = {};
+  panels.open(key, () => fakes('привет').entry);
+
+  assert.deepStrictEqual(panels.known(), [{ key, label: 'привет' }]);
+});

--- a/todo/PLAN_chat_with_other_ais.md
+++ b/todo/PLAN_chat_with_other_ais.md
@@ -181,6 +181,11 @@ keeping — the worst possible moment to discover a limit.
 - The transcript carries a **character budget**, checked before the request is built, not after it is
   refused. Approaching it is visible in the panel; crossing it offers the two honest actions —
   start again, or drop the oldest turns — and never silently truncates.
+- **A remote conversation is capped at THREE turns.** The owner’s decision, 2026-09-08. A server
+  model holds no conversation, so turn four re-sends everything said so far for the fourth time;
+  the cost of a thread grows quadratically while its usefulness does not. At the cap the panel says
+  so and offers the two honest actions - start again, or move this thread to a local model, which
+  does have memory. A cap is kinder than a budget nobody can see coming.
 - **`429` is transient, not terminal.** It means the queue is full, and the server says so with a
   `Retry-After`. The session backs off and retries within the turn's budget, reporting "waiting for a
   free account", and gives up only when the budget is gone.
@@ -333,11 +338,14 @@ record the observed timings beside the ones measured above.
    the build complexity today, and the sequence-number guard removes the harm rather than the delay.
 3. **Windows-only capture.** The keybinding path refuses elsewhere with a sentence naming the menu
    path, and that refusal is tested. The menu path is cross-platform as it stands.
-4. **Cost.** Every turn is a real vendor turn. The spending view already tracks these vendors; whether
-   chat turns should be counted there — and separated from review turns — is open, and the owner
-   decides it.
-5. **The transcript budget's number is not chosen yet.** It should come from a measurement of what the
-   server actually refuses, not from a guess, and phase 5 is where that measurement happens.
+4. **Cost is counted, and counted separately.** The owner’s decision, 2026-09-08: chat turns go
+   into the spending view like review turns, and are DISTINGUISHED from them. Same vendors, two
+   different questions - "what did the gate cost me" and "what did asking cost me" - and a single
+   total answers neither. The turn carries which it was; the view groups on it.
+5. **The transcript budget’s number is MEASURED, not chosen.** Confirmed by the owner, 2026-09-08.
+   Phase 5 finds what the real server actually refuses and cites it; a number picked on the day
+   would be a guess wearing a limit’s clothes. The three-turn cap above bounds the thread while
+   that measurement is still outstanding.
 
 ## Definition of Done
 
@@ -357,6 +365,9 @@ record the observed timings beside the ones measured above.
 - [ ] `coai.chatAutoSend` decides who sends: at the default the keybinding sends and the menu waits
       with the composer filled and focused, and both other values behave as the table says. The
       clipboard is never restored over something newer.
+- [ ] A remote conversation stops at three turns, saying so and offering the local model that has
+      memory - rather than growing a transcript until the server refuses it.
+- [ ] Chat turns appear in the spending view, separated from review turns.
 - [ ] The model picker lists local rows and, when a Team server answers, its catalog rows too.
 - [ ] The section holds a multi-line prompt box, defaulting to the single word `Explain`, and what it
       holds is what the passage is actually sent with.


### PR DESCRIPTION
Epic 2 of [`todo/PLAN_chat_with_other_ais.md`](todo/PLAN_chat_with_other_ais.md): the tab a
conversation lives in.

**Nothing here is reachable by a user yet** — no command, no keybinding, no menu item, no settings,
no vendor process. Nothing calls `createChatPanel`. That is epic 1's tail and epic 3.

## What it adds

| Module | What it is |
|---|---|
| `chatPage.ts` | The page, pure: the passage at the top, the messages, a composer, a thinking line, the ± zoom, a picker that vanishes at one model, the capped state, a failure region, an `onerror` trap that reports to the host. |
| `chatPanels.ts` | The registry, pure: one conversation per source tab, keyed by the tab **object**. |
| `chatMessages.ts` | What a message from the page means, pure. |
| `chatPanel.ts` | The `vscode` half, deliberately thin — the only part no unit test can reach. |

## Three gate rounds found four real defects

**The plan round** produced `chatMessages.ts`: every test exercised the pure registry and the pure
page, while the only module turning a webview message into an action was unreachable by tests — a
wrong message type would have shipped with everything green.

**Code round 1** found two of the same family, something outliving the thing it was named after:

- **A panel's callbacks closed over the tab KEY.** After a re-key, every message from that page was
  looked up under a key nobody held: sends dropped silently, and a close that could not find its
  entry left the vendor process running. A conversation now carries its own `id`.
- **`closeAll` disposed sessions without disposing panels** — on deactivation that left tabs open
  whose composer still took text with nothing behind it.

**Code round 2** (verdict `proceed`) added `closeById`, replaced the linear index scans, and made the
pick check read the models the conversation was last pushed rather than a predicate frozen at
creation — two places deciding what a valid model is, one unable to learn about a Team server's
catalog, is a drift with a bill attached.

## Decisions recorded from the owner

- A remote conversation is **capped at three turns** — it keeps no conversation, so turn four
  re-sends everything for the fourth time. The capped page offers *start again* and *continue with a
  local model*, because a locked box with no way out is not an answer.
- Chat turns are counted in the spending view and **separated from review turns**.
- The transcript budget's number will be **measured** against the real server, not chosen.

## Test plan

- `npm test` — **747 tests, 746 pass, 0 fail**, 1 pre-existing skip.
- `bundledPage.test.ts` now bundles the chat page too, which is what makes "a page module imports
  nothing from the host" a check. Its own limit is documented in it: it does **not** catch a dead
  import, because esbuild tree-shakes one — proved by injecting one that passed and a reachable call
  that failed.

## Still open

Whether VS Code `Tab` objects are stable while a tab stays open. A reviewer called the key design
Blocking on the claim that they are not. The design degrades safely either way — a uniquely named tab
re-keys and keeps its conversation, an ambiguous one opens a second tab, never a follow-up in
somebody else's conversation — and the probe extension now logs `tab identity: SAME|NEW` so the claim
is settled by measurement rather than argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added VS Code conversation tabs with chat messaging, model selection, adjustable text size, and local-model switching.
  - Added recovery options to restart or switch models when a remote conversation reaches its three-turn limit.
  - Added clearer handling for invalid messages and page errors.

- **Bug Fixes**
  - Improved conversation tab reliability, including tab tracking, cleanup, state updates, and focus restoration.
  - Prevented duplicate updates and rejected unavailable model selections.

- **Documentation**
  - Documented chat-tab behavior and session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->