### PR TITLE
fix(chat): the sweep's decisions move where the other decisions are

### DIFF
--- a/src_vs_code/src/chatLedger.ts
+++ b/src_vs_code/src/chatLedger.ts
@@ -153,7 +153,7 @@ export function ledgerName(ownerPid: number): string {
 
 /** The owner a ledger file belongs to, or 0 when the name is not one of ours. */
 export function ownerOf(fileName: string): number {
-  const found = /^chat-children-([0-9]{1,10})\.json$/.exec(fileName);
+  const found = /^chat-children-(\d{1,10})\.json$/.exec(fileName);
 
   return found === null ? 0 : Number(found[1]);
 }
@@ -231,4 +231,38 @@ export function killOutcome(exitCode: number, output: string): KillOutcome {
 /** A record is settled — struck out — unless nobody could tell what it was. */
 export function settled(outcome: KillOutcome): boolean {
   return outcome !== 'unknown';
+}
+
+/**
+ * Which ledger files this activation may open at all.
+ *
+ * <p>Three refusals, and the middle one is the whole reason the file name carries a pid: a file
+ * whose owner is still running belongs to another VS Code window that is using its children right
+ * now. Opening it would mean verifying processes that really are this extension's — every check
+ * would pass — and killing a conversation somebody is reading.</p>
+ *
+ * <p>Pure, with the liveness question injected, so the rule is a test rather than a claim.</p>
+ */
+export function filesToSweep(
+  names: readonly string[],
+  ownPid: number,
+  alive: (pid: number) => boolean,
+): readonly { readonly name: string; readonly owner: number }[] {
+  return names
+    .map((name) => ({ name, owner: ownerOf(name) }))
+    .filter((file) => file.owner !== 0 && file.owner !== ownPid && !alive(file.owner));
+}
+
+/** What to do with a ledger once its candidates have been asked about. */
+export type AfterSweep = 'remove' | 'rewrite';
+
+/**
+ * Remove the file, or write back what is left?
+ *
+ * <p>Removed only when everything in it was ASKED and everything answered. A sweep that ran out of
+ * time, or a record nobody could resolve, leaves a file — because a file kept too long costs a few
+ * hundred bytes and a file removed too early costs a process nobody can find.</p>
+ */
+export function afterSweep(kept: readonly ChildRecord[], askedEverything: boolean): AfterSweep {
+  return kept.length === 0 && askedEverything ? 'remove' : 'rewrite';
 }

--- a/src_vs_code/src/chatOrphans.ts
+++ b/src_vs_code/src/chatOrphans.ts
@@ -3,6 +3,8 @@ import { readdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   ChildRecord,
+  afterSweep,
+  filesToSweep,
   forgotten,
   imageOf,
   killOutcome,
@@ -201,22 +203,20 @@ export async function reconcile(storageDir: string, now = Date.now()): Promise<r
 
   const killed: string[] = [];
   const until = now + SWEEP_MS;
+  // Which files may be opened is a decision, and it lives with the other decisions: a file whose
+  // owner is still running belongs to a window using its children right now.
+  const ours = filesToSweep(names, process.pid, ownerAlive);
+  for (const file of ours) {
+    await tidy(join(storageDir, file.name), now, until, killed);
+  }
+  // The ones NOT swept because their owner looked alive: a pid the operating system has since handed
+  // to something long-lived would make a file invisible for ever. It cannot be acted on — but it can
+  // stop growing. (codex.)
+  const swept = new Set(ours.map((file) => file.name));
   for (const name of names) {
-    const owner = ownerOf(name);
-    const path = join(storageDir, name);
-    // Not a ledger, our own, or one whose window is still using it. The last is the important one:
-    // those children are alive on purpose.
-    if (owner === 0 || owner === process.pid) {
-      continue;
+    if (ownerOf(name) !== 0 && ownerOf(name) !== process.pid && !swept.has(name)) {
+      await removeIfLongDead(join(storageDir, name), now);
     }
-    if (ownerAlive(owner)) {
-      // A pid the operating system has since handed to something long-lived would make this file
-      // invisible for ever. It cannot be acted on — but it can stop growing. (codex.)
-      await removeIfLongDead(path, now);
-      continue;
-    }
-
-    await tidy(path, now, until, killed);
   }
 
   return killed;
@@ -255,7 +255,7 @@ async function tidy(path: string, now: number, until: number, killed: string[]):
   }
 
   try {
-    if (kept.length === 0 && asked) {
+    if (afterSweep(kept, asked) === 'remove') {
       await rm(path, { force: true });
     } else {
       writeAtomically(path, ledgerText(kept));

--- a/src_vs_code/src/test/chatLedger.test.ts
+++ b/src_vs_code/src/test/chatLedger.test.ts
@@ -3,6 +3,8 @@ import { test } from 'node:test';
 import {
   ChildRecord,
   FORGET_AFTER_MS,
+  afterSweep,
+  filesToSweep,
   NEAR_ENOUGH_MS,
   forgotten,
   imageOf,
@@ -167,4 +169,33 @@ test('an image this side would not put in a command produces NO command', () => 
   // reconstructed from another function by whoever reads this one.
   assert.strictEqual(verifyAndKill({ ...ours, image: "agy'; calc; '.exe" }), '');
   assert.notStrictEqual(verifyAndKill(ours), '');
+});
+
+test('a file whose owner is still running is not opened at all', () => {
+  // The whole reason the owner's pid is in the name. Opening it would mean verifying processes that
+  // really ARE this extension's — every check would pass — and killing a conversation somebody is
+  // reading in another VS Code window.
+  const alive = (pid: number): boolean => pid === 200;
+  const files = filesToSweep(
+    ['chat-children-100.json', 'chat-children-200.json', 'chat-children-300.json', 'settings.json'],
+    300,
+    alive,
+  );
+
+  assert.deepStrictEqual([...files], [{ name: 'chat-children-100.json', owner: 100 }]);
+});
+
+test('this window never sweeps its own ledger, whatever the operating system says about it', () => {
+  assert.deepStrictEqual([...filesToSweep(['chat-children-42.json'], 42, () => false)], []);
+});
+
+test('a ledger is removed only when everything in it was asked AND answered', () => {
+  const record = { pid: 1, image: 'agy.exe', startedMs: 5 };
+
+  assert.strictEqual(afterSweep([], true), 'remove');
+  // Something nobody could resolve, or a sweep that ran out of time: the file stays, because one
+  // kept too long costs a few hundred bytes and one removed too early costs a process nobody can find.
+  assert.strictEqual(afterSweep([record], true), 'rewrite');
+  assert.strictEqual(afterSweep([], false), 'rewrite');
+  assert.strictEqual(afterSweep([record], false), 'rewrite');
 });


### PR DESCRIPTION
SonarCloud failed the quality gate on #141, and not for the reason its one open issue suggested: **coverage on new code, 75.1 % against a threshold of 80.** (The issue it did raise was `[0-9]` instead of `\d`, fixed here too.)

The uncovered half was `chatOrphans.ts` — and what was uncovered there was not IO, it was **judgement that had been left on the IO side of the seam.** Two decisions move to `chatLedger.ts`, where every other rule about this feature already lives and is tested:

- **Which ledger files an activation may open at all.** Three refusals, and the middle one is the entire reason the owner's pid is in the file name: a file whose owner is still running belongs to another VS Code window that is using its children right now, and opening it would mean verifying processes that really are this extension's — every check would pass — and killing a conversation somebody is reading.
- **Whether a swept ledger is removed or written back.** Removed only when everything in it was asked AND answered, because a file kept too long costs a few hundred bytes and one removed too early costs a process nobody can find.

Both are pure, with the liveness question injected, so the rules are tests rather than claims — the same reason `chatHome` takes its `make` and `remove`.

## Test plan

- [x] `npm test` — **958 tests, 957 pass, 0 fail, 1 pre-existing skip.**
- [x] Live check green after the extraction: orphan **ENDED**, stranger **LEFT ALONE**, another window's live child **LEFT ALONE** with its file not read.
- [ ] SonarCloud's coverage condition on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
