### PR TITLE
refactor(server): what SonarCloud named on the Team-server PR

### DIFF
--- a/src_server/src/Jobs/JobKind.cs
+++ b/src_server/src/Jobs/JobKind.cs
@@ -57,29 +57,28 @@ public static class JobKinds
     /// </remarks>
     public static bool TryRead(string? said, out JobKind kind)
     {
-        kind = WhenNotSaid;
-        if (string.IsNullOrWhiteSpace(said))
-        {
-            return true;
-        }
+        var found = Named(said);
+        kind = found ?? WhenNotSaid;
 
-        // The NAMES, matched explicitly. `Enum.TryParse` also accepts the underlying numbers, so
-        // `kind: "1"` would have arrived as a chat and `kind: "0"` as a review — values no contract
-        // mentions, from a caller who cannot have meant them, deciding what a spending row says.
-        // (codex, code round.)
-        var named = said.Trim();
-        foreach (var known in Enum.GetValues<JobKind>())
-        {
-            if (Wire(known).Equals(named, StringComparison.OrdinalIgnoreCase))
-            {
-                kind = known;
-
-                return true;
-            }
-        }
-
-        return false;
+        return found is not null || string.IsNullOrWhiteSpace(said);
     }
+
+    /// <summary>The kind spelled by this name, or null when no kind is spelled that way.</summary>
+    /// <remarks>
+    /// The NAMES, matched explicitly. <c>Enum.TryParse</c> also accepts the underlying numbers, so
+    /// <c>kind: "1"</c> would have arrived as a chat and <c>kind: "0"</c> as a review — values no
+    /// contract mentions, from a caller who cannot have meant them, deciding what a spending row
+    /// says. (codex, code round.)
+    /// <para>Its own function because <see cref="TryRead"/> has an <c>out</c> parameter, which cannot
+    /// be assigned from inside a lambda; returning a nullable instead is what lets the search be one
+    /// expression rather than a loop. (SonarCloud S3267.)</para>
+    /// </remarks>
+    private static JobKind? Named(string? said) =>
+        string.IsNullOrWhiteSpace(said)
+            ? null
+            : Enum.GetValues<JobKind>()
+                .Cast<JobKind?>()
+                .FirstOrDefault(k => Wire(k!.Value).Equals(said.Trim(), StringComparison.OrdinalIgnoreCase));
 
     /// <summary>Whether the caller said anything at all about what this job is.</summary>
     public static bool WasSaid(string? said) => !string.IsNullOrWhiteSpace(said);

--- a/src_server/src/Jobs/JobPump.cs
+++ b/src_server/src/Jobs/JobPump.cs
@@ -57,7 +57,13 @@ public sealed class JobPump(
             // The store's own sentence, not a second one worked out here. It has already decided
             // WHICH clock ran out — an abandoned job and a timed-out one read very differently, and
             // recomputing after the record went terminal would have got the answer wrong.
-            log.LogInformation("job {Id} for {Email} {Reason}", job.Id, job.Email, job.Reason);
+            //
+            // Guarded, because the arguments are not constants and a sweep on a busy server walks
+            // every expired job to build them for a sink that may be discarding them. (CA1873.)
+            if (log.IsEnabled(LogLevel.Information))
+            {
+                log.LogInformation("job {Id} for {Email} {Reason}", job.Id, job.Email, job.Reason);
+            }
         }
     }
 

--- a/src_server/src/Jobs/ReviewEndpoints.cs
+++ b/src_server/src/Jobs/ReviewEndpoints.cs
@@ -44,56 +44,13 @@ public static class ReviewEndpoints
             }
 
             var now = DateTimeOffset.UtcNow;
-            var budget = TimeSpan.FromSeconds(request.TimeoutSeconds);
-            JobKinds.TryRead(request.Kind, out var kind);
-            var role = request.Role ?? string.Empty;
             var key = request.IdempotencyKey?.Trim() ?? string.Empty;
-            var (job, refused, position) = jobs.Submit(new JobRecord(
-                JobId.New(),
-                caller.Email,
-                request.Vendor,
-                request.Model,
-                role,
-                request.Prompt,
-                JobStatus.Queued,
-                now,
-                now + (queueWait ?? JobTransitions.DefaultQueueWait),
-                budget,
-                kind,
-                IdempotencyKey: key,
-                Fingerprint: key.Length == 0
-                    ? string.Empty
-                    : Idempotency.Fingerprint(
-                        caller.Email, request.Vendor, request.Model, role, request.Prompt, kind,
-                        request.TimeoutSeconds)),
-                now);
+            var (job, refused, position) = jobs.Submit(
+                Accepted(caller, request, key, now, queueWait), now);
 
-            if (refused == SubmitRefusal.KeyUsedForSomethingElse)
+            if (Rejected(ctx, jobs, refused, key) is { } rejection)
             {
-                // 409, not 400: the request is well formed and the key is well formed — what is wrong
-                // is that the two disagree with something the server already accepted. A person needs
-                // to know it was THIS key, because the fix is a new one.
-                return Results.Json(
-                    new ErrorDto(
-                        $"the idempotency key '{key}' was already used for a different request. A repeat "
-                        + "must carry the same vendor, model, role, kind, prompt and timeout; use a new key "
-                        + "for a new question."),
-                    ServerJsonContext.Default.ErrorDto,
-                    statusCode: StatusCodes.Status409Conflict);
-            }
-
-            if (refused == SubmitRefusal.TooManyQueued)
-            {
-                // A queue nobody drains is just a way to hold other people's turn, so the refusal is
-                // a 429 with a time — not a silent accept that never runs.
-                ctx.Response.Headers.RetryAfter = RetryAfterSeconds;
-
-                return Results.Json(
-                    new ErrorDto(
-                        $"you already have {jobs.PerCallerQueued} reviews waiting. They run as accounts "
-                        + "free up; this one was not accepted so it cannot sit behind them."),
-                    ServerJsonContext.Default.ErrorDto,
-                    statusCode: StatusCodes.Status429TooManyRequests);
+                return rejection;
             }
 
             await Task.CompletedTask;
@@ -150,6 +107,80 @@ public static class ReviewEndpoints
                 ? Results.NoContent()
                 : Missing(id, caller.Email, jobs);
         }).RequireCaller(gate);
+    }
+
+    /// <summary>
+    /// The job a well-formed request becomes.
+    /// </summary>
+    /// <remarks>
+    /// Out of the handler because it is a dozen lines of construction and none of it is a decision —
+    /// which is what made the handler read as though it had more branches than it has. (SonarCloud
+    /// S3776: 19 against the 15 this repository allows.)
+    /// </remarks>
+    private static JobRecord Accepted(
+        Caller caller, ReviewRequestDto request, string key, DateTimeOffset now, TimeSpan? queueWait)
+    {
+        // Its shape was checked by `Refusal` before anything reached here, so this cannot fail.
+        JobKinds.TryRead(request.Kind, out var kind);
+        var role = request.Role ?? string.Empty;
+
+        return new JobRecord(
+            JobId.New(),
+            caller.Email,
+            request.Vendor,
+            request.Model,
+            role,
+            request.Prompt,
+            JobStatus.Queued,
+            now,
+            now + (queueWait ?? JobTransitions.DefaultQueueWait),
+            TimeSpan.FromSeconds(request.TimeoutSeconds),
+            kind,
+            IdempotencyKey: key,
+            Fingerprint: key.Length == 0
+                ? string.Empty
+                : Idempotency.Fingerprint(
+                    caller.Email, request.Vendor, request.Model, role, request.Prompt, kind,
+                    request.TimeoutSeconds));
+    }
+
+    /// <summary>
+    /// What the STORE refused, as an answer — or null when it refused nothing.
+    /// </summary>
+    /// <remarks>
+    /// Two refusals, and they are different kinds of wrong. A 409 says the request is well formed and
+    /// so is the key: what disagrees is the two of them against something this server already
+    /// accepted, and the fix is a new key, so the message names the one that collided. A 429 says the
+    /// person is holding as many waiting reviews as they may, and it carries a time — a queue nobody
+    /// drains is just a way to hold other people's turn, and a silent accept that never runs is worse
+    /// than being told.
+    /// </remarks>
+    private static IResult? Rejected(HttpContext ctx, JobStore jobs, SubmitRefusal refused, string key)
+    {
+        if (refused == SubmitRefusal.KeyUsedForSomethingElse)
+        {
+            return Results.Json(
+                new ErrorDto(
+                    $"the idempotency key '{key}' was already used for a different request. A repeat "
+                    + "must carry the same vendor, model, role, kind, prompt and timeout; use a new key "
+                    + "for a new question."),
+                ServerJsonContext.Default.ErrorDto,
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        if (refused == SubmitRefusal.TooManyQueued)
+        {
+            ctx.Response.Headers.RetryAfter = RetryAfterSeconds;
+
+            return Results.Json(
+                new ErrorDto(
+                    $"you already have {jobs.PerCallerQueued} reviews waiting. They run as accounts "
+                    + "free up; this one was not accepted so it cannot sit behind them."),
+                ServerJsonContext.Default.ErrorDto,
+                statusCode: StatusCodes.Status429TooManyRequests);
+        }
+
+        return null;
     }
 
     /// <summary>Why this submission cannot be accepted, or null.</summary>

--- a/src_server/src/Usage/UsageReader.cs
+++ b/src_server/src/Usage/UsageReader.cs
@@ -111,34 +111,39 @@ public sealed class UsageReader(string dataDir)
         try
         {
             var entry = JsonSerializer.Deserialize(text, ServerJsonContext.Default.UsageEntryDto);
+            if (entry is null)
+            {
+                return null;
+            }
 
             // Invariant culture and RoundtripKind: the writer stamps ISO-8601 with "O", and parsing
             // that with the machine's own culture is how the same file reads differently on a
             // developer's box and on the VM. RoundtripKind keeps the offset instead of shifting it
             // into local time.
-            return entry is null
-                || !DateTimeOffset.TryParse(
-                    entry.Utc,
-                    CultureInfo.InvariantCulture,
-                    DateTimeStyles.RoundtripKind,
-                    out var at)
-                ? null
-                : new UsageLine(
-                    at.ToUniversalTime(),
-                    entry.Email ?? string.Empty,
-                    entry.Provider ?? string.Empty,
-                    entry.Model ?? string.Empty,
-                    entry.Role ?? string.Empty,
-                    entry.Outcome ?? string.Empty,
-                    entry.Seconds,
-                    entry.TokensIn,
-                    entry.TokensOut,
-                    entry.CostUsd,
-                    // A kind this build does not know is READ AS A REVIEW rather than refused. The
-                    // line is history: it already happened and it already cost money, and dropping
-                    // it from a spending report because a newer server wrote a word this one has not
-                    // heard would hide spending — which is the one thing this file must never do.
-                    JobKinds.TryRead(entry.Kind, out var kind) ? kind : JobKinds.WhenNotSaid);
+            if (!DateTimeOffset.TryParse(
+                    entry.Utc, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var at))
+            {
+                return null;
+            }
+
+            // A kind this build does not know is READ AS A REVIEW rather than refused. The line is
+            // history: it already happened and it already cost money, and dropping it from a spending
+            // report because a newer server wrote a word this one has not heard would hide spending —
+            // which is the one thing this file must never do.
+            var kind = JobKinds.TryRead(entry.Kind, out var said) ? said : JobKinds.WhenNotSaid;
+
+            return new UsageLine(
+                at.ToUniversalTime(),
+                entry.Email ?? string.Empty,
+                entry.Provider ?? string.Empty,
+                entry.Model ?? string.Empty,
+                entry.Role ?? string.Empty,
+                entry.Outcome ?? string.Empty,
+                entry.Seconds,
+                entry.TokensIn,
+                entry.TokensOut,
+                entry.CostUsd,
+                kind);
         }
         catch (JsonException)
         {

--- a/src_vs_code/src/teamServerView.ts
+++ b/src_vs_code/src/teamServerView.ts
@@ -135,9 +135,20 @@ export function kindLine(
   return `<div class="hint">${parts.join(' &middot; ')}</div>`;
 }
 
-/** What a kind is called on a page a person reads, rather than on the wire. */
+/**
+ * What a kind is called on a page a person reads, rather than on the wire.
+ *
+ * <p>A table, so a kind this build has not heard of falls through to its own name rather than to a
+ * branch somebody has to trace. The server may know one this panel does not — that is the ordinary
+ * state of a fleet — and showing what it said is better than showing nothing.</p>
+ */
+const KIND_NAMES: Readonly<Record<string, string>> = {
+  chat: 'conversations',
+  review: 'reviews',
+};
+
 function named(kind: string): string {
-  return kind === 'chat' ? 'conversations' : kind === 'review' ? 'reviews' : kind;
+  return KIND_NAMES[kind] ?? kind;
 }
 
 /**


### PR DESCRIPTION
Five issues SonarCloud raised on #148, all in code that PR introduced. Its quality gate passed
(98.8% coverage on new code), so none of them blocked — they are worth fixing because each sits at a
line somebody will have to read.

| Where | What |
|---|---|
| `ReviewEndpoints.cs` | **The one worth the name.** The POST handler had reached a cognitive complexity of 19 against the 15 this repository allows, and almost none of it was a decision. Building the record (`Accepted`) and turning the store's refusal into an answer (`Rejected`) are their own functions now, so the handler holds the four branches it actually has. |
| `UsageReader.cs` | `Parse` returns early instead of nesting a ternary inside a ternary. |
| `teamServerView.ts` | `named` is a lookup table, which also means a kind this build has not heard of falls through to its own name rather than to a branch somebody has to trace. |
| `JobKind.cs` | `TryRead` finds a kind through a nullable-returning helper. The loop existed only because an `out` parameter cannot be assigned inside a lambda — now said in a comment beside it, so the next person does not re-introduce the loop. |
| `JobPump.cs` | The sweep's log line is guarded by `IsEnabled`: its arguments are built for every expired job whether or not a sink wants them. |

**Tests**: server 226, extension 1013 (1012 + 1 pre-existing skip), `http/reviews` contracts 52/52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)