### PR TITLE
fix(chat): the clipboard marker comes from randomUUID, not Math.random

### DIFF
--- a/src_vs_code/src/selectionCapture.ts
+++ b/src_vs_code/src/selectionCapture.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { ProcessHandle } from './processLauncher';
 
 /**
@@ -47,9 +48,15 @@ export const CLIPBOARD_SENTINEL = 'COAI-CHAT-NOTHING-WAS-COPIED';
  * <p>A fixed sentinel is a string somebody can copy — this file's own source contains it, and
  * selecting that line would have been reported as "nothing was copied". A capture may fail for a
  * hundred reasons, but never for the CONTENT of what was selected. (local, the code round.)</p>
+ *
+ * <p>`randomUUID` rather than `Math.random`, and not because a clipboard marker needs to resist an
+ * attacker: nothing here is a secret and the string lives for a second. It is that arguing the case
+ * costs more than the import — SonarCloud reads `Math.random` as a security question (S2245) and
+ * marked the whole change C for it, and a reviewer reading this line a year from now would have to
+ * make the same argument again.</p>
  */
 export function markerFor(): string {
-  return `${CLIPBOARD_SENTINEL}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  return `${CLIPBOARD_SENTINEL}-${randomUUID()}`;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #119, which merged with a SonarCloud **Quality Gate failure**: `C Security Rating on New Code`, one issue — `typescript:S2245` on `selectionCapture.ts:52`, *"Make sure that using this pseudorandom number generator is safe here."*

It is safe: the clipboard marker is not a secret, it exists for about a second, and knowing it lets somebody make a capture report "nothing was copied" — which is a refusal, not a leak. But arguing that in a comment costs more than the import does, and the next reviewer would have to argue it again. `randomUUID` makes the question not arise.

## Test plan

- [x] `npm test` — 841 tests, 840 pass, 0 fail, 1 pre-existing skip.
- [x] No behaviour change: the guarantee under test is that two captures never borrow under the same marker (`two captures never borrow under the same marker`), and the collision test that was watched fail against a fixed sentinel still passes.
- [ ] SonarCloud green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
