### PR TITLE
refactor(chat): what SonarCloud named on the remote-chat PR

### DIFF
--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -20,7 +20,7 @@ import { ChatHome, adapterFor, chatHome, chatRuntimeRefusal, defaultExecutableFo
 import { chatProcessFor } from './chatProcess';
 import { launch } from './processLauncher';
 import { resolvedExecutable } from './versionProbe';
-import { REMOTE_CARRY_BUDGET, carriedTurn, openingTurn } from './chatPrompt';
+import { CARRY_BUDGET, REMOTE_CARRY_BUDGET, carriedTurn, openingTurn } from './chatPrompt';
 import { LanguageCode } from './settingsShape';
 import { sourceSession, TabSnapshot } from './sessionKey';
 import { triggerPlan } from './chatTrigger';
@@ -220,9 +220,10 @@ async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
   // because the process it is going to never heard any of it. Putting the carried version in the
   // transcript would print the entire history back at them under their own one-line question.
   const carrying = thread.carry;
-  const sent = carrying.length > 0
-    ? carriedTurn(carrying, text, chatLanguage(), thread.forgetful ? REMOTE_CARRY_BUDGET : undefined)
-    : text;
+  // Named, because a budget is the kind of thing that must be readable at a glance: a server takes
+  // less than a pipe, and which one this conversation is is the whole difference.
+  const budget = thread.forgetful ? REMOTE_CARRY_BUDGET : CARRY_BUDGET;
+  const sent = carrying.length > 0 ? carriedTurn(carrying, text, chatLanguage(), budget) : text;
 
   // The queue position, pushed as it changes. A local session never calls this back; a Team server
   // does on every poll, which is the difference between "the model is thinking" and "somebody else's

--- a/src_vs_code/src/remoteAsk.ts
+++ b/src_vs_code/src/remoteAsk.ts
@@ -33,8 +33,8 @@
  * role is a conversation, because every review carries one. Measured the same afternoon: empty role,
  * a model the catalog allows, and the answer came back.</p>
  *
- * <p>A `kind` field would say it better than an absence does, and it is a server change with its own
- * release. Recorded as the follow-up rather than smuggled into the role enum.</p>
+ * <p>An absence is a poor way to say something, so the turn also carries {@link CHAT_KIND} — sent
+ * ahead of the server that will read it, rather than smuggled into the role enum.</p>
  */
 export const CHAT_ROLE = '';
 
@@ -116,9 +116,9 @@ export function acceptedId(body: unknown): string {
 /**
  * What the server said about a review this poll.
  *
- * <p>The status strings are the server's, and an unknown one is treated as still running rather than
- * as a failure: a server that learns a new state must not turn every conversation into an error on
- * the day it ships. The deadline is what ends a turn that never resolves.</p>
+ * <p>The status strings are the server's, and one this build does not know is NAMED rather than
+ * waited out — see the comment where that decision is made. The deadline is what ends a turn that
+ * never resolves anyway; naming it is what makes the reason readable instead of a timeout.</p>
  */
 export function readStep(body: unknown): RemoteStep {
   const row = (body ?? {}) as Record<string, unknown>;
@@ -136,7 +136,7 @@ export function readStep(body: unknown): RemoteStep {
   if (status === 'failed' || status === 'error' || status === 'cancelled' || status === 'canceled') {
     return { kind: 'failure', failure: `the server reported: ${saidWhy(row, status)}` };
   }
-  if (status.length === 0 || RUNNING.includes(status)) {
+  if (status.length === 0 || RUNNING.has(status)) {
     return { kind: 'waiting', position };
   }
 
@@ -148,14 +148,23 @@ export function readStep(body: unknown): RemoteStep {
 }
 
 /** The states that mean "not finished yet". Measured from the server's own `JobStatus`. */
-const RUNNING: readonly string[] = ['queued', 'running', 'pending', 'claimed', 'waiting'];
+const RUNNING: ReadonlySet<string> = new Set(['queued', 'running', 'pending', 'claimed', 'waiting']);
 
-/** What the server said about a failure, in its own words when it gave any. */
+/**
+ * What the server said about a failure, in its own words when it gave any.
+ *
+ * <p>Three fields, in the order of how much they tell a person: what the vendor refused, then why
+ * the server stopped, then — when neither was given — the bare status, which at least names the
+ * state it ended in.</p>
+ */
 function saidWhy(row: Record<string, unknown>, status: string): string {
   const failure = typeof row['failure'] === 'string' ? row['failure'] : '';
+  if (failure.length > 0) {
+    return failure;
+  }
   const reason = typeof row['reason'] === 'string' ? row['reason'] : '';
 
-  return failure.length > 0 ? failure : reason.length > 0 ? reason : status;
+  return reason.length > 0 ? reason : status;
 }
 
 /**


### PR DESCRIPTION
Three issues SonarCloud raised on #145, all in code that PR introduced. Its quality gate passed
(91.0% coverage on new code), so none of them blocked — they are worth fixing anyway, because each
one is at a line somebody will have to read.

| Where | What |
|---|---|
| `chatCommand.ts` | The carry budget was a ternary nested inside a call argument. A person reading `oneTurn` has to unpick it to answer *how much of the conversation travels?* — which is the only question that line exists for. It is a named local now. |
| `remoteAsk.ts` | `saidWhy` chained three ternaries. It returns early on the field that tells a person most, so the fallbacks read as three steps in order of usefulness. |
| `remoteAsk.ts` | `RUNNING` is a `Set`, which is what a membership test wants. |

Two comments in the same file had gone stale inside the round that wrote them: `readStep` still
promised to wait out a status this build does not know — it names it now, which was an accepted
gate finding — and `CHAT_ROLE` still described `kind` as something a later release would add, when
the turn already carries it.

**Tests**: 1001 tests, 1000 pass, 0 fail, 1 pre-existing skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved turn budget handling for different model behaviors.
  * Updated remote status tracking to provide more reliable state checks.
* **Documentation**
  * Clarified how turn types and unknown statuses are represented during remote processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->