### PR TITLE
fix(panel): every page this extension opens can be searched

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -685,6 +685,27 @@ leaves the round gated with nothing on screen — a crash traded for a hang, whi
 crash at least says that something happened. `id` and `question` remain the only two that decide
 whether a question can be shown; the rest is metadata, and metadata is rendered, not adjudicated.
 
+## Every page can be searched (2026-09-09)
+
+The three `WebviewPanel`s this extension opens — the chat tab (`chatPanel.ts`), the rounds log
+(`roundsLogPanel.ts`) and the help page (`helpPanel.ts`) — are created with `enableFindWidget: true`
+beside `enableScripts` and `localResourceRoots`. That option is the whole of Ctrl+F: VS Code gives a
+webview panel the editor's own find bar for it and for nothing else, and without it the shortcut is
+silently dead. Two of the three pages are long text somebody reads — a transcript of answers, and a
+table built to be searched — so a dead Ctrl+F was a defect on both.
+
+The help page is in although it has a search box of its own. The find bar is chrome ABOVE the
+webview and displaces nothing, and the test that holds this is a discovery — it walks `src/` for
+every `createWebviewPanel(` call rather than naming three files, so a fourth panel is covered the day
+it is written. A test like that cannot carry an exception for one file without becoming the
+hand-written list it replaces. The sidebar is not affected: it is a `WebviewView`, and the API has no
+such option for one.
+
+`panelsAreSearchable.test.ts` reads each call's own arguments — cut out by balanced parentheses, with
+comments stripped — rather than the whole file, so a file that grows a second panel is checked twice
+and a comment naming the option cannot stand in for it. It refuses a spread in those options as well,
+because a spread could override the value where a source scan cannot see it.
+
 ## The update check can trust `…/releases` again (2026-09-08)
 
 `installer.ts` asks GitHub for the newest release and offers its asset. That was safe only while a

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -701,10 +701,19 @@ it is written. A test like that cannot carry an exception for one file without b
 hand-written list it replaces. The sidebar is not affected: it is a `WebviewView`, and the API has no
 such option for one.
 
-`panelsAreSearchable.test.ts` reads each call's own arguments — cut out by balanced parentheses, with
-comments stripped — rather than the whole file, so a file that grows a second panel is checked twice
-and a comment naming the option cannot stand in for it. It refuses a spread in those options as well,
-because a spread could override the value where a source scan cannot see it.
+**What the code round did to the test.** The first version matched `enableFindWidget: true` anywhere
+in a call's text, and three reviewers refused it independently for the same reason: a string literal,
+a comment, or an object one level down can all carry those words while the call VS Code receives has
+no such option — the guard stays green over a dead Ctrl+F. So `panelsAreSearchable.test.ts` now blanks
+every comment, string and regular expression first (delimiters kept, so offsets and bracket counts
+survive), which is also what makes the balanced-parenthesis cut of the arguments safe: a `)` inside a
+title can no longer close the count. The option is then required as a TOP-LEVEL property of the
+options object, exactly once, with a literal `true`, and a spread among those properties is refused
+because it could override the value out of sight. A second test in the file drives all seven evasions
+— absent, false, in a string, in a comment, nested, spread, a variable — plus the two formattings
+(`)` inside a string, the bracket on the next line) through the same code and watches it complain; a
+guard that cannot be described in a fixture is a guard nobody can trust. The discovery walks `.ts`,
+`.tsx`, `.mts` and `.cts`, so a panel arriving as a `.tsx` is not a panel nobody scans.
 
 ## The update check can trust `…/releases` again (2026-09-08)
 

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Extension 0.31.19 — 2026-09-09
+
+**Ctrl+F works.** The chat tab, the rounds log and the help page each open with the editor's own find
+bar now — a transcript of answers and a table built to be searched had both been pages nobody could
+search, because a webview only gets that bar when it is asked for one.
+
 ## Extension 0.31.18 · Server 0.18.15 — 2026-09-09
 
 **The log stopped sending every finding it has ever recorded, and started counting in SQL.** Reading

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.18",
+  "version": "0.31.19",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -96,7 +96,14 @@ export function createChatPanel(
     'coaiChat',
     state.title,
     vscode.ViewColumn.Active,
-    { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [] },
+    // `enableFindWidget` is the whole of Ctrl+F: the editor's find bar never reaches a webview panel
+    // without it, and an answer long enough to be worth searching is the ordinary case here.
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true,
+      enableFindWidget: true,
+      localResourceRoots: [],
+    },
   );
   panel.webview.html = chatPageHtml(state, crypto.randomBytes(16).toString('hex'));
 

--- a/src_vs_code/src/helpPanel.ts
+++ b/src_vs_code/src/helpPanel.ts
@@ -52,7 +52,9 @@ export function showHelp(): void {
     'coaiHelp',
     'ConnectOtherAIs — Help',
     vscode.ViewColumn.Active,
-    { enableScripts: true, localResourceRoots: [] },
+    // The page has a search box of its own; the find bar is chrome ABOVE the webview and displaces
+    // nothing, and one behaviour everywhere beats a page where Ctrl+F is dead for no visible reason.
+    { enableScripts: true, enableFindWidget: true, localResourceRoots: [] },
   );
   const render = (): void => {
     if (panel !== undefined) {

--- a/src_vs_code/src/roundsLogPanel.ts
+++ b/src_vs_code/src/roundsLogPanel.ts
@@ -111,7 +111,13 @@ export class RoundsLogPanel {
       vscode.ViewColumn.Active,
       // Kept alive while hidden behind another tab: the sort, the filters and the search text are
       // page state, and a page that is torn down when it is not visible loses them every time.
-      { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [] },
+      // `enableFindWidget` is the whole of Ctrl+F — a table built to be searched had no find bar.
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        enableFindWidget: true,
+        localResourceRoots: [],
+      },
     );
     this.panel = panel;
     panel.webview.html = roundsLogHtml(

--- a/src_vs_code/src/test/panelsAreSearchable.test.ts
+++ b/src_vs_code/src/test/panelsAreSearchable.test.ts
@@ -18,15 +18,27 @@ import { test } from 'node:test';
  * and the discovery is paired with known instances, so a scan that has stopped matching anything
  * cannot pass by matching nothing.</p>
  *
- * <p>The plan round asked for one thing the disposal scan does not do: the option must be inside the
- * call, not merely somewhere in the file. A file with two panels, or a comment naming the option,
- * would otherwise satisfy a whole-file match while the call under test stayed unsearchable. So each
- * call's own argument text is cut out by balanced parentheses and read on its own.</p>
+ * <p>The help page is in although it has a search box of its own: the find bar is chrome ABOVE the
+ * webview and displaces nothing, and a discovery that carried an exception for one file would be the
+ * hand-written list it exists to replace. `src/test` is skipped, as the disposal scan skips it — a
+ * panel in a test file is not a page anybody opens, and a scan that read this file would find the
+ * hostile fixtures below and call them owners.</p>
+ *
+ * <p><b>What the code round demanded, and why the checking is this careful.</b> Three reviewers
+ * refused a whole-file text match independently: a string literal, a comment, or a nested object can
+ * all carry the words `enableFindWidget: true` while the call VS Code actually receives has no such
+ * option — the guard would stay green over a dead Ctrl+F. So comments, string literals and regular
+ * expressions are blanked before anything is matched, the call's arguments are cut out by balanced
+ * parentheses (the blanking is what makes that safe: a `)` inside a title can no longer close the
+ * count), and the option is required as a TOP-LEVEL property of the options object. The second test
+ * in this file drives every one of those evasions through the same code and watches it complain.</p>
  */
 
 const SOURCE_ROOT = path.join(__dirname, '..', '..', 'src');
 
-/** Every `.ts` file under `src/`, tests excluded — the same walk the disposal scan uses. */
+/** Every extension `tsc` compiles here. A panel arriving as `.tsx` must not be a panel nobody scans. */
+const SOURCES = ['.ts', '.tsx', '.mts', '.cts'];
+
 function walk(dir: string): string[] {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const full = path.join(dir, entry.name);
@@ -34,40 +46,111 @@ function walk(dir: string): string[] {
       return entry.name === 'test' ? [] : walk(full);
     }
 
-    return entry.name.endsWith('.ts') ? [path.relative(SOURCE_ROOT, full)] : [];
+    return SOURCES.some((suffix) => entry.name.endsWith(suffix)) ? [path.relative(SOURCE_ROOT, full)] : [];
   });
 }
 
 const read = (file: string): string => fs.readFileSync(path.join(SOURCE_ROOT, file), 'utf8');
 
-/**
- * Comments removed, so a sentence ABOUT the option cannot stand in for the option.
- *
- * <p>Crude on purpose: this runs over one call's arguments, where a `//` inside a string literal
- * would be a URL nobody passes to `createWebviewPanel`. The alternative was a TypeScript AST in a
- * suite that has never needed one.</p>
- */
-const withoutComments = (text: string): string =>
-  text.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+/** Where a `/` opens a regular expression rather than dividing. The standard previous-token rule. */
+const BEFORE_REGEX = /[(,=:[!&|?{};+\-*%~^]/;
 
 /**
- * The argument text of every `createWebviewPanel(` call in one file, by balanced parentheses.
+ * The source with every comment, string and regular expression blanked to spaces, delimiters kept.
  *
- * <p>Returns one entry per call: a file that grows a second panel is checked twice rather than
- * passing on the strength of its first.</p>
+ * <p>Same length as the input on purpose: offsets stay meaningful, and a bracket inside a string can
+ * no longer be counted by anything downstream. Not a parser — a `/` after an identifier is read as
+ * division, so `return /x'/` would be misread. That case fails loudly rather than passing quietly,
+ * which is the direction a guard is allowed to be wrong in.</p>
  */
-function panelCalls(source: string): string[] {
+function blanked(source: string): string {
+  const out = [...source];
+  const blank = (from: number, to: number): void => {
+    for (let k = from; k < to && k < out.length; k += 1) {
+      if (out[k] !== '\n') {
+        out[k] = ' ';
+      }
+    }
+  };
+  const closes = (at: number, quote: string): number => {
+    for (let j = at + 1; j < source.length; j += 1) {
+      if (source[j] === '\\') {
+        j += 1;
+      } else if (source[j] === quote) {
+        return j;
+      }
+    }
+
+    return source.length;
+  };
+  const endOfRegex = (at: number): number => {
+    let inClass = false;
+    for (let j = at + 1; j < source.length; j += 1) {
+      const c = source[j];
+      if (c === '\\') {
+        j += 1;
+      } else if (c === '[') {
+        inClass = true;
+      } else if (c === ']') {
+        inClass = false;
+      } else if (c === '\n' || (c === '/' && !inClass)) {
+        return j;
+      }
+    }
+
+    return source.length;
+  };
+
+  let previous = '';
+  let i = 0;
+  while (i < source.length) {
+    const here = source[i];
+    const after = source[i + 1] ?? '';
+    if (here === '/' && after === '/') {
+      const stop = source.indexOf('\n', i);
+      const end = stop < 0 ? source.length : stop;
+      blank(i, end);
+      i = end;
+    } else if (here === '/' && after === '*') {
+      const stop = source.indexOf('*/', i + 2);
+      const end = stop < 0 ? source.length : stop + 2;
+      blank(i, end);
+      i = end;
+    } else if (here === '\'' || here === '"' || here === '`') {
+      const end = closes(i, here);
+      blank(i + 1, end);
+      i = end + 1;
+    } else if (here === '/' && (previous === '' || BEFORE_REGEX.test(previous))) {
+      const end = endOfRegex(i);
+      blank(i + 1, end);
+      i = end + 1;
+    } else {
+      if (here.trim().length > 0) {
+        previous = here;
+      }
+      i += 1;
+    }
+  }
+
+  return out.join('');
+}
+
+/** The text between the outermost brackets of every `createWebviewPanel(` call, blanked source in. */
+function callArguments(source: string): string[] {
   const calls: string[] = [];
-  const marker = 'createWebviewPanel(';
-  for (let at = source.indexOf(marker); at >= 0; at = source.indexOf(marker, at + 1)) {
+  // Whitespace and a comment may both sit between the name and its bracket; the comment is already
+  // spaces by the time this runs, so one whitespace class covers both.
+  const opening = /createWebviewPanel\s*\(/g;
+  for (let hit = opening.exec(source); hit !== null; hit = opening.exec(source)) {
+    const from = hit.index + hit[0].length - 1;
     let depth = 0;
-    for (let i = at + marker.length - 1; i < source.length; i += 1) {
+    for (let i = from; i < source.length; i += 1) {
       if (source[i] === '(') {
         depth += 1;
       } else if (source[i] === ')') {
         depth -= 1;
         if (depth === 0) {
-          calls.push(source.slice(at, i + 1));
+          calls.push(source.slice(from + 1, i));
           break;
         }
       }
@@ -77,37 +160,108 @@ function panelCalls(source: string): string[] {
   return calls;
 }
 
-test('every webview panel this extension opens gives it a find bar', () => {
-  const owners = walk(SOURCE_ROOT).filter((file) => /createWebviewPanel\(/.test(read(file)));
-
-  // The known instances, so a scan that stopped matching anything cannot pass by matching nothing.
-  assert.ok(owners.includes('chatPanel.ts'), `the chat tab is one of the owners this finds; found ${owners.join(', ')}`);
-  assert.ok(owners.includes('roundsLogPanel.ts'), `the rounds log is one of the owners this finds; found ${owners.join(', ')}`);
-  assert.ok(owners.includes('helpPanel.ts'), `the help page is one of the owners this finds; found ${owners.join(', ')}`);
-
-  for (const owner of owners) {
-    const calls = panelCalls(read(owner));
-    assert.ok(calls.length > 0, `${owner} names createWebviewPanel but no call could be read out of it`);
-
-    for (const call of calls) {
-      const args = withoutComments(call);
-      const hits = args.match(/enableFindWidget/g) ?? [];
-
-      assert.equal(
-        hits.length, 1,
-        `${owner}: exactly one enableFindWidget belongs in a panel's options — Ctrl+F does nothing without it`,
-      );
-      assert.match(
-        args, /enableFindWidget:\s*true/,
-        `${owner}: enableFindWidget must be true; present-but-false is the same dead Ctrl+F`,
-      );
-      // A spread could carry the option in — and could just as easily override it with false from a
-      // constant this scan never reads. Nothing spreads into these options today; the day something
-      // does, this test has to grow an AST rather than quietly stop guarding.
-      assert.doesNotMatch(
-        args, /\.\.\./,
-        `${owner}: a spread in a panel's options can override enableFindWidget where this test cannot see it`,
-      );
+/** Split at commas that are not inside a bracket of any kind. Arguments, or an object's properties. */
+function parts(text: string): string[] {
+  const found: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    const c = text[i];
+    if (c === '(' || c === '[' || c === '{') {
+      depth += 1;
+    } else if (c === ')' || c === ']' || c === '}') {
+      depth -= 1;
+    } else if (c === ',' && depth === 0) {
+      found.push(text.slice(start, i));
+      start = i + 1;
     }
   }
+  found.push(text.slice(start));
+
+  return found.map((part) => part.trim()).filter((part) => part.length > 0);
+}
+
+/**
+ * Everything wrong with the find bar in one file's panel calls. Empty means every page is searchable.
+ */
+export function findBarComplaints(source: string): string[] {
+  const clean = blanked(source);
+  const complaints: string[] = [];
+
+  for (const call of callArguments(clean)) {
+    const args = parts(call);
+    const options = args[args.length - 1] ?? '';
+    if (!options.startsWith('{') || !options.endsWith('}')) {
+      complaints.push('the options are not an object literal this scan can read');
+      continue;
+    }
+
+    const properties = parts(options.slice(1, -1));
+    const spread = properties.some((property) => property.startsWith('...'));
+    if (spread) {
+      complaints.push('a spread in a panel\'s options can override enableFindWidget out of sight');
+    }
+
+    const enabling = properties.filter((property) => /^enableFindWidget\s*:\s*true$/.test(property));
+    const mentions = (call.match(/enableFindWidget/g) ?? []).length;
+    if (enabling.length !== 1) {
+      complaints.push('enableFindWidget: true is not a top-level option of this call — Ctrl+F does nothing without it');
+    } else if (mentions !== 1) {
+      complaints.push('enableFindWidget is named more than once in this call; only the top-level option counts');
+    }
+  }
+
+  return complaints;
+}
+
+test('every webview panel this extension opens gives it a find bar', () => {
+  const owners = walk(SOURCE_ROOT).filter((file) => /createWebviewPanel\s*\(/.test(blanked(read(file))));
+
+  // The known instances, so a scan that stopped matching anything cannot pass by matching nothing.
+  const listed = owners.join(', ');
+  assert.ok(owners.includes('chatPanel.ts'), `the chat tab is one of the owners this finds; found ${listed}`);
+  assert.ok(owners.includes('roundsLogPanel.ts'), `the rounds log is one of the owners this finds; found ${listed}`);
+  assert.ok(owners.includes('helpPanel.ts'), `the help page is one of the owners this finds; found ${listed}`);
+
+  for (const owner of owners) {
+    const source = read(owner);
+    assert.ok(callArguments(blanked(source)).length > 0, `${owner} names createWebviewPanel but no call could be read out of it`);
+    assert.deepEqual(findBarComplaints(source), [], `${owner}: this page cannot be searched`);
+  }
+});
+
+test('the find-bar scan cannot be satisfied by a comment, a string or a nested object', () => {
+  // Every evasion the code round named, driven through the same code the scan above runs. A guard
+  // this file cannot describe in a fixture is a guard nobody can trust.
+  const call = (args: string): string => `vscode.window.createWebviewPanel(${args});`;
+  const good = '\'coaiChat\', title, vscode.ViewColumn.Active, { enableScripts: true, enableFindWidget: true, localResourceRoots: [] }';
+
+  assert.deepEqual(findBarComplaints(call(good)), [], 'the honest call is refused');
+  assert.deepEqual(
+    findBarComplaints(call('\'a)b\', title, column, { enableScripts: true, enableFindWidget: true }')), [],
+    'a bracket inside a string closed the argument list',
+  );
+  assert.deepEqual(
+    findBarComplaints('vscode.window.createWebviewPanel\n(\'a\', b, c, { enableFindWidget: true })'), [],
+    'a call whose bracket is on the next line was never discovered',
+  );
+
+  for (const [why, args] of [
+    ['the option is simply absent', '\'a\', title, column, { enableScripts: true }'],
+    ['the option is present and false', '\'a\', title, column, { enableScripts: true, enableFindWidget: false }'],
+    ['the words are in a string argument', '\'enableFindWidget: true\', title, column, { enableScripts: true }'],
+    ['the words are in a comment', '\'a\', title, column, { /* enableFindWidget: true */ enableScripts: true }'],
+    ['the option is nested one level down', '\'a\', title, column, { webviewOptions: { enableFindWidget: true } }'],
+    ['a spread could override it', '\'a\', title, column, { ...base, enableFindWidget: true }'],
+    ['the value is a variable, not true', '\'a\', title, column, { enableFindWidget: wanted }'],
+  ] as const) {
+    assert.notDeepEqual(findBarComplaints(call(args)), [], `${why}: the scan said nothing`);
+  }
+
+  // Two calls in one file: the second one's omission must not hide behind the first one's option.
+  assert.notDeepEqual(
+    findBarComplaints(`${call(good)}\n${call('\'b\', title, column, { enableScripts: true }')}`),
+    [],
+    'a file that grows a second panel is only checked once',
+  );
 });

--- a/src_vs_code/src/test/panelsAreSearchable.test.ts
+++ b/src_vs_code/src/test/panelsAreSearchable.test.ts
@@ -1,0 +1,113 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+/**
+ * Every page this extension opens can be searched with the editor's own find bar.
+ *
+ * <p>2026-09-09: Ctrl+F did nothing in the chat tab and nothing in the rounds log. Both are pages of
+ * long text — one of answers, one a table built to be searched — and neither had a find bar, because
+ * `createWebviewPanel` was called without `enableFindWidget`. VS Code gives a webview panel its real
+ * find bar for that one option and for nothing else.</p>
+ *
+ * <p>Structural, like the disposal scan in `theLogRefusesToOpen.test.ts`, and for the same reason:
+ * every panel owner imports `vscode`, which does not exist outside the extension host, so no unit
+ * test in this suite can call one. It follows that file's two rules as well — the owners are
+ * DISCOVERED rather than listed, so a fifth panel added next year is covered the day it is written;
+ * and the discovery is paired with known instances, so a scan that has stopped matching anything
+ * cannot pass by matching nothing.</p>
+ *
+ * <p>The plan round asked for one thing the disposal scan does not do: the option must be inside the
+ * call, not merely somewhere in the file. A file with two panels, or a comment naming the option,
+ * would otherwise satisfy a whole-file match while the call under test stayed unsearchable. So each
+ * call's own argument text is cut out by balanced parentheses and read on its own.</p>
+ */
+
+const SOURCE_ROOT = path.join(__dirname, '..', '..', 'src');
+
+/** Every `.ts` file under `src/`, tests excluded — the same walk the disposal scan uses. */
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === 'test' ? [] : walk(full);
+    }
+
+    return entry.name.endsWith('.ts') ? [path.relative(SOURCE_ROOT, full)] : [];
+  });
+}
+
+const read = (file: string): string => fs.readFileSync(path.join(SOURCE_ROOT, file), 'utf8');
+
+/**
+ * Comments removed, so a sentence ABOUT the option cannot stand in for the option.
+ *
+ * <p>Crude on purpose: this runs over one call's arguments, where a `//` inside a string literal
+ * would be a URL nobody passes to `createWebviewPanel`. The alternative was a TypeScript AST in a
+ * suite that has never needed one.</p>
+ */
+const withoutComments = (text: string): string =>
+  text.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+
+/**
+ * The argument text of every `createWebviewPanel(` call in one file, by balanced parentheses.
+ *
+ * <p>Returns one entry per call: a file that grows a second panel is checked twice rather than
+ * passing on the strength of its first.</p>
+ */
+function panelCalls(source: string): string[] {
+  const calls: string[] = [];
+  const marker = 'createWebviewPanel(';
+  for (let at = source.indexOf(marker); at >= 0; at = source.indexOf(marker, at + 1)) {
+    let depth = 0;
+    for (let i = at + marker.length - 1; i < source.length; i += 1) {
+      if (source[i] === '(') {
+        depth += 1;
+      } else if (source[i] === ')') {
+        depth -= 1;
+        if (depth === 0) {
+          calls.push(source.slice(at, i + 1));
+          break;
+        }
+      }
+    }
+  }
+
+  return calls;
+}
+
+test('every webview panel this extension opens gives it a find bar', () => {
+  const owners = walk(SOURCE_ROOT).filter((file) => /createWebviewPanel\(/.test(read(file)));
+
+  // The known instances, so a scan that stopped matching anything cannot pass by matching nothing.
+  assert.ok(owners.includes('chatPanel.ts'), `the chat tab is one of the owners this finds; found ${owners.join(', ')}`);
+  assert.ok(owners.includes('roundsLogPanel.ts'), `the rounds log is one of the owners this finds; found ${owners.join(', ')}`);
+  assert.ok(owners.includes('helpPanel.ts'), `the help page is one of the owners this finds; found ${owners.join(', ')}`);
+
+  for (const owner of owners) {
+    const calls = panelCalls(read(owner));
+    assert.ok(calls.length > 0, `${owner} names createWebviewPanel but no call could be read out of it`);
+
+    for (const call of calls) {
+      const args = withoutComments(call);
+      const hits = args.match(/enableFindWidget/g) ?? [];
+
+      assert.equal(
+        hits.length, 1,
+        `${owner}: exactly one enableFindWidget belongs in a panel's options — Ctrl+F does nothing without it`,
+      );
+      assert.match(
+        args, /enableFindWidget:\s*true/,
+        `${owner}: enableFindWidget must be true; present-but-false is the same dead Ctrl+F`,
+      );
+      // A spread could carry the option in — and could just as easily override it with false from a
+      // constant this scan never reads. Nothing spreads into these options today; the day something
+      // does, this test has to grow an AST rather than quietly stop guarding.
+      assert.doesNotMatch(
+        args, /\.\.\./,
+        `${owner}: a spread in a panel's options can override enableFindWidget where this test cannot see it`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
Ctrl+F did nothing in the chat tab and nothing in the rounds log. Both are pages of long text — one a
transcript of answers, one a table built to be searched — and neither had a find bar, because
`createWebviewPanel` was called without `enableFindWidget`. That option is the whole of Ctrl+F: VS
Code gives a webview panel the editor's own find bar for it and for nothing else.

All three panels take it now — the chat tab, the rounds log and the help page. The help page is in
although it has a search box of its own: the find bar is chrome ABOVE the webview and displaces
nothing, and the test that holds this is a discovery rather than a list, which cannot carry an
exception for one file without becoming the hand-written list it replaces. The sidebar is untouched —
it is a `WebviewView`, and the API has no such option for one.

## The test, and what the code round did to it

Every panel owner imports `vscode`, which does not exist outside the extension host, so no unit test
in this suite can call one. `panelsAreSearchable.test.ts` follows the repository's own idiom for that
case — the structural scan in `theLogRefusesToOpen.test.ts`, with its two rules: owners DISCOVERED
rather than listed, and paired with known instances so a scan that stopped matching anything cannot
pass by matching nothing.

The first version matched the option anywhere in a call's text. Three reviewers refused it
independently, for the same reason: a string literal, a comment, or an object one level down can all
carry `enableFindWidget: true` while the call VS Code receives has none — the guard stays green over
a dead Ctrl+F. So the scan now blanks comments, strings and regular expressions first (delimiters
kept, so a `)` inside a title can no longer close the balanced-parenthesis cut), and requires the
option as a TOP-LEVEL property of the options object, exactly once, with a literal `true`. A spread
among those properties is refused because it could override the value out of sight. Discovery walks
`.tsx`/`.mts`/`.cts` too, and tolerates a bracket on the next line.

A second test drives all seven evasions — absent, false, in a string, in a comment, nested, spread, a
variable — and both formattings through the same code and watches it complain.

## Evidence

- RED first: `chatPanel.ts: exactly one enableFindWidget belongs in a panel's options` against the
  unfixed tree, then green.
- The rewritten guard re-checked for teeth: the option removed from `helpPanel.ts` → `helpPanel.ts:
  this page cannot be searched`; restored → green.
- Whole suite: **1042 pass, 1 skipped, 0 fail**.
- `plan-lifecycle.mjs` clean; `pin-check.mjs` OK — 1 pin at its remote tip.

## The gate

Plan round `proceed` (3 reviewers, 11 findings, 10 accepted, 1 rejected with a reason). Code round
`proceed` (12 reviewers, 14 findings, 8 accepted and implemented above, 6 rejected with reasons —
chiefly two claims about the guard that the submitted code already handled, and a self-refuting
report of a syntax error in a comment).

## Not verified

Manual checking was done on Windows. The macOS shortcut (Cmd+F) and macOS focus behaviour were not
verified on this machine and are not claimed.

The plan this implements (`todo/PLAN_a_page_nobody_can_search.md`) is still on the unmerged #153, so
its promotion to `research/` follows once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)