### PR TITLE
feat(chat): a force-killed editor no longer leaves an authenticated CLI running

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -185,6 +185,32 @@ never quietly absent — the same rule the command follows.
 files are stored CRLF, and a required field would have meant sixteen unreviewable whole-file diffs.
 Absent means the defaults, which is what an untouched panel shows anyway.
 
+### What a force-killed editor leaves behind (2026-09-09)
+
+A chat is a vendor CLI signed in as the person, and it lives as long as its tab. Closing the tab
+kills it; deactivating the extension kills them all. **Neither runs when VS Code is force-killed** —
+the Task Manager, a battery that goes, an installer that restarts the machine — and what survives
+that is an authenticated process nobody can see and nobody will stop.
+
+So every child is written down as it starts and struck out as it ends, and the next activation reads
+what is left. In the ordinary case the file is empty and the whole mechanism costs nothing.
+
+**The dangerous part is the killing, and the ledger exists to make it safe.** The launcher has said
+so since it was written: a pid is not an identity, Windows hands used numbers out again, and killing
+by number can end whatever now holds it. A record is therefore three facts — the pid, the image, and
+WHEN it started — and all three must still hold. The operating system is asked who holds the number
+now (`Get-CimInstance Win32_Process`, which reports the name WITH its extension, unlike
+`Get-Process`), and a mismatch on either fact leaves the process alone.
+
+The case that decides the design is not the orphan. It is somebody’s own `claude`, running their own
+work, on a number an extension wrote down an hour ago: **killing that would be far worse than the
+orphan it was tidying up.** Every unhappy answer — no such process, a refusal, a PowerShell that
+would not start — means the same thing and kills nothing. The guard fails CLOSED.
+
+Verified live rather than reasoned: two real processes of the same image, one recorded honestly and
+one recorded with a start time an hour off. The first was ended, the second was left running, and
+the ledger came back empty.
+
 ### Three vendors, one seam (2026-09-09)
 
 The chat answered on one runtime because the master plan recorded a limitation as fact:

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -195,6 +195,14 @@ that is an authenticated process nobody can see and nobody will stop.
 So every child is written down as it starts and struck out as it ends, and the next activation reads
 what is left. In the ordinary case the file is empty and the whole mechanism costs nothing.
 
+**One ledger file per extension host, named after it.** `globalStorageUri` is shared by every VS
+Code window. A single file meant one window reading another window’s LIVE children and killing them
+as orphans — they really are this extension’s, so every identity check would have passed — and a
+person with two windows would have watched a working conversation die when they opened the second.
+The gate called it Blocking. The owner’s pid is in the file NAME, a window only reads files whose
+owner is gone, and two windows never write the same file, which also removes a cross-process write
+race that no in-memory promise could have covered.
+
 **The dangerous part is the killing, and the ledger exists to make it safe.** The launcher has said
 so since it was written: a pid is not an identity, Windows hands used numbers out again, and killing
 by number can end whatever now holds it. A record is therefore three facts — the pid, the image, and
@@ -202,14 +210,27 @@ WHEN it started — and all three must still hold. The operating system is asked
 now (`Get-CimInstance Win32_Process`, which reports the name WITH its extension, unlike
 `Get-Process`), and a mismatch on either fact leaves the process alone.
 
+**The check and the kill are ONE command.** A query followed by a kill is a window in which the
+verified process can exit and its number be handed to somebody else — small, and small windows
+around killing are precisely what this is for. The three facts are compared and the tree is ended
+inside a single PowerShell invocation, which also means a TREE kill: a Windows shim is a tree —
+`codex` is `codex.cmd` running `cmd.exe` running node — and ending only its root leaves the CLI that
+was actually working.
+
+**An answer nobody could get KEEPS the record.** No PowerShell, a refusal, a machine that is not
+Windows: the entry is retried at the next activation rather than dropped, because dropping it is how
+an orphan becomes permanent. A week is the bound on that — past it a pid means nothing on any
+machine that has rebooted.
+
 The case that decides the design is not the orphan. It is somebody’s own `claude`, running their own
 work, on a number an extension wrote down an hour ago: **killing that would be far worse than the
 orphan it was tidying up.** Every unhappy answer — no such process, a refusal, a PowerShell that
 would not start — means the same thing and kills nothing. The guard fails CLOSED.
 
-Verified live rather than reasoned: two real processes of the same image, one recorded honestly and
-one recorded with a start time an hour off. The first was ended, the second was left running, and
-the ledger came back empty.
+Verified live rather than reasoned, three processes and three ledger files: the orphan of a
+force-killed window was ENDED, a stranger of the same image recorded an hour off was LEFT ALONE,
+another window’s live child was LEFT ALONE and its file was not even read, the dead window’s file was
+removed and the live one was untouched.
 
 ### Three vendors, one seam (2026-09-09)
 

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -74,18 +74,6 @@ interface Thread {
 
 const threads = new WeakMap<object, Thread>();
 
-/**
- * Where this conversation's children are written down.
- *
- * <p>Kept per conversation because a model SWITCH starts a new process long after the command that
- * opened the tab has returned, and the ledger's home is something only the extension knows.</p>
- */
-const storages = new WeakMap<object, string>();
-
-function storageOf(entry: ChatEntry): string {
-  return storages.get(entry.id) ?? '';
-}
-
 /** The tabs, narrowed to what `sessionKey` judges on. */
 function snapshots(): { active: TabSnapshot | undefined; all: TabSnapshot[] } {
   const all: TabSnapshot[] = [];
@@ -313,13 +301,13 @@ function matchedSession(panels: ChatPanels): ReturnType<typeof sourceSession> {
  * id, and the id is not known until the first turn has been answered. A persistent vendor ignores
  * the argument entirely and gets the same argv every time.</p>
  */
-function started(vendor: Vendor, resolved: string, storageDir: string): { session: ChatSession; home: ChatHome } {
+function started(vendor: Vendor, resolved: string): { session: ChatSession; home: ChatHome } {
   const home: ChatHome = emptyTempDir();
   const adapter = adapterFor(vendor.runtime);
 
   return {
     session: new CliChatSession(
-      chatProcessFor(vendor, home.dir, resolved, storageDir),
+      chatProcessFor(vendor, home.dir, resolved),
       DEFAULT_BUDGETS,
       REAL_TIMERS,
       adapter,
@@ -416,7 +404,7 @@ async function switchNow(entry: ChatEntry, modelId: string): Promise<void> {
 
   thread.session.dispose();
   thread.home.release();
-  const replacement = started(vendor, cli.resolved, storageOf(entry));
+  const replacement = started(vendor, cli.resolved);
   thread.session = replacement.session;
   thread.home = replacement.home;
   thread.modelId = modelId;
@@ -439,9 +427,8 @@ function newConversation(
   ready: Extract<Ready, { ok: true }>,
   state: { readonly title: string; readonly passage: string; readonly draft: string },
   resolved: string,
-  storageDir: string,
 ): ChatEntry {
-  const first = started(ready.vendor, resolved, storageDir);
+  const first = started(ready.vendor, resolved);
   const session = first.session;
   const entry = createChatPanel(
     {
@@ -488,7 +475,6 @@ function newConversation(
   );
   // Recorded against the entry's OWN id, which `createChatPanel` made — not against the tab key,
   // which can move under a live conversation. That distinction cost a whole code round.
-  storages.set(entry.id, storageDir);
   threads.set(entry.id, {
     session,
     home: first.home,
@@ -510,12 +496,7 @@ function newConversation(
  * @param panels the registry of open conversations
  * @param args what VS Code handed it — a menu item passes the webview, a keybinding passes nothing
  */
-export async function chatWithOtherAi(
-  panels: ChatPanels,
-  args: readonly unknown[],
-  /** Where the orphan ledger lives — `context.globalStorageUri.fsPath`. */
-  storageDir = '',
-): Promise<void> {
+export async function chatWithOtherAi(panels: ChatPanels, args: readonly unknown[]): Promise<void> {
   const config = vscode.workspace.getConfiguration('coai');
   const settings = chatSettingsFrom((key) => config.get(key));
   const ready = readyToChat(config, settings.model);
@@ -569,7 +550,7 @@ export async function chatWithOtherAi(
     title: match.label,
     passage: passage.text,
     draft: plan.send ? '' : turn,
-  }, cli.resolved, storageDir));
+  }, cli.resolved));
 
   opened.entry.panel.reveal();
   if (plan.send) {

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -74,6 +74,18 @@ interface Thread {
 
 const threads = new WeakMap<object, Thread>();
 
+/**
+ * Where this conversation's children are written down.
+ *
+ * <p>Kept per conversation because a model SWITCH starts a new process long after the command that
+ * opened the tab has returned, and the ledger's home is something only the extension knows.</p>
+ */
+const storages = new WeakMap<object, string>();
+
+function storageOf(entry: ChatEntry): string {
+  return storages.get(entry.id) ?? '';
+}
+
 /** The tabs, narrowed to what `sessionKey` judges on. */
 function snapshots(): { active: TabSnapshot | undefined; all: TabSnapshot[] } {
   const all: TabSnapshot[] = [];
@@ -301,12 +313,17 @@ function matchedSession(panels: ChatPanels): ReturnType<typeof sourceSession> {
  * id, and the id is not known until the first turn has been answered. A persistent vendor ignores
  * the argument entirely and gets the same argv every time.</p>
  */
-function started(vendor: Vendor, resolved: string): { session: ChatSession; home: ChatHome } {
+function started(vendor: Vendor, resolved: string, storageDir: string): { session: ChatSession; home: ChatHome } {
   const home: ChatHome = emptyTempDir();
   const adapter = adapterFor(vendor.runtime);
 
   return {
-    session: new CliChatSession(chatProcessFor(vendor, home.dir, resolved), DEFAULT_BUDGETS, REAL_TIMERS, adapter),
+    session: new CliChatSession(
+      chatProcessFor(vendor, home.dir, resolved, storageDir),
+      DEFAULT_BUDGETS,
+      REAL_TIMERS,
+      adapter,
+    ),
     home,
   };
 }
@@ -399,7 +416,7 @@ async function switchNow(entry: ChatEntry, modelId: string): Promise<void> {
 
   thread.session.dispose();
   thread.home.release();
-  const replacement = started(vendor, cli.resolved);
+  const replacement = started(vendor, cli.resolved, storageOf(entry));
   thread.session = replacement.session;
   thread.home = replacement.home;
   thread.modelId = modelId;
@@ -422,8 +439,9 @@ function newConversation(
   ready: Extract<Ready, { ok: true }>,
   state: { readonly title: string; readonly passage: string; readonly draft: string },
   resolved: string,
+  storageDir: string,
 ): ChatEntry {
-  const first = started(ready.vendor, resolved);
+  const first = started(ready.vendor, resolved, storageDir);
   const session = first.session;
   const entry = createChatPanel(
     {
@@ -470,6 +488,7 @@ function newConversation(
   );
   // Recorded against the entry's OWN id, which `createChatPanel` made — not against the tab key,
   // which can move under a live conversation. That distinction cost a whole code round.
+  storages.set(entry.id, storageDir);
   threads.set(entry.id, {
     session,
     home: first.home,
@@ -491,7 +510,12 @@ function newConversation(
  * @param panels the registry of open conversations
  * @param args what VS Code handed it — a menu item passes the webview, a keybinding passes nothing
  */
-export async function chatWithOtherAi(panels: ChatPanels, args: readonly unknown[]): Promise<void> {
+export async function chatWithOtherAi(
+  panels: ChatPanels,
+  args: readonly unknown[],
+  /** Where the orphan ledger lives — `context.globalStorageUri.fsPath`. */
+  storageDir = '',
+): Promise<void> {
   const config = vscode.workspace.getConfiguration('coai');
   const settings = chatSettingsFrom((key) => config.get(key));
   const ready = readyToChat(config, settings.model);
@@ -545,7 +569,7 @@ export async function chatWithOtherAi(panels: ChatPanels, args: readonly unknown
     title: match.label,
     passage: passage.text,
     draft: plan.send ? '' : turn,
-  }, cli.resolved));
+  }, cli.resolved, storageDir));
 
   opened.entry.panel.reveal();
   if (plan.send) {

--- a/src_vs_code/src/chatLedger.ts
+++ b/src_vs_code/src/chatLedger.ts
@@ -1,0 +1,156 @@
+/**
+ * What was started, so a crash cannot leave it running.
+ *
+ * <p>A chat is a vendor CLI signed in as the person, and it lives as long as its tab. Closing the
+ * tab kills it; disposing the extension kills them all. Neither runs when VS Code is FORCE-killed —
+ * the Task Manager, a battery that went, an installer that restarts the machine — and what is left
+ * behind is an authenticated process nobody can see and nobody will stop.</p>
+ *
+ * <p>So every child is written down as it starts and struck out as it ends, and the next activation
+ * reads what is left. In the ordinary case the file is empty and the whole mechanism costs nothing.</p>
+ *
+ * <p><b>Killing by pid is the dangerous part, and this module exists to make it safe.</b> The
+ * launcher's own comment says it: Windows reuses pids, so a recorded number can belong to somebody
+ * else's process by the time anybody reads it — killing it would be worse than the orphan. A record
+ * is therefore three facts, and all three must still hold: the pid, the image it was, and WHEN it
+ * started. A reused pid is a different program, or the same program started at a different time, and
+ * either mismatch is enough to leave it alone.</p>
+ *
+ * <p>Pure, so those rules are tests rather than claims — the file, the process query and the kill
+ * are somebody else's job.</p>
+ */
+
+/** One child, as the ledger remembers it. */
+export interface ChildRecord {
+  readonly pid: number;
+  /** The executable's file name, lower-cased — what the operating system will call it back. */
+  readonly image: string;
+  /** Our own clock when it was started. Compared against what the OS says, not trusted alone. */
+  readonly startedMs: number;
+}
+
+/** What the operating system says about a pid NOW, or nothing when no such process exists. */
+export interface LivingProcess {
+  readonly image: string;
+  readonly createdMs: number;
+}
+
+/**
+ * How far apart the two clocks may be and still mean the same start.
+ *
+ * <p>Ours is taken just before `spawn` returns and the OS's is taken when the process was created,
+ * so the honest difference is milliseconds. Ten seconds is slack for a machine under load and a
+ * clock that ticks between the two readings; it is nowhere near long enough for a pid to be recycled
+ * onto a program of the same name, which is the only thing this tolerance risks.</p>
+ */
+export const NEAR_ENOUGH_MS = 10_000;
+
+/** The image name a path means, for comparing with what the OS reports. */
+export function imageOf(executable: string): string {
+  const tail = executable.split(/[\\/]/).pop() ?? '';
+
+  return tail.toLowerCase();
+}
+
+/** The ledger with this child in it, and no duplicate pid — a reused number replaces the old row. */
+export function recorded(entries: readonly ChildRecord[], child: ChildRecord): readonly ChildRecord[] {
+  return [...entries.filter((known) => known.pid !== child.pid), child];
+}
+
+/** The ledger without this child. Called when it ends, however it ends. */
+export function forgotten(entries: readonly ChildRecord[], pid: number): readonly ChildRecord[] {
+  return entries.filter((known) => known.pid !== pid);
+}
+
+/**
+ * Is the process now holding this pid the one we started?
+ *
+ * <p>Three facts, all of them required. A pid that nothing holds is already gone. A pid held by
+ * another program is a recycled number. A pid held by the same program but started at another time
+ * is a different run of it — somebody's own `claude`, most likely, which is precisely the thing that
+ * must not be killed.</p>
+ */
+export function isOurs(record: ChildRecord, alive: LivingProcess | undefined): boolean {
+  if (alive === undefined) {
+    return false;
+  }
+
+  return alive.image === record.image && Math.abs(alive.createdMs - record.startedMs) <= NEAR_ENOUGH_MS;
+}
+
+/**
+ * The ledger as it survived on disk.
+ *
+ * <p>Junk-safe by design: this file is read at activation, and a half-written line — the shape a
+ * force-kill leaves — must not stop an extension from starting. Anything unreadable is no ledger,
+ * which loses at most the chance to tidy up one crash.</p>
+ */
+export function parseLedger(text: string): readonly ChildRecord[] {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isRecord).map((row) => ({
+    pid: row.pid,
+    image: row.image.toLowerCase(),
+    startedMs: row.startedMs,
+  }));
+}
+
+function isRecord(value: unknown): value is ChildRecord {
+  const row = value as Partial<ChildRecord> | null;
+
+  return typeof row === 'object'
+    && row !== null
+    && typeof row.pid === 'number'
+    && Number.isInteger(row.pid)
+    && row.pid > 0
+    && typeof row.image === 'string'
+    && row.image.length > 0
+    && typeof row.startedMs === 'number'
+    && Number.isFinite(row.startedMs);
+}
+
+/** The ledger as text. Its own function so both halves agree about the shape on disk. */
+export function ledgerText(entries: readonly ChildRecord[]): string {
+  return JSON.stringify(entries);
+}
+
+/**
+ * What to ask Windows about a pid.
+ *
+ * <p>Two facts and nothing else, formatted by the shell so this side parses one line rather than a
+ * JSON dialect that changes between PowerShell versions. `Get-CimInstance` rather than
+ * `Get-Process`, because `Get-Process` reports a name with no extension and can throw on a process
+ * it may not inspect — and the extension is half of what identifies the image.</p>
+ *
+ * <p>Measured on this machine: `pwsh.exe|1788944157495`.</p>
+ */
+export function livingQuery(pid: number): string {
+  return `$p = Get-CimInstance Win32_Process -Filter "ProcessId=${pid}"; `
+    + 'if ($p) { "$($p.Name)|$([math]::Round(($p.CreationDate.ToUniversalTime() '
+    + "- [datetime]'1970-01-01').TotalMilliseconds))\" }";
+}
+
+/**
+ * What the query answered, or nothing at all.
+ *
+ * <p>Nothing covers every unhappy shape on purpose — no such process, a refusal, an error on
+ * stderr, a PowerShell that would not start. All of them mean the same thing here: this side cannot
+ * prove the pid is ours, so it is left alone. A guard that fails OPEN would kill strangers.</p>
+ */
+export function parseLiving(text: string): LivingProcess | undefined {
+  const line = text.split(/\r?\n/).map((one) => one.trim()).find((one) => one.includes('|'));
+  const [image, created] = (line ?? '').split('|');
+  const createdMs = Number(created);
+
+  return image !== undefined && image.length > 0 && Number.isFinite(createdMs) && createdMs > 0
+    ? { image: image.toLowerCase(), createdMs }
+    : undefined;
+}

--- a/src_vs_code/src/chatLedger.ts
+++ b/src_vs_code/src/chatLedger.ts
@@ -166,9 +166,14 @@ export function ownerOf(fileName: string): number {
  * around killing are not acceptable. So the three facts are compared and the tree is ended inside a
  * single invocation, and the script says which it did.</p>
  *
- * <p><b>`taskkill /t`, not `Terminate`</b>: a Windows shim is a tree — `codex` is `codex.cmd` running
- * `cmd.exe` running node — and ending only the root leaves the CLI that was actually working. The
- * launcher's own kill has said this since it was written.</p>
+ * <p><b>`taskkill` with the tree flags, not `Terminate`</b>: a Windows shim is a tree — `codex` is
+ * `codex.cmd` running `cmd.exe` running node — and ending only the root leaves the CLI that was
+ * actually working. Its EXIT CODE is checked: a `taskkill` that was refused used to be reported as
+ * a kill, which struck out the record and left the process running. (codex, the code round.)</p>
+ *
+ * <p>An image this side would not put in a command yields NO command — empty, which the caller reads
+ * as "nothing could be asked". `worthAsking` says the same thing earlier; a guarantee a reader has to
+ * reconstruct from another function is a guarantee waiting to be broken.</p>
  *
  * <p><b>`Get-CimInstance`, not `Get-Process`</b>: the latter reports a name with no extension and can
  * throw on a process it may not inspect, and the extension is half of what identifies an image. The
@@ -176,6 +181,10 @@ export function ownerOf(fileName: string): number {
  * date format, locale or time zone crosses the boundary. Measured on this machine.</p>
  */
 export function verifyAndKill(record: ChildRecord): string {
+  if (!safeImage(record.image)) {
+    return '';
+  }
+
   return [
     `$p = Get-CimInstance Win32_Process -Filter "ProcessId=${record.pid}"`,
     '$started = if ($p) { [math]::Round(($p.CreationDate.ToUniversalTime() '
@@ -183,7 +192,7 @@ export function verifyAndKill(record: ChildRecord): string {
     `if ($p -and $p.Name -eq '${record.image}' `
     + `-and [math]::Abs($started - ${record.startedMs}) -le ${NEAR_ENOUGH_MS}) {`,
     `  taskkill /pid ${record.pid} /t /f | Out-Null`,
-    '  "killed"',
+    '  if ($LASTEXITCODE -eq 0) { "killed" } else { "refused" }',
     '} elseif ($p) { "not ours" } else { "gone" }',
   ].join('\n');
 }
@@ -204,6 +213,11 @@ export function killOutcome(exitCode: number, output: string): KillOutcome {
     return 'unknown';
   }
   const said = output.toLowerCase();
+  if (said.includes('refused')) {
+    // The tree kill itself failed — access denied, a process protected from us. Unknown, so the
+    // record is KEPT and tried again rather than struck out over a process that is still running.
+    return 'unknown';
+  }
   if (said.includes('killed')) {
     return 'killed';
   }

--- a/src_vs_code/src/chatLedger.ts
+++ b/src_vs_code/src/chatLedger.ts
@@ -7,17 +7,24 @@
  * behind is an authenticated process nobody can see and nobody will stop.</p>
  *
  * <p>So every child is written down as it starts and struck out as it ends, and the next activation
- * reads what is left. In the ordinary case the file is empty and the whole mechanism costs nothing.</p>
+ * reads what is left. In the ordinary case there is nothing to read.</p>
+ *
+ * <p><b>One ledger per extension host, named after it.</b> `globalStorageUri` is SHARED by every VS
+ * Code window, so a single file would mean one window's activation reading another window's live
+ * children — and, since those children really are this extension's, verifying them as its own and
+ * killing them. A person with two windows would have watched a working conversation die when they
+ * opened the second. Raised as Blocking by the gate, and it is why the owner's pid is in the file
+ * NAME: a window only ever reads files whose owner is gone.</p>
  *
  * <p><b>Killing by pid is the dangerous part, and this module exists to make it safe.</b> The
  * launcher's own comment says it: Windows reuses pids, so a recorded number can belong to somebody
  * else's process by the time anybody reads it — killing it would be worse than the orphan. A record
  * is therefore three facts, and all three must still hold: the pid, the image it was, and WHEN it
- * started. A reused pid is a different program, or the same program started at a different time, and
- * either mismatch is enough to leave it alone.</p>
+ * started. The check and the kill happen inside ONE command, so almost nothing can happen between
+ * them; a separate query and kill leaves a window in which the pid can be handed on.</p>
  *
- * <p>Pure, so those rules are tests rather than claims — the file, the process query and the kill
- * are somebody else's job.</p>
+ * <p>Pure, so those rules are tests rather than claims — the files, the query and the kill are
+ * somebody else's job.</p>
  */
 
 /** One child, as the ledger remembers it. */
@@ -29,27 +36,44 @@ export interface ChildRecord {
   readonly startedMs: number;
 }
 
-/** What the operating system says about a pid NOW, or nothing when no such process exists. */
-export interface LivingProcess {
-  readonly image: string;
-  readonly createdMs: number;
-}
-
 /**
  * How far apart the two clocks may be and still mean the same start.
  *
- * <p>Ours is taken just before `spawn` returns and the OS's is taken when the process was created,
- * so the honest difference is milliseconds. Ten seconds is slack for a machine under load and a
- * clock that ticks between the two readings; it is nowhere near long enough for a pid to be recycled
- * onto a program of the same name, which is the only thing this tolerance risks.</p>
+ * <p>Ours is taken as `spawn` returns and the OS's is the process's creation time, so the honest
+ * difference is milliseconds. Both are absolute instants recorded once, so a clock the machine
+ * changes afterwards moves neither. Ten seconds is slack for a machine under load; it is nowhere
+ * near long enough for a pid to be recycled onto a program of the same name.</p>
  */
 export const NEAR_ENOUGH_MS = 10_000;
+
+/**
+ * How long an entry nobody could resolve is carried forward.
+ *
+ * <p>An activation that cannot ask the operating system anything — no PowerShell, a refusal, a
+ * machine that is not Windows — must not DELETE the record, or the orphan it could not verify
+ * becomes one nobody will ever find. So it is kept and retried. A week is the bound on that: past
+ * it, the pid means nothing on any machine that has rebooted, and the file would otherwise grow for
+ * ever. (codex, the plan round.)</p>
+ */
+export const FORGET_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** The image name a path means, for comparing with what the OS reports. */
 export function imageOf(executable: string): string {
   const tail = executable.split(/[\\/]/).pop() ?? '';
 
   return tail.toLowerCase();
+}
+
+/**
+ * An image name safe to put in a command.
+ *
+ * <p>It comes from a reviewer's `executablePath`, which is a person's own setting and therefore
+ * their own text. The verify-and-kill command carries it, so a name with a quote in it would be a
+ * quote in a PowerShell script. A file name has no business containing one; anything that does is
+ * not compared, and its record is left alone.</p>
+ */
+export function safeImage(image: string): boolean {
+  return /^[A-Za-z0-9](?:[A-Za-z0-9._+-]{0,120})$/.test(image);
 }
 
 /** The ledger with this child in it, and no duplicate pid — a reused number replaces the old row. */
@@ -62,20 +86,19 @@ export function forgotten(entries: readonly ChildRecord[], pid: number): readonl
   return entries.filter((known) => known.pid !== pid);
 }
 
-/**
- * Is the process now holding this pid the one we started?
- *
- * <p>Three facts, all of them required. A pid that nothing holds is already gone. A pid held by
- * another program is a recycled number. A pid held by the same program but started at another time
- * is a different run of it — somebody's own `claude`, most likely, which is precisely the thing that
- * must not be killed.</p>
- */
-export function isOurs(record: ChildRecord, alive: LivingProcess | undefined): boolean {
-  if (alive === undefined) {
-    return false;
-  }
+/** Old enough that its pid means nothing any more, whatever the operating system says. */
+export function tooOld(record: ChildRecord, now: number): boolean {
+  return now - record.startedMs > FORGET_AFTER_MS;
+}
 
-  return alive.image === record.image && Math.abs(alive.createdMs - record.startedMs) <= NEAR_ENOUGH_MS;
+/**
+ * Which records are worth asking the operating system about.
+ *
+ * <p>Not the ones too old to mean anything, and not the ones whose image could not appear in a
+ * command. Everything else is a candidate — the answer decides, not this.</p>
+ */
+export function worthAsking(entries: readonly ChildRecord[], now: number): readonly ChildRecord[] {
+  return entries.filter((record) => !tooOld(record, now) && safeImage(record.image));
 }
 
 /**
@@ -83,7 +106,8 @@ export function isOurs(record: ChildRecord, alive: LivingProcess | undefined): b
  *
  * <p>Junk-safe by design: this file is read at activation, and a half-written line — the shape a
  * force-kill leaves — must not stop an extension from starting. Anything unreadable is no ledger,
- * which loses at most the chance to tidy up one crash.</p>
+ * which loses at most the chance to tidy up one crash. A truncated row cannot half-match either:
+ * every one of the three facts is required, so half a record is no record.</p>
  */
 export function parseLedger(text: string): readonly ChildRecord[] {
   let value: unknown;
@@ -122,35 +146,75 @@ export function ledgerText(entries: readonly ChildRecord[]): string {
   return JSON.stringify(entries);
 }
 
-/**
- * What to ask Windows about a pid.
- *
- * <p>Two facts and nothing else, formatted by the shell so this side parses one line rather than a
- * JSON dialect that changes between PowerShell versions. `Get-CimInstance` rather than
- * `Get-Process`, because `Get-Process` reports a name with no extension and can throw on a process
- * it may not inspect — and the extension is half of what identifies the image.</p>
- *
- * <p>Measured on this machine: `pwsh.exe|1788944157495`.</p>
- */
-export function livingQuery(pid: number): string {
-  return `$p = Get-CimInstance Win32_Process -Filter "ProcessId=${pid}"; `
-    + 'if ($p) { "$($p.Name)|$([math]::Round(($p.CreationDate.ToUniversalTime() '
-    + "- [datetime]'1970-01-01').TotalMilliseconds))\" }";
+/** What a ledger file is called. The owner's pid is IN the name — see the note at the top. */
+export function ledgerName(ownerPid: number): string {
+  return `chat-children-${ownerPid}.json`;
+}
+
+/** The owner a ledger file belongs to, or 0 when the name is not one of ours. */
+export function ownerOf(fileName: string): number {
+  const found = /^chat-children-([0-9]{1,10})\.json$/.exec(fileName);
+
+  return found === null ? 0 : Number(found[1]);
 }
 
 /**
- * What the query answered, or nothing at all.
+ * The one command that checks and kills, because two commands leave a gap.
  *
- * <p>Nothing covers every unhappy shape on purpose — no such process, a refusal, an error on
- * stderr, a PowerShell that would not start. All of them mean the same thing here: this side cannot
- * prove the pid is ours, so it is left alone. A guard that fails OPEN would kill strangers.</p>
+ * <p>A query followed by a kill is a window in which the verified process can exit and its number be
+ * handed to somebody else — small, and the whole reason this module exists is that small windows
+ * around killing are not acceptable. So the three facts are compared and the tree is ended inside a
+ * single invocation, and the script says which it did.</p>
+ *
+ * <p><b>`taskkill /t`, not `Terminate`</b>: a Windows shim is a tree — `codex` is `codex.cmd` running
+ * `cmd.exe` running node — and ending only the root leaves the CLI that was actually working. The
+ * launcher's own kill has said this since it was written.</p>
+ *
+ * <p><b>`Get-CimInstance`, not `Get-Process`</b>: the latter reports a name with no extension and can
+ * throw on a process it may not inspect, and the extension is half of what identifies an image. The
+ * creation time is converted to epoch milliseconds HERE rather than parsed on the other side, so no
+ * date format, locale or time zone crosses the boundary. Measured on this machine.</p>
  */
-export function parseLiving(text: string): LivingProcess | undefined {
-  const line = text.split(/\r?\n/).map((one) => one.trim()).find((one) => one.includes('|'));
-  const [image, created] = (line ?? '').split('|');
-  const createdMs = Number(created);
+export function verifyAndKill(record: ChildRecord): string {
+  return [
+    `$p = Get-CimInstance Win32_Process -Filter "ProcessId=${record.pid}"`,
+    '$started = if ($p) { [math]::Round(($p.CreationDate.ToUniversalTime() '
+    + "- [datetime]'1970-01-01').TotalMilliseconds) } else { 0 }",
+    `if ($p -and $p.Name -eq '${record.image}' `
+    + `-and [math]::Abs($started - ${record.startedMs}) -le ${NEAR_ENOUGH_MS}) {`,
+    `  taskkill /pid ${record.pid} /t /f | Out-Null`,
+    '  "killed"',
+    '} elseif ($p) { "not ours" } else { "gone" }',
+  ].join('\n');
+}
 
-  return image !== undefined && image.length > 0 && Number.isFinite(createdMs) && createdMs > 0
-    ? { image: image.toLowerCase(), createdMs }
-    : undefined;
+/** What one verify-and-kill came to. Anything unreadable is `unknown` — and `unknown` keeps the row. */
+export type KillOutcome = 'killed' | 'not ours' | 'gone' | 'unknown';
+
+/**
+ * What the command said.
+ *
+ * <p>`unknown` is every unhappy shape — a refusal, an error on stderr, a PowerShell that would not
+ * start, a machine that is not Windows. It kills nothing and, unlike the other three, it does NOT
+ * settle the record: an entry nobody could ask about is retried at the next activation rather than
+ * quietly dropped, because dropping it is how an orphan becomes permanent.</p>
+ */
+export function killOutcome(exitCode: number, output: string): KillOutcome {
+  if (exitCode !== 0) {
+    return 'unknown';
+  }
+  const said = output.toLowerCase();
+  if (said.includes('killed')) {
+    return 'killed';
+  }
+  if (said.includes('not ours')) {
+    return 'not ours';
+  }
+
+  return said.includes('gone') ? 'gone' : 'unknown';
+}
+
+/** A record is settled — struck out — unless nobody could tell what it was. */
+export function settled(outcome: KillOutcome): boolean {
+  return outcome !== 'unknown';
 }

--- a/src_vs_code/src/chatOrphans.ts
+++ b/src_vs_code/src/chatOrphans.ts
@@ -54,6 +54,25 @@ const SWEEP_MS = 30_000;
 /** This host's own children, in memory. It is the only writer of its own file. */
 let mine: readonly ChildRecord[] = [];
 
+/**
+ * Where this host writes, bound ONCE.
+ *
+ * <p>It used to travel as an argument through six functions — the command, the conversation, the
+ * process factory — which meant a module-level list of children paired with a per-call directory:
+ * two things that must agree, with nothing making them. An extension host has one
+ * `globalStorageUri` for its whole life, so it is set at activation and never asked for again, and
+ * the code that starts a child no longer has to know where a ledger lives. (codex and gemini, the
+ * second code round.)</p>
+ *
+ * <p>Empty means no ledger: the tests, and any caller that never opened one.</p>
+ */
+let home = '';
+
+/** Bind the ledger's directory. Called once, from `activate`. */
+export function openLedger(storageDir: string): void {
+  home = storageDir;
+}
+
 /** Where this extension host writes. Nobody else writes here; nobody else reads it while we live. */
 export function ledgerPath(storageDir: string, ownerPid = process.pid): string {
   return join(storageDir, ledgerName(ownerPid));
@@ -73,31 +92,31 @@ function writeAtomically(path: string, text: string): void {
 }
 
 /** Say what went wrong rather than swallow it: a ledger that cannot be written is a child nobody can clean up. */
-function saved(storageDir: string): void {
+function saved(): void {
   try {
-    mkdirSync(storageDir, { recursive: true });
-    writeAtomically(ledgerPath(storageDir), ledgerText(mine));
+    mkdirSync(home, { recursive: true });
+    writeAtomically(ledgerPath(home), ledgerText(mine));
   } catch (reason) {
     console.warn(`[coai] the chat ledger could not be written: ${reason instanceof Error ? reason.message : reason}`);
   }
 }
 
 /** Write this child down, before it can be orphaned. Synchronous, on purpose — see the note above. */
-export function remember(storageDir: string, pid: number, executable: string, now = Date.now()): void {
-  if (pid <= 0 || storageDir.length === 0) {
+export function remember(pid: number, executable: string, now = Date.now()): void {
+  if (pid <= 0 || home.length === 0) {
     return;
   }
   mine = recorded(mine, { pid, image: imageOf(executable), startedMs: now });
-  saved(storageDir);
+  saved();
 }
 
 /** Strike it out. Called when the child ends, however it ends — an exit, an error, a kill. */
-export function forget(storageDir: string, pid: number): void {
-  if (pid <= 0 || storageDir.length === 0) {
+export function forget(pid: number): void {
+  if (pid <= 0 || home.length === 0) {
     return;
   }
   mine = forgotten(mine, pid);
-  saved(storageDir);
+  saved();
 }
 
 /**

--- a/src_vs_code/src/chatOrphans.ts
+++ b/src_vs_code/src/chatOrphans.ts
@@ -1,0 +1,130 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  ChildRecord,
+  LivingProcess,
+  forgotten,
+  imageOf,
+  isOurs,
+  ledgerText,
+  livingQuery,
+  parseLedger,
+  parseLiving,
+  recorded,
+} from './chatLedger';
+import { capture } from './versionProbe';
+import { killByPid } from './processLauncher';
+
+/**
+ * The ledger's world-facing half: the file, the question, and the kill.
+ *
+ * <p>Every rule about WHETHER to kill lives in `chatLedger.ts` and is tested there. This file does
+ * the three things that need a machine — read and write one small file, ask the operating system who
+ * holds a pid, and end a process — and holds no judgement of its own.</p>
+ *
+ * <p><b>Writes are serialised through one promise.</b> `codex` starts a process per turn, so a busy
+ * conversation records and forgets often, and two overlapping read-modify-writes would lose one of
+ * them. The chain costs nothing and removes the whole class.</p>
+ */
+
+/** Where the ledger lives. One file per installation, beside everything else this extension keeps. */
+export function ledgerPath(storageDir: string): string {
+  return join(storageDir, 'chat-children.json');
+}
+
+/** How long the process query may take before this side gives up and kills nothing. */
+const QUERY_MS = 5_000;
+
+let queue: Promise<unknown> = Promise.resolve();
+
+/** Run a read-modify-write with nothing else in it. Never rejects: a ledger is not worth a crash. */
+function serialised(work: () => Promise<void>): Promise<void> {
+  const mine = queue.then(work).catch(() => undefined);
+  queue = mine;
+
+  return mine;
+}
+
+async function entriesIn(path: string): Promise<readonly ChildRecord[]> {
+  try {
+    return parseLedger(await readFile(path, 'utf8'));
+  } catch {
+    // No file is the ordinary case: nothing has been started yet, or the last shutdown was clean.
+    return [];
+  }
+}
+
+/** Write this child down, before it can be orphaned. */
+export function remember(storageDir: string, pid: number, executable: string, now = Date.now()): Promise<void> {
+  if (pid <= 0) {
+    return Promise.resolve();
+  }
+
+  return serialised(async () => {
+    const path = ledgerPath(storageDir);
+    const entries = recorded(await entriesIn(path), { pid, image: imageOf(executable), startedMs: now });
+    await writeFile(path, ledgerText(entries), 'utf8');
+  });
+}
+
+/** Strike it out. Called when the child ends, however it ends — an exit, an error, a kill. */
+export function forget(storageDir: string, pid: number): Promise<void> {
+  if (pid <= 0) {
+    return Promise.resolve();
+  }
+
+  return serialised(async () => {
+    const path = ledgerPath(storageDir);
+    await writeFile(path, ledgerText(forgotten(await entriesIn(path), pid)), 'utf8');
+  });
+}
+
+/** What the operating system says about a pid, or nothing when it will not say. */
+async function living(pid: number): Promise<LivingProcess | undefined> {
+  if (process.platform !== 'win32') {
+    // `ps -o comm=,lstart=` differs between BSD and GNU and this feature's copy helper is Windows
+    // only anyway. Nothing is claimed rather than guessed, so nothing is killed.
+    return undefined;
+  }
+  const asked = await capture(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', livingQuery(pid)],
+    false,
+    QUERY_MS,
+  );
+
+  return asked.code === 0 ? parseLiving(asked.output) : undefined;
+}
+
+/**
+ * Clean up after a crash: kill what is still ours, and forget the rest.
+ *
+ * <p>Called once at activation. In the ordinary case the ledger is empty — the previous shutdown
+ * struck out every child — and this returns without asking the operating system anything.</p>
+ *
+ * @returns how many processes were actually killed, for the caller to log
+ */
+export async function reconcile(storageDir: string): Promise<number> {
+  const path = ledgerPath(storageDir);
+  const entries = await entriesIn(path);
+  if (entries.length === 0) {
+    return 0;
+  }
+
+  let killed = 0;
+  for (const record of entries) {
+    // Re-checked, every time, against the two facts the ledger kept. A pid alone would be a licence
+    // to kill whatever the operating system has since handed that number to.
+    if (isOurs(record, await living(record.pid))) {
+      killByPid(record.pid);
+      killed += 1;
+    }
+  }
+  // Emptied whatever happened: an entry that could not be verified is an entry that will never be
+  // verified, and carrying it forward would ask the same unanswerable question at every activation.
+  await serialised(async () => {
+    await writeFile(path, ledgerText([]), 'utf8');
+  });
+
+  return killed;
+}

--- a/src_vs_code/src/chatOrphans.ts
+++ b/src_vs_code/src/chatOrphans.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { readdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   ChildRecord,
@@ -11,6 +12,7 @@ import {
   parseLedger,
   recorded,
   settled,
+  tooOld,
   verifyAndKill,
   worthAsking,
 } from './chatLedger';
@@ -20,107 +22,114 @@ import { capture } from './versionProbe';
  * The ledger's world-facing half: the files, the command, and the log line.
  *
  * <p>Every rule about WHETHER a process may be killed lives in `chatLedger.ts` and is tested there.
- * This file does the things that need a machine — read and write small files, run one command per
+ * This file does the things that need a machine — write one small file, run one command per
  * candidate, say what happened — and holds no judgement of its own.</p>
  *
  * <p><b>One file per extension host.</b> `globalStorageUri` is shared by every VS Code window, and a
  * single shared file meant one window reading another window's LIVE children and killing them as
  * orphans. The owner's pid is in the file name, a window only reads files whose owner is gone, and
- * two windows never write the same file — which also removes the cross-process write race that no
- * in-memory promise could have covered. (gemini and local, one plan round, three findings.)</p>
+ * two windows never write the same file. (gemini and local, the plan round, three findings.)</p>
+ *
+ * <p><b>Our own file is written SYNCHRONOUSLY, from memory.</b> The window this feature guards
+ * against is a force-kill, and a queued asynchronous write is exactly what a force-kill does not
+ * wait for: a child launched and killed a millisecond later would never have been written down. The
+ * list of this host's children lives in memory — it is the only writer of its own file, so there is
+ * nothing to read back — and every change is one small `writeFileSync`. Measured in the order of a
+ * millisecond, against a guarantee that is otherwise not a guarantee. (codex, the code round.)</p>
  */
 
 /** How long one verify-and-kill may take before this side gives up and keeps the record. */
 const COMMAND_MS = 8_000;
+
+/**
+ * How long the whole sweep may take.
+ *
+ * <p>One command per candidate, and a candidate exists only after a crash — so the ordinary sweep is
+ * empty and a bad one is two or three. A bound anyway: nothing that runs at activation should be
+ * able to run for minutes because a machine's PowerShell is unwell. What is left unasked stays in
+ * the file and is retried next time, which is the same answer as any other unresolved record.</p>
+ */
+const SWEEP_MS = 30_000;
+
+/** This host's own children, in memory. It is the only writer of its own file. */
+let mine: readonly ChildRecord[] = [];
 
 /** Where this extension host writes. Nobody else writes here; nobody else reads it while we live. */
 export function ledgerPath(storageDir: string, ownerPid = process.pid): string {
   return join(storageDir, ledgerName(ownerPid));
 }
 
-let queue: Promise<unknown> = Promise.resolve();
-
 /**
- * Run a read-modify-write with nothing else in it.
+ * Write a ledger file so that a crash cannot leave half of one.
  *
- * <p>`codex` starts a process per turn, so a busy conversation records and forgets often and two
- * overlapping read-modify-writes inside this process would lose one. Across processes the file name
- * does the same job. A failure is SAID rather than swallowed — a ledger that cannot be written means
- * a child that cannot be cleaned up, and that is worth a line in the host log even though it is not
- * worth failing a conversation over.</p>
+ * <p>A plain write truncates first, and a force-kill in that window leaves a file that parses to
+ * nothing — losing the very record it exists to keep. Written beside it and renamed over it instead;
+ * a rename within one directory is atomic on both filesystems this ships to. (codex, the code round.)</p>
  */
-function serialised(what: string, work: () => Promise<void>): Promise<void> {
-  const mine = queue.then(work).catch((reason: unknown) => {
-    console.warn(`[coai] the chat ledger could not be ${what}: ${reason instanceof Error ? reason.message : reason}`);
-  });
-  queue = mine;
-
-  return mine;
+function writeAtomically(path: string, text: string): void {
+  const beside = `${path}.${process.pid}.tmp`;
+  writeFileSync(beside, text, 'utf8');
+  renameSync(beside, path);
 }
 
-async function entriesIn(path: string): Promise<readonly ChildRecord[]> {
+/** Say what went wrong rather than swallow it: a ledger that cannot be written is a child nobody can clean up. */
+function saved(storageDir: string): void {
   try {
-    return parseLedger(await readFile(path, 'utf8'));
-  } catch {
-    // No file is the ordinary case: nothing has been started yet, or the last shutdown was clean.
-    return [];
+    mkdirSync(storageDir, { recursive: true });
+    writeAtomically(ledgerPath(storageDir), ledgerText(mine));
+  } catch (reason) {
+    console.warn(`[coai] the chat ledger could not be written: ${reason instanceof Error ? reason.message : reason}`);
   }
 }
 
-/** Write this child down, before it can be orphaned. */
-export function remember(storageDir: string, pid: number, executable: string, now = Date.now()): Promise<void> {
+/** Write this child down, before it can be orphaned. Synchronous, on purpose — see the note above. */
+export function remember(storageDir: string, pid: number, executable: string, now = Date.now()): void {
   if (pid <= 0 || storageDir.length === 0) {
-    return Promise.resolve();
+    return;
   }
-
-  return serialised('written', async () => {
-    await mkdir(storageDir, { recursive: true });
-    const path = ledgerPath(storageDir);
-    const entries = recorded(await entriesIn(path), { pid, image: imageOf(executable), startedMs: now });
-    await writeFile(path, ledgerText(entries), 'utf8');
-  });
+  mine = recorded(mine, { pid, image: imageOf(executable), startedMs: now });
+  saved(storageDir);
 }
 
 /** Strike it out. Called when the child ends, however it ends — an exit, an error, a kill. */
-export function forget(storageDir: string, pid: number): Promise<void> {
+export function forget(storageDir: string, pid: number): void {
   if (pid <= 0 || storageDir.length === 0) {
-    return Promise.resolve();
+    return;
   }
-
-  return serialised('struck out', async () => {
-    const path = ledgerPath(storageDir);
-    await writeFile(path, ledgerText(forgotten(await entriesIn(path), pid)), 'utf8');
-  });
+  mine = forgotten(mine, pid);
+  saved(storageDir);
 }
 
 /**
  * Is the process that wrote this ledger still running?
  *
- * <p>Signal 0 asks without sending anything. A pid that is alive belongs to another VS Code window
- * that is using its own children right now, and its file is not ours to read. A pid that has been
- * recycled onto something else reads as alive, and the answer is then to leave the file alone —
- * which loses a tidy-up and kills nothing, the direction this whole module errs in.</p>
+ * <p>Signal 0 asks without sending anything, and the ERROR is the answer: `ESRCH` means no such
+ * process, and anything else — `EPERM` most of all — means a process that exists and will not be
+ * inspected by us. Treating that as dead would be the one mistake this module cannot afford: it
+ * would read another window's ledger and kill the children it is using right now. So only `ESRCH`
+ * is death, and everything else is life. (gemini, the code round.)</p>
  */
 function ownerAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
 
     return true;
-  } catch {
-    return false;
+  } catch (reason) {
+    return (reason as NodeJS.ErrnoException).code !== 'ESRCH';
   }
 }
 
 /** One candidate: check the three facts and end its tree, inside a single command. */
 async function endIfOurs(record: ChildRecord): Promise<ReturnType<typeof killOutcome>> {
-  if (process.platform !== 'win32') {
-    // The verify-and-kill is PowerShell, and this feature's selection capture is Windows-only
-    // anyway. Nothing is claimed rather than guessed, so nothing is killed and the record is kept.
+  const command = verifyAndKill(record);
+  if (process.platform !== 'win32' || command.length === 0) {
+    // The verify-and-kill is PowerShell, and a record whose image could not appear in a command is
+    // one this side refuses to build one for. Nothing claimed, nothing killed, the record kept.
     return 'unknown';
   }
   const ran = await capture(
     'powershell.exe',
-    ['-NoProfile', '-NonInteractive', '-Command', verifyAndKill(record)],
+    ['-NoProfile', '-NonInteractive', '-Command', command],
     false,
     COMMAND_MS,
   );
@@ -128,14 +137,30 @@ async function endIfOurs(record: ChildRecord): Promise<ReturnType<typeof killOut
   return killOutcome(ran.code, ran.output);
 }
 
+/** Everything in this file is older than the bound — nothing in it can be asked about ever again. */
+async function longDead(path: string, entries: readonly ChildRecord[], now: number): Promise<boolean> {
+  if (entries.length === 0) {
+    try {
+      // An empty ledger from a dead window is finished business; one being written right now is not.
+      const age = now - (await stat(path)).mtimeMs;
+
+      return age > SWEEP_MS;
+    } catch {
+      return false;
+    }
+  }
+
+  return entries.every((record) => tooOld(record, now));
+}
+
 /**
  * Clean up after a crash: end what is still provably ours, and keep what nobody could ask about.
  *
- * <p>Called once at activation, and never awaited by it. In the ordinary case there is one file —
+ * <p>Called once at activation and never awaited by it. In the ordinary case there is one file —
  * this host's own, which is not read — and nothing else to do.</p>
  *
- * @returns what was ended — each one named, so a person who sees a line about it can tell WHICH
- *   process went. A count alone is the one thing nobody can act on. (local, the plan round.)
+ * @returns what was ended, each one named: a count is the one thing nobody can act on if it was
+ *   ever the wrong process. (local, the plan round.)
  */
 export async function reconcile(storageDir: string, now = Date.now()): Promise<readonly string[]> {
   if (storageDir.length === 0) {
@@ -144,43 +169,90 @@ export async function reconcile(storageDir: string, now = Date.now()): Promise<r
   let names: string[];
   try {
     names = await readdir(storageDir);
-  } catch {
+  } catch (reason) {
+    const code = (reason as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      // A directory that cannot be read is not the same as one with nothing in it, and the
+      // difference is a cleanup that silently never happens. (codex, the code round.)
+      console.warn(`[coai] the chat ledger directory could not be read: ${code ?? reason}`);
+    }
+
     return [];
   }
 
   const killed: string[] = [];
+  const until = now + SWEEP_MS;
   for (const name of names) {
     const owner = ownerOf(name);
+    const path = join(storageDir, name);
     // Not a ledger, our own, or one whose window is still using it. The last is the important one:
     // those children are alive on purpose.
-    if (owner === 0 || owner === process.pid || ownerAlive(owner)) {
+    if (owner === 0 || owner === process.pid) {
+      continue;
+    }
+    if (ownerAlive(owner)) {
+      // A pid the operating system has since handed to something long-lived would make this file
+      // invisible for ever. It cannot be acted on — but it can stop growing. (codex.)
+      await removeIfLongDead(path, now);
       continue;
     }
 
-    const path = join(storageDir, name);
-    const entries = await entriesIn(path);
-    const kept: ChildRecord[] = [];
-    for (const record of worthAsking(entries, now)) {
-      const outcome = await endIfOurs(record);
-      if (outcome === 'killed') {
-        killed.push(`${record.image} (pid ${record.pid}, started ${new Date(record.startedMs).toISOString()})`);
-      }
-      if (!settled(outcome)) {
-        // Nobody could tell. Kept and retried, because dropping it is how an orphan becomes
-        // permanent — a machine with no PowerShell would otherwise lose the record on the first
-        // activation after the crash. (codex, the plan round.)
-        kept.push(record);
-      }
-    }
-
-    await serialised('tidied', async () => {
-      if (kept.length === 0) {
-        await rm(path, { force: true });
-      } else {
-        await writeFile(path, ledgerText(kept), 'utf8');
-      }
-    });
+    await tidy(path, now, until, killed);
   }
 
   return killed;
+}
+
+/** One dead window's ledger: ask about what is worth asking about, keep what nobody could answer. */
+async function tidy(path: string, now: number, until: number, killed: string[]): Promise<void> {
+  let entries: readonly ChildRecord[];
+  try {
+    entries = parseLedger(readFileSync(path, 'utf8'));
+  } catch (reason) {
+    // Unreadable is NOT empty. Deleting it here would throw away the only record of a process this
+    // side could not reach — the exact outcome the ledger exists to prevent. (codex.)
+    console.warn(`[coai] a chat ledger could not be read: ${(reason as NodeJS.ErrnoException).code ?? reason}`);
+
+    return;
+  }
+
+  const kept: ChildRecord[] = [];
+  let asked = true;
+  for (const record of worthAsking(entries, now)) {
+    if (Date.now() > until) {
+      // Out of time. What was not asked stays, and is asked at the next activation.
+      asked = false;
+      kept.push(record);
+      continue;
+    }
+    const outcome = await endIfOurs(record);
+    if (outcome === 'killed') {
+      killed.push(`${record.image} (pid ${record.pid}, started ${new Date(record.startedMs).toISOString()})`);
+    }
+    if (!settled(outcome)) {
+      // Nobody could tell. Kept and retried, because dropping it is how an orphan becomes permanent.
+      kept.push(record);
+    }
+  }
+
+  try {
+    if (kept.length === 0 && asked) {
+      await rm(path, { force: true });
+    } else {
+      writeAtomically(path, ledgerText(kept));
+    }
+  } catch (reason) {
+    console.warn(`[coai] a chat ledger could not be tidied: ${reason instanceof Error ? reason.message : reason}`);
+  }
+}
+
+/** A file nobody will ever be able to act on, removed so it cannot accumulate. */
+async function removeIfLongDead(path: string, now: number): Promise<void> {
+  try {
+    if (await longDead(path, parseLedger(readFileSync(path, 'utf8')), now)) {
+      await rm(path, { force: true });
+    }
+  } catch {
+    // Unreadable, or gone already. Either way there is nothing to do and nothing to say.
+  }
 }

--- a/src_vs_code/src/chatOrphans.ts
+++ b/src_vs_code/src/chatOrphans.ts
@@ -1,45 +1,58 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   ChildRecord,
-  LivingProcess,
   forgotten,
   imageOf,
-  isOurs,
+  killOutcome,
+  ledgerName,
   ledgerText,
-  livingQuery,
+  ownerOf,
   parseLedger,
-  parseLiving,
   recorded,
+  settled,
+  verifyAndKill,
+  worthAsking,
 } from './chatLedger';
 import { capture } from './versionProbe';
-import { killByPid } from './processLauncher';
 
 /**
- * The ledger's world-facing half: the file, the question, and the kill.
+ * The ledger's world-facing half: the files, the command, and the log line.
  *
- * <p>Every rule about WHETHER to kill lives in `chatLedger.ts` and is tested there. This file does
- * the three things that need a machine — read and write one small file, ask the operating system who
- * holds a pid, and end a process — and holds no judgement of its own.</p>
+ * <p>Every rule about WHETHER a process may be killed lives in `chatLedger.ts` and is tested there.
+ * This file does the things that need a machine — read and write small files, run one command per
+ * candidate, say what happened — and holds no judgement of its own.</p>
  *
- * <p><b>Writes are serialised through one promise.</b> `codex` starts a process per turn, so a busy
- * conversation records and forgets often, and two overlapping read-modify-writes would lose one of
- * them. The chain costs nothing and removes the whole class.</p>
+ * <p><b>One file per extension host.</b> `globalStorageUri` is shared by every VS Code window, and a
+ * single shared file meant one window reading another window's LIVE children and killing them as
+ * orphans. The owner's pid is in the file name, a window only reads files whose owner is gone, and
+ * two windows never write the same file — which also removes the cross-process write race that no
+ * in-memory promise could have covered. (gemini and local, one plan round, three findings.)</p>
  */
 
-/** Where the ledger lives. One file per installation, beside everything else this extension keeps. */
-export function ledgerPath(storageDir: string): string {
-  return join(storageDir, 'chat-children.json');
-}
+/** How long one verify-and-kill may take before this side gives up and keeps the record. */
+const COMMAND_MS = 8_000;
 
-/** How long the process query may take before this side gives up and kills nothing. */
-const QUERY_MS = 5_000;
+/** Where this extension host writes. Nobody else writes here; nobody else reads it while we live. */
+export function ledgerPath(storageDir: string, ownerPid = process.pid): string {
+  return join(storageDir, ledgerName(ownerPid));
+}
 
 let queue: Promise<unknown> = Promise.resolve();
 
-/** Run a read-modify-write with nothing else in it. Never rejects: a ledger is not worth a crash. */
-function serialised(work: () => Promise<void>): Promise<void> {
-  const mine = queue.then(work).catch(() => undefined);
+/**
+ * Run a read-modify-write with nothing else in it.
+ *
+ * <p>`codex` starts a process per turn, so a busy conversation records and forgets often and two
+ * overlapping read-modify-writes inside this process would lose one. Across processes the file name
+ * does the same job. A failure is SAID rather than swallowed — a ledger that cannot be written means
+ * a child that cannot be cleaned up, and that is worth a line in the host log even though it is not
+ * worth failing a conversation over.</p>
+ */
+function serialised(what: string, work: () => Promise<void>): Promise<void> {
+  const mine = queue.then(work).catch((reason: unknown) => {
+    console.warn(`[coai] the chat ledger could not be ${what}: ${reason instanceof Error ? reason.message : reason}`);
+  });
   queue = mine;
 
   return mine;
@@ -56,11 +69,12 @@ async function entriesIn(path: string): Promise<readonly ChildRecord[]> {
 
 /** Write this child down, before it can be orphaned. */
 export function remember(storageDir: string, pid: number, executable: string, now = Date.now()): Promise<void> {
-  if (pid <= 0) {
+  if (pid <= 0 || storageDir.length === 0) {
     return Promise.resolve();
   }
 
-  return serialised(async () => {
+  return serialised('written', async () => {
+    await mkdir(storageDir, { recursive: true });
     const path = ledgerPath(storageDir);
     const entries = recorded(await entriesIn(path), { pid, image: imageOf(executable), startedMs: now });
     await writeFile(path, ledgerText(entries), 'utf8');
@@ -69,62 +83,104 @@ export function remember(storageDir: string, pid: number, executable: string, no
 
 /** Strike it out. Called when the child ends, however it ends — an exit, an error, a kill. */
 export function forget(storageDir: string, pid: number): Promise<void> {
-  if (pid <= 0) {
+  if (pid <= 0 || storageDir.length === 0) {
     return Promise.resolve();
   }
 
-  return serialised(async () => {
+  return serialised('struck out', async () => {
     const path = ledgerPath(storageDir);
     await writeFile(path, ledgerText(forgotten(await entriesIn(path), pid)), 'utf8');
   });
 }
 
-/** What the operating system says about a pid, or nothing when it will not say. */
-async function living(pid: number): Promise<LivingProcess | undefined> {
-  if (process.platform !== 'win32') {
-    // `ps -o comm=,lstart=` differs between BSD and GNU and this feature's copy helper is Windows
-    // only anyway. Nothing is claimed rather than guessed, so nothing is killed.
-    return undefined;
+/**
+ * Is the process that wrote this ledger still running?
+ *
+ * <p>Signal 0 asks without sending anything. A pid that is alive belongs to another VS Code window
+ * that is using its own children right now, and its file is not ours to read. A pid that has been
+ * recycled onto something else reads as alive, and the answer is then to leave the file alone —
+ * which loses a tidy-up and kills nothing, the direction this whole module errs in.</p>
+ */
+function ownerAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+
+    return true;
+  } catch {
+    return false;
   }
-  const asked = await capture(
+}
+
+/** One candidate: check the three facts and end its tree, inside a single command. */
+async function endIfOurs(record: ChildRecord): Promise<ReturnType<typeof killOutcome>> {
+  if (process.platform !== 'win32') {
+    // The verify-and-kill is PowerShell, and this feature's selection capture is Windows-only
+    // anyway. Nothing is claimed rather than guessed, so nothing is killed and the record is kept.
+    return 'unknown';
+  }
+  const ran = await capture(
     'powershell.exe',
-    ['-NoProfile', '-NonInteractive', '-Command', livingQuery(pid)],
+    ['-NoProfile', '-NonInteractive', '-Command', verifyAndKill(record)],
     false,
-    QUERY_MS,
+    COMMAND_MS,
   );
 
-  return asked.code === 0 ? parseLiving(asked.output) : undefined;
+  return killOutcome(ran.code, ran.output);
 }
 
 /**
- * Clean up after a crash: kill what is still ours, and forget the rest.
+ * Clean up after a crash: end what is still provably ours, and keep what nobody could ask about.
  *
- * <p>Called once at activation. In the ordinary case the ledger is empty — the previous shutdown
- * struck out every child — and this returns without asking the operating system anything.</p>
+ * <p>Called once at activation, and never awaited by it. In the ordinary case there is one file —
+ * this host's own, which is not read — and nothing else to do.</p>
  *
- * @returns how many processes were actually killed, for the caller to log
+ * @returns what was ended — each one named, so a person who sees a line about it can tell WHICH
+ *   process went. A count alone is the one thing nobody can act on. (local, the plan round.)
  */
-export async function reconcile(storageDir: string): Promise<number> {
-  const path = ledgerPath(storageDir);
-  const entries = await entriesIn(path);
-  if (entries.length === 0) {
-    return 0;
+export async function reconcile(storageDir: string, now = Date.now()): Promise<readonly string[]> {
+  if (storageDir.length === 0) {
+    return [];
+  }
+  let names: string[];
+  try {
+    names = await readdir(storageDir);
+  } catch {
+    return [];
   }
 
-  let killed = 0;
-  for (const record of entries) {
-    // Re-checked, every time, against the two facts the ledger kept. A pid alone would be a licence
-    // to kill whatever the operating system has since handed that number to.
-    if (isOurs(record, await living(record.pid))) {
-      killByPid(record.pid);
-      killed += 1;
+  const killed: string[] = [];
+  for (const name of names) {
+    const owner = ownerOf(name);
+    // Not a ledger, our own, or one whose window is still using it. The last is the important one:
+    // those children are alive on purpose.
+    if (owner === 0 || owner === process.pid || ownerAlive(owner)) {
+      continue;
     }
+
+    const path = join(storageDir, name);
+    const entries = await entriesIn(path);
+    const kept: ChildRecord[] = [];
+    for (const record of worthAsking(entries, now)) {
+      const outcome = await endIfOurs(record);
+      if (outcome === 'killed') {
+        killed.push(`${record.image} (pid ${record.pid}, started ${new Date(record.startedMs).toISOString()})`);
+      }
+      if (!settled(outcome)) {
+        // Nobody could tell. Kept and retried, because dropping it is how an orphan becomes
+        // permanent — a machine with no PowerShell would otherwise lose the record on the first
+        // activation after the crash. (codex, the plan round.)
+        kept.push(record);
+      }
+    }
+
+    await serialised('tidied', async () => {
+      if (kept.length === 0) {
+        await rm(path, { force: true });
+      } else {
+        await writeFile(path, ledgerText(kept), 'utf8');
+      }
+    });
   }
-  // Emptied whatever happened: an entry that could not be verified is an entry that will never be
-  // verified, and carrying it forward would ask the same unanswerable question at every activation.
-  await serialised(async () => {
-    await writeFile(path, ledgerText([]), 'utf8');
-  });
 
   return killed;
 }

--- a/src_vs_code/src/chatProcess.ts
+++ b/src_vs_code/src/chatProcess.ts
@@ -38,11 +38,12 @@ export function chatProcessFor(
       return child;
     }
 
-    // Written down BEFORE anything is asked of it, because the window this guards against is the
-    // whole of the child's life — including the first second of it.
-    void remember(storageDir, child.pid, spec.executable);
+    // Written down BEFORE anything is asked of it, and SYNCHRONOUSLY: the window this guards
+    // against is a force-kill, which is exactly what a queued write does not survive. A child
+    // launched and orphaned a millisecond later would otherwise never have been written down.
+    remember(storageDir, child.pid, spec.executable);
     const strike = (): void => {
-      void forget(storageDir, child.pid);
+      forget(storageDir, child.pid);
     };
     child.onExit(strike);
     child.onError(strike);

--- a/src_vs_code/src/chatProcess.ts
+++ b/src_vs_code/src/chatProcess.ts
@@ -1,6 +1,7 @@
 import { ProcessHandle, launch } from './processLauncher';
 import { Vendor } from './vendors';
 import { launchSpecFor } from './cliChatLaunch';
+import { forget, remember } from './chatOrphans';
 
 /**
  * How to start a turn for one vendor, as one function a session can hold.
@@ -10,6 +11,12 @@ import { launchSpecFor } from './cliChatLaunch';
  * The day a vendor needs an environment variable or a container, this is the only file that should
  * have to change. (gemini, the second code round.)</p>
  *
+ * <p><b>Every child is written down here, and struck out when it ends.</b> A chat is a vendor CLI
+ * signed in as the person; closing the tab kills it and disposing the extension kills them all, but
+ * neither runs when the editor is FORCE-killed. The ledger is what the next activation reads —
+ * `chatLedger.ts` decides what may be killed on the strength of it, and this is the one place that
+ * knows a child was born at all.</p>
+ *
  * <p><b>Its own module, and the reason is a test that failed.</b> The obvious home was
  * `cliChatLaunch.ts`, next to `launchSpecFor` — and putting it there made `bundledPage.test.ts` go
  * red with `require is not defined`. `chatModels` reads the runtime list from `cliChatLaunch` and
@@ -17,10 +24,29 @@ import { launchSpecFor } from './cliChatLaunch';
  * bundle and esbuild dutifully inlined a `require` into a webview. The guard exists for exactly
  * this, it caught it in one run, and the fix is a file the page's import graph never touches.</p>
  */
-export function chatProcessFor(vendor: Vendor, home: string, resolved: string): (resume: string) => ProcessHandle {
+export function chatProcessFor(
+  vendor: Vendor,
+  home: string,
+  resolved: string,
+  /** Where the ledger lives. Empty means no ledger — the tests, and nothing else. */
+  storageDir = '',
+): (resume: string) => ProcessHandle {
   return (resume) => {
     const spec = launchSpecFor(vendor, home, resume, resolved);
+    const child = launch(spec.executable, spec.args, { cwd: spec.cwd, shell: spec.shell });
+    if (storageDir.length === 0) {
+      return child;
+    }
 
-    return launch(spec.executable, spec.args, { cwd: spec.cwd, shell: spec.shell });
+    // Written down BEFORE anything is asked of it, because the window this guards against is the
+    // whole of the child's life — including the first second of it.
+    void remember(storageDir, child.pid, spec.executable);
+    const strike = (): void => {
+      void forget(storageDir, child.pid);
+    };
+    child.onExit(strike);
+    child.onError(strike);
+
+    return child;
   };
 }

--- a/src_vs_code/src/chatProcess.ts
+++ b/src_vs_code/src/chatProcess.ts
@@ -24,26 +24,18 @@ import { forget, remember } from './chatOrphans';
  * bundle and esbuild dutifully inlined a `require` into a webview. The guard exists for exactly
  * this, it caught it in one run, and the fix is a file the page's import graph never touches.</p>
  */
-export function chatProcessFor(
-  vendor: Vendor,
-  home: string,
-  resolved: string,
-  /** Where the ledger lives. Empty means no ledger — the tests, and nothing else. */
-  storageDir = '',
-): (resume: string) => ProcessHandle {
+export function chatProcessFor(vendor: Vendor, home: string, resolved: string): (resume: string) => ProcessHandle {
   return (resume) => {
     const spec = launchSpecFor(vendor, home, resume, resolved);
     const child = launch(spec.executable, spec.args, { cwd: spec.cwd, shell: spec.shell });
-    if (storageDir.length === 0) {
-      return child;
-    }
 
     // Written down BEFORE anything is asked of it, and SYNCHRONOUSLY: the window this guards
     // against is a force-kill, which is exactly what a queued write does not survive. A child
     // launched and orphaned a millisecond later would otherwise never have been written down.
-    remember(storageDir, child.pid, spec.executable);
+    // Where the ledger lives is not this function's business — it was bound once, at activation.
+    remember(child.pid, spec.executable);
     const strike = (): void => {
-      forget(storageDir, child.pid);
+      forget(child.pid);
     };
     child.onExit(strike);
     child.onError(strike);

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { ChatPanels } from './chatPanels';
 import { chatWithOtherAi } from './chatCommand';
+import { reconcile } from './chatOrphans';
 import { coaiDataDir } from './dataDir';
 import { installFailureHint, SingleFlight } from './coaiInstall';
 import { claudeSnippet, copiedMessage } from './claudeSnippet';
@@ -99,6 +100,15 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // One registry per window: a conversation belongs to a Claude Code tab, and tabs are per window.
   const chatPanels = new ChatPanels();
+  // What the LAST run left behind. Deactivation ends every chat child, and so does closing a tab —
+  // but neither runs when the editor is force-killed, and what survives that is a vendor CLI signed
+  // in as the person with nobody to stop it. Every candidate is re-identified before anything is
+  // killed; see `chatLedger.ts`, which is where that judgement lives.
+  void reconcile(context.globalStorageUri.fsPath).then((killed) => {
+    if (killed > 0) {
+      console.warn(`[coai] ended ${killed} chat process(es) left by a previous session`);
+    }
+  });
 
   context.subscriptions.push(
     {
@@ -123,7 +133,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // 'Chat with other AI' item in Claude Code's own right-click menu — and the command tells them
     // apart by what VS Code hands it, because only one of them can copy the selection itself.
     vscode.commands.registerCommand('coai.chatWithOtherAi', (...args: unknown[]) => {
-      void chatWithOtherAi(chatPanels, args);
+      void chatWithOtherAi(chatPanels, args, context.globalStorageUri.fsPath);
     }),
     // Deactivation is not a tab closing: nobody has told VS Code about these panels, so both the
     // panel and the vendor process behind it have to be ended here or they outlive the extension.

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { ChatPanels } from './chatPanels';
 import { chatWithOtherAi } from './chatCommand';
-import { reconcile } from './chatOrphans';
+import { openLedger, reconcile } from './chatOrphans';
 import { coaiDataDir } from './dataDir';
 import { installFailureHint, SingleFlight } from './coaiInstall';
 import { claudeSnippet, copiedMessage } from './claudeSnippet';
@@ -100,6 +100,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // One registry per window: a conversation belongs to a Claude Code tab, and tabs are per window.
   const chatPanels = new ChatPanels();
+  // Bound once, and never asked for again: an extension host has one storage directory for its
+  // whole life, and threading it through six functions paired a per-call path with a module-level
+  // list of children — two things that must agree, with nothing making them.
+  openLedger(context.globalStorageUri.fsPath);
   // What the LAST run left behind. Deactivation ends every chat child, and so does closing a tab —
   // but neither runs when the editor is force-killed, and what survives that is a vendor CLI signed
   // in as the person with nobody to stop it. Every candidate is re-identified before anything is
@@ -141,7 +145,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // 'Chat with other AI' item in Claude Code's own right-click menu — and the command tells them
     // apart by what VS Code hands it, because only one of them can copy the selection itself.
     vscode.commands.registerCommand('coai.chatWithOtherAi', (...args: unknown[]) => {
-      void chatWithOtherAi(chatPanels, args, context.globalStorageUri.fsPath);
+      void chatWithOtherAi(chatPanels, args);
     }),
     // Deactivation is not a tab closing: nobody has told VS Code about these panels, so both the
     // panel and the vendor process behind it have to be ended here or they outlive the extension.

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -104,9 +104,11 @@ export function activate(context: vscode.ExtensionContext): void {
   // but neither runs when the editor is force-killed, and what survives that is a vendor CLI signed
   // in as the person with nobody to stop it. Every candidate is re-identified before anything is
   // killed; see `chatLedger.ts`, which is where that judgement lives.
-  void reconcile(context.globalStorageUri.fsPath).then((killed) => {
-    if (killed > 0) {
-      console.warn(`[coai] ended ${killed} chat process(es) left by a previous session`);
+  void reconcile(context.globalStorageUri.fsPath).then((ended) => {
+    for (const one of ended) {
+      // Named rather than counted: a line saying "ended 1 process" is the one thing nobody can act
+      // on if it was ever the wrong one.
+      console.warn(`[coai] ended a chat process left by a previous session: ${one}`);
     }
   });
 

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -104,13 +104,19 @@ export function activate(context: vscode.ExtensionContext): void {
   // but neither runs when the editor is force-killed, and what survives that is a vendor CLI signed
   // in as the person with nobody to stop it. Every candidate is re-identified before anything is
   // killed; see `chatLedger.ts`, which is where that judgement lives.
-  void reconcile(context.globalStorageUri.fsPath).then((ended) => {
-    for (const one of ended) {
-      // Named rather than counted: a line saying "ended 1 process" is the one thing nobody can act
-      // on if it was ever the wrong one.
-      console.warn(`[coai] ended a chat process left by a previous session: ${one}`);
-    }
-  });
+  void reconcile(context.globalStorageUri.fsPath)
+    .then((ended) => {
+      for (const one of ended) {
+        // Named rather than counted: a line saying "ended 1 process" is the one thing nobody can act
+        // on if it was ever the wrong one.
+        console.warn(`[coai] ended a chat process left by a previous session: ${one}`);
+      }
+    })
+    // The outer edge of a detached call ends in a catch that says something — `reliability.md`, and
+    // an unhandled rejection during activation is a defect this repository has already paid for.
+    .catch((reason: unknown) => {
+      console.warn(`[coai] the chat orphan sweep failed: ${reason instanceof Error ? reason.message : reason}`);
+    });
 
   context.subscriptions.push(
     {

--- a/src_vs_code/src/processLauncher.ts
+++ b/src_vs_code/src/processLauncher.ts
@@ -44,6 +44,15 @@ export interface LaunchOptions {
 }
 
 export interface ProcessHandle {
+  /**
+   * The child's process id, or 0 when it never started.
+   *
+   * <p>For the LEDGER, and for nothing else here: a chat child is written down as it starts so a
+   * force-killed editor cannot leave an authenticated CLI running. Killing by this number is only
+   * safe against a process whose identity has been re-checked — see `chatLedger.ts`, and the note
+   * on `killTree` below for why the launcher itself never does it.</p>
+   */
+  readonly pid: number;
   /** Write one line (a newline is appended). `false` when the pipe is already gone. */
   writeLine(line: string): boolean;
   /**
@@ -122,6 +131,7 @@ export function launch(target: string, args: readonly string[], options: LaunchO
  */
 function failedHandle(reason: string): ProcessHandle {
   return {
+    pid: 0,
     writeLine: () => false,
     writeAndEnd: () => false,
     onStdout: () => () => undefined,
@@ -275,6 +285,7 @@ function liveHandle(child: ReturnType<typeof spawn>, shell: boolean): ProcessHan
   });
 
   return {
+    pid: child.pid ?? 0,
     writeLine: (line) => writeLine(child, line),
     writeAndEnd: (text) => writeAndEnd(child, text),
     onStdout: stdout.on,
@@ -323,6 +334,31 @@ function writeLine(child: ReturnType<typeof spawn>, line: string): boolean {
     // learns the turn failed from `onExit`/`onError`, which is where it can say so.
     return false;
   }
+}
+
+/**
+ * Kill a process by NUMBER, for a caller that has proved the number is still theirs.
+ *
+ * <p>Everything else in this file kills through `child.kill()` for the reason stated below: a pid is
+ * not an identity, and Windows hands used numbers out again. There is exactly one case where a
+ * handle does not exist — a child recorded before the editor was force-killed, found again at the
+ * next activation — and `chatLedger.ts` is what makes it safe: the image and the start time must
+ * both still match before this is called. Nothing here re-checks that, so nothing else may call it.</p>
+ */
+export function killByPid(pid: number): void {
+  if (pid <= 0) {
+    return;
+  }
+  if (process.platform !== 'win32') {
+    try {
+      process.kill(pid);
+    } catch {
+      // Gone between the check and the kill is the outcome we wanted anyway.
+    }
+
+    return;
+  }
+  spawnTaskkill(pid);
 }
 
 /**

--- a/src_vs_code/src/processLauncher.ts
+++ b/src_vs_code/src/processLauncher.ts
@@ -337,31 +337,6 @@ function writeLine(child: ReturnType<typeof spawn>, line: string): boolean {
 }
 
 /**
- * Kill a process by NUMBER, for a caller that has proved the number is still theirs.
- *
- * <p>Everything else in this file kills through `child.kill()` for the reason stated below: a pid is
- * not an identity, and Windows hands used numbers out again. There is exactly one case where a
- * handle does not exist — a child recorded before the editor was force-killed, found again at the
- * next activation — and `chatLedger.ts` is what makes it safe: the image and the start time must
- * both still match before this is called. Nothing here re-checks that, so nothing else may call it.</p>
- */
-export function killByPid(pid: number): void {
-  if (pid <= 0) {
-    return;
-  }
-  if (process.platform !== 'win32') {
-    try {
-      process.kill(pid);
-    } catch {
-      // Gone between the check and the kill is the outcome we wanted anyway.
-    }
-
-    return;
-  }
-  spawnTaskkill(pid);
-}
-
-/**
  * Kill what we started — the whole tree when a shell is between us and the real process.
  *
  * <p><b>`child.kill()`, never `process.kill(pid)`</b>: a probe that exits in the same tick the timer

--- a/src_vs_code/src/test/chatLedger.test.ts
+++ b/src_vs_code/src/test/chatLedger.test.ts
@@ -2,23 +2,29 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
   ChildRecord,
+  FORGET_AFTER_MS,
   NEAR_ENOUGH_MS,
   forgotten,
   imageOf,
-  isOurs,
+  killOutcome,
+  ledgerName,
   ledgerText,
-  livingQuery,
+  ownerOf,
   parseLedger,
-  parseLiving,
   recorded,
+  safeImage,
+  settled,
+  tooOld,
+  verifyAndKill,
+  worthAsking,
 } from '../chatLedger';
 
 /**
  * The ledger that stops a force-killed editor from leaving an authenticated CLI running.
  *
- * <p>Every rule here is about the ONE dangerous thing this feature does: kill a process by a number
- * written down earlier. The launcher's own comment says why that is dangerous — Windows reuses pids
- * — and these are the tests that make it safe.</p>
+ * <p>Every rule here is about the ONE dangerous thing this feature does: end a process that a file
+ * says was ours. The launcher's own comment explains why that is dangerous — a pid is not an
+ * identity and Windows hands used numbers out again — and these are the tests that make it safe.</p>
  */
 
 const ours: ChildRecord = { pid: 4242, image: 'agy.exe', startedMs: 1_700_000_000_000 };
@@ -39,33 +45,41 @@ test('forgetting a pid nobody recorded changes nothing', () => {
   assert.deepStrictEqual([...forgotten([ours], 999)], [ours]);
 });
 
-test('a pid nothing holds is already gone, and is not killed', () => {
-  assert.strictEqual(isOurs(ours, undefined), false);
+test('the ledger is named after the window that owns it, and reads back the same way', () => {
+  // `globalStorageUri` is shared by every VS Code window. One file would mean one window's
+  // activation reading another window's LIVE children — and killing them, because they really are
+  // this extension's. A person with two windows would have watched a working conversation die.
+  assert.strictEqual(ledgerName(9182), 'chat-children-9182.json');
+  assert.strictEqual(ownerOf('chat-children-9182.json'), 9182);
 });
 
-test('a pid held by ANOTHER program is a recycled number, and is left alone', () => {
-  // The whole reason this module exists. Killing it would be worse than the orphan it was meant to
-  // clean up: the number belongs to whatever the operating system handed it to next.
-  assert.strictEqual(isOurs(ours, { image: 'chrome.exe', createdMs: ours.startedMs }), false);
+test('a file that is not one of ours has no owner, so nothing reads it', () => {
+  for (const stranger of ['settings.json', 'chat-children.json', 'chat-children-.json', 'chat-children-x.json', '']) {
+    assert.strictEqual(ownerOf(stranger), 0, `it claimed ownership of: ${stranger}`);
+  }
 });
 
-test('the same program started at ANOTHER time is somebody else’s run of it', () => {
-  // This is the case that would hurt most: a person's own `agy`, running their own work, killed by
-  // an extension tidying up after a crash it had nothing to do with.
-  assert.strictEqual(
-    isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs + NEAR_ENOUGH_MS + 1 }),
-    false,
-  );
-  assert.strictEqual(
-    isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs - NEAR_ENOUGH_MS - 1 }),
-    false,
-  );
+test('a record too old to mean anything is not asked about at all', () => {
+  // Past a week the number means nothing on any machine that has rebooted, and a file nobody can
+  // resolve would otherwise grow for ever.
+  const now = ours.startedMs + FORGET_AFTER_MS + 1;
+
+  assert.strictEqual(tooOld(ours, now), true);
+  assert.strictEqual(tooOld(ours, ours.startedMs + FORGET_AFTER_MS - 1), false);
+  assert.deepStrictEqual([...worthAsking([ours], now)], []);
+  assert.deepStrictEqual([...worthAsking([ours], ours.startedMs + 1000)], [ours]);
 });
 
-test('the same program at the same moment is ours, within a tolerance for two clocks', () => {
-  assert.strictEqual(isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs }), true);
-  assert.strictEqual(isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs + 900 }), true);
-  assert.strictEqual(isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs - 900 }), true);
+test('an image name that could not appear in a command is never put in one', () => {
+  // It comes from a reviewer's `executablePath`, which is a person's own text, and the
+  // verify-and-kill command carries it. A file name has no business holding a quote.
+  for (const bad of ["agy'.exe", 'agy" ; calc', 'a b.exe', 'agy$x', '', '..', "'"]) {
+    assert.strictEqual(safeImage(bad), false, `it would have put this in a script: ${bad}`);
+  }
+  for (const fine of ['agy.exe', 'codex.cmd', 'claude', 'node-22.exe', 'a_b+c.exe']) {
+    assert.strictEqual(safeImage(fine), true, `it refused an ordinary name: ${fine}`);
+  }
+  assert.deepStrictEqual([...worthAsking([{ ...ours, image: "a'b" }], ours.startedMs)], []);
 });
 
 test('an image name is compared as the operating system reports it, whatever path it came from', () => {
@@ -73,6 +87,40 @@ test('an image name is compared as the operating system reports it, whatever pat
   assert.strictEqual(imageOf('/usr/local/bin/claude'), 'claude');
   assert.strictEqual(imageOf('codex.cmd'), 'codex.cmd');
   assert.strictEqual(imageOf(''), '');
+});
+
+test('the command checks all three facts and ends a TREE, in one invocation', () => {
+  // One invocation, because a query followed by a kill is a window in which the verified process can
+  // exit and its number be handed on — and small windows around killing are the thing this module
+  // exists to close. A tree, because a Windows shim is `cmd.exe` running the real program.
+  const command = verifyAndKill(ours);
+
+  assert.match(command, /ProcessId=4242/, 'the pid is not in the query');
+  assert.match(command, /\$p\.Name -eq 'agy\.exe'/, 'the image is not compared');
+  assert.match(command, new RegExp(`Abs\\(\\$started - ${ours.startedMs}\\)`), 'the start time is not compared');
+  assert.match(command, new RegExp(`-le ${NEAR_ENOUGH_MS}`), 'the tolerance is not the documented one');
+  assert.match(command, /taskkill \/pid 4242 \/t \/f/, 'only the top process would be ended');
+  assert.match(command, /Get-CimInstance/, 'Get-Process reports a name with no extension');
+  // The epoch conversion happens in PowerShell, so no date format, locale or time zone crosses over.
+  assert.match(command, /TotalMilliseconds/);
+});
+
+test('the command says which of the three things it did', () => {
+  assert.strictEqual(killOutcome(0, 'killed\r\n'), 'killed');
+  assert.strictEqual(killOutcome(0, 'not ours'), 'not ours');
+  assert.strictEqual(killOutcome(0, 'gone'), 'gone');
+});
+
+test('anything else is unknown — and unknown kills nothing and KEEPS the record', () => {
+  // The direction this whole module errs in. An entry nobody could ask about is retried at the next
+  // activation, because dropping it is how an orphan becomes permanent.
+  for (const [code, said] of [[1, 'killed'], [0, ''], [0, 'Get-CimInstance : access denied'], [0, 'huh']] as const) {
+    assert.strictEqual(killOutcome(code, said), 'unknown', `it read a verdict out of: ${code} / ${said}`);
+  }
+  assert.strictEqual(settled('unknown'), false);
+  for (const outcome of ['killed', 'not ours', 'gone'] as const) {
+    assert.strictEqual(settled(outcome), true);
+  }
 });
 
 test('a ledger a force-kill left half-written is no ledger, not a crash at activation', () => {
@@ -104,24 +152,4 @@ test('what is written is what comes back', () => {
     [...parseLedger(ledgerText(entries))],
     [ours, { pid: 77, image: 'claude.exe', startedMs: 5 }],
   );
-});
-
-test('the question asked of Windows names the pid and returns two facts', () => {
-  const query = livingQuery(4242);
-
-  assert.match(query, /ProcessId=4242/);
-  assert.match(query, /Get-CimInstance/, 'Get-Process reports a name with no extension');
-  assert.match(query, /CreationDate/, 'without the start time a recycled pid is indistinguishable');
-});
-
-test('the answer is read as two facts, and anything else is no answer at all', () => {
-  // Measured on this machine, from the real query: `pwsh.exe|1788944157495`.
-  assert.deepStrictEqual(parseLiving('pwsh.exe|1788944157495'), { image: 'pwsh.exe', createdMs: 1788944157495 });
-  assert.deepStrictEqual(parseLiving('  AGY.EXE|1788944157495  \n'), { image: 'agy.exe', createdMs: 1788944157495 });
-
-  // Every unhappy shape means the same thing: this side cannot prove the pid is ours, so nothing is
-  // killed. A guard that failed OPEN would kill strangers.
-  for (const nothing of ['', 'agy.exe', '|123', 'agy.exe|', 'agy.exe|soon', 'agy.exe|0', 'Get-CimInstance : failed']) {
-    assert.strictEqual(parseLiving(nothing), undefined, `it read a process out of: ${nothing}`);
-  }
 });

--- a/src_vs_code/src/test/chatLedger.test.ts
+++ b/src_vs_code/src/test/chatLedger.test.ts
@@ -153,3 +153,18 @@ test('what is written is what comes back', () => {
     [ours, { pid: 77, image: 'claude.exe', startedMs: 5 }],
   );
 });
+
+test('a taskkill that was REFUSED is not a kill, and keeps the record', () => {
+  // It used to print "killed" whatever taskkill did, so an access-denied refusal struck out the
+  // record and left the process running — the exact outcome this module exists to prevent.
+  assert.match(verifyAndKill(ours), /LASTEXITCODE/, 'the kill reports success without checking it');
+  assert.strictEqual(killOutcome(0, 'refused'), 'unknown');
+  assert.strictEqual(settled(killOutcome(0, 'refused')), false, 'a refused kill struck out its record');
+});
+
+test('an image this side would not put in a command produces NO command', () => {
+  // `worthAsking` filters these earlier. Saying it here too means the guarantee does not have to be
+  // reconstructed from another function by whoever reads this one.
+  assert.strictEqual(verifyAndKill({ ...ours, image: "agy'; calc; '.exe" }), '');
+  assert.notStrictEqual(verifyAndKill(ours), '');
+});

--- a/src_vs_code/src/test/chatLedger.test.ts
+++ b/src_vs_code/src/test/chatLedger.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  ChildRecord,
+  NEAR_ENOUGH_MS,
+  forgotten,
+  imageOf,
+  isOurs,
+  ledgerText,
+  livingQuery,
+  parseLedger,
+  parseLiving,
+  recorded,
+} from '../chatLedger';
+
+/**
+ * The ledger that stops a force-killed editor from leaving an authenticated CLI running.
+ *
+ * <p>Every rule here is about the ONE dangerous thing this feature does: kill a process by a number
+ * written down earlier. The launcher's own comment says why that is dangerous — Windows reuses pids
+ * — and these are the tests that make it safe.</p>
+ */
+
+const ours: ChildRecord = { pid: 4242, image: 'agy.exe', startedMs: 1_700_000_000_000 };
+
+test('a child is written down, and struck out when it ends', () => {
+  const one = recorded([], ours);
+  assert.deepStrictEqual([...one], [ours]);
+  assert.deepStrictEqual([...forgotten(one, 4242)], []);
+});
+
+test('a pid that comes round again replaces its old row rather than doubling it', () => {
+  const later: ChildRecord = { pid: 4242, image: 'codex.cmd', startedMs: 1_700_000_900_000 };
+
+  assert.deepStrictEqual([...recorded([ours], later)], [later]);
+});
+
+test('forgetting a pid nobody recorded changes nothing', () => {
+  assert.deepStrictEqual([...forgotten([ours], 999)], [ours]);
+});
+
+test('a pid nothing holds is already gone, and is not killed', () => {
+  assert.strictEqual(isOurs(ours, undefined), false);
+});
+
+test('a pid held by ANOTHER program is a recycled number, and is left alone', () => {
+  // The whole reason this module exists. Killing it would be worse than the orphan it was meant to
+  // clean up: the number belongs to whatever the operating system handed it to next.
+  assert.strictEqual(isOurs(ours, { image: 'chrome.exe', createdMs: ours.startedMs }), false);
+});
+
+test('the same program started at ANOTHER time is somebody else’s run of it', () => {
+  // This is the case that would hurt most: a person's own `agy`, running their own work, killed by
+  // an extension tidying up after a crash it had nothing to do with.
+  assert.strictEqual(
+    isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs + NEAR_ENOUGH_MS + 1 }),
+    false,
+  );
+  assert.strictEqual(
+    isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs - NEAR_ENOUGH_MS - 1 }),
+    false,
+  );
+});
+
+test('the same program at the same moment is ours, within a tolerance for two clocks', () => {
+  assert.strictEqual(isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs }), true);
+  assert.strictEqual(isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs + 900 }), true);
+  assert.strictEqual(isOurs(ours, { image: 'agy.exe', createdMs: ours.startedMs - 900 }), true);
+});
+
+test('an image name is compared as the operating system reports it, whatever path it came from', () => {
+  assert.strictEqual(imageOf('C:\\Users\\somebody\\AppData\\Local\\agy\\bin\\AGY.EXE'), 'agy.exe');
+  assert.strictEqual(imageOf('/usr/local/bin/claude'), 'claude');
+  assert.strictEqual(imageOf('codex.cmd'), 'codex.cmd');
+  assert.strictEqual(imageOf(''), '');
+});
+
+test('a ledger a force-kill left half-written is no ledger, not a crash at activation', () => {
+  // This file is read while the extension is starting. A half-written line is exactly the shape the
+  // failure it exists for leaves behind, and it must cost at most one missed tidy-up.
+  for (const junk of ['', '[{"pid":42', 'null', '"a string"', '{}', '[1,2,3]']) {
+    assert.deepStrictEqual([...parseLedger(junk)], [], `it read something out of: ${junk}`);
+  }
+});
+
+test('a row missing any of the three facts is not a row worth killing on', () => {
+  const text = JSON.stringify([
+    { pid: 0, image: 'agy.exe', startedMs: 1 },
+    { pid: -3, image: 'agy.exe', startedMs: 1 },
+    { pid: 1.5, image: 'agy.exe', startedMs: 1 },
+    { pid: 7, image: '', startedMs: 1 },
+    { pid: 8, image: 'agy.exe' },
+    { pid: 9, image: 'agy.exe', startedMs: 'soon' },
+    ours,
+  ]);
+
+  assert.deepStrictEqual([...parseLedger(text)], [ours]);
+});
+
+test('what is written is what comes back', () => {
+  const entries = recorded(recorded([], ours), { pid: 77, image: 'CLAUDE.EXE', startedMs: 5 });
+
+  assert.deepStrictEqual(
+    [...parseLedger(ledgerText(entries))],
+    [ours, { pid: 77, image: 'claude.exe', startedMs: 5 }],
+  );
+});
+
+test('the question asked of Windows names the pid and returns two facts', () => {
+  const query = livingQuery(4242);
+
+  assert.match(query, /ProcessId=4242/);
+  assert.match(query, /Get-CimInstance/, 'Get-Process reports a name with no extension');
+  assert.match(query, /CreationDate/, 'without the start time a recycled pid is indistinguishable');
+});
+
+test('the answer is read as two facts, and anything else is no answer at all', () => {
+  // Measured on this machine, from the real query: `pwsh.exe|1788944157495`.
+  assert.deepStrictEqual(parseLiving('pwsh.exe|1788944157495'), { image: 'pwsh.exe', createdMs: 1788944157495 });
+  assert.deepStrictEqual(parseLiving('  AGY.EXE|1788944157495  \n'), { image: 'agy.exe', createdMs: 1788944157495 });
+
+  // Every unhappy shape means the same thing: this side cannot prove the pid is ours, so nothing is
+  // killed. A guard that failed OPEN would kill strangers.
+  for (const nothing of ['', 'agy.exe', '|123', 'agy.exe|', 'agy.exe|soon', 'agy.exe|0', 'Get-CimInstance : failed']) {
+    assert.strictEqual(parseLiving(nothing), undefined, `it read a process out of: ${nothing}`);
+  }
+});

--- a/src_vs_code/src/test/cliChatSession.test.ts
+++ b/src_vs_code/src/test/cliChatSession.test.ts
@@ -62,6 +62,7 @@ function fakeChild(): FakeChild {
 
   return {
     handle: {
+      pid: 1234,
       writeAndEnd: (text: string) => {
       written.push(text);
 

--- a/src_vs_code/src/test/perTurnSession.test.ts
+++ b/src_vs_code/src/test/perTurnSession.test.ts
@@ -62,6 +62,7 @@ function perTurnLauncher(): { start: (resume: string) => ProcessHandle; turns: F
     const turn: { resume: string; prompt: string } = { resume, prompt: '' };
 
     const handle: ProcessHandle = {
+      pid: 4242,
       // Both, because this launcher drives both shapes: a per-turn child is written to and CLOSED,
       // a persistent one is written a line at a time down a pipe that stays open.
       writeLine: (line: string) => {

--- a/todo/PLAN_chat_with_other_ais.md
+++ b/todo/PLAN_chat_with_other_ais.md
@@ -401,10 +401,15 @@ costs a few hundred bytes, and a file deleted too early costs a process nobody c
 - [ ] Follow-up questions are answered in the same conversation without re-sending the passage on the
       local path, and correctly with a bounded transcript on the remote one.
 - [x] **Closing a tab kills its process; a process that dies is reported and re-created; VS Code
-      being force-killed leaves no orphan behind.** The last of those is the ledger: every child is
-      written down as it starts and struck out as it ends, and the next activation kills what is
-      still provably ours — the pid, the image and the start time must all match, because a pid
-      alone would be a licence to kill whatever the operating system handed that number to next.
+      being force-killed leaves no orphan behind — ON WINDOWS, WHERE THE MACHINE CAN BE ASKED.**
+      Every child is written down as it starts and struck out as it ends, and the next activation
+      ends what is still provably ours: the pid, the image and the start time must all match,
+      because a pid alone would be a licence to kill whatever the operating system handed that
+      number to next. **Two cases it deliberately does not cover**, because the alternative is
+      killing strangers: an activation that cannot run PowerShell keeps the record and retries
+      rather than guessing, and an owner pid the operating system has recycled onto a long-lived
+      process makes its file unreadable — bounded by removing it after a week, and by the reboot
+      that would end the orphan anyway. Named here rather than left to be discovered.
 - [ ] A turn cannot start while another is running.
 - [ ] `coai.chatAutoSend` decides who sends: at the default the keybinding sends and the menu waits
       with the composer filled and focused, and both other values behave as the table says. The

--- a/todo/PLAN_chat_with_other_ais.md
+++ b/todo/PLAN_chat_with_other_ais.md
@@ -384,8 +384,11 @@ record the observed timings beside the ones measured above.
 - [ ] Two sessions **sharing a label** get two panels, and a follow-up never lands in the other one.
 - [ ] Follow-up questions are answered in the same conversation without re-sending the passage on the
       local path, and correctly with a bounded transcript on the remote one.
-- [ ] Closing a tab kills its process; a process that dies is reported and re-created; VS Code being
-      force-killed leaves no orphan behind.
+- [x] **Closing a tab kills its process; a process that dies is reported and re-created; VS Code
+      being force-killed leaves no orphan behind.** The last of those is the ledger: every child is
+      written down as it starts and struck out as it ends, and the next activation kills what is
+      still provably ours — the pid, the image and the start time must all match, because a pid
+      alone would be a licence to kill whatever the operating system handed that number to next.
 - [ ] A turn cannot start while another is running.
 - [ ] `coai.chatAutoSend` decides who sends: at the default the keybinding sends and the menu waits
       with the composer filled and focused, and both other values behave as the table says. The

--- a/todo/PLAN_chat_with_other_ais.md
+++ b/todo/PLAN_chat_with_other_ais.md
@@ -341,6 +341,22 @@ selection, watch a real answer land in the panel over BOTH paths (a local CLI mo
 Team-server model), kill the CLI process by hand mid-conversation and watch the panel recover, and
 record the observed timings beside the ones measured above.
 
+## What grows, and who retires it
+
+The orphan ledger writes files, which makes it a growth surface — and the rule is that a plan
+introducing one names its size, its owner and what an interruption leaves behind, before the first
+write. It was written first and the section second; the gate was right to ask.
+
+| What | How big | Who retires it | Interrupted |
+|---|---|---|---|
+| One ledger file per extension HOST, under `globalStorageUri` | A few hundred bytes: one row per live chat child, and a conversation has one at a time. A window with three chats open holds three rows | The owning window, on every change — the file is rewritten from memory as children start and end, and holds `[]` when nothing is running | A force-kill leaves the file with its rows. The next activation of ANY window reads it, ends what is still provably that window's, and deletes the file |
+| Files belonging to windows that are gone | One per force-kill that is never followed by another activation. In practice zero or one | The next activation, which removes the file once every row is settled | A sweep that runs out of its 30-second budget leaves the unasked rows in place and is retried at the next activation |
+| Rows nobody could resolve | Bounded by a week (`FORGET_AFTER_MS`), after which they are not asked about at all | The same sweep | A machine with no PowerShell keeps its rows and retries for a week, then stops asking. It kills nothing in the meantime |
+| A file whose owner pid was recycled onto a long-lived process | Would be invisible for ever, so it is removed once everything in it is past the week bound | The sweep, without asking about anything in it | Nothing: it is a delete, and a delete that fails is retried next time |
+
+Nothing here is unbounded, and the failure direction is always the same one: a file kept too long
+costs a few hundred bytes, and a file deleted too early costs a process nobody can find.
+
 ## Risks and open questions
 
 1. ~~**`Tab` object identity is an assumption about the host.**~~ **Measured 2026-09-08 and it


### PR DESCRIPTION
Story 1.4 of [todo/PLAN_chat_with_other_ais.md](todo/PLAN_chat_with_other_ais.md) — the last line of its Definition of Done that nothing else covered.

A chat is a vendor CLI **signed in as the person**, living as long as its tab. Closing the tab kills it; deactivating the extension kills them all. **Neither runs when VS Code is force-killed** — the Task Manager, a battery that goes, an installer that restarts the machine — and what survives is a process nobody can see and nobody will stop. `codex` widens the window: it starts a process per turn.

## The design

Every child is written down as it starts and struck out as it ends; the next activation reads what is left. `chatLedger.ts` is pure and holds every rule; `chatOrphans.ts` does the files and the command; `extension.ts` sweeps once, without awaiting.

**Killing by pid is the dangerous part, and this exists to make it safe.** `processLauncher.ts` has said since it was written that a pid is not an identity — Windows hands used numbers out again. A record is **three facts** — the pid, the image, and WHEN it started — compared and acted on **inside one PowerShell invocation**, because a query followed by a kill is a window in which the verified process can exit and its number be handed on.

**The case that decides the design is not the orphan.** It is somebody's own `claude`, on a number this extension wrote down an hour ago. Killing that would be far worse than the orphan it was tidying up. Every unhappy answer kills nothing, and an unresolved record is kept and retried rather than dropped.

## What the gate changed, in three rounds

**Plan round** — the defect that mattered was mine: **`globalStorageUri` is shared by every VS Code window**, so a single ledger file meant one window's activation reading another window's LIVE children and killing them. Every identity check would have passed, because they really are this extension's. A person with two windows would have watched a working conversation die when they opened the second. The owner's pid is now in the file NAME.

**Code round 1** — **the record is written synchronously.** It was queued and asynchronous, and the window this whole feature guards against is a force-kill, which is exactly what a queued write does not survive. Also: a refused `taskkill` used to be reported as a kill (striking out the record and leaving the process running); ledger files are written beside and renamed over, because a plain write truncates first; only `ESRCH` counts as death, since `EPERM` means a process that exists and would have been read as dead; an unreadable ledger is no longer deleted as though empty; the sweep is bounded; `killByPid` is gone.

It also caught a process error before CI did: the branch was stale, so its diff downgraded the extension from 0.31.13 to 0.31.12 and deleted that release's changelog entry.

**Code round 2** (`good_enough`) — the ledger's home is bound once at activation instead of travelling through six functions, and the plan's checkbox now says what the implementation actually guarantees rather than more.

## Test plan

- [x] `npm test` — **955 tests, 954 pass, 0 fail, 1 pre-existing skip**; seventeen of them new, over the rules that decide what may be killed.
- [x] **Live**, because no unit test can prove a query or a kill — three real processes and three ledger files: the orphan of a force-killed window **ENDED**, a stranger of the same image recorded an hour off **LEFT ALONE**, another window's live child **LEFT ALONE** with its file not even read, the dead window's file removed and the live one untouched.
- [x] Watched fail first: a refused `taskkill` reported as a kill, and an unsafe image reaching a command.

## What it deliberately does not cover

Named in the plan rather than left to be discovered: an activation that cannot run PowerShell keeps the record and retries rather than guessing, and an owner pid the operating system has recycled onto a long-lived process makes its file unreadable — bounded by removing it after a week, and by the reboot that would end the orphan anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic cleanup for chat processes left running after VS Code is force-closed.
  - On the next activation, orphaned processes are verified by identity before being terminated, with safeguards to avoid affecting unrelated processes.
  - Unresolved cleanup attempts are retained for retry, with stale records eventually discarded.

- **Documentation**
  - Documented the orphan-process cleanup design, safeguards, limits, and supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->