### PR TITLE
feat(panel): the Chat other AIs section — four settings that reach a model

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -134,6 +134,32 @@ somebody's behalf:
 And the keybinding now says it is working: `withProgress` puts *Copying the selection…* in the status
 bar for the ~1.7 s PowerShell takes, because a shortcut that appears to do nothing gets pressed again,
 which is how one question becomes two.
+### The four settings, and where they are edited (2026-09-09)
+
+`coai.chatPrompt`, `coai.chatLanguage`, `coai.chatAutoSend` and `coai.chatModel` reach a MODEL —
+they decide what is asked, in which language, who presses send and which vendor is billed. They
+shipped editable only in `settings.json`, which is where a prompt goes to be forgotten; the
+**Chat other AIs** section beside *Reviewers* now holds all four, with the prompt as a multi-line
+box because one word is the default rather than the limit.
+
+**One reader, both sides.** The section renders `chatSettingsFrom(...)` and the command calls
+`chatSettingsFrom(...)` — the same function over the same per-side config reader. That is why these
+four are NOT folded into `CoaiSettings`: two readers for one set of keys is a drift this repository
+has already paid for twice, and the panel would eventually show something the conversation does not
+use. A test drives one settings file through the reader and asserts the section renders exactly what
+it returned.
+
+**A model named in the settings that cannot answer is shown as chosen, and as unable.** Without the
+option the browser falls back to the first one and the panel reads *the first one that can answer*
+while `settings.json` says `codex`: a section describing a state that is not the one the command
+will refuse. It is selected so what is configured is what is shown, and disabled so it cannot be
+picked again once it is left. Reviewers on other runtimes are named underneath with the reason,
+never quietly absent — the same rule the command follows.
+
+`PanelState.chat` is optional for the reason `teamServers` is: sixteen fixtures predate it, the
+files are stored CRLF, and a required field would have meant sixteen unreviewable whole-file diffs.
+Absent means the defaults, which is what an untouched panel shows anyway.
+
 ### A conversation is a process, and it ends four ways (2026-09-08)
 
 ```mermaid

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -142,6 +142,31 @@ shipped editable only in `settings.json`, which is where a prompt goes to be for
 **Chat other AIs** section beside *Reviewers* now holds all four, with the prompt as a multi-line
 box because one word is the default rather than the limit.
 
+```mermaid
+flowchart LR
+  J["settings.json<br/>coai.chatPrompt · chatLanguage<br/>chatAutoSend · chatModel"]
+  R(["chatSettingsFrom()<br/>one reader, every fallback"])
+  P["Chat other AIs section<br/>panelView.chatBody"]
+  C["chatWithOtherAi<br/>the command"]
+  V["coai.vendors"]
+  M(["chatModelsFrom()<br/>offered · refused"])
+  T["the conversation tab"]
+
+  J --> R
+  R --> P
+  R --> C
+  V --> M
+  M --> P
+  M --> C
+  C --> T
+
+  classDef one fill:#1f6feb22,stroke:#1f6feb;
+  class R,M one;
+```
+
+Two functions are read by both halves, and that is the whole architecture of this section: what the
+panel shows and what the conversation uses cannot disagree, because neither has a reader of its own.
+
 **One reader, both sides.** The section renders `chatSettingsFrom(...)` and the command calls
 `chatSettingsFrom(...)` — the same function over the same per-side config reader. That is why these
 four are NOT folded into `CoaiSettings`: two readers for one set of keys is a drift this repository

--- a/src_vs_code/src/chatSettings.ts
+++ b/src_vs_code/src/chatSettings.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_CHAT_PROMPT } from './chatPrompt';
-import { LanguageCode } from './settingsShape';
+import { LANGUAGES, LanguageCode } from './settingsShape';
 
 /**
  * The four settings the chat feature owns, parsed from whatever `settings.json` actually holds.
@@ -40,7 +40,14 @@ export interface ChatSettings {
   readonly model: string;
 }
 
-const LANGUAGES: readonly LanguageCode[] = ['en', 'es', 'de', 'ru', 'uk'];
+/**
+ * The codes, taken from the catalog rather than written out again.
+ *
+ * <p>There were two lists: this one, and `LANGUAGES` in `settingsShape.ts` with the native labels
+ * the menus are built from. Two lists of the same five things drift the day a sixth is added — the
+ * menu would offer it and this reader would refuse it, silently, back to English.</p>
+ */
+const CODES: readonly LanguageCode[] = LANGUAGES.map((language) => language.code);
 
 /** A string, or the fallback — `settings.json` is a file a person edits by hand. */
 function text(value: unknown, fallback: string): string {
@@ -63,7 +70,7 @@ export function chatSettingsFrom(read: (key: string) => unknown): ChatSettings {
     // English by default, and NOT `coai.helpLanguage`: that one is set to English on the owner's
     // machine, so borrowing it would have delivered English explanations — exactly what the feature
     // exists to avoid. One setting cannot answer two questions that disagree.
-    language: LANGUAGES.includes(language as LanguageCode) ? (language as LanguageCode) : 'en',
+    language: CODES.includes(language as LanguageCode) ? (language as LanguageCode) : 'en',
     autoSend: CHAT_AUTO_SEND.includes(autoSend as ChatAutoSend)
       ? (autoSend as ChatAutoSend)
       : DEFAULT_AUTO_SEND,

--- a/src_vs_code/src/help.ts
+++ b/src_vs_code/src/help.ts
@@ -24,6 +24,28 @@ export const HELP = {
     'After a plan passes, the gate tells the assistant to break it into 2-4 epics and each epic into 2-4 logically complete stories, and to close every story properly: review the diff through this gate, fix what it accepts, update the documentation and the tests, commit — then start the next one. The gate measures the plan you sent (length, build steps, files, subsystems) and says whether it needs epics, stories or nothing; that is a heuristic, and the assistant is told it may disagree in writing. The order is given ONCE per assistant: each epic comes back here for its own plan review, and a piece of a split is told that it is one — build it as a single unit, close it properly, and say so if it is genuinely too big — rather than being told to split again, which would have no end.',
   splitWithFable:
     'The split itself is done by Fable at its highest version — deciding what the epics and stories ARE is the judgement that shapes everything after it — and the risky stories go back to it: payments, money, authentication, security, architecture, data migration. The ordinary ones run on Opus. Fable here is a model of YOUR assistant, not a reviewer in the list above, so this box is the whole decision: tick it if the assistant you use can run Fable. Until 0.29.4 the order was withheld unless a Fable REVIEWER was configured, which nobody does and nobody should — so the switch did nothing at all.',
+  chatPrompt:
+    'What the selected passage is sent with. One word — Explain — unless you change it, and the box '
+    + 'is several lines high because a word is not always enough: "explain this to somebody who knows '
+    + 'C# but not Rust" is a different question from "explain this". The passage itself always arrives '
+    + 'below your instruction, fenced and marked as material, so a paragraph that reads like an order '
+    + 'is treated as text rather than obeyed.',
+  chatLanguage:
+    'The language the OTHER AI answers in. Deliberately not the language of these help pages: that '
+    + 'one is English on most machines, and borrowing it would deliver English explanations — which '
+    + 'is the one thing this feature exists to avoid. English by default, because the models are best '
+    + 'at it; set it to yours if a dense English answer is what sent you here.',
+  chatAutoSend:
+    'Who presses send. The keybinding copies the selection itself, one keystroke earlier, so it can '
+    + 'be trusted to be the passage you meant — it asks straight away. The right-click menu cannot '
+    + 'copy for you (closing the menu takes the selection out of the panel), so it takes whatever you '
+    + 'last copied and fills the box for you to send, because it has no way to know how old that is. '
+    + 'Always sends on both paths; Never fills the box on both.',
+  chatModel:
+    'Which reviewer answers a chat. Empty means the first one that can, which is what most people '
+    + 'want. Only reviewers on a runtime the chat can speak to appear here; any other configured '
+    + 'reviewer is listed underneath with the reason, rather than quietly missing — a picker with a '
+    + 'gap in it cannot tell you whether it is a bug or a policy.',
   vendorStages:
     'Which stages this reviewer is asked. Measured over fourteen judged runs: a local model was '
     + '19 % useful on a plan and 3 % on code, while writing more findings than both hosted vendors '

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import * as vscode from 'vscode';
+import { chatSettingsFrom } from './chatSettings';
 import { ViewHandle, isDisposedRejection } from './viewHandle';
 import { pastedSnippetStatus } from './snippetInWorkspace';
 import { discoverEngine, LocalEngine, openAiBaseOf, probeEngine } from './localEngines';
@@ -465,6 +466,9 @@ export class PanelProvider implements vscode.WebviewViewProvider {
       teamServers: this.teamServerStates(config),
       providers: this.providerHealth(),
       usageScope: this.usageScope,
+      // Through the reader the COMMAND uses, not a second one: the section edits exactly what the
+      // conversation will read, including every fallback for a value somebody typed by hand.
+      chat: chatSettingsFrom((key: string) => this.read(config)(key)),
     };
 
     // Two update paths, and which one runs is the whole fix for the pickers.

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -466,9 +466,12 @@ export class PanelProvider implements vscode.WebviewViewProvider {
       teamServers: this.teamServerStates(config),
       providers: this.providerHealth(),
       usageScope: this.usageScope,
-      // Through the reader the COMMAND uses, not a second one: the section edits exactly what the
-      // conversation will read, including every fallback for a value somebody typed by hand.
-      chat: chatSettingsFrom((key: string) => this.read(config)(key)),
+      // Straight from the configuration, exactly as the COMMAND reads it — not through the
+      // per-side reader beside it. These four are person-level by design (`chatSettings.ts` says
+      // so, and none of them is in `OVERLAID_SETTINGS`), so routing them through an overlay that
+      // will never hold them would only invite somebody to add them to it one day and split the
+      // one reader in two.
+      chat: chatSettingsFrom((key: string) => config.get(key)),
     };
 
     // Two update paths, and which one runs is the whole fix for the pickers.

--- a/src_vs_code/src/panelView.ts
+++ b/src_vs_code/src/panelView.ts
@@ -7,7 +7,9 @@ import {
 import { canonicalTeamServerUrl } from './teamServers';
 import { escapeHtml } from './escapeHtml';
 import { availabilityOf, ProviderHealth, ProvidersAnswer } from './providers';
-import { CoaiSettings, enabledCodeRoles, roleIsOn } from './settingsShape';
+import { ChatSettings, chatSettingsFrom } from './chatSettings';
+import { ChatModelList, chatModelsFrom } from './chatModels';
+import { CoaiSettings, LANGUAGES, enabledCodeRoles, roleIsOn } from './settingsShape';
 import { Escalation } from './escalations';
 import { HELP, HelpKey } from './help';
 import { ModelChoice, modelsFor, modelsProvenance, RemoteProvenance } from './models';
@@ -147,6 +149,18 @@ export interface PanelState {
    * button rather than as an error.</p>
    */
   readonly cliStatus: Readonly<Record<string, CliStatus>>;
+  /**
+   * The four settings the chat feature owns.
+   *
+   * <p>Optional for the same reason {@link teamServers} is: the provider always supplies it, and
+   * sixteen test fixtures predate it. Absent means the defaults, which is what a panel that has
+   * never been touched shows anyway.</p>
+   *
+   * <p>Its own field rather than part of {@link CoaiSettings} because it has its own reader —
+   * `chatSettingsFrom` — and the command uses that reader without a panel in sight. Two readers for
+   * one set of keys is the drift this repository has already paid for twice.</p>
+   */
+  readonly chat?: ChatSettings | undefined;
 }
 
 /**
@@ -163,6 +177,7 @@ export function panelHtml(state: PanelState, nonce: string, nowMs: number = Date
   const body = [
     `<div id="live-questions">${questionsSection(state.questions)}</div>`,
     section('reviewers', 'Reviewers', open, reviewersBody(state)),
+    section('chat', 'Chat other AIs', open, chatBody(state.chat ?? DEFAULT_CHAT, state.vendors)),
     section('prompts', 'Prompts per round', open, promptsBody(state)),
     section('gate', 'The gate', open, gateBody(state.settings)),
     section('limits', 'Limits', open, limitsBody(state.settings, state.vendors.filter((v) => v.enabled && v.code).length)),
@@ -243,6 +258,75 @@ ${body}
 </script>
 </body>
 </html>`;
+}
+
+/** What the section shows when nothing has been configured — the reader's own fallbacks. */
+const DEFAULT_CHAT: ChatSettings = chatSettingsFrom(() => undefined);
+
+/**
+ * The option for a model the settings NAME and the chat cannot use.
+ *
+ * <p>Without it the browser falls back to the first option and the section reads "the first one that
+ * can answer" while `settings.json` says `codex` — a panel describing a state that is not the one
+ * the command will refuse. Selected, so what is configured is what is shown; disabled, so it cannot
+ * be chosen again once it is left. Three reviewers raised this from three directions on one round.</p>
+ */
+function strandedOption(model: string, models: ChatModelList): string {
+  if (model.length === 0 || models.offered.some((offered) => offered.id === model)) {
+    return '';
+  }
+
+  return `    <option value="${escapeHtml(model)}" selected disabled>${escapeHtml(model)} — cannot answer a chat</option>`;
+}
+
+/**
+ * The `Chat other AIs` section.
+ *
+ * <p>Four settings that reach a MODEL rather than a pixel, which is why they are here instead of in
+ * `settings.json` where they started: a prompt nobody can see is a prompt nobody corrects, and the
+ * one that ships is a single word.</p>
+ *
+ * <p><b>The model list is the models that can ANSWER, and the ones that cannot are named.</b> Same
+ * rule as the command: a person who configured `codex` and finds a picker quietly missing it cannot
+ * tell a bug from a policy. The list comes from `chatModelsFrom`, which is the same function the
+ * conversation itself picks from — one source, so the picker and the tab cannot disagree.</p>
+ */
+function chatBody(chat: ChatSettings, vendors: readonly Vendor[]): string {
+  const models = chatModelsFrom(vendors);
+  const refusals = models.refused.map((row) => row.reason);
+
+  return `<div class="field">
+  ${labelled('chatPrompt', 'What to ask about the selection', 'chatPrompt')}
+  <textarea id="chatPrompt" data-setting="chatPrompt" rows="3"
+    placeholder="${escapeHtml(DEFAULT_CHAT.prompt)}">${escapeHtml(chat.prompt)}</textarea>
+</div>
+<div class="field">
+  ${labelled('chatLanguage', 'Answer in', 'chatLanguage')}
+  <select id="chatLanguage" data-setting="chatLanguage">
+${LANGUAGES.map((language) =>
+    `    <option value="${language.code}"${language.code === chat.language ? ' selected' : ''}>`
+    + `${escapeHtml(language.label)}</option>`).join('\n')}
+  </select>
+</div>
+<div class="field">
+  ${labelled('chatAutoSend', 'Who presses send', 'chatAutoSend')}
+  <select id="chatAutoSend" data-setting="chatAutoSend">
+    <option value="keyboard"${chat.autoSend === 'keyboard' ? ' selected' : ''}>The keybinding sends; the menu waits</option>
+    <option value="always"${chat.autoSend === 'always' ? ' selected' : ''}>Always send at once</option>
+    <option value="never"${chat.autoSend === 'never' ? ' selected' : ''}>Never — always let me press Enter</option>
+  </select>
+</div>
+<div class="field">
+  ${labelled('chatModel', 'Which model answers', 'chatModel')}
+  <select id="chatModel" data-setting="chatModel">
+    <option value=""${chat.model.length === 0 ? ' selected' : ''}>The first one that can answer</option>
+${models.offered.map((model) =>
+    `    <option value="${escapeHtml(model.id)}"${model.id === chat.model ? ' selected' : ''}>`
+    + `${escapeHtml(model.label)}</option>`).join('\n')}
+${strandedOption(chat.model, models)}
+  </select>
+${refusals.map((reason) => `  <div class="hint">${escapeHtml(reason)}</div>`).join('\n')}
+</div>`;
 }
 
 /**
@@ -1234,6 +1318,10 @@ const CSS = `
      the defect - not the boxes themselves. */
   .vendor .stages.off { opacity: .55; }
   .sec-server    > summary { color: var(--tone-uxdx); }
+  /* The chat borrows the UX tone rather than taking a sixth colour: it is the one section that is
+     not about the gate at all, and a new hue would say "another kind of setting" when what it is
+     is another kind of WORK. */
+  .sec-chat      > summary { color: var(--tone-uxdx); }
   .sec-usage     > summary { color: var(--tone-arch); }
   .sec-rounds    > summary { color: var(--tone-plan); }
   .section > summary::-webkit-details-marker { display: none; }

--- a/src_vs_code/src/test/chatSection.test.ts
+++ b/src_vs_code/src/test/chatSection.test.ts
@@ -4,7 +4,7 @@ import { PanelState, panelHtml } from '../panelView';
 import { DEFAULTS } from '../settingsShape';
 import { DEFAULT_VENDORS, Vendor } from '../vendors';
 import { SNIPPET_VERSION } from '../claudeSnippet';
-import { ChatSettings, chatSettingsFrom } from '../chatSettings';
+import { CHAT_AUTO_SEND, ChatSettings, chatSettingsFrom } from '../chatSettings';
 import { escapeHtml } from '../escapeHtml';
 
 /**
@@ -99,7 +99,9 @@ test('who presses send is a choice, and its three values are all offered', () =>
   const body = chatSection(panelHtml(state(), 'n0nce'));
 
   assert.match(body, /<select[^>]*data-setting="chatAutoSend"/);
-  for (const value of ['always', 'keyboard', 'never']) {
+  // From the catalog, not retyped: a fourth value added to `CHAT_AUTO_SEND` and not rendered would
+  // leave a hand-written list green while the control lost an option. (codex and gemini.)
+  for (const value of CHAT_AUTO_SEND) {
     assert.ok(body.includes(`value="${value}"`), `${value} is not on offer`);
   }
   assert.match(body, /<option value="keyboard" selected>/, 'the default is not the selected one');

--- a/src_vs_code/src/test/chatSection.test.ts
+++ b/src_vs_code/src/test/chatSection.test.ts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { PanelState, panelHtml } from '../panelView';
+import { DEFAULTS } from '../settingsShape';
+import { DEFAULT_VENDORS, Vendor } from '../vendors';
+import { SNIPPET_VERSION } from '../claudeSnippet';
+import { ChatSettings, chatSettingsFrom } from '../chatSettings';
+import { escapeHtml } from '../escapeHtml';
+
+/**
+ * The `Chat other AIs` section: the four settings, edited where everything else is edited.
+ *
+ * <p>Asked for in the owner's own words — *"в меню справа нужно добавть мультилайн инпут, где чел
+ * вводит промт, с которым скопированное должно уезжать в выбранную ии, по умолчанию одно слово
+ * Explain"* and *"какую модель исп, аналогично ревьюверам"*. Until this section existed the four
+ * `coai.chat*` keys could only be changed by hand in `settings.json`, which is where settings go
+ * to be forgotten.</p>
+ *
+ * <p>The tests are on the MARKUP rather than on a `vscode` call, exactly like every other section
+ * here: what the panel renders is the whole of what it decides, and the write path behind
+ * `data-setting` is one generic route that `settingWrite.test.ts` already covers.</p>
+ */
+
+const chat: ChatSettings = { prompt: 'Explain', language: 'en', autoSend: 'keyboard', model: '' };
+
+function vendor(over: Partial<Vendor> = {}): Vendor {
+  return {
+    id: 'antigravity',
+    runtime: 'antigravity',
+    model: 'gemini-3.7-flash-high',
+    enabled: true,
+    plan: true,
+    code: true,
+    baseUrl: '',
+    executablePath: '',
+    pricePerMillionIn: 0,
+    pricePerMillionOut: 0,
+    ...over,
+  };
+}
+
+const state = (over: Partial<PanelState> = {}): PanelState => ({
+  settings: DEFAULTS,
+  vendors: DEFAULT_VENDORS,
+  codexModels: [], agyModels: [],
+  localEngines: {},
+  server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
+  side: '',
+  perSide: false,
+  questions: [],
+  sessions: [],
+  openSections: ['chat'],
+  usage: [],
+  usageWindow: 'week',
+  cliStatus: {},
+  modelPrices: {},
+  snippetStatus: { kind: 'current', current: SNIPPET_VERSION },
+  latestServerVersion: '',
+  chat,
+  ...over,
+});
+
+/** Just the section, so an assertion cannot pass on something another section happens to render. */
+function chatSection(html: string): string {
+  const start = html.indexOf('data-section="chat"');
+  assert.ok(start > 0, 'the panel renders no Chat other AIs section at all');
+  const end = html.indexOf('</details>', start);
+
+  return html.slice(start, end);
+}
+
+test('the prompt is a MULTILINE box, because the prompt is not always one word', () => {
+  // The default is one word — `Explain` — precisely so that nobody has to maintain it. What is
+  // asked for is the room to write a paragraph when the one word is not enough.
+  const body = chatSection(panelHtml(state(), 'n0nce'));
+
+  assert.match(body, /<textarea[^>]*data-setting="chatPrompt"/, 'the prompt is not a textarea');
+  assert.ok(body.includes('>Explain</textarea>'), 'the box does not hold the prompt it will send');
+});
+
+test('a prompt somebody typed comes back, escaped rather than executed', () => {
+  const body = chatSection(panelHtml(state({
+    chat: { ...chat, prompt: 'Explain this <b>simply</b> & in short' },
+  }), 'n0nce'));
+
+  assert.ok(body.includes('Explain this &lt;b&gt;simply&lt;/b&gt; &amp; in short'), 'the prompt reached the page raw');
+});
+
+test('the answer language is its own control, and not the language of these pages', () => {
+  // `coai.helpLanguage` is English on the owner's machine, which is exactly why borrowing it would
+  // have delivered English explanations — the one thing this feature exists to avoid.
+  const body = chatSection(panelHtml(state({ chat: { ...chat, language: 'ru' } }), 'n0nce'));
+
+  assert.match(body, /<select[^>]*data-setting="chatLanguage"/);
+  assert.match(body, /<option value="ru" selected>/, 'the chosen language is not the selected one');
+});
+
+test('who presses send is a choice, and its three values are all offered', () => {
+  const body = chatSection(panelHtml(state(), 'n0nce'));
+
+  assert.match(body, /<select[^>]*data-setting="chatAutoSend"/);
+  for (const value of ['always', 'keyboard', 'never']) {
+    assert.ok(body.includes(`value="${value}"`), `${value} is not on offer`);
+  }
+  assert.match(body, /<option value="keyboard" selected>/, 'the default is not the selected one');
+});
+
+test('the model list is the models that can actually answer, with its own model named', () => {
+  const body = chatSection(panelHtml(state({
+    vendors: [vendor(), vendor({ id: 'second', model: 'gemini-3.7-pro' })],
+  }), 'n0nce'));
+
+  assert.match(body, /<select[^>]*data-setting="chatModel"/);
+  assert.ok(body.includes('gemini-3.7-flash-high'), 'a row is offered without saying which model it is');
+  assert.ok(body.includes('gemini-3.7-pro'), 'the second row is missing');
+});
+
+test('an unset model reads as the first one offered, not as an empty box', () => {
+  const body = chatSection(panelHtml(state({ vendors: [vendor()] }), 'n0nce'));
+
+  assert.match(body, /<option value=""[^>]*selected>[^<]*first/i, 'an empty setting looks like a broken control');
+});
+
+test('a reviewer the chat cannot speak to is named in the section, not silently absent', () => {
+  // The same rule the command follows: a person who configured `codex` and finds it missing from a
+  // picker cannot tell a bug from a policy.
+  const body = chatSection(panelHtml(state({
+    vendors: [vendor(), vendor({ id: 'codex', runtime: 'codex' })],
+  }), 'n0nce'));
+
+  assert.ok(body.includes('codex'), 'the refused reviewer is not mentioned at all');
+  assert.match(body, /can only speak to/, 'it is mentioned without saying why it cannot answer');
+});
+
+test('a panel with no chat settings at all still renders the section, on the defaults', () => {
+  // Sixteen test fixtures predate this field. Absent means the defaults, exactly as it does for the
+  // Team servers beside it — the alternative was sixteen whole-file CRLF diffs nobody can review.
+  const body = chatSection(panelHtml(state({ chat: undefined }), 'n0nce'));
+
+  assert.ok(body.includes('>Explain</textarea>'), 'the default prompt is not what an absent setting shows');
+});
+
+test('a model the settings NAME and which cannot answer is shown as chosen, and as unable', () => {
+  // Otherwise the browser selects the first option and the panel quietly reads "the first one that
+  // can answer" while `settings.json` says `codex` — the section describing a state that is not the
+  // one the command will refuse. Disabled, so it cannot be re-picked once it is left. (codex,
+  // gemini and local, one finding from three directions.)
+  const body = chatSection(panelHtml(state({
+    vendors: [vendor(), vendor({ id: 'codex', runtime: 'codex' })],
+    chat: { ...chat, model: 'codex' },
+  }), 'n0nce'));
+
+  assert.match(body, /<option value="codex"[^>]*selected[^>]*disabled|<option value="codex"[^>]*disabled[^>]*selected/,
+    'the configured model is not shown as the chosen one');
+  assert.ok(!/<option value=""[^>]*selected/.test(body), 'the panel claims no model is chosen while one is');
+});
+
+test('the panel and the command read the same settings through the same reader', () => {
+  // There is no extension-host harness here, so this is the closest a test can get to "what the
+  // section shows is what the conversation will use": both sides are driven from ONE `settings.json`
+  // and the rendered values are compared against the reader's own answer. (codex, the plan round.)
+  const file: Record<string, unknown> = {
+    chatPrompt: 'Объясни по-русски, коротко',
+    chatLanguage: 'ru',
+    chatAutoSend: 'always',
+    chatModel: 'second',
+  };
+  const asCommandReadsIt = chatSettingsFrom((key) => file[key]);
+  const body = chatSection(panelHtml(state({
+    vendors: [vendor(), vendor({ id: 'second' })],
+    chat: asCommandReadsIt,
+  }), 'n0nce'));
+
+  assert.ok(body.includes(`>${escapeHtml(asCommandReadsIt.prompt)}</textarea>`), 'the box shows a different prompt');
+  assert.ok(body.includes(`<option value="${asCommandReadsIt.language}" selected>`), 'a different language is selected');
+  assert.ok(body.includes(`<option value="${asCommandReadsIt.autoSend}" selected>`), 'a different send rule is selected');
+  assert.ok(body.includes(`<option value="${asCommandReadsIt.model}" selected>`), 'a different model is selected');
+});


### PR DESCRIPTION
Phase 4 of [todo/PLAN_chat_with_other_ais.md](todo/PLAN_chat_with_other_ais.md), and the last thing the owner asked for that was not built: *"в меню справа нужно добавть мультилайн инпут, где чел вводит промт, с которым скопированное должно уезжать в выбранную ии. по умолчанию одно слово Explain"* and *"какую модель исп, аналогично ревьюверам"*.

`coai.chatPrompt`, `coai.chatLanguage`, `coai.chatAutoSend` and `coai.chatModel` reach a MODEL — what is asked, in which language, who presses send, which vendor is billed. Until now all four were editable only by hand in `settings.json`, which is where a prompt goes to be forgotten.

## What it adds

One collapsible section beside *Reviewers*: the prompt as a **multi-line box** (one word is the default, not the limit), the answer language from the catalog the other menus are built from, who presses send as three sentences rather than three keys, and the model list — which is `chatModelsFrom`, **the same function the conversation itself picks from**, so the picker and the tab cannot disagree. A reviewer on a runtime the chat cannot speak to is named underneath with the reason, never quietly absent.

Four `HELP` entries (the tooltip key type is derived from the catalog, so a control without one is a compile error) and a section tone, which `updateButton.test.ts` already requires of every section.

## Decisions worth arguing with

- **Not folded into `CoaiSettings`.** These four have their own reader, `chatSettingsFrom`, and the command uses it with no panel in sight. One reader, both halves — two readers for one set of keys is a drift this repository has already paid for twice. The provider now reads them straight from the configuration exactly as the command does.
- **`PanelState.chat` is optional**, like `teamServers` and for the reason in that field's own comment: sixteen fixtures predate it, the files are CRLF, and a required field means sixteen unreviewable whole-file diffs. Absent means the defaults.
- **One language list.** `chatSettings.ts` had its own array of the five codes beside the catalog in `settingsShape.ts`; it now derives from it. Two lists of the same five things drift the day a sixth is added — the menu would offer it and the reader would refuse it, silently, back to English.

## What the gate changed

**Plan round** (12 findings, 2 taken): a model the settings NAME and which cannot answer is now rendered as a **selected, disabled** option saying so — without it the browser fell back to the first option and the section read *the first one that can answer* while `settings.json` said `codex`, a panel describing a state that is not the one the command refuses. Raised by all three reviewers from three directions. And an **agreement test**: there is no extension-host harness here, so the closest a test can get to "what the section shows is what the conversation uses" is to drive one settings file through the reader both halves call and compare.

**Code round** (verdict `proceed`, 12 reviewers, 21 findings, 3 taken): the test derives the send options from `CHAT_AUTO_SEND` instead of retyping them; the provider reads straight from the configuration; and the module doc gained the flow diagram the knowledge-base rule asks for.

One Blocking finding was wrong and is worth recording: `getConfiguration('coai')` already binds the section, so `config.get('chatPrompt')` reads `coai.chatPrompt` — the prefix it wanted added would have looked up `coai.coai.chatPrompt`. Two more Blockings claimed a missing `data-setting`, a missing `rows` and an unescaped prompt; all three are in the diff, with tests.

## Test plan

- [x] `npm test` — **891 tests, 890 pass, 0 fail, 1 pre-existing skip.**
- [x] Watched fail first, each with its own symptom: a one-line input instead of the box (*"the prompt is not a textarea"*), the refusals filtered away (*"the refused reviewer is not mentioned at all"*), and the stranded option removed (*"the configured model is not shown as the chosen one"*).
- [x] `settingsAreDeclared.test.ts` still passes — every control the panel renders is a declared setting, and all four were declared with the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
