### PR TITLE
docs(deploy): the key rotation is done, and the plan should not read as if it were pending

### DIFF
--- a/research/PLAN_deploy_key_is_a_button.md
+++ b/research/PLAN_deploy_key_is_a_button.md
@@ -219,9 +219,19 @@ artefact, and this plan's wrapper downloads one.
 
 ## The open tail
 
-- The old unrestricted `coai-deploy-ci` key is removed from the host only after a real deploy has
-  passed through the restricted one — installing the new key, testing it, re-issuing the secret and
-  revoking the old is a sequence, and doing it in one step is how a deploy path locks itself out.
+- ~~The old unrestricted key is removed only after a real deploy has passed through the restricted
+  one.~~ **Done, 2026-09-09.** It was not replaced: the same key already in `COAI_DEPLOY_KEY` was
+  given the `restrict,command=` prefix in place, which reaches the goal — that key can no longer open
+  a root shell — without any private-key material moving anywhere. `authorized_keys` was backed up to
+  `authorized_keys.before-coai-lockdown` first, and the proof is a real deploy of `0.5.5` through the
+  new path afterwards: run 34329776612, every step green, the rollback step skipped because nothing
+  needed it.
+
+  What that run showed, in its own words: the wrapper found `.claude/rules/shared` modified and said
+  so before discarding it, refreshed the checkout to `56831d3`, fetched the archive, reported
+  `sha256 verified`, and handed it to the release script — which canaried one real review per vendor.
+  `bin` moved to `0.5.5-20260909T085527Z`, the trail kept the previous three, loopback and the public
+  URL both answered `{"ok":true,"version":"0.5.5"}`, and no staging directory was left behind.
 - The wrapper is not covered by a shell test suite of its own; its refusals are executed by
   `install.test.ts` through `sh`, which is the boundary that matters, but the accept paths are
   asserted only as text because running them would deploy something.


### PR DESCRIPTION
The promoted plan carried the key rotation as an open tail — correctly, when it was written. It is done now, and a plan in `research/` that describes finished work as outstanding is the thing `research/` exists not to be.

**It shipped slightly differently.** The key was not replaced: the one already in `COAI_DEPLOY_KEY` was given the `restrict,command=` prefix in place. That reaches the goal — it can no longer open a root shell — without any private-key material moving anywhere, and without a window in which two keys are authorised. `authorized_keys` was backed up first.

**The proof is a real deploy**, run [34329776612](https://github.com/oleksandrdubyna88/dew_flow_connect_other_ais/actions/runs/34329776612), through the new path:

```
the checkout had local modifications; discarding them:  M .claude/rules/shared
refreshing /opt/coai/src ...
checkout: 56831d3
fetching coai-server-0.5.5-linux-x64.tar.gz ...
artefact: coai-server-0.5.5-linux-x64.tar.gz, sha256 verified
canary — one real review per configured vendor
loopback: {"ok":true,"version":"0.5.5"}
public:   {"ok":true,"version":"0.5.5"}
```

On the host afterwards: `bin -> releases/0.5.5-20260909T085527Z`, the trail keeping the previous three, no staging directory left behind, and both deploy keys on that box now locked to their own wrapper.

Documentation only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
