### PR TITLE
fix(panel): the prompt box keeps what was typed into it

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -762,6 +762,58 @@ were. `usageWindow` and `latestServerVersion` are now in the key; the spending R
 region, so they advance mid-round without closing a dropdown. The window tabs deliberately sit
 OUTSIDE that region: a button inside a patched region loses its click listener on the next tick.
 
+### A third answer beside repaint and patch: WITHHOLD (2026-09-09)
+
+The prompt box in *Chat other AIs* forgot what was typed into it. Two halves, and a measurement that
+refuted the obvious fix before it was written.
+
+**The measurement.** `chatPrompt` was suspected of repainting the panel on every save, which is why
+the draft plan called "save as you type" a trap. It does not: the paint decision is `staticKey`, and
+its eleven fields are `settings`, `vendors`, `codexModels`, `localEngines`, `server`, `side`,
+`latestServerVersion`, `usageWindow`, `openSections`, `teamServers` and `usageScope`. `state.chat` is
+not one of them, and `state.settings` is `CoaiSettings`, which the chat keys are deliberately not
+part of. A chat setting cannot rebuild the page. That is now an assertion in
+`thePromptBoxRemembers.test.ts`, so adding `chat` to the key fails with that sentence instead of
+making the box flicker.
+
+**What actually killed the draft** is the same reading from the other side. `render()` runs
+unconditionally every five seconds from the escalation watcher, recomputing all eleven, and four of
+them move with nobody touching the panel — the local-engine probe, the server's own `--version`, the
+published-release fetch and the Team-server catalog — while `settings` moves whenever any other
+control is written, from this window or another one sharing `settings.json`. Any of those rebuilt the
+document, and the typed text existed only in that document, because the `[data-setting]` listener
+posted on `change`, which a textarea fires at BLUR.
+
+**Half one: a textarea is written as it is typed.** One message per 400 ms pause rather than one per
+key, flushed at once on blur, on the panel being hidden, and on the page unloading. Selects and
+checkboxes keep `change` alone — a dropdown must not save half-chosen.
+
+**Half two: the page is not rebuilt under a focused control.** The page reports focus in and out of
+any `[data-setting]` control and `render` withholds the html assignment while one is held, patching
+the live regions as usual. The key is not recorded while a paint is withheld, so the next render
+after focus leaves paints what this one could not. A transition between two controls reports neither
+edge — the focusout of the one being left arrives before the focusin of the one being entered, and a
+repaint in between would land on a caret that is on its way.
+
+**The hold is capped at 30 seconds, absolute from the moment focus was gained.** Not renewed by
+typing: a hold a keystroke renews has no bound, and `focusout` is not guaranteed — switch to another
+application mid-sentence and the panel would never learn the box was abandoned. Nothing is lost when
+the cap expires, because the value was written 400 ms after the last keystroke and the paint carries
+`PanelState.focus`, which the page uses to put the caret back at the end of the box. That name is
+echoed from a message the WEBVIEW sent and is written into the page's own script, so it is refused
+unless it matches `[A-Za-z0-9_]+` — dropped rather than escaped, because no legitimate setting name
+needs a quote.
+
+**Writes queue, and a render waits for them.** `onDidReceiveMessage` fired `void this.write(...)` per
+message, so two writes raced and a render could read a configuration a write had not finished
+applying. They go on one chain now, the chain recovers from a rejection instead of staying poisoned,
+and `render` awaits it before deciding anything — without which blur → `change` → write → focusout →
+render is a race the render can win, re-stamping the box from the value being replaced.
+
+The page's script is now EXECUTED by its tests against a fake document rather than scanned as text: a
+script can contain an `input` listener, a debounce and a focus message while posting the wrong key, a
+stale value or the wrong order, and a scan would call that green.
+
 ### The rounds view refreshes for a RESTORED tab too
 
 `refreshRoundsFile` rewrites `rounds.md` only while somebody has it open, and "open" was an exact

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -795,20 +795,48 @@ after focus leaves paints what this one could not. A transition between two cont
 edge — the focusout of the one being left arrives before the focusin of the one being entered, and a
 repaint in between would land on a caret that is on its way.
 
-**The hold is capped at 30 seconds, absolute from the moment focus was gained.** Not renewed by
-typing: a hold a keystroke renews has no bound, and `focusout` is not guaranteed — switch to another
-application mid-sentence and the panel would never learn the box was abandoned. Nothing is lost when
-the cap expires, because the value was written 400 ms after the last keystroke and the paint carries
-`PanelState.focus`, which the page uses to put the caret back at the end of the box. That name is
-echoed from a message the WEBVIEW sent and is written into the page's own script, so it is refused
-unless it matches `[A-Za-z0-9_]+` — dropped rather than escaped, because no legitimate setting name
-needs a quote.
+**The hold is capped at 30 seconds, from the start of the editing SESSION.** Not renewed by typing,
+and not by tabbing to the next control either — the code round found that half, and it is the same
+defect twice: a cap a keystroke or a focus change renews is a cap with no bound. `focusout` is not
+guaranteed on top of that: switch to another application mid-sentence and the panel would never learn
+the box was abandoned, which is the whole reason there is a cap at all. Closing the sidebar fires no
+`focusout` either, so disposal forgets the editing state outright; without that a view resolved again
+inside the cap would refuse to paint and would refocus a control from a page that no longer exists.
+
+**Nothing is lost when the cap expires.** The value was written 400 ms after the last keystroke, and
+the paint carries `PanelState.focus` — `{ id, start, end }`. The id is `setting|vendor|role`, not the
+setting name: a role-keyed control and a vendor-keyed one both carry `data-setting="rounds"`, and a
+name would refocus whichever of them the document held first. The caret rides on the debounced write
+that already happens, so it costs no message of its own, and it is clamped to the length of the value
+the rebuilt page holds. The page compares the id as DATA against ids it builds from its own
+attributes — it never becomes a selector. On the way out it is refused unless it matches
+`[A-Za-z0-9_.-]+\|[A-Za-z0-9_.-]*\|[A-Za-z0-9_.-]*`, the caret is coerced to two ordered
+non-negative integers, and the serialised result has `<` escaped: a whitelist alone is a guarantee
+that depends on nobody widening it.
+
+**One write per change, not two.** `change` compares a control with the value it held when it gained
+FOCUS, not with the value last sent — so typing, pausing past the write, then clicking away wrote the
+same string twice. The page remembers what it last posted per control and skips a repeat.
 
 **Writes queue, and a render waits for them.** `onDidReceiveMessage` fired `void this.write(...)` per
 message, so two writes raced and a render could read a configuration a write had not finished
 applying. They go on one chain now, the chain recovers from a rejection instead of staying poisoned,
 and `render` awaits it before deciding anything — without which blur → `change` → write → focusout →
-render is a race the render can win, re-stamping the box from the value being replaced.
+render is a race the render can win, re-stamping the box from the value being replaced. It awaits the
+queue until it is STABLE rather than once, because a write appended while the render was suspended
+would otherwise be read a moment too late; bounded to five rounds, since under continuous typing the
+queue never settles and a render that waits for silence is a render that never happens.
+
+`choosePrompt` and `run` deliberately do NOT join that queue. `choosePrompt` renders at the end of
+itself and `render` awaits the queue, so queueing it would deadlock; and `run` installs binaries and
+starts processes, so a render waiting behind one would freeze the panel for as long as an install
+takes.
+
+**The open tail.** A `config.update` that REJECTS — an unwritable `settings.json` — leaves the typed
+value in the document and nowhere else, and the paint that eventually lands replaces it. The person
+is told by the error notification `save` already raises, and surviving it properly would mean the
+host keeping a shadow copy of what every dirty control holds: a second source of truth for a control
+value, which is the drift this module has already paid for twice. Named here rather than built.
 
 The page's script is now EXECUTED by its tests against a fake document rather than scanned as text: a
 script can contain an `input` listener, a debounce and a focus message while posting the wrong key, a

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.19",
+  "version": "0.31.20",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -240,7 +240,8 @@ export class PanelProvider implements vscode.WebviewViewProvider {
    * one being entered.</p>
    */
   private editingSince = 0;
-  private editingSetting = '';
+  private editingId = '';
+  private editingCaret: readonly [number, number] = [0, 0];
   /**
    * Every write, in the order the page asked for it.
    *
@@ -259,13 +260,18 @@ export class PanelProvider implements vscode.WebviewViewProvider {
 
   resolveWebviewView(view: vscode.WebviewView): void {
     this.held.hold(view);
+    // A new document, so nothing in it is focused yet — whatever the last one left behind.
+    this.forgetEditing();
     // Only ever clears the handle when THIS view is still the one held: VS Code re-creates a hidden
     // view when it is shown again, so a late callback from a replaced view would otherwise blank
     // the live one and stop the sidebar updating until something else resolved it.
-    view.onDidDispose(() => this.held.release(view));
+    view.onDidDispose(() => {
+      this.held.release(view);
+      this.forgetEditing();
+    });
     view.webview.options = { enableScripts: true };
     view.webview.onDidReceiveMessage(
-      (m: { type: string; key?: string; value?: unknown; vendor?: string; command?: string; id?: string; open?: boolean; role?: string; round?: number; setting?: string; editing?: boolean }) => {
+      (m: { type: string; key?: string; value?: unknown; vendor?: string; command?: string; id?: string; open?: boolean; role?: string; round?: number; editing?: boolean; start?: number; end?: number }) => {
         if (m.type === 'section' && m.id !== undefined) {
           this.openSections = m.open === true
             ? [...new Set([...this.openSections, m.id])]
@@ -275,7 +281,7 @@ export class PanelProvider implements vscode.WebviewViewProvider {
         } else if (m.type === 'setting') {
           this.enqueue(() => this.write({ key: m.key, value: m.value, vendor: m.vendor, role: m.role }));
         } else if (m.type === 'focus') {
-          this.editing(m.editing === true, m.setting ?? '');
+          this.editing(m.editing === true, m.id ?? '', Number(m.start), Number(m.end));
         } else if (m.type === 'command') {
           void this.run(m.command, m.id);
         }
@@ -481,7 +487,18 @@ export class PanelProvider implements vscode.WebviewViewProvider {
     // and then `focusout`, and the render the release asks for would otherwise overtake the write
     // it followed and re-stamp the box with the value being replaced — the symptom, reintroduced by
     // the fix. `queued` never stays rejected; see `enqueue`.
-    await this.queued;
+    //
+    // Awaited until it is STABLE, because a write appended while this render was suspended would
+    // otherwise be read a moment too late. Bounded: under continuous typing the queue never settles,
+    // and a render that waits for silence is a render that never happens.
+    for (let round = 0; round < 5; round += 1) {
+      const seen = this.queued;
+      // eslint-disable-next-line no-await-in-loop -- the point is to wait for each one in turn.
+      await seen;
+      if (seen === this.queued) {
+        break;
+      }
+    }
     const config = vscode.workspace.getConfiguration('coai');
     const settings = settingsFrom((section) => config.get(section));
     const vendors = vendorsFrom(this.read(config)('vendors'));
@@ -522,7 +539,9 @@ export class PanelProvider implements vscode.WebviewViewProvider {
       // Only while something IS focused — and by the time a paint gets past the hold below, that
       // means the hold ran out under it. An ordinary paint carries nothing and steals nobody's
       // focus.
-      focus: this.editingSince > 0 ? this.editingSetting : '',
+      focus: this.editingSince > 0
+        ? { id: this.editingId, start: this.editingCaret[0], end: this.editingCaret[1] }
+        : undefined,
     };
 
     // Two update paths, and which one runs is the whole fix for the pickers.
@@ -989,16 +1008,35 @@ export class PanelProvider implements vscode.WebviewViewProvider {
    * exactly this, and `render` awaits the write queue first, so the paint it produces carries what
    * was typed rather than what it replaced.</p>
    */
-  private editing(editing: boolean, setting: string): void {
+  private editing(editing: boolean, id: string, start: number, end: number): void {
     if (editing) {
-      this.editingSince = Date.now();
-      this.editingSetting = setting;
+      // Only the FIRST focus of a session starts the clock. Tabbing from one control to the next
+      // must not renew it: a cap a focus change renews is a cap with no bound, which is the same
+      // defect as a cap a keystroke renews. The id and the caret are refreshed every time, because
+      // the paint that eventually lands must find the control the person is in NOW.
+      if (this.editingSince === 0) {
+        this.editingSince = Date.now();
+      }
+      this.editingId = id;
+      this.editingCaret = [start, end];
 
       return;
     }
-    this.editingSince = 0;
-    this.editingSetting = '';
+    this.forgetEditing();
     void this.render();
+  }
+
+  /**
+   * Nothing is being edited.
+   *
+   * <p>Also on DISPOSAL, and that is not tidiness: closing the sidebar mid-sentence fires no
+   * `focusout`, so a view resolved again within the cap would refuse to paint and would refocus a
+   * control from a page that no longer exists.</p>
+   */
+  private forgetEditing(): void {
+    this.editingSince = 0;
+    this.editingId = '';
+    this.editingCaret = [0, 0];
   }
 
   private async write(message: SettingMessage): Promise<void> {

--- a/src_vs_code/src/panelProvider.ts
+++ b/src_vs_code/src/panelProvider.ts
@@ -12,6 +12,7 @@ import {
   OPEN_BY_DEFAULT,
   panelHtml,
   staticKey,
+  withholdsRepaint,
   VSCODE_COMMAND_FOR,
 } from './panelView';
 import { parseSession, SessionFile } from './rounds';
@@ -231,6 +232,23 @@ export class PanelProvider implements vscode.WebviewViewProvider {
   /** The rounds database as last read, and when — a read is a process spawn. */
   private roundsLogCache: DbLog = EMPTY_LOG;
   private roundsLogAt = 0;
+  /**
+   * When a control in the page gained focus, and which one. 0 means none has it.
+   *
+   * <p>What `withholdsRepaint` reads. The page reports both edges, and a transition between two
+   * controls reports neither — the focusout of the one being left arrives before the focusin of the
+   * one being entered.</p>
+   */
+  private editingSince = 0;
+  private editingSetting = '';
+  /**
+   * Every write, in the order the page asked for it.
+   *
+   * <p>`onDidReceiveMessage` used to fire `void this.write(...)` per message, so two writes raced
+   * and a render could read a configuration a write had not finished applying. They queue now, and
+   * `render` awaits the queue.</p>
+   */
+  private queued: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -247,7 +265,7 @@ export class PanelProvider implements vscode.WebviewViewProvider {
     view.onDidDispose(() => this.held.release(view));
     view.webview.options = { enableScripts: true };
     view.webview.onDidReceiveMessage(
-      (m: { type: string; key?: string; value?: unknown; vendor?: string; command?: string; id?: string; open?: boolean; role?: string; round?: number }) => {
+      (m: { type: string; key?: string; value?: unknown; vendor?: string; command?: string; id?: string; open?: boolean; role?: string; round?: number; setting?: string; editing?: boolean }) => {
         if (m.type === 'section' && m.id !== undefined) {
           this.openSections = m.open === true
             ? [...new Set([...this.openSections, m.id])]
@@ -255,7 +273,9 @@ export class PanelProvider implements vscode.WebviewViewProvider {
         } else if (m.type === 'prompt' && m.role !== undefined && m.round !== undefined) {
           void this.choosePrompt(m.role, m.round, String(m.value));
         } else if (m.type === 'setting') {
-          void this.write({ key: m.key, value: m.value, vendor: m.vendor, role: m.role });
+          this.enqueue(() => this.write({ key: m.key, value: m.value, vendor: m.vendor, role: m.role }));
+        } else if (m.type === 'focus') {
+          this.editing(m.editing === true, m.setting ?? '');
         } else if (m.type === 'command') {
           void this.run(m.command, m.id);
         }
@@ -457,6 +477,11 @@ export class PanelProvider implements vscode.WebviewViewProvider {
     if (this.held.view === undefined) {
       return;
     }
+    // Never render from a configuration this panel has not finished writing. Blur fires `change`
+    // and then `focusout`, and the render the release asks for would otherwise overtake the write
+    // it followed and re-stamp the box with the value being replaced — the symptom, reintroduced by
+    // the fix. `queued` never stays rejected; see `enqueue`.
+    await this.queued;
     const config = vscode.workspace.getConfiguration('coai');
     const settings = settingsFrom((section) => config.get(section));
     const vendors = vendorsFrom(this.read(config)('vendors'));
@@ -494,6 +519,10 @@ export class PanelProvider implements vscode.WebviewViewProvider {
       // will never hold them would only invite somebody to add them to it one day and split the
       // one reader in two.
       chat: chatSettingsFrom((key: string) => config.get(key)),
+      // Only while something IS focused — and by the time a paint gets past the hold below, that
+      // means the hold ran out under it. An ordinary paint carries nothing and steals nobody's
+      // focus.
+      focus: this.editingSince > 0 ? this.editingSetting : '',
     };
 
     // Two update paths, and which one runs is the whole fix for the pickers.
@@ -517,7 +546,12 @@ export class PanelProvider implements vscode.WebviewViewProvider {
     }
 
     const key = staticKey(state);
-    if (key !== this.paintedKey) {
+    // A third answer, between the two: WITHHOLD. Assigning the html rebuilds the document, and a
+    // document rebuilt under a focused control takes the caret and anything typed since the last
+    // write with it — which is how `поясни` was lost, five times a minute, to probes and version
+    // checks nobody asked for. The key is deliberately NOT recorded while a paint is withheld, so
+    // the next render after focus leaves paints what this one could not.
+    if (key !== this.paintedKey && !withholdsRepaint(this.editingSince, Date.now())) {
       // Guarded as well as null-checked, because disposal can still land between the line above and
       // this one — and recorded only AFTER the paint succeeded. Setting it first was a defect of
       // its own: a disposal here left `paintedKey` claiming this state was painted, so the view VS
@@ -935,6 +969,38 @@ export class PanelProvider implements vscode.WebviewViewProvider {
    * the vendor list back unchanged, and `coai.rounds` was never written at all — which read, from
    * the panel, as a number that would not stick.</p>
    */
+  /**
+   * Put one write on the queue, and keep the queue usable whatever it does.
+   *
+   * <p>The work runs on both settle paths of the promise before it, and its own rejection is
+   * swallowed here — a chain left rejected would never write another setting and would take
+   * `render`'s `await` down with it, so a single failed update would freeze the panel for the life
+   * of the window. A failure has already been reported to the person by {@link save}, which is the
+   * only place that knows what could not be written.</p>
+   */
+  private enqueue(work: () => Promise<void>): void {
+    this.queued = this.queued.then(work, work).catch(() => undefined);
+  }
+
+  /**
+   * The page reporting that a control gained or lost focus.
+   *
+   * <p>Losing it renders at once: a paint withheld while the person was typing has been waiting for
+   * exactly this, and `render` awaits the write queue first, so the paint it produces carries what
+   * was typed rather than what it replaced.</p>
+   */
+  private editing(editing: boolean, setting: string): void {
+    if (editing) {
+      this.editingSince = Date.now();
+      this.editingSetting = setting;
+
+      return;
+    }
+    this.editingSince = 0;
+    this.editingSetting = '';
+    void this.render();
+  }
+
   private async write(message: SettingMessage): Promise<void> {
     const write = settingWrite(message);
     if (write === undefined) {

--- a/src_vs_code/src/panelView.ts
+++ b/src_vs_code/src/panelView.ts
@@ -161,6 +161,49 @@ export interface PanelState {
    * one set of keys is the drift this repository has already paid for twice.</p>
    */
   readonly chat?: ChatSettings | undefined;
+  /**
+   * The `data-setting` name of the control that had focus when this paint could no longer be
+   * withheld — so the page can put the caret back where the person left it.
+   *
+   * <p>Optional, like {@link PanelState.chat}: absent means nothing was focused, which is the
+   * ordinary paint. Only ever a setting NAME; {@link panelHtml} refuses anything else before it can
+   * reach the page's script.</p>
+   */
+  readonly focus?: string | undefined;
+}
+
+/**
+ * How long a textarea waits after the last keystroke before its value is written.
+ *
+ * <p>One write per pause rather than one per key. Short enough that leaving the window cannot
+ * plausibly cost a sentence, long enough that a fast typist does not produce a write per character.
+ * The value is flushed at once on blur, on the panel being hidden and on the page unloading, so this
+ * is the delay for somebody who stops typing and does nothing else at all.</p>
+ */
+export const SAVE_AFTER_MS = 400;
+
+/**
+ * How long a full repaint may be withheld from a focused control before it lands anyway.
+ *
+ * <p>Absolute, from the moment focus was gained — not renewed by typing. A hold a keystroke renews
+ * is a hold with no bound, and `focusout` is not guaranteed: switch to another application
+ * mid-sentence and the panel would never learn the box was abandoned. Nothing is lost when the cap
+ * expires — the value was written {@link SAVE_AFTER_MS} after the last keystroke, and the paint
+ * carries {@link PanelState.focus}, so the caret comes back.</p>
+ */
+export const REPAINT_HOLD_MS = 30_000;
+
+/**
+ * Whether a repaint must wait, because a control is being edited and the hold has not run out.
+ *
+ * <p>Pure, and beside {@link staticKey} on purpose: which of the two update paths runs is the one
+ * decision this panel makes that no test can reach through `vscode`, so both halves of it live
+ * where a test can call them.</p>
+ *
+ * @param editingSince when a control gained focus, or 0 when none has it
+ */
+export function withholdsRepaint(editingSince: number, now: number): boolean {
+  return editingSince > 0 && now - editingSince < REPAINT_HOLD_MS;
 }
 
 /**
@@ -171,6 +214,18 @@ export interface PanelState {
  * once and afterwards only visit when something is waiting on you.</p>
  */
 export const OPEN_BY_DEFAULT: readonly string[] = [];
+
+/**
+ * A setting name, or nothing at all — never anything that could end a script element.
+ *
+ * <p>{@link PanelState.focus} is echoed back from a message the WEBVIEW sent, and it is written into
+ * the page's own script as a string literal. A name is `[A-Za-z0-9_]`, every declared setting key
+ * is, and anything else is dropped rather than escaped: there is no legitimate value here that
+ * needs a quote or a bracket, so refusing them costs nothing and closes the injection outright.</p>
+ */
+function focusName(focus: string | undefined): string {
+  return focus !== undefined && /^[A-Za-z0-9_]+$/.test(focus) ? focus : '';
+}
 
 export function panelHtml(state: PanelState, nonce: string, nowMs: number = Date.now()): string {
   const open = state.openSections.length === 0 ? OPEN_BY_DEFAULT : state.openSections;
@@ -200,17 +255,89 @@ export function panelHtml(state: PanelState, nonce: string, nowMs: number = Date
 ${body}
 <script nonce="${nonce}">
   const vscode = acquireVsCodeApi();
+
+  const save = (el) => {
+    const value = el.type === 'checkbox' ? el.checked : el.type === 'number' ? Number(el.value) : el.value;
+    if (value === '__other__') {
+      // Not a model — a request to type one; the input box comes from the provider side.
+      vscode.postMessage({ type: 'command', command: 'customModel', id: el.dataset.vendor });
+      return;
+    }
+    vscode.postMessage({ type: 'setting', key: el.dataset.setting, value,
+                         vendor: el.dataset.vendor, role: el.dataset.role });
+  };
+
+  // A textarea fires \`change\` at BLUR, so everything typed before that lived only in the DOM — and
+  // a repaint, which can land from five causes that are nobody's doing, threw the DOM away with it.
+  // A textarea is written as it is TYPED now: one message per pause rather than one per key, and
+  // flushed the moment the box is left, the panel is hidden, or the page goes away. A select and a
+  // checkbox keep \`change\` alone — a dropdown must not save half-chosen.
+  let waiting = null;
+  let timer = 0;
+  const forget = () => {
+    if (timer !== 0) {
+      clearTimeout(timer);
+      timer = 0;
+    }
+    waiting = null;
+  };
+  const flush = () => {
+    const el = waiting;
+    forget();
+    if (el !== null) {
+      save(el);
+    }
+  };
+
   for (const el of document.querySelectorAll('[data-setting]')) {
-    el.addEventListener('change', () => {
-      const value = el.type === 'checkbox' ? el.checked : el.type === 'number' ? Number(el.value) : el.value;
-      if (value === '__other__') {
-        // Not a model — a request to type one; the input box comes from the provider side.
-        vscode.postMessage({ type: 'command', command: 'customModel', id: el.dataset.vendor });
+    el.addEventListener('change', () => { forget(); save(el); });
+    if (el.tagName === 'TEXTAREA') {
+      el.addEventListener('input', () => {
+        waiting = el;
+        if (timer !== 0) {
+          clearTimeout(timer);
+        }
+        timer = setTimeout(() => { timer = 0; flush(); }, ${SAVE_AFTER_MS});
+      });
+    }
+    el.addEventListener('focusin', () =>
+      vscode.postMessage({ type: 'focus', setting: el.dataset.setting, editing: true }));
+    el.addEventListener('focusout', (event) => {
+      // The value first, ALWAYS, and the release second: the provider repaints when it hears the
+      // release, and a repaint that overtook the write would re-stamp the box from the value being
+      // replaced — the very symptom this fixes.
+      flush();
+      // Tabbing from one control to the next is not a moment to rebuild the page. The focusout of
+      // the control being left arrives before the focusin of the one being entered, so a release
+      // here would repaint over a caret that is on its way.
+      const next = event.relatedTarget;
+      if (next && next.dataset && next.dataset.setting !== undefined) {
         return;
       }
-      vscode.postMessage({ type: 'setting', key: el.dataset.setting, value,
-                           vendor: el.dataset.vendor, role: el.dataset.role });
+      vscode.postMessage({ type: 'focus', setting: el.dataset.setting, editing: false });
     });
+  }
+  // Neither is a blur, and both can be the last thing that happens to this page.
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      flush();
+    }
+  });
+  window.addEventListener('pagehide', () => flush());
+
+  // A repaint that could not be withheld any longer lands under a focused control. The provider
+  // names it, and the caret comes back to the end of what is in it — the end rather than where it
+  // was, because a caret position per keystroke is a message per keystroke, and this happens only
+  // after half a minute of focus that never moved.
+  const focusOn = '${focusName(state.focus)}';
+  if (focusOn !== '') {
+    const back = document.querySelector('[data-setting="' + focusOn + '"]');
+    if (back !== null) {
+      back.focus();
+      if (typeof back.setSelectionRange === 'function') {
+        back.setSelectionRange(back.value.length, back.value.length);
+      }
+    }
   }
   for (const el of document.querySelectorAll('[data-prompt]')) {
     el.addEventListener('change', () =>

--- a/src_vs_code/src/panelView.ts
+++ b/src_vs_code/src/panelView.ts
@@ -169,7 +169,21 @@ export interface PanelState {
    * ordinary paint. Only ever a setting NAME; {@link panelHtml} refuses anything else before it can
    * reach the page's script.</p>
    */
-  readonly focus?: string | undefined;
+  readonly focus?: PanelFocus | undefined;
+}
+
+/**
+ * The control that had focus when a paint could no longer be withheld, and where its caret was.
+ *
+ * <p>`id` is `setting|vendor|role`, not the setting name alone: a role-keyed control and a
+ * vendor-keyed one both carry `data-setting="rounds"`, so a name would refocus whichever of them
+ * the document happened to hold first. The page builds this id from its own attributes and compares
+ * it as DATA — it is never put into a selector, so nothing here can become one.</p>
+ */
+export interface PanelFocus {
+  readonly id: string;
+  readonly start: number;
+  readonly end: number;
 }
 
 /**
@@ -215,16 +229,28 @@ export function withholdsRepaint(editingSince: number, now: number): boolean {
  */
 export const OPEN_BY_DEFAULT: readonly string[] = [];
 
+/** `setting|vendor|role`, each of them a name. Nothing that could end a script or open a tag. */
+const FOCUS_ID = /^[A-Za-z0-9_.-]+\|[A-Za-z0-9_.-]*\|[A-Za-z0-9_.-]*$/;
+
 /**
- * A setting name, or nothing at all — never anything that could end a script element.
+ * {@link PanelState.focus} as a literal the page's own script can hold, or `null`.
  *
- * <p>{@link PanelState.focus} is echoed back from a message the WEBVIEW sent, and it is written into
- * the page's own script as a string literal. A name is `[A-Za-z0-9_]`, every declared setting key
- * is, and anything else is dropped rather than escaped: there is no legitimate value here that
- * needs a quote or a bracket, so refusing them costs nothing and closes the injection outright.</p>
+ * <p>Three layers, because this value is echoed back from a message the WEBVIEW sent and is written
+ * into a `<script>`: the id must match {@link FOCUS_ID} or the whole thing is dropped rather than
+ * escaped — no legitimate control id needs a quote — the caret is coerced to two ordered
+ * non-negative integers, and `<` is escaped in the serialised result so that widening the pattern
+ * one day cannot reopen the hole. The code round asked for a serialiser instead of a whitelist; it
+ * has both, because a whitelist alone is a guarantee that depends on nobody editing it.</p>
  */
-function focusName(focus: string | undefined): string {
-  return focus !== undefined && /^[A-Za-z0-9_]+$/.test(focus) ? focus : '';
+function focusLiteral(focus: PanelFocus | undefined): string {
+  if (focus === undefined || !FOCUS_ID.test(focus.id)) {
+    return 'null';
+  }
+  const whole = (value: number): number => (Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0);
+  const start = whole(focus.start);
+
+  return JSON.stringify({ id: focus.id, start, end: Math.max(start, whole(focus.end)) })
+    .replace(/</g, '\\u003c');
 }
 
 export function panelHtml(state: PanelState, nonce: string, nowMs: number = Date.now()): string {
@@ -256,6 +282,10 @@ ${body}
 <script nonce="${nonce}">
   const vscode = acquireVsCodeApi();
 
+  // What names ONE control. A role-keyed control and a vendor-keyed one can share a setting name,
+  // so a name alone would refocus whichever of them the document holds first.
+  const idOf = (el) => el.dataset.setting + '|' + (el.dataset.vendor || '') + '|' + (el.dataset.role || '');
+  const posted = new Map();
   const save = (el) => {
     const value = el.type === 'checkbox' ? el.checked : el.type === 'number' ? Number(el.value) : el.value;
     if (value === '__other__') {
@@ -263,9 +293,22 @@ ${body}
       vscode.postMessage({ type: 'command', command: 'customModel', id: el.dataset.vendor });
       return;
     }
+    // \`change\` compares with the value the control had when it gained FOCUS, not with the value
+    // last sent — so typing, pausing past the write, then blurring wrote the same string twice.
+    if (posted.get(el) === value) {
+      return;
+    }
+    posted.set(el, value);
     vscode.postMessage({ type: 'setting', key: el.dataset.setting, value,
                          vendor: el.dataset.vendor, role: el.dataset.role });
   };
+  const reportFocus = (el, editing) => vscode.postMessage({
+    type: 'focus',
+    id: idOf(el),
+    editing,
+    start: typeof el.selectionStart === 'number' ? el.selectionStart : 0,
+    end: typeof el.selectionEnd === 'number' ? el.selectionEnd : 0,
+  });
 
   // A textarea fires \`change\` at BLUR, so everything typed before that lived only in the DOM — and
   // a repaint, which can land from five causes that are nobody's doing, threw the DOM away with it.
@@ -297,11 +340,12 @@ ${body}
         if (timer !== 0) {
           clearTimeout(timer);
         }
-        timer = setTimeout(() => { timer = 0; flush(); }, ${SAVE_AFTER_MS});
+        // The caret rides along with the write, so a paint that lands later puts it back where it
+        // is rather than at the end — and it costs no message of its own.
+        timer = setTimeout(() => { timer = 0; flush(); reportFocus(el, true); }, ${SAVE_AFTER_MS});
       });
     }
-    el.addEventListener('focusin', () =>
-      vscode.postMessage({ type: 'focus', setting: el.dataset.setting, editing: true }));
+    el.addEventListener('focusin', () => reportFocus(el, true));
     el.addEventListener('focusout', (event) => {
       // The value first, ALWAYS, and the release second: the provider repaints when it hears the
       // release, and a repaint that overtook the write would re-stamp the box from the value being
@@ -314,7 +358,7 @@ ${body}
       if (next && next.dataset && next.dataset.setting !== undefined) {
         return;
       }
-      vscode.postMessage({ type: 'focus', setting: el.dataset.setting, editing: false });
+      reportFocus(el, false);
     });
   }
   // Neither is a blur, and both can be the last thing that happens to this page.
@@ -329,14 +373,20 @@ ${body}
   // names it, and the caret comes back to the end of what is in it — the end rather than where it
   // was, because a caret position per keystroke is a message per keystroke, and this happens only
   // after half a minute of focus that never moved.
-  const focusOn = '${focusName(state.focus)}';
-  if (focusOn !== '') {
-    const back = document.querySelector('[data-setting="' + focusOn + '"]');
-    if (back !== null) {
+  const focusOn = ${focusLiteral(state.focus)};
+  if (focusOn !== null) {
+    for (const back of document.querySelectorAll('[data-setting]')) {
+      if (idOf(back) !== focusOn.id) {
+        continue;
+      }
       back.focus();
       if (typeof back.setSelectionRange === 'function') {
-        back.setSelectionRange(back.value.length, back.value.length);
+        // Clamped: the value the page was rebuilt with can be shorter than the one the caret was
+        // measured in, and a range past the end is a range nobody asked for.
+        const end = Math.min(focusOn.end, back.value.length);
+        back.setSelectionRange(Math.min(focusOn.start, end), end);
       }
+      break;
     }
   }
   for (const el of document.querySelectorAll('[data-prompt]')) {

--- a/src_vs_code/src/test/thePromptBoxRemembers.test.ts
+++ b/src_vs_code/src/test/thePromptBoxRemembers.test.ts
@@ -1,0 +1,348 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { PanelState, REPAINT_HOLD_MS, panelHtml, staticKey, withholdsRepaint } from '../panelView';
+import { DEFAULTS } from '../settingsShape';
+import { DEFAULT_VENDORS } from '../vendors';
+import { SNIPPET_VERSION } from '../claudeSnippet';
+import { ChatSettings } from '../chatSettings';
+
+/**
+ * What is typed into *What to ask about the selection* stays typed.
+ *
+ * <p>2026-09-09: the operator typed `поясни` into the sidebar's prompt box and it came back holding
+ * what it held before. `coai.chatPrompt` is what every chat turn opens with, so a prompt that does
+ * not save is a feature that cannot be configured.</p>
+ *
+ * <p><b>The measurement, because the draft plan's premise was wrong.</b> It said the obvious fix —
+ * save on `input` — makes things worse, since every save is a `config.update`, every update fires
+ * `onDidChangeConfiguration`, and the listener repaints, so the box would lose focus after every
+ * character. It does not: `render()` only assigns `webview.html` when `staticKey` moves, and
+ * `staticKey` reads eleven fields of which `chat` is not one. A chat setting cannot repaint the
+ * panel. That is asserted below, so the day somebody adds `chat` to the key this design fails loudly
+ * rather than silently.</p>
+ *
+ * <p>What DOES kill the draft is that a full repaint can land at any moment from five causes that
+ * are nobody's doing — a local-engine probe, the server's own version, the published release, the
+ * Team-server catalog, and any other setting written from any window — while the typed text exists
+ * only in the DOM, because the `[data-setting]` listener posted on `change`, which a textarea fires
+ * at BLUR. Hence two halves: the value is durable as it is typed, and a repaint does not rebuild the
+ * page under a focused control.</p>
+ *
+ * <p>These tests RUN the page's own script. The code round on the plan refused a text scan of it —
+ * a script can contain an `input` listener, a debounce and a focus message while posting the wrong
+ * key, a stale value or the wrong order, and a scan would call that green. So the script is executed
+ * against a fake document and the messages it posts are read.</p>
+ */
+
+const chat: ChatSettings = { prompt: 'Explain', language: 'en', autoSend: 'keyboard', model: '' };
+
+const state = (over: Partial<PanelState> = {}): PanelState => ({
+  settings: DEFAULTS,
+  vendors: DEFAULT_VENDORS,
+  codexModels: [], agyModels: [],
+  localEngines: {},
+  server: { kind: 'absent', version: '', remembered: false, updateOffered: false },
+  side: '',
+  perSide: false,
+  questions: [],
+  sessions: [],
+  openSections: ['chat'],
+  usage: [],
+  usageWindow: 'week',
+  cliStatus: {},
+  modelPrices: {},
+  snippetStatus: { kind: 'current', current: SNIPPET_VERSION },
+  latestServerVersion: '',
+  chat,
+  ...over,
+});
+
+// ---------------------------------------------------------------------------------------------
+// A document just real enough to run the page's script against.
+// ---------------------------------------------------------------------------------------------
+
+interface FakeEvent {
+  readonly relatedTarget?: FakeElement | null;
+}
+
+class FakeElement {
+  readonly listeners = new Map<string, ((event: FakeEvent) => void)[]>();
+  focused = false;
+  caret: readonly [number, number] = [0, 0];
+
+  constructor(
+    readonly tagName: string,
+    readonly dataset: Record<string, string | undefined>,
+    public value = '',
+    readonly type = '',
+  ) {}
+
+  addEventListener(kind: string, handler: (event: FakeEvent) => void): void {
+    this.listeners.set(kind, [...(this.listeners.get(kind) ?? []), handler]);
+  }
+
+  fire(kind: string, event: FakeEvent = {}): void {
+    for (const handler of this.listeners.get(kind) ?? []) {
+      handler(event);
+    }
+  }
+
+  focus(): void {
+    this.focused = true;
+  }
+
+  setSelectionRange(start: number, end: number): void {
+    this.caret = [start, end];
+  }
+}
+
+interface Page {
+  readonly posted: readonly Record<string, unknown>[];
+  readonly elements: readonly FakeElement[];
+  fire(index: number, kind: string, event?: FakeEvent): void;
+  document(kind: string, hidden?: boolean): void;
+  tick(): void;
+}
+
+/** The `<script>` the panel ships, cut out of its own html. */
+function pageScript(html: string): string {
+  const open = html.indexOf('<script');
+  const start = html.indexOf('>', open) + 1;
+  const end = html.indexOf('</script>', start);
+  assert.ok(open >= 0 && end > start, 'the panel page has no script to run');
+
+  return html.slice(start, end);
+}
+
+/** Run the panel's script over a handful of controls and collect everything it posts. */
+function run(elements: readonly FakeElement[], over: Partial<PanelState> = {}): Page {
+  const posted: Record<string, unknown>[] = [];
+  const documentListeners = new Map<string, ((event: FakeEvent) => void)[]>();
+  const timers = new Map<number, () => void>();
+  let nextTimer = 1;
+  let hidden = false;
+
+  const query = (selector: string): FakeElement[] => {
+    if (selector === '[data-setting]') {
+      return [...elements];
+    }
+    const named = /^\[data-setting="([^"]*)"\]$/.exec(selector);
+    if (named !== null) {
+      return elements.filter((el) => el.dataset.setting === named[1]);
+    }
+
+    return [];
+  };
+  const fakeDocument = {
+    querySelectorAll: query,
+    querySelector: (selector: string): FakeElement | null => query(selector)[0] ?? null,
+    getElementById: (): null => null,
+    addEventListener: (kind: string, handler: (event: FakeEvent) => void): void => {
+      documentListeners.set(kind, [...(documentListeners.get(kind) ?? []), handler]);
+    },
+    get visibilityState(): string {
+      return hidden ? 'hidden' : 'visible';
+    },
+  };
+  const fakeWindow = {
+    addEventListener: (kind: string, handler: (event: FakeEvent) => void): void => {
+      documentListeners.set(kind, [...(documentListeners.get(kind) ?? []), handler]);
+    },
+  };
+  const later = (fn: () => void): number => {
+    timers.set(nextTimer, fn);
+
+    return nextTimer++;
+  };
+  const cancel = (id: number): void => {
+    timers.delete(id);
+  };
+
+  const script = pageScript(panelHtml(state(over), 'test-nonce'));
+  // eslint-disable-next-line no-new-func -- the shipped script is the thing under test; a scan of
+  // its text is what the code round refused.
+  const body = new Function('acquireVsCodeApi', 'document', 'window', 'setTimeout', 'clearTimeout', script);
+  body(
+    () => ({ postMessage: (message: Record<string, unknown>) => { posted.push(message); } }),
+    fakeDocument,
+    fakeWindow,
+    later,
+    cancel,
+  );
+
+  return {
+    posted,
+    elements,
+    fire: (index, kind, event) => { elements[index].fire(kind, event); },
+    document: (kind, hide = false) => {
+      hidden = hide;
+      for (const handler of documentListeners.get(kind) ?? []) {
+        handler({});
+      }
+    },
+    tick: () => {
+      const due = [...timers.values()];
+      timers.clear();
+      for (const fn of due) {
+        fn();
+      }
+    },
+  };
+}
+
+const promptBox = (): FakeElement => new FakeElement('TEXTAREA', { setting: 'chatPrompt' });
+const languagePicker = (): FakeElement => new FakeElement('SELECT', { setting: 'chatLanguage' }, 'en');
+const settings = (page: Page): Record<string, unknown>[] =>
+  page.posted.filter((message) => message.type === 'setting');
+const focusMessages = (page: Page): Record<string, unknown>[] =>
+  page.posted.filter((message) => message.type === 'focus');
+
+// ---------------------------------------------------------------------------------------------
+
+test('what is typed into the prompt box is saved without waiting for a blur', () => {
+  const box = promptBox();
+  const page = run([box, languagePicker()]);
+
+  box.value = 'по';
+  page.fire(0, 'input');
+  box.value = 'поясни';
+  page.fire(0, 'input');
+  page.tick();
+
+  assert.deepEqual(settings(page), [{
+    type: 'setting', key: 'chatPrompt', value: 'поясни', vendor: undefined, role: undefined,
+  }], 'one save, carrying the last thing typed');
+});
+
+test('a dropdown still saves when it is chosen, never as it is typed', () => {
+  const picker = languagePicker();
+  const page = run([promptBox(), picker]);
+
+  picker.value = 'ru';
+  page.fire(1, 'input');
+  page.tick();
+
+  assert.deepEqual(settings(page), [], 'a half-chosen dropdown was written to settings');
+
+  page.fire(1, 'change');
+
+  assert.equal(settings(page).length, 1, 'choosing a language saved nothing');
+  assert.equal(settings(page)[0].key, 'chatLanguage');
+  assert.equal(settings(page)[0].value, 'ru');
+});
+
+test('the page says when a control has focus, so nothing rebuilds it underneath', () => {
+  const box = promptBox();
+  const page = run([box, languagePicker()]);
+
+  page.fire(0, 'focusin');
+
+  assert.deepEqual(focusMessages(page), [{ type: 'focus', setting: 'chatPrompt', editing: true }]);
+
+  page.fire(0, 'focusout', { relatedTarget: null });
+
+  assert.deepEqual(focusMessages(page)[1], { type: 'focus', setting: 'chatPrompt', editing: false });
+});
+
+test('moving between two controls is not a moment to rebuild the page', () => {
+  const box = promptBox();
+  const picker = languagePicker();
+  const page = run([box, picker]);
+
+  page.fire(0, 'focusin');
+  page.fire(0, 'focusout', { relatedTarget: picker });
+  page.fire(1, 'focusin');
+
+  assert.deepEqual(
+    focusMessages(page).filter((message) => message.editing === false), [],
+    'the page was released for a repaint while focus was still inside it',
+  );
+  // Paired with the transition actually being seen, so this cannot pass by reporting nothing at all.
+  assert.deepEqual(focusMessages(page).map((message) => message.setting), ['chatPrompt', 'chatLanguage']);
+});
+
+test('leaving the box writes what was typed, before it says the box is free', () => {
+  const box = promptBox();
+  const page = run([box, languagePicker()]);
+
+  page.fire(0, 'focusin');
+  box.value = 'поясни';
+  page.fire(0, 'input');
+  page.fire(0, 'focusout', { relatedTarget: null });
+
+  const order = page.posted.map((message) => `${String(message.type)}:${String(message.value ?? message.editing)}`);
+  assert.deepEqual(order, ['focus:true', 'setting:поясни', 'focus:false'],
+    'the value must be written before the panel is told it may repaint');
+});
+
+test('a panel that is being hidden writes what was typed into it', () => {
+  const box = promptBox();
+  const page = run([box, languagePicker()]);
+
+  box.value = 'поясни';
+  page.fire(0, 'input');
+  page.document('visibilitychange', true);
+
+  assert.deepEqual(settings(page).map((message) => message.value), ['поясни']);
+});
+
+test('a paint that could not be withheld any longer puts the caret back', () => {
+  const box = promptBox();
+  box.value = 'поясни';
+  const page = run([box, languagePicker()], { focus: 'chatPrompt' });
+
+  assert.equal(page.elements[0].focused, true, 'the control the paint landed under was not refocused');
+  assert.deepEqual(page.elements[0].caret, [6, 6], 'the caret did not return to the end of what was typed');
+});
+
+test('an ordinary paint takes nobody’s focus', () => {
+  const page = run([promptBox(), languagePicker()]);
+
+  assert.equal(page.elements[0].focused, false, 'a repaint stole focus into the sidebar');
+});
+
+test('a focus name that is not a setting name never reaches the page', () => {
+  const hostile = panelHtml(state({ focus: '</script><script>alert(1)' }), 'test-nonce');
+
+  assert.ok(!hostile.includes('alert(1)'), 'a value echoed from the webview was written into its own script');
+  assert.match(hostile, /const focusOn = '';/, 'the name was escaped rather than refused');
+});
+
+test('a chat setting cannot repaint the panel — the measurement this design rests on', () => {
+  // The draft plan said saving on `input` would repaint after every character. It cannot: the paint
+  // decision is `staticKey`, and `chat` is not one of the eleven fields it reads. Asserted so that
+  // adding `chat` to the key fails HERE, with this sentence, rather than by making the box flicker.
+  const typed: ChatSettings = { ...chat, prompt: 'поясни' };
+
+  assert.equal(staticKey(state({ chat: typed })), staticKey(state()),
+    'a chat setting now moves the repaint key, and saving as you type would rebuild the page per keystroke');
+});
+
+test('a repaint waits for a focused control, and not forever', () => {
+  const now = 1_000_000;
+
+  assert.equal(withholdsRepaint(0, now), false, 'nothing is focused, so nothing may be withheld');
+  assert.equal(withholdsRepaint(now - 1_000, now), true, 'a paint landed on a control being edited');
+  assert.equal(withholdsRepaint(now - REPAINT_HOLD_MS, now), false, 'the hold has no bound');
+  assert.equal(withholdsRepaint(now - REPAINT_HOLD_MS - 1, now), false, 'the hold outlived its cap');
+});
+
+test('the host never renders from a configuration it has not finished writing', () => {
+  // Structural: `panelProvider.ts` imports `vscode`, so no unit test here can instantiate it — the
+  // idiom of `theLogRefusesToOpen.test.ts`. These three are orderings and lifetimes inside one
+  // class, which is exactly what a unit test could not see even if it could reach them.
+  const source = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'panelProvider.ts'), 'utf8');
+
+  const awaits = source.indexOf('await this.queued;');
+  const paints = source.indexOf('const key = staticKey(state);');
+  assert.ok(awaits > 0 && paints > awaits, 'render must await the write queue before it decides what to paint');
+
+  assert.match(source, /if \(key !== this\.paintedKey && !withholdsRepaint\(this\.editingSince, Date\.now\(\)\)\)/,
+    'the paint no longer consults whether a control is being edited');
+  assert.match(source, /this\.queued = this\.queued\.then\(work, work\)\.catch\(/,
+    'a rejected write would poison the queue and freeze every later one');
+  assert.match(source, /this\.enqueue\(\(\) => this\.write\(/,
+    'settings are written straight off the message again, so two of them can race');
+});

--- a/src_vs_code/src/test/thePromptBoxRemembers.test.ts
+++ b/src_vs_code/src/test/thePromptBoxRemembers.test.ts
@@ -71,6 +71,8 @@ class FakeElement {
   readonly listeners = new Map<string, ((event: FakeEvent) => void)[]>();
   focused = false;
   caret: readonly [number, number] = [0, 0];
+  selectionStart = 0;
+  selectionEnd = 0;
 
   constructor(
     readonly tagName: string,
@@ -95,6 +97,8 @@ class FakeElement {
 
   setSelectionRange(start: number, end: number): void {
     this.caret = [start, end];
+    this.selectionStart = start;
+    this.selectionEnd = end;
   }
 }
 
@@ -194,6 +198,8 @@ function run(elements: readonly FakeElement[], over: Partial<PanelState> = {}): 
 
 const promptBox = (): FakeElement => new FakeElement('TEXTAREA', { setting: 'chatPrompt' });
 const languagePicker = (): FakeElement => new FakeElement('SELECT', { setting: 'chatLanguage' }, 'en');
+/** Two controls that share a setting name and are told apart only by their role. */
+const roundsFor = (role: string): FakeElement => new FakeElement('INPUT', { setting: 'rounds', role }, '2', 'number');
 const settings = (page: Page): Record<string, unknown>[] =>
   page.posted.filter((message) => message.type === 'setting');
 const focusMessages = (page: Page): Record<string, unknown>[] =>
@@ -239,11 +245,13 @@ test('the page says when a control has focus, so nothing rebuilds it underneath'
 
   page.fire(0, 'focusin');
 
-  assert.deepEqual(focusMessages(page), [{ type: 'focus', setting: 'chatPrompt', editing: true }]);
+  assert.deepEqual(focusMessages(page),
+    [{ type: 'focus', id: 'chatPrompt||', editing: true, start: 0, end: 0 }]);
 
   page.fire(0, 'focusout', { relatedTarget: null });
 
-  assert.deepEqual(focusMessages(page)[1], { type: 'focus', setting: 'chatPrompt', editing: false });
+  assert.deepEqual(focusMessages(page)[1],
+    { type: 'focus', id: 'chatPrompt||', editing: false, start: 0, end: 0 });
 });
 
 test('moving between two controls is not a moment to rebuild the page', () => {
@@ -260,7 +268,7 @@ test('moving between two controls is not a moment to rebuild the page', () => {
     'the page was released for a repaint while focus was still inside it',
   );
   // Paired with the transition actually being seen, so this cannot pass by reporting nothing at all.
-  assert.deepEqual(focusMessages(page).map((message) => message.setting), ['chatPrompt', 'chatLanguage']);
+  assert.deepEqual(focusMessages(page).map((message) => message.id), ['chatPrompt||', 'chatLanguage||']);
 });
 
 test('leaving the box writes what was typed, before it says the box is free', () => {
@@ -291,10 +299,30 @@ test('a panel that is being hidden writes what was typed into it', () => {
 test('a paint that could not be withheld any longer puts the caret back', () => {
   const box = promptBox();
   box.value = 'поясни';
-  const page = run([box, languagePicker()], { focus: 'chatPrompt' });
+  const page = run([box, languagePicker()], { focus: { id: 'chatPrompt||', start: 2, end: 2 } });
 
   assert.equal(page.elements[0].focused, true, 'the control the paint landed under was not refocused');
-  assert.deepEqual(page.elements[0].caret, [6, 6], 'the caret did not return to the end of what was typed');
+  assert.deepEqual(page.elements[0].caret, [2, 2], 'the caret did not come back where it was');
+});
+
+test('the caret is put back inside a value the rebuilt page is shorter than', () => {
+  const box = promptBox();
+  box.value = 'по';
+  const page = run([box], { focus: { id: 'chatPrompt||', start: 40, end: 90 } });
+
+  assert.deepEqual(page.elements[0].caret, [2, 2], 'a range past the end of the box was asked for');
+});
+
+test('two controls sharing a setting name are told apart', () => {
+  // `rounds` is carried by one control per role. A focus anchor that were the setting NAME alone
+  // would refocus whichever of them the document holds first — which is never the one being edited
+  // unless it happens to be Architecture.
+  const architecture = roundsFor('Architecture');
+  const security = roundsFor('SecurityReliability');
+  run([architecture, security], { focus: { id: 'rounds||SecurityReliability', start: 1, end: 1 } });
+
+  assert.equal(security.focused, true, 'the control that was being edited was not the one refocused');
+  assert.equal(architecture.focused, false, 'a namesake control took the focus');
 });
 
 test('an ordinary paint takes nobody’s focus', () => {
@@ -304,10 +332,17 @@ test('an ordinary paint takes nobody’s focus', () => {
 });
 
 test('a focus name that is not a setting name never reaches the page', () => {
-  const hostile = panelHtml(state({ focus: '</script><script>alert(1)' }), 'test-nonce');
+  const hostile = panelHtml(
+    state({ focus: { id: '</script><script>alert(1)', start: 0, end: 0 } }), 'test-nonce');
 
   assert.ok(!hostile.includes('alert(1)'), 'a value echoed from the webview was written into its own script');
-  assert.match(hostile, /const focusOn = '';/, 'the name was escaped rather than refused');
+  assert.match(hostile, /const focusOn = null;/, 'the id was escaped rather than refused');
+
+  // And a caret that is not two ordered whole numbers is coerced rather than carried.
+  const silly = panelHtml(
+    state({ focus: { id: 'chatPrompt||', start: -5, end: Number.NaN } }), 'test-nonce');
+
+  assert.match(silly, /const focusOn = \{"id":"chatPrompt\|\|","start":0,"end":0\};/);
 });
 
 test('a chat setting cannot repaint the panel — the measurement this design rests on', () => {
@@ -335,7 +370,7 @@ test('the host never renders from a configuration it has not finished writing', 
   // class, which is exactly what a unit test could not see even if it could reach them.
   const source = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'panelProvider.ts'), 'utf8');
 
-  const awaits = source.indexOf('await this.queued;');
+  const awaits = source.indexOf('const seen = this.queued;');
   const paints = source.indexOf('const key = staticKey(state);');
   assert.ok(awaits > 0 && paints > awaits, 'render must await the write queue before it decides what to paint');
 
@@ -345,4 +380,29 @@ test('the host never renders from a configuration it has not finished writing', 
     'a rejected write would poison the queue and freeze every later one');
   assert.match(source, /this\.enqueue\(\(\) => this\.write\(/,
     'settings are written straight off the message again, so two of them can race');
+});
+
+test('leaving a box the pause already saved does not write it a second time', () => {
+  const box = promptBox();
+  const page = run([box, languagePicker()]);
+
+  box.value = 'поясни';
+  page.fire(0, 'input');
+  page.tick();
+  page.fire(0, 'change');
+  page.fire(0, 'focusout', { relatedTarget: null });
+
+  assert.deepEqual(settings(page).map((message) => message.value), ['поясни'],
+    'the same value was written twice — `change` compares with the value at focus, not the one sent');
+});
+
+test('the hold is not renewed by moving between controls, and disposal forgets it', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'panelProvider.ts'), 'utf8');
+
+  assert.match(source, /if \(this\.editingSince === 0\) \{\s*\n\s*this\.editingSince = Date\.now\(\);/,
+    'every focus restarts the clock again, so tabbing between controls withholds a paint forever');
+  assert.match(source, /onDidDispose\(\(\) => \{[\s\S]{0,120}this\.forgetEditing\(\);/,
+    'a sidebar closed mid-sentence leaves the host believing a control is still being edited');
+  assert.match(source, /const seen = this\.queued;[\s\S]{0,200}if \(seen !== this\.queued\)|if \(seen === this\.queued\)/,
+    'render awaits one snapshot of the queue, so a write appended while it waited is read too late');
 });


### PR DESCRIPTION
Type an instruction into *What to ask about the selection* and it came back holding what it held
before. `coai.chatPrompt` is what every chat turn opens with, so a prompt that cannot be saved is a
feature that cannot be configured.

## The measurement came first, and it refuted the plan's own premise

The plan said "save on `input`" would make it worse: every save is a `config.update`, every update
fires `onDidChangeConfiguration`, the listener repaints, so the box would lose focus after every
character. **It cannot.** `render()` assigns `webview.html` only when `staticKey` moves, and
`staticKey`'s eleven fields are `settings`, `vendors`, `codexModels`, `localEngines`, `server`,
`side`, `latestServerVersion`, `usageWindow`, `openSections`, `teamServers`, `usageScope`.
`state.chat` is not one of them, and `state.settings` is `CoaiSettings`, which the chat keys are
deliberately not part of. That is now an assertion, so adding `chat` to the key fails with that
sentence rather than by making the box flicker.

**What did kill the draft** is the same reading from the other side. `render()` runs unconditionally
every five seconds from the escalation tick and recomputes all eleven; four of them move with nobody
touching the panel — the local-engine probe, the server's own `--version`, the published release, the
Team-server catalog — and `settings` moves whenever any other control is written, from this window or
another one sharing `settings.json`. Each rebuilt the document, and the typed text lived only in that
document, because the `[data-setting]` listener posted on `change`, which a textarea fires at BLUR.

## Two halves

**A textarea is written as it is typed** — one message per 400 ms pause, flushed at once on blur, on
the panel being hidden and on the page unloading. Selects and checkboxes keep `change` alone: a
dropdown must not save half-chosen.

**The page is not rebuilt under a focused control.** A third answer beside repaint and patch:
withhold. `render` holds the html assignment while a `[data-setting]` control has focus, keeps
patching the live regions, records no key while it withholds, and paints when focus leaves. A move
between two controls reports neither edge — the focusout of the one being left arrives before the
focusin of the one entered.

The hold is capped at 30 seconds from the start of the editing session, renewed by neither a
keystroke nor a tab, because `focusout` is not guaranteed: switch application mid-sentence and the
panel would never learn the box was abandoned. Nothing is lost by the paint that ends it — the value
was written 400 ms after the last keystroke, and the paint carries the control and its caret.

Writes queue and a render awaits the queue until it is stable: blur → `change` → write → focusout →
render is a race the render can win, re-stamping the box from the value being replaced.

## The tests run the page's own script

The plan round refused a text scan of it, correctly: a script can contain an `input` listener, a
debounce and a focus message while posting the wrong key, a stale value or the wrong order, and a
scan would call that green. The shipped script is executed against a fake document and the messages
it posts are read, including their ORDER.

## Evidence

- RED first: typing posted nothing at all (`actual: []` against one save carrying `поясни`) and no
  focus was ever reported.
- The host guard re-checked for teeth by reverting it — `the paint no longer consults whether a
  control is being edited`.
- Whole suite: **1058 pass, 1 skipped, 0 fail**. `plan-lifecycle.mjs` clean; `pin-check.mjs` OK.

## The gate

Plan round `good_enough` — 3 reviewers, 14 findings, 12 accepted and built, 2 rejected with reasons.
Code round `good_enough` — 12 reviewers, 25 findings, 9 accepted and built, 16 rejected with reasons.

The four that mattered: the cap was renewed by every `focusin`, so tabbing between controls withheld
a paint forever; the caret went to the end of the box; the focus anchor was the setting name, which
two controls can share; and `change` re-wrote a value the pause had already written.

Two rejections worth naming: queueing `choosePrompt` would **deadlock** (it awaits `render`, and
`render` awaits the queue), and two reviewers reported that `render` checks the hold before awaiting
the queue — it does not, the await is its first statement and a structural test asserts that order by
index.

## Named rather than built

A `config.update` that rejects leaves the typed value in the document and nowhere else, and the paint
that eventually lands replaces it. The person is told by the notification `save` already raises.
Surviving it properly means a host-side shadow copy of every dirty control — a second source of truth
for a control's value, which is the drift this module has already paid for twice. It is recorded as
an open tail in `module_extension.md`.

Manual verification was on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)