### PR TITLE
chore(release): extension 0.31.10 — chat with other AIs, from a selection

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Extension 0.31.10 — 2026-09-08
+
+**Ask another vendor’s model about a passage, without leaving the editor.** Select a paragraph in
+your assistant’s answer, press `Ctrl+Alt+A`, and a tab opens — named after that assistant session —
+where a different vendor’s model explains it in your language, in a conversation you can carry on.
+The same thing sits in the panel’s right-click menu as **Chat with other AI**.
+
+A dense English answer is not always a clear one, and asking the model that wrote it to explain
+itself gets you the same words again. Doing this by hand is five steps — select, copy, switch to a
+browser, new chat, paste — several times an hour.
+
+**The two doors behave differently, and they have to.** From the keybinding the panel still holds
+the keyboard, so the selection is copied for you and the question is asked at once. The menu cannot
+do that — closing it takes the selection out of the panel — so it takes what you last copied and
+puts it in the composer for you to send. `coai.chatAutoSend` overrules that in either direction, and
+the passage is shown at the top of the tab so you can see what is about to be asked.
+
+Four settings are yours: `coai.chatPrompt` (the prompt the passage travels with, one word `Explain`
+by default), `coai.chatLanguage` (the language the other AI answers in — English by default, and
+deliberately not the language of the help pages), `coai.chatAutoSend`, and `coai.chatModel`. They
+are edited in `settings.json` for now; a section beside *Reviewers* comes next.
+
+**What it will not do yet.** Only a reviewer on the `antigravity` runtime can answer a chat, and a
+row on any other runtime is refused BY NAME rather than quietly missing from the picker — a model
+you NAMED and which cannot answer is never silently replaced by another vendor’s. Copying the
+selection needs Windows; elsewhere the keybinding says so and points at the menu, which works
+everywhere. Picking a different model in an open tab starts a new process, and the answer after it
+says the conversation restarted, because it genuinely does not remember the earlier turns.
+
+The whole thing went through this product’s own gate three times — a plan round and two code rounds,
+eighteen reviewers between them — and what those rounds changed is worth naming: the copy helper
+now WAITS for your own modifiers to come up instead of forcing them up under your fingers; a
+clipboard it could not read (an image, a file) is never written to, because it could never be given
+back; and the clipboard it borrows is put back only if nothing else wrote to it while you waited.
+
 ## Extension 0.31.9 — 2026-09-08
 
 **A code-review role can be switched off.** Each of the four boxes — Conventions, Architecture,

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.9",
+  "version": "0.31.10",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Releases epic 3 of [todo/PLAN_chat_with_other_ais.md](todo/PLAN_chat_with_other_ais.md), merged in #119 and #120.

**Why the version has to move:** `extension-v0.31.9` was tagged before this feature existed, and the release job refuses a tag that disagrees with the manifest. The published 0.31.9 therefore does NOT contain the chat; anyone running it (including the owner, from a hand-built `.vsix`) is ahead of the Marketplace until this ships.

## What ships

Select a paragraph in your assistant's answer, press `Ctrl+Alt+A`, and a tab named after that assistant session opens with another vendor's model explaining it — in your language, in a conversation you can carry on. The same command is in the panel's right-click menu; because closing that menu takes the selection out of the webview, the menu path takes what you last copied and, by default, fills the composer rather than sending. `coai.chatAutoSend` overrules that either way.

Four settings, edited in `settings.json` until the panel section lands: `coai.chatPrompt` (default `Explain`), `coai.chatLanguage` (default English, deliberately not the help pages' language), `coai.chatAutoSend`, `coai.chatModel`.

Only a reviewer on the `antigravity` runtime can answer so far; a row on any other runtime is refused by name rather than quietly missing, and a model you NAMED and which cannot answer is never silently replaced by another vendor's.

## Test plan

- [x] `npm test` — 841 tests, 840 pass, 0 fail, 1 pre-existing skip.
- [x] The feature was used live on 0.31.9-built bits before release: tab named from the session, passage at the top, answer in the tab.
- [ ] After merge: tag `extension-v0.31.10` on main, and confirm the release job builds the `.vsix` and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Chat with other AI,” allowing users to send selected assistant responses to another model for explanation in a dedicated conversation tab.
  - Added settings for chat prompts, language, automatic sending, and model selection.
  - Added keyboard shortcut and context-menu support for starting chats.

- **Limitations**
  - Responses currently require supported reviewers on the Antigravity runtime.
  - Selection copying requires Windows.
  - Switching models in an open tab starts a new conversation without prior context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->