### PR TITLE
feat(chat): a conversation held in one long-lived vendor process

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -44,6 +44,27 @@ authenticated child nobody can see and nobody will stop; one that dies with a st
 conversation somebody is still reading.
 ### A conversation is a process, and it ends four ways (2026-09-08)
 
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Starting: send, no process
+  Starting --> Ready: init
+  Starting --> Failed: startup budget · launcher threw · died before init
+  Ready --> Asking: one NDJSON line
+  Asking --> Ready: result SUCCESS
+  Asking --> Ready: result ERROR (the model refused; the process lives)
+  Asking --> Failed: turn budget · exit · error
+  Failed --> Starting: the next send, with contextLost
+  Ready --> [*]: dispose
+  Starting --> [*]: dispose (the waiter is told at once)
+```
+
+Four ends, one of them a person closing a tab. `Failed` always kills the tree: a process that has
+stopped answering must not be handed the next turn. The edge back into `Starting` is the one that
+carries `contextLost` — the replacement never heard the passage, and the first answer afterwards
+says so rather than reading as a model that has lost the thread.
+
+
 `cliChatSession.ts` holds one long-lived vendor process per conversation. The protocol was measured
 rather than read: `agy --input-format stream-json --output-format stream-json` takes one NDJSON
 message per line and answers `init`, then `step_update`s, then a `result`. The message schema came

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -42,6 +42,31 @@ sat beside it. The fallback now requires the label to name exactly one panel.
 tested: closing one tab disposes ONE session, its own. A vendor process that outlives its tab is an
 authenticated child nobody can see and nobody will stop; one that dies with a stranger’s tab loses a
 conversation somebody is still reading.
+### A conversation is a process, and it ends four ways (2026-09-08)
+
+`cliChatSession.ts` holds one long-lived vendor process per conversation. The protocol was measured
+rather than read: `agy --input-format stream-json --output-format stream-json` takes one NDJSON
+message per line and answers `init`, then `step_update`s, then a `result`. The message schema came
+out of the binary’s own refusal - `stream input message is missing the "event" field` - after
+`type:` was the first guess and the wrong one.
+
+The file is shaped by the four ways such a process ends, three of which the first plan did not
+mention and the gate raised as five separate findings: disposal, an exit of its own, a start that
+never reaches `init`, and a turn that is never answered. The last two are separate budgets with
+separate sentences, because **it would not start** and **it will not answer** send a person to
+different places. Both kill the process; a child that has stopped answering must not be handed the
+next turn as though nothing happened.
+
+Turns are serialised in the session, not merely discouraged in the page. The page disables its
+composer, but a page is a suggestion - two sends arriving together must not interleave two turns
+down one pipe, and the second waits rather than being refused, because refusing loses what somebody
+typed.
+
+**One defect found by its own tests, worth keeping.** The launcher REPLAYS what a child said before
+its first subscriber, which is what makes a fast `init` safe - and the session subscribed and only
+then registered the waiter, so the replayed `init` arrived with nobody to tell. Every turn hung for
+the whole startup budget. It now ASKS what happened after subscribing rather than waiting for a
+signal already sent.
 ### One spawn site, and why it grew a handle (2026-09-08)
 
 `processLauncher.ts` owns the only `spawn` in `src/` that this extension controls. It is the version

--- a/src_vs_code/src/chatSession.ts
+++ b/src_vs_code/src/chatSession.ts
@@ -1,0 +1,50 @@
+/**
+ * What a conversation is, whichever side of the machine answers it.
+ *
+ * <p>Two implementations will satisfy this: `cliChatSession.ts` holds a real conversation in a
+ * long-lived vendor process, and `remoteChatSession.ts` has none and re-sends its transcript to the
+ * Team server. The panel must not know which it holds — but the PERSON must, because the difference
+ * shows up in latency, in cost, and in a three-turn limit that only one of them has.</p>
+ */
+
+/** What one turn produced: an answer, or a sentence saying why there is none. */
+export type TurnResult =
+  | { readonly ok: true; readonly answer: string }
+  | { readonly ok: false; readonly failure: string };
+
+export interface ChatSession {
+  /**
+   * Ask, and wait for the answer.
+   *
+   * <p>Never rejects: a turn that fails answers `ok: false` with a sentence, because every caller
+   * would otherwise have to write the same try/catch and the page has a region for exactly this.
+   * Turns are serialised — a second `send` while one is in flight waits its turn rather than
+   * interleaving down the same pipe.</p>
+   */
+  send(text: string): Promise<TurnResult>;
+
+  /** End it. Safe to call twice; a session already gone stays gone. */
+  dispose(): void;
+}
+
+/** How long each phase may take. Separate, because they fail differently and read differently. */
+export interface TurnBudgets {
+  /**
+   * From launch to the CLI's `init` event.
+   *
+   * <p>Measured on this machine: 3.6–6.6 s. A process that never reaches `init` failed to START —
+   * a missing binary, a refused sign-in — which is a different sentence from one that started and
+   * then said nothing.</p>
+   */
+  readonly startupMs: number;
+
+  /**
+   * From the line being written to the turn's `result`.
+   *
+   * <p>Measured: 9.4 s for a real explanation, 4.3 s for a short follow-up. The budget is not the
+   * measurement — it is the point past which waiting is no longer reasonable.</p>
+   */
+  readonly turnMs: number;
+}
+
+export const DEFAULT_BUDGETS: TurnBudgets = { startupMs: 30_000, turnMs: 180_000 };

--- a/src_vs_code/src/chatSession.ts
+++ b/src_vs_code/src/chatSession.ts
@@ -9,7 +9,20 @@
 
 /** What one turn produced: an answer, or a sentence saying why there is none. */
 export type TurnResult =
-  | { readonly ok: true; readonly answer: string }
+  | {
+    readonly ok: true;
+    readonly answer: string;
+    /**
+     * The process answering this turn is not the one that heard the earlier ones.
+     *
+     * <p>A vendor CLI that died takes the conversation with it - the next question starts a new
+     * process with no memory of the passage or of anything already said, and its answer will read
+     * as a model that has lost the thread. The session cannot prevent that; what it must not do is
+     * HIDE it. A reviewer raised exactly this on the plan round, and it is the difference between
+     * "the model is being obtuse" and "the conversation restarted".</p>
+     */
+    readonly contextLost?: true;
+  }
   | { readonly ok: false; readonly failure: string };
 
 export interface ChatSession {

--- a/src_vs_code/src/cliChatSession.ts
+++ b/src_vs_code/src/cliChatSession.ts
@@ -6,17 +6,19 @@ import { ChatSession, TurnBudgets, TurnResult } from './chatSession';
  *
  * <p>The protocol was MEASURED, not read out of a manual: `agy --input-format stream-json
  * --output-format stream-json` takes one NDJSON message per line and answers `init`, then
- * `step_update`s, then a `result`, per turn. Three turns down one pipe were answered by one process
- * with the context preserved — turn 3 resolved "now simpler" against turn 2 without the passage
- * being repeated. The schema came out of the binary's own error strings after it refused `type:`
- * with `stream input message is missing the "event" field`.</p>
+ * `step_update`s, then a `result`. Three turns down one pipe were answered by one process with the
+ * context preserved — turn 3 resolved "now simpler" against turn 2 without the passage being
+ * repeated. The schema came out of the binary's own error strings after it refused `type:` with
+ * `stream input message is missing the "event" field`.</p>
  *
  * <p><b>A long-lived child has four ways to end, and only one of them is a person closing a tab.</b>
  * The first version of the plan described that one; the gate raised the other three as five separate
  * findings. They are the shape of this file:</p>
  *
  * <ol>
- *   <li><b>Disposal</b> — the tab closed. The tree is killed.</li>
+ *   <li><b>Disposal</b> — the tab closed. The tree is killed, and anything waiting is told at once,
+ *       including a start that has not finished: without that, closing a tab left the caller waiting
+ *       the whole thirty-second startup budget for an answer nobody was going to read.</li>
  *   <li><b>It exits on its own</b> — token exhaustion, a crash, an OS kill. The turn in flight fails
  *       with a sentence, and the NEXT send starts a new process rather than writing into a closed
  *       pipe. `EPIPE` is a state to report, never an unhandled rejection.</li>
@@ -26,6 +28,13 @@ import { ChatSession, TurnBudgets, TurnResult } from './chatSession';
  *   <li><b>It never answers</b> — no `result` inside the turn budget. Killed, so the next turn is
  *       not asked of a process that has already stopped listening.</li>
  * </ol>
+ *
+ * <p><b>A conversation that restarts says so.</b> A dead process takes the conversation with it —
+ * the replacement never heard the passage or anything already said, and its answer reads as a model
+ * that has lost the thread. The session cannot prevent that; what it must not do is hide it. The
+ * failure that reports the death says the conversation has to start again, and the first answer
+ * afterwards carries `contextLost`. It is counted from the first turn SENT, not the first ANSWERED:
+ * a process that died before answering still took a question with it.</p>
  *
  * <p><b>One turn at a time, enforced here rather than hoped for in the page.</b> The page disables
  * its composer, but a page is a suggestion: two `send` calls arriving together must not interleave
@@ -66,12 +75,15 @@ interface Pending {
   readonly cancelBudget: () => void;
 }
 
+const CLOSED = 'the conversation was closed';
+
 export class CliChatSession implements ChatSession {
   private child: ProcessHandle | undefined;
   private unsubscribe: Unsubscribe | undefined;
   private ready = false;
   private pending: Pending | undefined;
   private waitingForInit: ((started: string) => void) | undefined;
+  private cancelStartBudget: (() => void) | undefined;
   /**
    * What the start already came to, when it came to it before anybody was waiting.
    *
@@ -81,8 +93,16 @@ export class CliChatSession implements ChatSession {
    * sent and hung for the entire startup budget on every turn. Found by its own tests.</p>
    */
   private startOutcome: string | undefined;
-  /** Whether this conversation has ever been answered - a first turn cannot have lost a context. */
-  private everAnswered = false;
+  /**
+   * Which child the callbacks belong to.
+   *
+   * <p>A killed child can deliver its `exit` AFTER the next send has started a replacement, and the
+   * stale callback would then clear the new child and fail its turn. Every subscription carries the
+   * generation it was made in and does nothing once that generation is over. (codex, the code round.)</p>
+   */
+  private generation = 0;
+  /** Whether anything has been asked yet — a first turn has no conversation to lose. */
+  private everSent = false;
   /** The next answer comes from a process that never heard the earlier turns. Told once, then cleared. */
   private contextLost = false;
   private queue: Promise<unknown> = Promise.resolve();
@@ -106,23 +126,32 @@ export class CliChatSession implements ChatSession {
 
   send(text: string): Promise<TurnResult> {
     // The queue IS the serialisation. Chaining on the previous turn's settlement means a second
-    // caller waits rather than opening a second turn on the same pipe.
-    const mine = this.queue.then(() => this.turn(text));
-    this.queue = mine.catch(() => undefined);
+    // caller waits rather than opening a second turn on the same pipe. The catch is not decoration:
+    // `send` promises never to reject, and an injected launcher that throws would otherwise break
+    // that promise and the queue with it. (Four reviewers, one finding.)
+    const mine = this.queue.then(() => this.turn(text)).catch((reason: unknown) => failed(reason));
+    this.queue = mine;
 
     return mine;
   }
 
   dispose(): void {
     this.disposed = true;
-    this.settle({ ok: false, failure: 'the conversation was closed' });
+    // A start that has not finished is waiting too, and nobody was telling it. Closing a tab used to
+    // leave the caller waiting the whole startup budget. (codex, the code round, twice.)
+    this.cancelStartBudget?.();
+    this.cancelStartBudget = undefined;
+    const waiting = this.waitingForInit;
+    this.waitingForInit = undefined;
+    waiting?.(CLOSED);
+    this.settle({ ok: false, failure: CLOSED });
     this.stop();
   }
 
   /** One turn, start to finish, with nothing else in the pipe. */
   private async turn(text: string): Promise<TurnResult> {
     if (this.disposed) {
-      return { ok: false, failure: 'the conversation was closed' };
+      return { ok: false, failure: CLOSED };
     }
 
     const started = await this.ensureStarted();
@@ -130,6 +159,7 @@ export class CliChatSession implements ChatSession {
       return { ok: false, failure: started };
     }
 
+    this.everSent = true;
     const line = JSON.stringify({ event: 'user', message: { role: 'user', content: text } });
     if (this.child?.writeLine(line) !== true) {
       // The pipe went between the last event and this write. Not an error to throw: the next send
@@ -144,7 +174,7 @@ export class CliChatSession implements ChatSession {
         // Killed, not merely abandoned: a process that has stopped answering must not be handed the
         // next turn as though nothing happened.
         this.stop();
-        this.settle({ ok: false, failure: 'the model did not answer in time' });
+        this.settle({ ok: false, failure: this.withRestart('the model did not answer in time') });
       });
       this.pending = { settle: resolve, cancelBudget };
     });
@@ -157,10 +187,17 @@ export class CliChatSession implements ChatSession {
     }
 
     this.startOutcome = undefined;
-    const child = this.start();
+    let child: ProcessHandle;
+    try {
+      child = this.start();
+    } catch (reason) {
+      // `send` promises never to reject, and an injected launcher is somebody else's code.
+      return Promise.resolve(`the model’s process could not be started: ${message(reason)}`);
+    }
     this.child = child;
     this.ready = false;
-    this.listen(child);
+    this.generation += 1;
+    this.listen(child, this.generation);
 
     // Ask what happened rather than wait to be told: the replay above may already have delivered it.
     if (this.ready) {
@@ -173,6 +210,7 @@ export class CliChatSession implements ChatSession {
     return new Promise<string>((resolve) => {
       const cancelBudget = this.timers.after(this.budgets.startupMs, () => {
         this.waitingForInit = undefined;
+        this.cancelStartBudget = undefined;
         // What the child managed to say before giving up is the difference between "not installed"
         // and "installed, and refusing your sign-in". Read BEFORE the kill, which reads better
         // beside it. (local, the plan round.)
@@ -180,20 +218,27 @@ export class CliChatSession implements ChatSession {
         this.stop();
         resolve(said.length === 0
           ? 'the model’s process did not start'
-          : 'the model’s process did not start: ' + said);
+          : `the model’s process did not start: ${said}`);
       });
+      this.cancelStartBudget = cancelBudget;
       this.waitingForInit = (failure: string) => {
         cancelBudget();
+        this.cancelStartBudget = undefined;
         this.waitingForInit = undefined;
         resolve(failure);
       };
     });
   }
 
-  private listen(child: ProcessHandle): void {
-    this.unsubscribe = child.onLine((line) => this.onLine(line));
-    child.onError((reason) => this.onGone(`the model’s process failed to run: ${reason}`));
-    child.onExit(() => this.onGone(`the model’s process ended: ${child.stderrTail().trim().slice(-400)}`));
+  private listen(child: ProcessHandle, generation: number): void {
+    const mine = (run: () => void): void => {
+      if (generation === this.generation) {
+        run();
+      }
+    };
+    this.unsubscribe = child.onLine((line) => mine(() => this.onLine(line)));
+    child.onError((reason) => mine(() => this.onGone(`the model’s process failed to run: ${reason}`)));
+    child.onExit(() => mine(() => this.onGone(ended(child.stderrTail()))));
   }
 
   /** One line of NDJSON. Anything unreadable is skipped: a CLI may log where it pleases. */
@@ -221,7 +266,6 @@ export class CliChatSession implements ChatSession {
     if (status === 'SUCCESS') {
       const lost = this.contextLost;
       this.contextLost = false;
-      this.everAnswered = true;
       this.settle(lost
         ? { ok: true, answer: answer.trim(), contextLost: true }
         : { ok: true, answer: answer.trim() });
@@ -238,13 +282,19 @@ export class CliChatSession implements ChatSession {
   private onGone(failure: string): void {
     this.child = undefined;
     this.ready = false;
-    // Only a conversation that HAD something to lose can lose it. A process that never answered
-    // takes nothing with it, and saying "the conversation restarted" about a first turn would be
-    // noise where the real news is that it failed at all.
-    this.contextLost = this.contextLost || this.everAnswered;
+    // Only a conversation that HAD something to lose can lose it, and what it takes is the question
+    // as much as the answer: a process that died before replying still swallowed a turn.
+    this.contextLost = this.contextLost || this.everSent;
     this.startOutcome = failure;
     this.waitingForInit?.(failure);
-    this.settle({ ok: false, failure });
+    this.settle({ ok: false, failure: this.withRestart(failure) });
+  }
+
+  /** The same sentence, saying that the thread is gone when it is. */
+  private withRestart(failure: string): string {
+    return this.everSent && this.contextLost
+      ? `${failure}. The conversation has to start again — the next answer will not remember this one`
+      : failure;
   }
 
   /** End whatever turn is waiting, once. */
@@ -262,12 +312,31 @@ export class CliChatSession implements ChatSession {
   private stop(): void {
     // A killed process takes the conversation with it exactly as a dead one does - the budget that
     // killed it does not make the loss less real, and the next answer must still say so.
-    this.contextLost = this.contextLost || this.everAnswered;
+    this.contextLost = this.contextLost || this.everSent;
     const child = this.child;
     this.child = undefined;
     this.ready = false;
+    // Past this line no callback of that child is ours any more.
+    this.generation += 1;
     this.unsubscribe?.();
     this.unsubscribe = undefined;
     child?.kill();
   }
+}
+
+/** What a child left behind, or that it left nothing — never a sentence ending in a bare colon. */
+function ended(stderr: string): string {
+  const tail = stderr.trim().slice(-400);
+
+  return tail.length === 0 ? 'the model’s process ended unexpectedly' : `the model’s process ended: ${tail}`;
+}
+
+/** A thrown thing, as a sentence. */
+function message(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason);
+}
+
+/** The last resort: a turn that threw where nothing was supposed to. */
+function failed(reason: unknown): TurnResult {
+  return { ok: false, failure: `the turn failed unexpectedly: ${message(reason)}` };
 }

--- a/src_vs_code/src/cliChatSession.ts
+++ b/src_vs_code/src/cliChatSession.ts
@@ -1,0 +1,251 @@
+import { ProcessHandle, Unsubscribe } from './processLauncher';
+import { ChatSession, TurnBudgets, TurnResult } from './chatSession';
+
+/**
+ * A conversation held in one long-lived vendor process.
+ *
+ * <p>The protocol was MEASURED, not read out of a manual: `agy --input-format stream-json
+ * --output-format stream-json` takes one NDJSON message per line and answers `init`, then
+ * `step_update`s, then a `result`, per turn. Three turns down one pipe were answered by one process
+ * with the context preserved — turn 3 resolved "now simpler" against turn 2 without the passage
+ * being repeated. The schema came out of the binary's own error strings after it refused `type:`
+ * with `stream input message is missing the "event" field`.</p>
+ *
+ * <p><b>A long-lived child has four ways to end, and only one of them is a person closing a tab.</b>
+ * The first version of the plan described that one; the gate raised the other three as five separate
+ * findings. They are the shape of this file:</p>
+ *
+ * <ol>
+ *   <li><b>Disposal</b> — the tab closed. The tree is killed.</li>
+ *   <li><b>It exits on its own</b> — token exhaustion, a crash, an OS kill. The turn in flight fails
+ *       with a sentence, and the NEXT send starts a new process rather than writing into a closed
+ *       pipe. `EPIPE` is a state to report, never an unhandled rejection.</li>
+ *   <li><b>It never starts</b> — no `init` inside the startup budget. Killed, and said differently
+ *       from the case below, because "it would not start" and "it will not answer" send a person to
+ *       different places.</li>
+ *   <li><b>It never answers</b> — no `result` inside the turn budget. Killed, so the next turn is
+ *       not asked of a process that has already stopped listening.</li>
+ * </ol>
+ *
+ * <p><b>One turn at a time, enforced here rather than hoped for in the page.</b> The page disables
+ * its composer, but a page is a suggestion: two `send` calls arriving together must not interleave
+ * two turns down one pipe, and the second waits rather than being refused — refusing would lose what
+ * somebody typed.</p>
+ *
+ * <p>Everything that touches the world is injected: the launcher, and the timers. That is what lets
+ * the failure paths above be tested at all — a suite that waited three minutes for a turn budget is
+ * a suite nobody runs.</p>
+ */
+
+/** A cancellable delay. Injected so a test can expire a budget without waiting for one. */
+export interface Timers {
+  after(ms: number, run: () => void): () => void;
+}
+
+export const REAL_TIMERS: Timers = {
+  after: (ms, run) => {
+    const handle = setTimeout(run, ms);
+
+    return () => clearTimeout(handle);
+  },
+};
+
+/** One line of the CLI's output, as far as this file cares. */
+interface CliEvent {
+  readonly event?: unknown;
+  readonly result?: {
+    readonly status?: unknown;
+    readonly response?: unknown;
+    readonly error?: unknown;
+  };
+}
+
+/** What a turn is waiting for, and how to end its wait. */
+interface Pending {
+  readonly settle: (result: TurnResult) => void;
+  readonly cancelBudget: () => void;
+}
+
+export class CliChatSession implements ChatSession {
+  private child: ProcessHandle | undefined;
+  private unsubscribe: Unsubscribe | undefined;
+  private ready = false;
+  private pending: Pending | undefined;
+  private waitingForInit: ((started: string) => void) | undefined;
+  /**
+   * What the start already came to, when it came to it before anybody was waiting.
+   *
+   * <p>The launcher REPLAYS what a child said before its first subscriber — which is the whole
+   * reason it does, and it means `init`, or a death, can land INSIDE the subscription below, at a
+   * moment when there is nobody to tell. The first version waited for a signal that had already been
+   * sent and hung for the entire startup budget on every turn. Found by its own tests.</p>
+   */
+  private startOutcome: string | undefined;
+  private queue: Promise<unknown> = Promise.resolve();
+  private disposed = false;
+
+  /**
+   * @param start launches the vendor process — injected, so this file spawns nothing itself
+   * @param budgets how long the start and each turn may take
+   * @param timers the clock, injected so a test can expire a budget in a millisecond
+   */
+  constructor(
+    private readonly start: () => ProcessHandle,
+    private readonly budgets: TurnBudgets,
+    private readonly timers: Timers = REAL_TIMERS,
+  ) {}
+
+  /** Whether a process is currently alive. For the tests, and for a caller that wants to say so. */
+  get running(): boolean {
+    return this.child !== undefined;
+  }
+
+  send(text: string): Promise<TurnResult> {
+    // The queue IS the serialisation. Chaining on the previous turn's settlement means a second
+    // caller waits rather than opening a second turn on the same pipe.
+    const mine = this.queue.then(() => this.turn(text));
+    this.queue = mine.catch(() => undefined);
+
+    return mine;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.settle({ ok: false, failure: 'the conversation was closed' });
+    this.stop();
+  }
+
+  /** One turn, start to finish, with nothing else in the pipe. */
+  private async turn(text: string): Promise<TurnResult> {
+    if (this.disposed) {
+      return { ok: false, failure: 'the conversation was closed' };
+    }
+
+    const started = await this.ensureStarted();
+    if (started !== '') {
+      return { ok: false, failure: started };
+    }
+
+    const line = JSON.stringify({ event: 'user', message: { role: 'user', content: text } });
+    if (this.child?.writeLine(line) !== true) {
+      // The pipe went between the last event and this write. Not an error to throw: the next send
+      // starts a new process, which is what a person pressing Enter again expects to happen.
+      this.stop();
+
+      return { ok: false, failure: 'the model’s process had already gone; ask again to start a new one' };
+    }
+
+    return new Promise<TurnResult>((resolve) => {
+      const cancelBudget = this.timers.after(this.budgets.turnMs, () => {
+        // Killed, not merely abandoned: a process that has stopped answering must not be handed the
+        // next turn as though nothing happened.
+        this.stop();
+        this.settle({ ok: false, failure: 'the model did not answer in time' });
+      });
+      this.pending = { settle: resolve, cancelBudget };
+    });
+  }
+
+  /** An empty string when a process is up and has said `init`; otherwise the reason it is not. */
+  private ensureStarted(): Promise<string> {
+    if (this.child !== undefined && this.ready) {
+      return Promise.resolve('');
+    }
+
+    this.startOutcome = undefined;
+    const child = this.start();
+    this.child = child;
+    this.ready = false;
+    this.listen(child);
+
+    // Ask what happened rather than wait to be told: the replay above may already have delivered it.
+    if (this.ready) {
+      return Promise.resolve('');
+    }
+    if (this.startOutcome !== undefined) {
+      return Promise.resolve(this.startOutcome);
+    }
+
+    return new Promise<string>((resolve) => {
+      const cancelBudget = this.timers.after(this.budgets.startupMs, () => {
+        this.waitingForInit = undefined;
+        this.stop();
+        resolve('the model’s process did not start');
+      });
+      this.waitingForInit = (failure: string) => {
+        cancelBudget();
+        this.waitingForInit = undefined;
+        resolve(failure);
+      };
+    });
+  }
+
+  private listen(child: ProcessHandle): void {
+    this.unsubscribe = child.onLine((line) => this.onLine(line));
+    child.onError((reason) => this.onGone(`the model’s process failed to run: ${reason}`));
+    child.onExit(() => this.onGone(`the model’s process ended: ${child.stderrTail().trim().slice(-400)}`));
+  }
+
+  /** One line of NDJSON. Anything unreadable is skipped: a CLI may log where it pleases. */
+  private onLine(line: string): void {
+    let event: CliEvent;
+    try {
+      event = JSON.parse(line) as CliEvent;
+    } catch {
+      return;
+    }
+
+    if (event.event === 'init') {
+      this.ready = true;
+      this.waitingForInit?.('');
+
+      return;
+    }
+    if (event.event !== 'result') {
+      return;
+    }
+
+    const status = typeof event.result?.status === 'string' ? event.result.status : '';
+    const answer = typeof event.result?.response === 'string' ? event.result.response : '';
+    const error = typeof event.result?.error === 'string' ? event.result.error : '';
+    if (status === 'SUCCESS') {
+      this.settle({ ok: true, answer: answer.trim() });
+
+      return;
+    }
+    // An ERROR result is an error, not an empty answer. The CLI reports a refused input this way -
+    // it is how the NDJSON schema was discovered - and a page showing nothing would look like a
+    // model with nothing to say.
+    this.settle({ ok: false, failure: error.length > 0 ? error : `the model answered with ${status || 'no status'}` });
+  }
+
+  /** The process has gone, whether it meant to or not. */
+  private onGone(failure: string): void {
+    this.child = undefined;
+    this.ready = false;
+    this.startOutcome = failure;
+    this.waitingForInit?.(failure);
+    this.settle({ ok: false, failure });
+  }
+
+  /** End whatever turn is waiting, once. */
+  private settle(result: TurnResult): void {
+    const pending = this.pending;
+    if (pending === undefined) {
+      return;
+    }
+    this.pending = undefined;
+    pending.cancelBudget();
+    pending.settle(result);
+  }
+
+  /** Kill the process and forget it. Idempotent — `dispose` and a budget can both arrive. */
+  private stop(): void {
+    const child = this.child;
+    this.child = undefined;
+    this.ready = false;
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    child?.kill();
+  }
+}

--- a/src_vs_code/src/cliChatSession.ts
+++ b/src_vs_code/src/cliChatSession.ts
@@ -81,6 +81,10 @@ export class CliChatSession implements ChatSession {
    * sent and hung for the entire startup budget on every turn. Found by its own tests.</p>
    */
   private startOutcome: string | undefined;
+  /** Whether this conversation has ever been answered - a first turn cannot have lost a context. */
+  private everAnswered = false;
+  /** The next answer comes from a process that never heard the earlier turns. Told once, then cleared. */
+  private contextLost = false;
   private queue: Promise<unknown> = Promise.resolve();
   private disposed = false;
 
@@ -169,8 +173,14 @@ export class CliChatSession implements ChatSession {
     return new Promise<string>((resolve) => {
       const cancelBudget = this.timers.after(this.budgets.startupMs, () => {
         this.waitingForInit = undefined;
+        // What the child managed to say before giving up is the difference between "not installed"
+        // and "installed, and refusing your sign-in". Read BEFORE the kill, which reads better
+        // beside it. (local, the plan round.)
+        const said = child.stderrTail().trim().slice(-300);
         this.stop();
-        resolve('the model’s process did not start');
+        resolve(said.length === 0
+          ? 'the model’s process did not start'
+          : 'the model’s process did not start: ' + said);
       });
       this.waitingForInit = (failure: string) => {
         cancelBudget();
@@ -209,7 +219,12 @@ export class CliChatSession implements ChatSession {
     const answer = typeof event.result?.response === 'string' ? event.result.response : '';
     const error = typeof event.result?.error === 'string' ? event.result.error : '';
     if (status === 'SUCCESS') {
-      this.settle({ ok: true, answer: answer.trim() });
+      const lost = this.contextLost;
+      this.contextLost = false;
+      this.everAnswered = true;
+      this.settle(lost
+        ? { ok: true, answer: answer.trim(), contextLost: true }
+        : { ok: true, answer: answer.trim() });
 
       return;
     }
@@ -223,6 +238,10 @@ export class CliChatSession implements ChatSession {
   private onGone(failure: string): void {
     this.child = undefined;
     this.ready = false;
+    // Only a conversation that HAD something to lose can lose it. A process that never answered
+    // takes nothing with it, and saying "the conversation restarted" about a first turn would be
+    // noise where the real news is that it failed at all.
+    this.contextLost = this.contextLost || this.everAnswered;
     this.startOutcome = failure;
     this.waitingForInit?.(failure);
     this.settle({ ok: false, failure });
@@ -241,6 +260,9 @@ export class CliChatSession implements ChatSession {
 
   /** Kill the process and forget it. Idempotent — `dispose` and a budget can both arrive. */
   private stop(): void {
+    // A killed process takes the conversation with it exactly as a dead one does - the budget that
+    // killed it does not make the loss less real, and the next answer must still say so.
+    this.contextLost = this.contextLost || this.everAnswered;
     const child = this.child;
     this.child = undefined;
     this.ready = false;

--- a/src_vs_code/src/test/cliChatSession.test.ts
+++ b/src_vs_code/src/test/cliChatSession.test.ts
@@ -1,0 +1,408 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { CliChatSession, Timers } from '../cliChatSession';
+import { ProcessHandle } from '../processLauncher';
+import { TurnBudgets } from '../chatSession';
+
+/**
+ * The four ways a long-lived vendor process ends, and the one way it answers.
+ *
+ * <p>Nothing here starts a real process. What is being asserted is the STATE MACHINE — what happens
+ * when `init` never comes, when a turn goes unanswered, when the child dies mid-sentence — and every
+ * one of those would otherwise need a real failure to reproduce, or a suite that waits three minutes
+ * for a budget. The launcher itself is tested against real children in `processLauncher.test.ts`;
+ * this file tests what is built on top of it.</p>
+ *
+ * <p><b>The fake replays, and that is not a convenience.</b> The first version of it appended
+ * listeners and delivered nothing that had arrived before them — and every test in this file timed
+ * out, because a session subscribes on a microtask while a real child can have spoken already. The
+ * REAL launcher buffers until its first subscriber for exactly that reason (it was a finding on its
+ * own code round). A fake weaker than the thing it stands for does not simplify a test; it tests a
+ * program that does not exist.</p>
+ */
+
+const BUDGETS: TurnBudgets = { startupMs: 1000, turnMs: 2000 };
+
+/** Let every queued microtask and immediate run, so the session gets as far as it can. */
+const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+interface FakeChild {
+  readonly handle: ProcessHandle;
+  readonly written: readonly string[];
+  say(line: string): void;
+  exit(): void;
+  fail(reason: string): void;
+  killed(): number;
+  setStderr(text: string): void;
+}
+
+/** A launcher's child that says what the test tells it to — with the real one's replay contract. */
+function fakeChild(): FakeChild {
+  const written: string[] = [];
+  let lineListeners: ((line: string) => void)[] = [];
+  const held: string[] = [];
+  let opened = false;
+  let exitListeners: ((code: number) => void)[] = [];
+  let errorListeners: ((reason: string) => void)[] = [];
+  let ended: { kind: 'exit'; code: number } | { kind: 'error'; reason: string } | undefined;
+  let kills = 0;
+  let stderr = '';
+  let alive = true;
+
+  const deliver = (line: string): void => {
+    if (!opened) {
+      held.push(line);
+
+      return;
+    }
+    for (const listener of lineListeners) {
+      listener(line);
+    }
+  };
+
+  return {
+    handle: {
+      writeLine: (line: string) => {
+        if (!alive) {
+          return false;
+        }
+        written.push(line);
+
+        return true;
+      },
+      onStdout: () => () => undefined,
+      onLine: (listener) => {
+        opened = true;
+        lineListeners = [...lineListeners, listener];
+        const pending = held.splice(0, held.length);
+        for (const line of pending) {
+          listener(line);
+        }
+
+        return () => {
+          lineListeners = lineListeners.filter((known) => known !== listener);
+        };
+      },
+      onExit: (listener) => {
+        if (ended?.kind === 'exit') {
+          listener(ended.code);
+
+          return;
+        }
+        exitListeners = [...exitListeners, listener];
+      },
+      onError: (listener) => {
+        if (ended?.kind === 'error') {
+          listener(ended.reason);
+
+          return;
+        }
+        errorListeners = [...errorListeners, listener];
+      },
+      stderrTail: () => stderr,
+      kill: () => {
+        kills += 1;
+        alive = false;
+      },
+    },
+    written,
+    say: deliver,
+    exit: () => {
+      alive = false;
+      ended = { kind: 'exit', code: 0 };
+      for (const listener of exitListeners) {
+        listener(0);
+      }
+    },
+    fail: (reason) => {
+      alive = false;
+      ended = { kind: 'error', reason };
+      for (const listener of errorListeners) {
+        listener(reason);
+      }
+    },
+    killed: () => kills,
+    setStderr: (text) => {
+      stderr = text;
+    },
+  };
+}
+
+/** Timers the test drives by hand: nothing here ever waits for a real millisecond. */
+function fakeTimers(): Timers & { expire(): void } {
+  let pending: (() => void)[] = [];
+
+  return {
+    after: (_ms, run) => {
+      pending = [...pending, run];
+
+      return () => {
+        pending = pending.filter((known) => known !== run);
+      };
+    },
+    expire: () => {
+      const due = pending;
+      pending = [];
+      for (const run of due) {
+        run();
+      }
+    },
+  };
+}
+
+const INIT = JSON.stringify({ event: 'init', conversation_id: 'c1' });
+const STEP = JSON.stringify({ event: 'step_update', step_update: { step_index: 0 } });
+const ok = (answer: string): string =>
+  JSON.stringify({ event: 'result', result: { status: 'SUCCESS', response: answer } });
+
+/**
+ * Start a turn, let the session get as far as writing it, and hand the promise back UNAWAITED.
+ *
+ * <p>Wrapped in an object on purpose. An `async` function that returns a promise ADOPTS it, so a
+ * helper declared `Promise<Promise<T>>` silently waits for the turn it was supposed to hand over -
+ * and every test here deadlocked on an answer that could not be said until the helper returned. The
+ * wrapper is what stops the flattening.</p>
+ */
+async function asking(
+  session: CliChatSession,
+  child: FakeChild,
+  text: string,
+): Promise<{ answering: Promise<unknown> }> {
+  const answering = session.send(text);
+  child.say(INIT);
+  await flush();
+
+  return { answering };
+}
+
+test('a turn is exactly one NDJSON line, in the schema the CLI actually accepts', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering } = await asking(session, child, 'why is it pinned?');
+  child.say(STEP);
+  child.say(ok('because a worktree is cheap'));
+
+  assert.deepStrictEqual(await answering, { ok: true, answer: 'because a worktree is cheap' });
+  assert.strictEqual(child.written.length, 1, 'a turn wrote more than one line');
+  // The shape came out of the binary's own refusal: `stream input message is missing the "event"
+  // field`. `type:` was the first guess and it was wrong.
+  assert.deepStrictEqual(JSON.parse(child.written[0]!), {
+    event: 'user',
+    message: { role: 'user', content: 'why is it pinned?' },
+  });
+});
+
+test('a second turn is answered by the same process', async () => {
+  // The regression test a REJECTED finding earned. A reviewer called `--mode plan` Blocking on the
+  // claim that a planning mode is a single-prompt batch which exits after one turn; three measured
+  // turns down one pipe said otherwise. A CLI upgrade could still make the reviewer right, and this
+  // is what would notice.
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering: first } = await asking(session, child, 'one');
+  child.say(ok('answer one'));
+  await first;
+
+  const second = session.send('two');
+  await flush();
+  child.say(ok('answer two'));
+
+  assert.deepStrictEqual(await second, { ok: true, answer: 'answer two' });
+  assert.strictEqual(child.written.length, 2);
+  assert.strictEqual(session.running, true, 'the process did not survive its first turn');
+});
+
+test('one launch, however many turns', async () => {
+  let launches = 0;
+  const child = fakeChild();
+  const session = new CliChatSession(
+    () => {
+      launches += 1;
+
+      return child.handle;
+    },
+    BUDGETS,
+    fakeTimers(),
+  );
+
+  const { answering: first } = await asking(session, child, 'one');
+  child.say(ok('a'));
+  await first;
+  const second = session.send('two');
+  await flush();
+  child.say(ok('b'));
+  await second;
+
+  assert.strictEqual(launches, 1, 'the startup cost was paid twice');
+});
+
+test('a turn sent while one is in flight waits, and never interleaves', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering: first } = await asking(session, child, 'one');
+  const second = session.send('two');
+  await flush();
+
+  // Nothing of the second turn may be on the wire while the first is unanswered.
+  assert.strictEqual(child.written.length, 1, 'two turns went down one pipe at once');
+
+  child.say(ok('answer one'));
+  assert.deepStrictEqual(await first, { ok: true, answer: 'answer one' });
+
+  await flush();
+  assert.strictEqual(child.written.length, 2, 'the queued turn never went out');
+  child.say(ok('answer two'));
+  assert.deepStrictEqual(await second, { ok: true, answer: 'answer two' });
+});
+
+test('an ERROR result is an error, not an empty answer', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering } = await asking(session, child, 'hello');
+  child.say(JSON.stringify({ event: 'result', result: { status: 'ERROR', response: '', error: 'the model refused' } }));
+
+  // A page showing nothing would look like a model with nothing to say.
+  assert.deepStrictEqual(await answering, { ok: false, failure: 'the model refused' });
+});
+
+test('a line that is not JSON is skipped rather than fatal', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  child.say('a CLI may log wherever it pleases');
+  const { answering } = await asking(session, child, 'hello');
+  child.say('[warn] and it does');
+  child.say(ok('still fine'));
+
+  assert.deepStrictEqual(await answering, { ok: true, answer: 'still fine' });
+});
+
+test('a process that never says init fails with its own sentence, and is killed', async () => {
+  const child = fakeChild();
+  const timers = fakeTimers();
+  const session = new CliChatSession(() => child.handle, BUDGETS, timers);
+
+  const answering = session.send('hello');
+  await flush();
+  timers.expire();
+
+  const result = await answering as { ok: boolean; failure?: string };
+  assert.strictEqual(result.ok, false);
+  // "It would not start" and "it will not answer" send a person to different places.
+  assert.match(result.failure ?? '', /did not start/);
+  assert.strictEqual(child.killed(), 1, 'a process that would not start was left running');
+});
+
+test('a turn that is never answered fails at its budget, and the process is killed', async () => {
+  const child = fakeChild();
+  const timers = fakeTimers();
+  const session = new CliChatSession(() => child.handle, BUDGETS, timers);
+
+  const { answering } = await asking(session, child, 'hello');
+  timers.expire();
+
+  const result = await answering as { ok: boolean; failure?: string };
+  assert.strictEqual(result.ok, false);
+  assert.match(result.failure ?? '', /did not answer in time/);
+  assert.strictEqual(child.killed(), 1, 'a process that stopped answering was handed the next turn');
+  assert.strictEqual(session.running, false);
+});
+
+test('a process that exits mid-turn fails that turn and says what it left behind', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering } = await asking(session, child, 'hello');
+  child.setStderr('out of tokens');
+  child.exit();
+
+  const result = await answering as { ok: boolean; failure?: string };
+  assert.strictEqual(result.ok, false);
+  assert.match(result.failure ?? '', /out of tokens/);
+});
+
+test('the next turn after a death starts a new process rather than writing into a closed pipe', async () => {
+  let launches = 0;
+  let current = fakeChild();
+  const session = new CliChatSession(
+    () => {
+      launches += 1;
+
+      return current.handle;
+    },
+    BUDGETS,
+    fakeTimers(),
+  );
+
+  const { answering: first } = await asking(session, current, 'one');
+  current.exit();
+  await first;
+
+  current = fakeChild();
+  const second = session.send('two');
+  current.say(INIT);
+  await flush();
+  current.say(ok('back again'));
+
+  assert.deepStrictEqual(await second, { ok: true, answer: 'back again' });
+  assert.strictEqual(launches, 2, 'the dead process was asked a second question');
+});
+
+test('a launch that fails at all is a sentence, not a rejection', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const answering = session.send('hello');
+  await flush();
+  child.fail('spawn agy ENOENT');
+
+  const result = await answering as { ok: boolean; failure?: string };
+  assert.strictEqual(result.ok, false);
+  assert.match(result.failure ?? '', /ENOENT/);
+});
+
+test('disposal kills the process and ends the turn that was waiting', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering } = await asking(session, child, 'hello');
+  session.dispose();
+
+  const result = await answering as { ok: boolean; failure?: string };
+  assert.strictEqual(result.ok, false);
+  assert.match(result.failure ?? '', /closed/);
+  assert.strictEqual(child.killed(), 1, 'a vendor process outlived its tab');
+});
+
+test('a disposed conversation refuses politely rather than starting a process', async () => {
+  let launches = 0;
+  const child = fakeChild();
+  const session = new CliChatSession(
+    () => {
+      launches += 1;
+
+      return child.handle;
+    },
+    BUDGETS,
+    fakeTimers(),
+  );
+  session.dispose();
+
+  const result = await session.send('anybody there?');
+
+  assert.strictEqual(result.ok, false);
+  assert.strictEqual(launches, 0, 'a closed conversation started a vendor process');
+});
+
+test('disposing twice is not an error', () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  session.dispose();
+
+  assert.doesNotThrow(() => session.dispose());
+});

--- a/src_vs_code/src/test/cliChatSession.test.ts
+++ b/src_vs_code/src/test/cliChatSession.test.ts
@@ -349,7 +349,8 @@ test('the next turn after a death starts a new process rather than writing into 
   await flush();
   current.say(ok('back again'));
 
-  assert.deepStrictEqual(await second, { ok: true, answer: 'back again' });
+  // The dead process took the first question with it, so this answer says the thread restarted.
+  assert.deepStrictEqual(await second, { ok: true, answer: 'back again', contextLost: true });
   assert.strictEqual(launches, 2, 'the dead process was asked a second question');
 });
 
@@ -551,4 +552,102 @@ test('a process that dies before init says what it left on stderr', async () => 
   const result = await answering as { ok: boolean; failure?: string };
   assert.strictEqual(result.ok, false);
   assert.match(result.failure ?? '', /IneligibleTierError/);
+});
+
+/* ------------------------------------------------------------------------------------------------
+ * The code round of story 1.3. Seventeen findings accepted; these are the three that were defects
+ * rather than wording, and each fails against the version reviewed.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('a launcher that throws is a failure, not a rejection', async () => {
+  // `send` promises never to reject. The launcher is injected - somebody else's code - and node
+  // refuses a `.cmd` without a shell with a synchronous EINVAL, so this is not hypothetical.
+  // (Four reviewers, one finding.)
+  const session = new CliChatSession(
+    () => {
+      throw new Error('spawn EINVAL');
+    },
+    BUDGETS,
+    fakeTimers(),
+  );
+
+  const result = await session.send('hello') as { ok: boolean; failure?: string };
+
+  assert.strictEqual(result.ok, false);
+  assert.match(result.failure ?? '', /EINVAL/);
+});
+
+test('closing the tab during a start settles the wait at once, not in thirty seconds', async () => {
+  // dispose() cancelled the process but never the START, so a caller waited the whole startup budget
+  // for an answer nobody was going to read. (codex, the code round, twice.)
+  const child = fakeChild();
+  const timers = fakeTimers();
+  const session = new CliChatSession(() => child.handle, BUDGETS, timers);
+
+  const answering = session.send('hello');
+  await flush();
+  session.dispose();
+
+  const result = await answering as { ok: boolean; failure?: string };
+  assert.strictEqual(result.ok, false);
+  assert.match(result.failure ?? '', /closed/);
+  assert.strictEqual(timers.armed(), 0, 'the startup budget was left running after the close');
+});
+
+test('a killed child cannot disturb the process that replaced it', async () => {
+  // A killed child delivers its exit event LATER. Without a generation on the subscription, that
+  // stale callback cleared the new child and failed its turn. (codex, the code round.)
+  let current = fakeChild();
+  const stale = current;
+  const session = new CliChatSession(() => current.handle, BUDGETS, fakeTimers());
+
+  const { answering: first } = await asking(session, current, 'one');
+  current.say(ok('answer one'));
+  await first;
+
+  current.exit();
+  current = fakeChild();
+  const second = session.send('two');
+  current.say(INIT);
+  await flush();
+
+  // The old child speaks up after its replacement is already listening.
+  stale.exit();
+  current.say(ok('answer two'));
+
+  const result = await second as { ok: boolean; answer?: string };
+  assert.strictEqual(result.ok, true, 'a dead child killed the conversation that replaced it');
+  assert.strictEqual(result.answer, 'answer two');
+});
+
+test('a process that ends saying nothing does not end a sentence with a colon', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering } = await asking(session, child, 'hello');
+  child.exit();
+
+  const result = await answering as { ok: boolean; failure?: string };
+  assert.strictEqual(result.ok, false);
+  assert.doesNotMatch(result.failure ?? '', /ended: *($|\.)/, 'the failure ends in a bare colon');
+  assert.match(result.failure ?? '', /unexpectedly/);
+});
+
+test('a death after a question, before any answer, still counts as a lost conversation', async () => {
+  // everAnswered was the wrong gate: a process that died before replying still swallowed a turn,
+  // and the replacement never heard it. (codex, the code round.)
+  let current = fakeChild();
+  const session = new CliChatSession(() => current.handle, BUDGETS, fakeTimers());
+
+  const { answering: first } = await asking(session, current, 'one');
+  current.exit();
+  await first;
+
+  current = fakeChild();
+  const second = session.send('two');
+  current.say(INIT);
+  await flush();
+  current.say(ok('answer two'));
+
+  assert.deepStrictEqual(await second, { ok: true, answer: 'answer two', contextLost: true });
 });

--- a/src_vs_code/src/test/cliChatSession.test.ts
+++ b/src_vs_code/src/test/cliChatSession.test.ts
@@ -129,7 +129,7 @@ function fakeChild(): FakeChild {
 }
 
 /** Timers the test drives by hand: nothing here ever waits for a real millisecond. */
-function fakeTimers(): Timers & { expire(): void } {
+function fakeTimers(): Timers & { expire(): void; armed(): number } {
   let pending: (() => void)[] = [];
 
   return {
@@ -147,6 +147,7 @@ function fakeTimers(): Timers & { expire(): void } {
         run();
       }
     },
+    armed: () => pending.length,
   };
 }
 
@@ -405,4 +406,149 @@ test('disposing twice is not an error', () => {
   session.dispose();
 
   assert.doesNotThrow(() => session.dispose());
+});
+
+/* ------------------------------------------------------------------------------------------------
+ * What the plan round of story 1.3 asked for. Seven findings accepted, five rejected; these are the
+ * seven, as assertions.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('an answer from a process that never heard the earlier turns says so', async () => {
+  // A vendor CLI that died takes the conversation with it. The session cannot prevent that; what it
+  // must not do is hide it, or the next answer reads as a model being obtuse rather than as a
+  // conversation that restarted. (gemini, the plan round.)
+  let current = fakeChild();
+  const session = new CliChatSession(() => current.handle, BUDGETS, fakeTimers());
+
+  const { answering: first } = await asking(session, current, 'one');
+  current.say(ok('answer one'));
+  assert.deepStrictEqual(await first, { ok: true, answer: 'answer one' });
+
+  current.exit();
+  current = fakeChild();
+  const second = session.send('two');
+  current.say(INIT);
+  await flush();
+  current.say(ok('answer two'));
+
+  assert.deepStrictEqual(await second, { ok: true, answer: 'answer two', contextLost: true });
+});
+
+test('a first answer is never reported as having lost a context', async () => {
+  // Nothing was there to lose. Saying so would be noise where the real news is elsewhere.
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering } = await asking(session, child, 'one');
+  child.say(ok('answer one'));
+
+  assert.deepStrictEqual(await answering, { ok: true, answer: 'answer one' });
+});
+
+test('the loss is reported once, not for ever after', async () => {
+  let current = fakeChild();
+  const session = new CliChatSession(() => current.handle, BUDGETS, fakeTimers());
+  const { answering: first } = await asking(session, current, 'one');
+  current.say(ok('a'));
+  await first;
+  current.exit();
+
+  current = fakeChild();
+  const second = session.send('two');
+  current.say(INIT);
+  await flush();
+  current.say(ok('b'));
+  await second;
+
+  const third = session.send('three');
+  await flush();
+  current.say(ok('c'));
+
+  assert.deepStrictEqual(await third, { ok: true, answer: 'c' }, 'the restart was announced twice');
+});
+
+test('only the startup budget is armed before a turn is written', async () => {
+  // The two budgets are separate and never run together: one guards reaching `init`, the other
+  // guards being answered. A reviewer feared they overlapped and that a turn budget could fire
+  // during startup; this is the assertion that they do not. (local, the plan round.)
+  const child = fakeChild();
+  const timers = fakeTimers();
+  const session = new CliChatSession(() => child.handle, BUDGETS, timers);
+
+  void session.send('hello');
+  await flush();
+  assert.strictEqual(timers.armed(), 1, 'more than one budget was armed at once');
+
+  child.say(INIT);
+  await flush();
+  assert.strictEqual(timers.armed(), 1, 'the startup budget outlived the start');
+});
+
+test('a turn queued behind a killed one starts a new process rather than a dead pipe', async () => {
+  let current = fakeChild();
+  const timers = fakeTimers();
+  const session = new CliChatSession(() => current.handle, BUDGETS, timers);
+
+  const { answering: first } = await asking(session, current, 'one');
+  current.say(ok('answer one'));
+  await first;
+
+  const second = session.send('two');
+  await flush();
+  timers.expire();
+  await second;
+
+  current = fakeChild();
+  const third = session.send('three');
+  current.say(INIT);
+  await flush();
+  current.say(ok('from the new one'));
+
+  // The killed process took the conversation with it, so this answer is honest about that too.
+  assert.deepStrictEqual(await third, { ok: true, answer: 'from the new one', contextLost: true });
+});
+
+test('a turn queued behind a disposal is answered rather than left hanging', async () => {
+  // Every send must settle. A queued turn that never resolves leaves the page disabled for ever,
+  // which is worse than a refusal. (codex, the plan round.)
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering: first } = await asking(session, child, 'one');
+  const second = session.send('two');
+  session.dispose();
+
+  const a = await first as { ok: boolean };
+  const b = await second as { ok: boolean };
+  assert.strictEqual(a.ok, false);
+  assert.strictEqual(b.ok, false);
+});
+
+test('a result with a status nobody knows is a failure that names it', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering } = await asking(session, child, 'hello');
+  child.say(JSON.stringify({ event: 'result', result: { status: 'CANCELLED', response: '', error: '' } }));
+
+  const result = await answering as { ok: boolean; failure?: string };
+  assert.strictEqual(result.ok, false);
+  assert.match(result.failure ?? '', /CANCELLED/);
+});
+
+test('a process that dies before init says what it left on stderr', async () => {
+  // "Not installed" and "installed, and refusing your sign-in" are different problems, and the
+  // sentence has to tell them apart. (local, the plan round.)
+  const child = fakeChild();
+  const timers = fakeTimers();
+  const session = new CliChatSession(() => child.handle, BUDGETS, timers);
+
+  const answering = session.send('hello');
+  await flush();
+  child.setStderr('IneligibleTierError: this client is no longer supported');
+  timers.expire();
+
+  const result = await answering as { ok: boolean; failure?: string };
+  assert.strictEqual(result.ok, false);
+  assert.match(result.failure ?? '', /IneligibleTierError/);
 });


### PR DESCRIPTION
Story 1.3 of [`todo/PLAN_chat_with_other_ais.md`](todo/PLAN_chat_with_other_ais.md).

## What it is

One long-lived vendor process per conversation, speaking the protocol that was **measured** rather
than read: `agy --input-format stream-json --output-format stream-json` takes one NDJSON message per
line and answers `init`, then `step_update`s, then a `result`. The message schema came out of the
binary's own refusal — `stream input message is missing the "event" field` — after `type:` turned out
to be the wrong first guess.

## The file is shaped by the four ways such a process ends

Three of them the first plan did not mention, and the gate raised them as five separate findings:

| End | What happens |
|---|---|
| Disposal | The tree is killed. |
| It exits on its own | The turn in flight fails with what the child left on stderr; the **next** send starts a new process rather than writing into a closed pipe. |
| It never starts | No `init` inside the startup budget. Killed, and said **differently** from the case below — "it would not start" and "it will not answer" send a person to different places. |
| It never answers | No `result` inside the turn budget. Killed, so the next turn is not asked of a process that has stopped listening. |

Turns are serialised **here**, not merely discouraged in the page: a page is a suggestion, and two
sends arriving together must not interleave down one pipe. The second waits rather than being
refused, because refusing loses what somebody typed.

Everything that touches the world is injected — the launcher and the timers — which is what lets the
failure paths be tested at all. A suite that waited three minutes for a turn budget is a suite nobody
runs.

## Two defects the tests found, both worth keeping

**In the production code.** The launcher replays what a child said before its first subscriber —
which is exactly what makes a fast `init` safe. The session subscribed and only *then* registered its
waiter, so the replayed `init` arrived with nobody to tell, and **every turn hung for the whole
startup budget**. It now asks what happened after subscribing rather than waiting for a signal
already sent.

**In the test double, and it hid the first one.** The first fake child appended listeners without
replaying — weaker than the real handle it stood for. A fake weaker than the thing it stands for does
not simplify a test; it tests a program that does not exist.

## Test plan

- `npm test` — **734 tests, 733 pass, 0 fail**, 1 pre-existing skip.
- 14 of them are this story's, over the state machine with a fake launcher and hand-driven timers:
  the NDJSON framing, a second turn answered by the same process (the regression test a *rejected*
  gate finding earned), a queued turn that never interleaves, an `ERROR` result that is an error
  rather than an empty answer, both budgets with their own sentences, a mid-turn death, a relaunch
  after one, and disposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)