### PR TITLE
chore(release): extension 0.31.12 — the model switch carries the conversation

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Extension 0.31.12 — 2026-09-08
+
+**Switching the model in a chat tab now takes the conversation with it.** Both the questions and
+the answers: the model you switch to carries on from where the last one stopped, instead of
+starting again with nothing.
+
+A vendor CLI keeps its context inside its own process — there is no transcript to hand over and no
+session to resume — so the only way across is to say it all again. That happens once, inside your
+next question, and never again: from there the new process remembers exactly as the old one did.
+Nothing is sent at the moment you switch, so moving a conversation and then not continuing it costs
+nothing at all.
+
+What travels is bounded at 60 000 characters, newest first, and if a conversation is longer than
+that the turn says so rather than being silently cut by the vendor. A single answer bigger than the
+whole budget is cut with a marker instead of dropped. And because the conversation being carried is
+another AI's text, it is fenced with a one-time delimiter and every line is indented under whoever
+said it: a line inside an answer that reads like a new question cannot become one.
+
+A switch that cannot be made says so instead of leaving you on the old model quietly, and a switch
+asked for while an answer is still arriving tells you it is waiting for that answer first.
+
 ## Extension 0.31.11 — 2026-09-08
 
 **The rounds log gets its findings back.** The *What it keeps missing* tab was empty and the table
@@ -26,8 +47,6 @@ This one went through the product's own gate twice, and the code round is worth 
 reviewers found that the fix had reintroduced its own defect in its fallback path — pushes at a page
 that could not receive them were still being recorded as delivered. Four of them said so
 independently, from three different roles.
-
-## Extension 0.31.10 — 2026-09-08
 
 **Ask another vendor’s model about a passage, without leaving the editor.** Select a paragraph in
 your assistant’s answer, press `Ctrl+Alt+A`, and a tab opens — named after that assistant session —

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.11",
+  "version": "0.31.12",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Two corrections in one, because they are the same mistake seen from both ends.

**0.31.10 was never tagged.** Another session took the next number for `extension-v0.31.11` while this work was in review, and that tag was cut from a commit that already contained the chat trigger (#119, #120). So the chat shipped — inside 0.31.11 — under a CHANGELOG heading that named a release nobody can install. The heading is gone and the story now sits under 0.31.11, which is the release it was actually in.

**0.31.12 is what is new:** the model switch carries the conversation (#125), which merged after that tag was cut and is therefore in no release yet.

## What ships in 0.31.12

Switching the model in a chat tab takes the conversation with it — questions and answers both — instead of starting again. A vendor CLI keeps its context inside its own process, so the only way across is to say it again: once, inside your next question, and never after that. Nothing is sent at the moment of the switch, so moving a conversation and not continuing it costs nothing.

Bounded at 60 000 characters newest-first with the loss stated in the turn; a single answer bigger than the whole budget is cut with a marker rather than dropped; the transcript is fenced with a one-time delimiter and every line is indented under whoever said it, so a line inside an answer that reads like a new question cannot become one. A switch that cannot be made says so instead of leaving you quietly on the old model, and one asked for while an answer is still arriving says it is waiting for that answer first.

## Test plan

- [x] `npm test` — **881 tests, 880 pass, 0 fail, 1 pre-existing skip** (the count includes the parallel session's own additions, now on main).
- [ ] After merge: tag `extension-v0.31.12`, and confirm the release job builds the `.vsix` and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
