### PR TITLE
feat(chat): a turn can be stopped, and the conversation survives it

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -372,15 +372,63 @@ stateDiagram-v2
   Asking --> Ready: result SUCCESS
   Asking --> Ready: result ERROR (the model refused; the process lives)
   Asking --> Failed: turn budget · exit · error
+  Asking --> Stopped: stop (the person)
+  Stopped --> Starting: the next send, carrying the transcript
   Failed --> Starting: the next send, with contextLost
   Ready --> [*]: dispose
   Starting --> [*]: dispose (the waiter is told at once)
 ```
 
-Four ends, one of them a person closing a tab. `Failed` always kills the tree: a process that has
-stopped answering must not be handed the next turn. The edge back into `Starting` is the one that
-carries `contextLost` — the replacement never heard the passage, and the first answer afterwards
-says so rather than reading as a model that has lost the thread.
+Five ends, one of them a person closing a tab and one a person ending a single answer. `Failed`
+always kills the tree: a process that has stopped answering must not be handed the next turn. The
+edge back into `Starting` is the one that carries `contextLost` — the replacement never heard the
+passage, and the first answer afterwards says so rather than reading as a model that has lost the
+thread.
+
+### `stop()` — ending a turn without ending the conversation (2026-09-09)
+
+`ChatSession` has a third method beside `send` and `dispose`. A measured turn is 9.4 s and a long one
+much more, and until now a question sent by accident could only be waited out — and billed.
+
+`stop()` ends the turn that is running NOW and leaves the session able to take another. **A stop that
+names nothing does nothing**: with no turn in flight it neither kills an idle process nor marks a
+conversation lost. That is not defensive coding, it is the whole guarantee — a stop can arrive late (a
+queued bridge message, a second press, a keybinding pressed as the answer lands), and the identity of
+the turn being ended lives in a closure created by that turn and cleared the moment it settles by any
+route. A stop one tick late finds `undefined`; a stop after the next turn began finds that turn's own
+closure, which is why the host also checks the turn NUMBER before calling this at all.
+
+What a stop costs differs by session shape, and the session knows which it is:
+
+| shape | vendor | what the kill costs | what the next turn does |
+|---|---|---|---|
+| persistent | `claude`, `agy` | the conversation — it lived in that process | re-sends the transcript (`contextLost: true`) |
+| per-turn | `codex` | the answer only — the thread is in the vendor's store | resumes by the same thread id |
+| remote | a Team server | nothing — a server remembers nothing anyway | submits as usual |
+
+The failure arm of `TurnResult` grew two optional flags to carry that: `stopped`, so a caller can tell
+an instruction that was obeyed from a defect, and `contextLost`, so it knows whether to re-send.
+`contextLost` is set for a stop and **not** for a crash — a stop is the person's decision, whereas
+silently re-sending a transcript because a third-party CLI fell over bills somebody for an accident.
+That case is [its own plan](../todo/PLAN_a_dead_process_could_carry_the_conversation_too.md), gated on
+measuring how often it happens.
+
+The remote half settles the turn through a `Promise.race` rather than by waiting for the poll in
+flight: a long poll holds the connection for up to eight seconds, and waiting that out is the very
+complaint the feature answers. The job is cancelled on the server in the same breath — `DELETE
+api/reviews/{id}`, which already existed — because a queued job holds a slot on a shared vendor
+account and the drop-on-no-poll sweep would not take it back for three minutes. Whatever the abandoned
+poll eventually answers is dropped; a race settles once, so an answer landing after a stop cannot turn
+a stopped turn into an answered one.
+
+`chatCommand.ts` records the stop in the transcript before carrying it. The question is appended
+*before* the turn is sent, so a turn ending without an answer leaves the transcript on a dangling
+question; carrying that would hand the next model a question nobody answered with no sign it was
+abandoned, and the turn after would append a second `you` on top of the first.
+
+> The Stop CONTROL is not here yet. This is the seam half; the button in `chatStatusHtml` belongs to
+> the chat-page lane, which owns that file. The seam is complete and tested without it, and the host
+> route already accepts the message the button will post.
 
 
 `cliChatSession.ts` holds one long-lived vendor process per conversation. The protocol was measured

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -372,8 +372,9 @@ stateDiagram-v2
   Asking --> Ready: result SUCCESS
   Asking --> Ready: result ERROR (the model refused; the process lives)
   Asking --> Failed: turn budget · exit · error
+  Starting --> Stopped: stop (the person), before init
   Asking --> Stopped: stop (the person)
-  Stopped --> Starting: the next send, carrying the transcript
+  Stopped --> Starting: the next send, carrying the transcript ONLY when contextLost
   Failed --> Starting: the next send, with contextLost
   Ready --> [*]: dispose
   Starting --> [*]: dispose (the waiter is told at once)
@@ -398,6 +399,20 @@ the turn being ended lives in a closure created by that turn and cleared the mom
 route. A stop one tick late finds `undefined`; a stop after the next turn began finds that turn's own
 closure, which is why the host also checks the turn NUMBER before calling this at all.
 
+**The handle is armed before the process starts, not after the question is written.** Startup is a
+measured 3.6–6.6 s — a large share of the wait a person is pressing stop to end — and the first draft
+armed it only once the line had gone down the pipe, which made a stop during launch a silent no-op:
+the process went on starting, took the question and answered it. Four reviewers across three vendors
+found that on the code round. A stop during startup now cancels the start budget, tells the waiter,
+kills the child and settles the turn, which is everything `dispose` does to a start in progress minus
+the disposal itself.
+
+**There is no stop wildcard.** The bridge refuses a `stop` that does not name a turn, and refuses one
+naming anything that is not a whole positive number — a string, a negative, a fraction, `NaN`. An
+earlier version let a missing number mean "whichever is running", for a page too old to send one;
+three vendors pointed out that this hands back the exact defect the number exists to prevent, and
+there is no such page, because `stop` and its turn number ship in the same release.
+
 What a stop costs differs by session shape, and the session knows which it is:
 
 | shape | vendor | what the kill costs | what the next turn does |
@@ -419,7 +434,16 @@ complaint the feature answers. The job is cancelled on the server in the same br
 api/reviews/{id}`, which already existed — because a queued job holds a slot on a shared vendor
 account and the drop-on-no-poll sweep would not take it back for three minutes. Whatever the abandoned
 poll eventually answers is dropped; a race settles once, so an answer landing after a stop cannot turn
-a stopped turn into an answered one.
+a stopped turn into an answered one. That race covers the SUBMIT as well as the polling, because a
+POST can take twenty seconds and a stop pressed during one must not be waited out.
+
+Which turn a remote poll belongs to is a **generation number**, not a boolean. The first draft used a
+`stopped` flag that the next turn reset — so turn A's poll, sitting in an `await` when A was stopped,
+woke up after turn B had cleared the flag, decided it was not stopped after all, and carried on
+polling A's cancelled job and pushing A's queue positions into B's tab. Three reviewers found it. A
+number cannot be un-stopped: each turn captures its own value, every stop and every new turn moves the
+session past it, and the loop re-checks staleness the instant each poll returns rather than at the top
+of the next iteration.
 
 `chatCommand.ts` records the stop in the transcript before carrying it. The question is appended
 *before* the turn is sent, so a turn ending without an answer leaves the transcript on a dangling

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -61,6 +61,16 @@ interface Thread extends ChatMemory {
   /** Whether a turn is in flight. Only so a switch can say out loud that it is waiting for one. */
   running: boolean;
   /**
+   * Which turn of this conversation is running, counted from 1. Never reset.
+   *
+   * <p>It exists so a STOP can name what it means to stop. The page renders its control against the
+   * turn it is watching and posts that number back; a stop naming anything else is refused here. A
+   * bridge message can land a tick after the answer did, and by then the next question can already
+   * be in flight — without the number the second press of a button would end the turn that the first
+   * press was too late to reach. (codex and gemini, the plan round.)</p>
+   */
+  turn: number;
+  /**
    * The conversation to hand the NEXT turn, because the process it goes to never heard it.
    *
    * <p>Empty in the ordinary case. Filled when the person switches model: a vendor CLI keeps its
@@ -206,6 +216,7 @@ async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
   }
   thread.messages = [...thread.messages, { role: 'you', text }];
   thread.running = true;
+  thread.turn += 1;
   show(entry, true, '');
 
   // A forgetful model is handed the conversation EVERY time, not only after a switch: the server
@@ -236,6 +247,22 @@ async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
   });
   thread.running = false;
   if (!result.ok) {
+    // A STOPPED turn is written down before anything is carried, and the order is the whole finding.
+    // The question was appended before the turn was sent, so a turn that ends without an answer
+    // leaves the transcript ending on a dangling question. Handing THAT to a fresh process gives the
+    // next model a question nobody answered with no sign it was abandoned — and the turn after it
+    // appends a second `you` directly on top of the first. One line saying what happened makes the
+    // transcript true, and it is only then worth carrying. (gemini, the plan round, Blocking.)
+    if (result.stopped === true) {
+      thread.messages = [...thread.messages, { role: 'model', text: '(you stopped this answer)' }];
+    }
+    // And only a vendor that LOST the conversation needs it re-sent. `contextLost` on the failure arm
+    // is the session saying which of the two it is: a killed process that held the thread says yes, a
+    // per-turn vendor resuming by id and a server that never remembered anything say nothing. Set
+    // after the line above, so what is carried is the transcript a reader would recognise.
+    if (result.contextLost === true) {
+      thread.carry = [...thread.messages];
+    }
     // The carry is NOT cleared here. A turn that failed carried nothing anywhere, and clearing it
     // would mean the retry — the same question, one keypress later — reaches the new model with no
     // conversation behind it, which is the exact thing the switch existed to prevent. (gemini, the
@@ -544,6 +571,23 @@ function newConversation(
           switchModel(found, modelId);
         }
       },
+      onStop: (id, turn) => {
+        const found = panels.entryOf(id);
+        const thread = threads.get(id);
+        if (found === undefined || thread === undefined || !thread.running) {
+          // Nothing is running, or the tab is already gone. A stop is a message about a turn, and
+          // there is no turn — killing the process for it would cost the conversation for a keypress
+          // that arrived too late to mean anything.
+          return;
+        }
+        if (turn !== 0 && turn !== thread.turn) {
+          // The page named a turn that is no longer the running one, which is what a late or a
+          // repeated press looks like from here. Refused rather than applied to whatever happens to
+          // be in flight now — that turn is a different question the person has not asked to stop.
+          return;
+        }
+        thread.session.stop();
+      },
       onClosed: (id) => {
         // The registry disposes the session the ENTRY was created with, which after a model switch
         // is no longer the one that is running. So the thread's own current session is ended here
@@ -574,6 +618,9 @@ function newConversation(
     models: ready.models,
     modelId: ready.modelId,
     running: false,
+    // Counted from 1 by the first turn, so 0 is "this conversation has not asked anything yet" and
+    // can never be mistaken for a turn a stop could name.
+    turn: 0,
     ...memoryOf(ready.vendor),
     carry: [],
     messages: [],

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -580,10 +580,13 @@ function newConversation(
           // that arrived too late to mean anything.
           return;
         }
-        if (turn !== 0 && turn !== thread.turn) {
+        if (turn !== thread.turn) {
           // The page named a turn that is no longer the running one, which is what a late or a
           // repeated press looks like from here. Refused rather than applied to whatever happens to
           // be in flight now — that turn is a different question the person has not asked to stop.
+          // There is no wildcard to fall back to: the bridge already refuses a stop that names no
+          // turn, so `turn` here is always a real number a page chose. (codex and gemini, the code
+          // round, on both halves of this rule.)
           return;
         }
         thread.session.stop();

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -574,7 +574,7 @@ function newConversation(
       onStop: (id, turn) => {
         const found = panels.entryOf(id);
         const thread = threads.get(id);
-        if (found === undefined || thread === undefined || !thread.running) {
+        if (found === undefined || thread?.running !== true) {
           // Nothing is running, or the tab is already gone. A stop is a message about a turn, and
           // there is no turn — killing the process for it would cost the conversation for a keypress
           // that arrived too late to mean anything.

--- a/src_vs_code/src/chatMessages.ts
+++ b/src_vs_code/src/chatMessages.ts
@@ -33,12 +33,19 @@ export type ChatCommand =
   | { readonly kind: 'send'; readonly text: string }
   | { readonly kind: 'pick'; readonly id: string }
   /**
-   * End the turn numbered `turn`; `0` means whichever is running.
+   * End the turn numbered `turn`, and no other. Always 1 or more.
    *
    * <p>The number is what stops a LATE stop from ending the turn after the one it was pressed for.
    * The page disables its own control, but a keybinding does not go through it and a bridge message
-   * can land a tick after the answer did — by which time the next question may already be in flight.
-   * Zero is what a page too old to name a turn sends, and it still means the useful thing.</p>
+   * can land a tick after the answer did — by which time the next question may already be in
+   * flight.</p>
+   *
+   * <p><b>There is no wildcard, deliberately.</b> The first draft let a missing number mean "whichever
+   * is running", for a page too old to send one. Two vendors pointed out that this hands back the
+   * exact defect the number exists to prevent — and there is no such page: `stop` and its turn number
+   * are being added in the same release, so a page that can ask for a stop can always say which one.
+   * A stop that names no turn is therefore not a stop, and is ignored like any other message this
+   * host does not understand.</p>
    */
   | { readonly kind: 'stop'; readonly turn: number }
   | { readonly kind: 'zoom'; readonly delta: number }
@@ -71,15 +78,17 @@ function zoomOf(message: PageMessage): ChatCommand {
 }
 
 /**
- * Which turn a stop names, or `0` for "whichever is running".
+ * Which turn a stop names, or `0` for "this named no turn at all".
  *
- * <p>Clamped the way the zoom delta is, and for the same reason: the value comes from a surface the
- * host does not control, and this one is compared against a live counter. Anything that is not a
- * whole positive number is not a turn — a page too old to send one, and a page sending nonsense,
- * both mean the same thing here and are treated the same way.</p>
+ * <p>`0` is not a value a caller may act on — `chatCommandOf` turns it into `ignore`. It exists only
+ * so this function has something to return for input that is not a turn: a missing field, a string,
+ * a negative, a fraction, `NaN`, an unsafe integer. All of those mean the message cannot be obeyed,
+ * and refusing them here is the boundary rule — a value from a surface the host does not control is
+ * validated before it reaches anything that acts on it. (Three vendors, the code round: an earlier
+ * version coerced every one of these into a wildcard that stopped whatever happened to be running.)</p>
  */
 function turnOf(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
     return 0;
   }
 
@@ -119,8 +128,11 @@ export function chatCommandOf(message: PageMessage | undefined): ChatCommand {
 
       return id.length === 0 ? IGNORE : { kind: 'pick', id };
     }
-    case 'stop':
-      return { kind: 'stop', turn: turnOf(message.turn) };
+    case 'stop': {
+      const turn = turnOf(message.turn);
+
+      return turn === 0 ? IGNORE : { kind: 'stop', turn };
+    }
     case 'restart':
       return { kind: 'restart' };
     case 'useLocal':

--- a/src_vs_code/src/chatMessages.ts
+++ b/src_vs_code/src/chatMessages.ts
@@ -26,11 +26,21 @@ export interface PageMessage {
   readonly id?: unknown;
   readonly delta?: unknown;
   readonly message?: unknown;
+  readonly turn?: unknown;
 }
 
 export type ChatCommand =
   | { readonly kind: 'send'; readonly text: string }
   | { readonly kind: 'pick'; readonly id: string }
+  /**
+   * End the turn numbered `turn`; `0` means whichever is running.
+   *
+   * <p>The number is what stops a LATE stop from ending the turn after the one it was pressed for.
+   * The page disables its own control, but a keybinding does not go through it and a bridge message
+   * can land a tick after the answer did — by which time the next question may already be in flight.
+   * Zero is what a page too old to name a turn sends, and it still means the useful thing.</p>
+   */
+  | { readonly kind: 'stop'; readonly turn: number }
   | { readonly kind: 'zoom'; readonly delta: number }
   | { readonly kind: 'restart' }
   | { readonly kind: 'useLocal' }
@@ -58,6 +68,22 @@ function zoomOf(message: PageMessage): ChatCommand {
   }
 
   return { kind: 'zoom', delta: Math.max(-1, Math.min(1, Math.trunc(message.delta))) };
+}
+
+/**
+ * Which turn a stop names, or `0` for "whichever is running".
+ *
+ * <p>Clamped the way the zoom delta is, and for the same reason: the value comes from a surface the
+ * host does not control, and this one is compared against a live counter. Anything that is not a
+ * whole positive number is not a turn — a page too old to send one, and a page sending nonsense,
+ * both mean the same thing here and are treated the same way.</p>
+ */
+function turnOf(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    return 0;
+  }
+
+  return value;
 }
 
 /**
@@ -93,6 +119,8 @@ export function chatCommandOf(message: PageMessage | undefined): ChatCommand {
 
       return id.length === 0 ? IGNORE : { kind: 'pick', id };
     }
+    case 'stop':
+      return { kind: 'stop', turn: turnOf(message.turn) };
     case 'restart':
       return { kind: 'restart' };
     case 'useLocal':

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -43,6 +43,13 @@ export interface ChatPanelHooks {
   readonly onSend: (id: object, text: string) => void;
   /** The person chose a different model — already checked against the offered list. */
   readonly onPick: (id: object, modelId: string) => void;
+  /**
+   * The person stopped the answer they were waiting for.
+   *
+   * <p>`turn` is the turn the page believed was running; `0` means "whichever is". The host checks
+   * it, because this message can land after the turn it names has already finished.</p>
+   */
+  readonly onStop: (id: object, turn: number) => void;
   /** VS Code closed the tab — the registry must forget it and end its session. */
   readonly onClosed: (id: object) => void;
   /** Start again with the same passage. */
@@ -163,6 +170,10 @@ async function handle(id: object, message: PageMessage, hooks: ChatPanelHooks): 
       } else {
         hooks.onPageError(id, `that model is not one this conversation offers: ${command.id}`);
       }
+
+      return;
+    case 'stop':
+      hooks.onStop(id, command.turn);
 
       return;
     case 'restart':

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -46,8 +46,12 @@ export interface ChatPanelHooks {
   /**
    * The person stopped the answer they were waiting for.
    *
-   * <p>`turn` is the turn the page believed was running; `0` means "whichever is". The host checks
-   * it, because this message can land after the turn it names has already finished.</p>
+   * <p>`turn` is the turn the page believed was running — a whole number counted from 1, never 0.
+   * The host stops that turn and no other, because this message can land after the turn it names has
+   * already finished, by which time the next question may be in flight. A page that cannot say which
+   * turn it means gets no stop at all: `chatCommandOf` refuses such a message before it reaches this
+   * hook, so there is no wildcard to fall back on. (Whoever writes the button in `chatPage.ts`: send
+   * the turn the state you rendered was carrying.)</p>
    */
   readonly onStop: (id: object, turn: number) => void;
   /** VS Code closed the tab — the registry must forget it and end its session. */

--- a/src_vs_code/src/chatSession.ts
+++ b/src_vs_code/src/chatSession.ts
@@ -23,7 +23,37 @@ export type TurnResult =
      */
     readonly contextLost?: true;
   }
-  | { readonly ok: false; readonly failure: string };
+  | {
+    readonly ok: false;
+    readonly failure: string;
+    /**
+     * The turn ended with no answer AND took the conversation with it.
+     *
+     * <p>The same fact the `ok: true` arm reports, on the arm where it is ACTIONABLE rather than
+     * merely honest. A vendor that holds the conversation inside its own process loses it whenever
+     * that process is killed — by a budget, by a crash, or now by a person pressing stop — and the
+     * only thing that can put it back is the caller re-sending the transcript on the next turn.
+     * Without a flag on this arm the caller cannot tell the two failures apart, so it either carries
+     * the transcript after every failure (paying for it) or after none (losing it).</p>
+     *
+     * <p><b>Set for a STOP and not for a crash, deliberately.</b> A stop is the person's own
+     * decision, so re-sending the conversation is finishing what they asked for. A process that FELL
+     * OVER is nobody's decision, and silently re-sending a whole transcript because a third-party CLI
+     * crashed bills somebody for an accident — which is why that case is a separate plan of its own,
+     * gated on measuring how often it actually happens
+     * (`todo/PLAN_a_dead_process_could_carry_the_conversation_too.md`). A crashed turn still SAYS the
+     * conversation restarted, as it always has; what it does not do is spend money on it unasked.</p>
+     */
+    readonly contextLost?: true;
+    /**
+     * The person ended this turn. Nothing went wrong.
+     *
+     * <p>A stop and a crash both arrive as `ok: false` with a sentence, and they are opposite things:
+     * one is an instruction that was obeyed, the other is a defect. Matching on the sentence would
+     * tie every caller to its wording and to its translations.</p>
+     */
+    readonly stopped?: true;
+  };
 
 export interface ChatSession {
   /**
@@ -35,6 +65,23 @@ export interface ChatSession {
    * interleaving down the same pipe.</p>
    */
   send(text: string, onWaiting?: (position: number) => void): Promise<TurnResult>;
+
+  /**
+   * End the turn that is running NOW, and leave the conversation able to take another.
+   *
+   * <p>Not `dispose`. A stop ends one turn; the session stays open and the next `send` works. What
+   * that costs differs by vendor and the session knows which it is: a process that HOLDS the
+   * conversation loses it when it is killed, and says so with `contextLost` so the caller re-sends
+   * the transcript; a vendor that keeps the conversation in its own store resumes by id and loses
+   * nothing; a Team server holds no conversation at all and only needs telling to drop the job.</p>
+   *
+   * <p><b>A stop that names nothing does nothing.</b> With no turn in flight this is a no-op — it
+   * does not kill an idle process and it does not mark a conversation lost. That matters because a
+   * stop can arrive late: a queued bridge message, a second press, a keybinding pressed as the
+   * answer lands. The alternative is a healthy conversation thrown away for a keypress that was
+   * already too late to mean anything. (gemini, codex and the local reviewer, the plan round.)</p>
+   */
+  stop(): void;
 
   /** End it. Safe to call twice; a session already gone stays gone. */
   dispose(): void;

--- a/src_vs_code/src/cliChatSession.ts
+++ b/src_vs_code/src/cliChatSession.ts
@@ -108,6 +108,18 @@ export class CliChatSession implements ChatSession {
   private contextLost = false;
   private queue: Promise<unknown> = Promise.resolve();
   private disposed = false;
+  /**
+   * How to end the turn that is running now, as a stop. Undefined when none is.
+   *
+   * <p>This IS the turn's identity, and it is a closure rather than a number so that it cannot name
+   * the wrong turn: it is created by the turn it ends and cleared the moment that turn settles by
+   * ANY route — answered, failed, timed out, stopped. A stop arriving one tick late therefore finds
+   * `undefined` and does nothing, and a stop arriving after the NEXT turn has started finds that
+   * turn's own closure. A counter compared by hand would have had to be right in six places; this is
+   * right because there is nowhere else to put it. (codex and gemini, the plan round — "a delayed
+   * stop can terminate the following turn because stop has no turn identity".)</p>
+   */
+  private endTurnAsStopped: (() => void) | undefined;
 
   /**
    * @param start launches the vendor process — injected, so this file spawns nothing itself
@@ -145,6 +157,21 @@ export class CliChatSession implements ChatSession {
     return mine;
   }
 
+  /**
+   * End the turn that is running now; leave the session able to answer the next question.
+   *
+   * <p>The kill is the one `dispose` has always used. What is different is the sequel: `disposed` is
+   * NOT set, so the next `send` starts a process again, and for a vendor that held the conversation
+   * in the killed process the turn reports `contextLost` so its caller re-sends the transcript. For
+   * a per-turn vendor `killChild` leaves the thread id alone and the next turn resumes by it, which
+   * is why this method needs no branch of its own for the two shapes.</p>
+   */
+  stop(): void {
+    // Not guarded on `disposed` separately: a disposed session has already settled its turn, so the
+    // closure is gone and this is the same no-op by the same rule.
+    this.endTurnAsStopped?.();
+  }
+
   dispose(): void {
     this.disposed = true;
     // A start that has not finished is waiting too, and nobody was telling it. Closing a tab used to
@@ -155,7 +182,7 @@ export class CliChatSession implements ChatSession {
     this.waitingForInit = undefined;
     waiting?.(CLOSED);
     this.settle({ ok: false, failure: CLOSED });
-    this.stop();
+    this.killChild();
   }
 
   /** One turn, start to finish, with nothing else in the pipe. */
@@ -177,7 +204,7 @@ export class CliChatSession implements ChatSession {
     if (this.child?.writeLine(line) !== true) {
       // The pipe went between the last event and this write. Not an error to throw: the next send
       // starts a new process, which is what a person pressing Enter again expects to happen.
-      this.stop();
+      this.killChild();
 
       return { ok: false, failure: 'the model’s process had already gone; ask again to start a new one' };
     }
@@ -186,10 +213,18 @@ export class CliChatSession implements ChatSession {
       const cancelBudget = this.timers.after(this.budgets.turnMs, () => {
         // Killed, not merely abandoned: a process that has stopped answering must not be handed the
         // next turn as though nothing happened.
-        this.stop();
+        this.killChild();
         this.settle({ ok: false, failure: this.withRestart('the model did not answer in time') });
       });
       this.pending = { settle: resolve, cancelBudget };
+      this.endTurnAsStopped = (): void => {
+        // The order is the finding: kill FIRST, so `contextLost` is already true when the result is
+        // built, and only then settle. Reversed, the turn would report a conversation it still had
+        // and the caller would carry nothing into a process that heard nothing. (the local reviewer,
+        // the plan round — "the carry mark must be set before the turn resolves".)
+        this.killChild();
+        this.settle(this.stopped());
+      };
     });
   }
 
@@ -237,7 +272,7 @@ export class CliChatSession implements ChatSession {
         // and "installed, and refusing your sign-in". Read BEFORE the kill, which reads better
         // beside it. (local, the plan round.)
         const said = child.stderrTail().trim().slice(-300);
-        this.stop();
+        this.killChild();
         resolve(said.length === 0
           ? 'the model’s process did not start'
           : `the model’s process did not start: ${said}`);
@@ -310,7 +345,7 @@ export class CliChatSession implements ChatSession {
     // Written and then CLOSED: `codex exec -` reads until end of input, so a turn whose stream stays
     // open is a turn that never starts. Measured, and the reason `writeAndEnd` exists at all.
     if (!child.writeAndEnd(this.adapter.encode(text))) {
-      this.stop();
+      this.killChild();
 
       return Promise.resolve({ ok: false, failure: 'the model’s process had already gone; ask again to start a new one' });
     }
@@ -327,13 +362,24 @@ export class CliChatSession implements ChatSession {
           return;
         }
         done = true;
+        // Cleared on EVERY exit from this turn, exactly as `settle` does for the persistent shape:
+        // a stop that arrives after the turn ended must find nothing to end.
+        this.endTurnAsStopped = undefined;
         cancelBudget();
-        this.stop();
+        this.killChild();
         resolve(result);
       };
       const cancelBudget = this.timers.after(this.budgets.turnMs, () => {
         finish({ ok: false, failure: 'the model did not answer in time' });
       });
+      // No `contextLost` here, and that is the inversion this shape is built on: `killChild` marks a
+      // conversation lost only for a PERSISTENT adapter, and the thread id this turn was told lives
+      // on in `this.sessionId`, so the next question resumes the same conversation. Stopping a codex
+      // turn costs the answer and nothing else. (codex, the plan round, asked for this to be proven
+      // rather than asserted — `perTurnSession.test.ts` does.)
+      this.endTurnAsStopped = (): void => {
+        finish({ ok: false, failure: 'you stopped this answer', stopped: true });
+      };
 
       child.onLine((line) => {
         const event = this.adapter.classify(line);
@@ -395,8 +441,27 @@ export class CliChatSession implements ChatSession {
       : failure;
   }
 
-  /** End whatever turn is waiting, once. */
+  /** What a stopped turn on THIS vendor looks like, asked after the process is already gone. */
+  private stopped(): TurnResult {
+    return this.contextLost
+      ? {
+        ok: false,
+        failure: 'you stopped this answer — the next question re-sends the conversation so far',
+        contextLost: true,
+        stopped: true,
+      }
+      : { ok: false, failure: 'you stopped this answer', stopped: true };
+  }
+
+  /**
+   * End whatever turn is waiting, once.
+   *
+   * <p>The single choke point for a persistent turn, which is why the stop closure is cleared here:
+   * every way a turn can end goes through this method, so there is no route that leaves a stale
+   * closure behind for a late stop to find.</p>
+   */
   private settle(result: TurnResult): void {
+    this.endTurnAsStopped = undefined;
     const pending = this.pending;
     if (pending === undefined) {
       return;
@@ -406,8 +471,13 @@ export class CliChatSession implements ChatSession {
     pending.settle(result);
   }
 
-  /** Kill the process and forget it. Idempotent — `dispose` and a budget can both arrive. */
-  private stop(): void {
+  /**
+   * Kill the process and forget it. Idempotent — `dispose` and a budget can both arrive.
+   *
+   * <p>Named for what it does rather than for what asks for it, because a PUBLIC `stop` now exists
+   * beside it and means something narrower: this ends the process, that ends the turn.</p>
+   */
+  private killChild(): void {
     // A killed process takes the conversation with it exactly as a dead one does - the budget that
     // killed it does not make the loss less real, and the next answer must still say so. UNLESS the
     // vendor keeps the conversation itself: a per-turn child exits after every single answer, and

--- a/src_vs_code/src/cliChatSession.ts
+++ b/src_vs_code/src/cliChatSession.ts
@@ -68,6 +68,7 @@ interface Pending {
 }
 
 const CLOSED = 'the conversation was closed';
+const STOPPED = 'you stopped this answer';
 
 export class CliChatSession implements ChatSession {
   private child: ProcessHandle | undefined;
@@ -194,6 +195,49 @@ export class CliChatSession implements ChatSession {
       return this.perTurn(text);
     }
 
+    // The stop handle is installed BEFORE the process is started, not after the question is written.
+    // Startup is 3.6-6.6 s measured — a large share of the wait a person presses stop to end — and a
+    // handle installed after it made a stop during launch a silent no-op: the process went on
+    // starting, took the question and answered it. (Four reviewers across three vendors, the code
+    // round, which is as clear a signal as that gate gives.)
+    const stopping = new Promise<TurnResult>((resolve) => {
+      this.endTurnAsStopped = (): void => {
+        // Everything `dispose` does to a start in progress, minus the disposal itself. A waiter
+        // nobody tells is a caller sitting out the whole startup budget for a turn already over.
+        this.cancelStartBudget?.();
+        this.cancelStartBudget = undefined;
+        const waiting = this.waitingForInit;
+        this.waitingForInit = undefined;
+        waiting?.(STOPPED);
+        // Kill FIRST, so `contextLost` is already true when the result is built. Reversed, the turn
+        // would report a conversation it no longer has and the caller would carry nothing into a
+        // process that heard nothing. (the local reviewer, the plan round.)
+        this.killChild();
+        const result = this.stopped();
+        // Whichever stage this turn had reached. `settle` ends one already waiting on the pipe and
+        // returns early when there is none; `resolve` ends one still in startup. Both are safe to
+        // run: a race settles once, and so does `settle`.
+        this.settle(result);
+        resolve(result);
+      };
+    });
+    const asking = this.askAndWait(text);
+    // Attached before the race. If the stop wins, this promise still settles later with nobody
+    // reading it, and a rejection nobody handles takes down the extension host rather than the turn.
+    asking.catch(() => undefined);
+
+    try {
+      return await Promise.race([stopping, asking]);
+    } finally {
+      // Every exit from this turn, including the ones that never reach `settle` — a start that
+      // failed returns its sentence directly. A closure left behind here is a stop that would kill
+      // an idle process later.
+      this.endTurnAsStopped = undefined;
+    }
+  }
+
+  /** Start the process if it is not up, write the question, and wait for the answer. */
+  private async askAndWait(text: string): Promise<TurnResult> {
     const started = await this.ensureStarted();
     if (started !== '') {
       return { ok: false, failure: started };
@@ -217,14 +261,6 @@ export class CliChatSession implements ChatSession {
         this.settle({ ok: false, failure: this.withRestart('the model did not answer in time') });
       });
       this.pending = { settle: resolve, cancelBudget };
-      this.endTurnAsStopped = (): void => {
-        // The order is the finding: kill FIRST, so `contextLost` is already true when the result is
-        // built, and only then settle. Reversed, the turn would report a conversation it still had
-        // and the caller would carry nothing into a process that heard nothing. (the local reviewer,
-        // the plan round — "the carry mark must be set before the turn resolves".)
-        this.killChild();
-        this.settle(this.stopped());
-      };
     });
   }
 
@@ -378,7 +414,7 @@ export class CliChatSession implements ChatSession {
       // turn costs the answer and nothing else. (codex, the plan round, asked for this to be proven
       // rather than asserted — `perTurnSession.test.ts` does.)
       this.endTurnAsStopped = (): void => {
-        finish({ ok: false, failure: 'you stopped this answer', stopped: true });
+        finish({ ok: false, failure: STOPPED, stopped: true });
       };
 
       child.onLine((line) => {
@@ -446,11 +482,11 @@ export class CliChatSession implements ChatSession {
     return this.contextLost
       ? {
         ok: false,
-        failure: 'you stopped this answer — the next question re-sends the conversation so far',
+        failure: `${STOPPED} — the next question re-sends the conversation so far`,
         contextLost: true,
         stopped: true,
       }
-      : { ok: false, failure: 'you stopped this answer', stopped: true };
+      : { ok: false, failure: STOPPED, stopped: true };
   }
 
   /**

--- a/src_vs_code/src/remoteChatSession.ts
+++ b/src_vs_code/src/remoteChatSession.ts
@@ -76,14 +76,16 @@ export class RemoteChatSession implements ChatSession {
   private running = false;
 
   /**
-   * The person stopped THIS turn. Cleared when the next one starts.
+   * Which turn is current. Bumped by every new turn AND by every stop.
    *
-   * <p>Deliberately not `disposed`: that flag is terminal and every guard reading it means "this
-   * session is over". A stop ends a turn and leaves the session able to take another, so it needs a
-   * flag of its own — reusing `disposed` would have made the second question after a stop return
-   * "the conversation was closed" for a conversation that is open.</p>
+   * <p>A GENERATION rather than a boolean, and the difference is a defect three reviewers found in
+   * the first version. That one used a `stopped` flag reset at the start of each turn — so a poll
+   * loop belonging to turn A, sitting in an `await` when A was stopped, woke up after turn B had
+   * cleared the flag, decided it was not stopped after all, and carried on polling A's cancelled job
+   * and pushing A's queue positions into B's tab. A number cannot be un-stopped: turn A captures its
+   * own value and every later stop or turn moves the session past it for good.</p>
    */
-  private stopped = false;
+  private generation = 0;
 
   /** Settles the turn without waiting for the poll in flight. Undefined when no turn is waiting. */
   private wakeOnStop: (() => void) | undefined;
@@ -131,16 +133,34 @@ export class RemoteChatSession implements ChatSession {
       // finished work for nothing.
       return;
     }
-    this.stopped = true;
+    // Past this line the turn that was running is stale for good, whatever it is awaiting and
+    // whatever turn comes next.
+    this.generation += 1;
     const id = this.inFlight;
     this.inFlight = '';
     if (id.length > 0) {
-      void this.transport.cancel(id);
+      this.drop(id);
     }
-    // Undefined in the window between `submit` going out and its id coming back. That window is not
-    // lost: `turn` checks `stopped` where the id first exists, exactly as it already checks
-    // `disposed` there, and cancels then.
+    // Undefined only in the window between `submit` going out and its id coming back; that window is
+    // covered where the id first exists, by the same staleness check.
     this.wakeOnStop?.();
+  }
+
+  /**
+   * Tell the server to drop a job, and never let saying so break anything.
+   *
+   * <p>Nothing waits for this and nothing can act on its failure — the turn is already over on this
+   * side. What matters is that a `DELETE` refused by a network blip becomes a dropped promise rather
+   * than an unhandled rejection in the extension host, which is a window taken down for a job that
+   * the server's own sweep will collect anyway. (codex and gemini, the code round.)</p>
+   */
+  private drop(id: string): void {
+    void this.transport.cancel(id).catch(() => undefined);
+  }
+
+  /** Whether the turn that captured `mine` is still the one this session is running. */
+  private stale(mine: number): boolean {
+    return this.disposed || mine !== this.generation;
   }
 
   dispose(): void {
@@ -150,7 +170,7 @@ export class RemoteChatSession implements ChatSession {
     if (id.length > 0) {
       // A queued review nobody is waiting for is a vendor slot somebody else could have had, and on
       // a shared account that is the scarcest thing the server has. Cancelled, not abandoned.
-      void this.transport.cancel(id);
+      this.drop(id);
     }
   }
 
@@ -158,12 +178,23 @@ export class RemoteChatSession implements ChatSession {
     if (this.disposed) {
       return { ok: false, failure: 'the conversation was closed' };
     }
-    // A NEW turn, so last turn's stop is spent. Reset here rather than in `stop` itself, because
-    // between the two is exactly where a person decides whether to ask again.
-    this.stopped = false;
+    const mine = this.generation + 1;
+    this.generation = mine;
     this.running = true;
+    // The stop signal is armed BEFORE the submit, and the race covers the submit as well as the
+    // polling. Armed after, a stop pressed while the POST was still in flight had no resolver to
+    // call and nothing to cancel, so the person went on waiting out a request that can take twenty
+    // seconds. (codex, the code round, twice.)
+    const stopping = new Promise<TurnResult>((resolve) => {
+      this.wakeOnStop = () => resolve(STOPPED);
+    });
+    const asking = this.submitAndWait(text, mine, onWaiting);
+    // Attached before the race: the loser still settles, with nobody reading it, and a rejection
+    // nobody handles is an unhandled rejection in the extension host.
+    asking.catch(() => undefined);
+
     try {
-      return await this.submitAndWait(text, onWaiting);
+      return await Promise.race([stopping, asking]);
     } finally {
       this.running = false;
       this.wakeOnStop = undefined;
@@ -171,8 +202,12 @@ export class RemoteChatSession implements ChatSession {
     }
   }
 
-  /** The turn proper, with `running` already true so a stop arriving mid-flight is not a no-op. */
-  private async submitAndWait(text: string, onWaiting?: (position: number) => void): Promise<TurnResult> {
+  /** Submit the question and wait for its answer; `mine` is the generation this turn belongs to. */
+  private async submitAndWait(
+    text: string,
+    mine: number,
+    onWaiting?: (position: number) => void,
+  ): Promise<TurnResult> {
     const deadline = this.now() + this.budgets.turnMs;
     const seconds = Math.max(1, Math.floor(this.budgets.turnMs / 1000));
     // One name for this TURN — the SAME one when this is the person retrying a turn that failed,
@@ -202,54 +237,46 @@ export class RemoteChatSession implements ChatSession {
     // and cancelled nothing — and the job the server has just accepted would then run, hold a vendor
     // slot on a shared account and answer into a tab that closed. Checked HERE, where the id first
     // exists, because that is the first moment there is anything to cancel. (codex, the code round.)
-    if (this.disposed) {
-      void this.transport.cancel(id);
+    // A close or a stop that ran while the POST was in flight found no id to cancel, because there
+    // was none yet. Checked HERE because this is the first moment the job has a name — otherwise it
+    // runs to the end of its budget on a shared vendor account and answers into nothing. The two
+    // keep their own sentences: a closed tab and a stopped answer send a person to different places.
+    if (this.stale(mine)) {
+      this.drop(id);
 
-      return { ok: false, failure: 'the conversation was closed' };
-    }
-    // The same window, for the same reason, for a stop instead of a close: `stop` ran while the POST
-    // was in flight, found no id to cancel and settled nothing. Checked HERE because this is the
-    // first moment the job has a name. (The dispose case above is the precedent; a stop needed it
-    // too and would otherwise have left the job running for the sweep to find.)
-    if (this.stopped) {
-      void this.transport.cancel(id);
-
-      return STOPPED;
+      return this.disposed ? { ok: false, failure: 'the conversation was closed' } : STOPPED;
     }
     this.inFlight = id;
 
-    const waiting = this.waitFor(id, deadline, onWaiting);
-    // Attached BEFORE the race. If the stop wins, this promise still settles later with nobody
-    // reading it, and a rejection nobody handles is an unhandled rejection that takes the window
-    // down rather than the turn.
-    waiting.catch(() => undefined);
-
-    return Promise.race([
-      waiting,
-      new Promise<TurnResult>((resolve) => {
-        this.wakeOnStop = () => resolve(STOPPED);
-      }),
-    ]);
+    return this.waitFor(id, deadline, mine, onWaiting);
   }
 
   /** Poll until it answers, fails, or the deadline passes. */
   private async waitFor(
     id: string,
     deadline: number,
+    mine: number,
     onWaiting?: (position: number) => void,
   ): Promise<TurnResult> {
     let refusals = 0;
-    // `stopped` as well as `disposed`: the race has already settled the turn, and this loop carrying
-    // on would keep polling a job the server has been told to cancel.
-    while (!this.disposed && !this.stopped) {
+    // Staleness, not just disposal: once this turn has been stopped the race has already answered
+    // its caller, and carrying on would poll a job the server has been told to drop.
+    while (!this.stale(mine)) {
       const remaining = deadline - this.now();
       if (remaining <= 0) {
-        void this.transport.cancel(id);
+        this.drop(id);
 
         return { ok: false, failure: 'the server did not answer in time' };
       }
 
       const asked = await this.transport.poll(id, waitSecondsFor(remaining));
+      // Checked the instant the await returns, not at the top of the next iteration. A poll holds the
+      // connection for up to eight seconds, and a stop pressed during one must not be answered by
+      // reading its result, calling this turn's `onWaiting` into a tab now showing a different turn,
+      // or looping once more. (gemini, codex and the local reviewer, the code round.)
+      if (this.stale(mine)) {
+        break;
+      }
       if (asked.status === 429) {
         // The shared-account ceiling doing its job: somebody else's round has the vendor. Waiting is
         // the answer, and the wait grows so that a queue full for a minute is not polled every second.

--- a/src_vs_code/src/remoteChatSession.ts
+++ b/src_vs_code/src/remoteChatSession.ts
@@ -26,6 +26,15 @@ import { Timers } from './cliChatSession';
  */
 const POLL_GAP_MS = 500;
 
+/**
+ * What a stopped remote turn is.
+ *
+ * <p>No `contextLost`. A Team server holds no conversation to lose — the transcript is re-sent on
+ * every turn anyway, which is what `forgetful` means — so stopping one costs the answer and nothing
+ * else. Saying the conversation restarted here would be a sentence about a loss that did not happen.</p>
+ */
+const STOPPED: TurnResult = { ok: false, failure: 'you stopped this answer', stopped: true };
+
 /** One request to the server, already carrying its token and its base URL. */
 export interface RemoteTransport {
   /** POST a review. Answers the parsed body, or a sentence saying why not. */
@@ -63,6 +72,22 @@ export class RemoteChatSession implements ChatSession {
    */
   private retry: { readonly text: string; readonly key: string } | undefined;
 
+  /** Whether a turn is between its submit and its result. What makes an idle `stop` a no-op. */
+  private running = false;
+
+  /**
+   * The person stopped THIS turn. Cleared when the next one starts.
+   *
+   * <p>Deliberately not `disposed`: that flag is terminal and every guard reading it means "this
+   * session is over". A stop ends a turn and leaves the session able to take another, so it needs a
+   * flag of its own — reusing `disposed` would have made the second question after a stop return
+   * "the conversation was closed" for a conversation that is open.</p>
+   */
+  private stopped = false;
+
+  /** Settles the turn without waiting for the poll in flight. Undefined when no turn is waiting. */
+  private wakeOnStop: (() => void) | undefined;
+
   constructor(
     private readonly transport: RemoteTransport,
     private readonly vendor: RemoteVendor,
@@ -85,6 +110,39 @@ export class RemoteChatSession implements ChatSession {
     return mine;
   }
 
+  /**
+   * End the turn the server is running, and keep the conversation.
+   *
+   * <p>Two obligations that pull in opposite directions, which is why this is not simply `dispose`
+   * without the flag. The person must see the turn end AT ONCE — a poll can be holding the
+   * connection for eight seconds and waiting that out is the very complaint this feature answers —
+   * and the server must be TOLD, because a queued job holds a slot on a shared vendor account and
+   * the drop-on-no-poll sweep would not take it back for three minutes.</p>
+   *
+   * <p>So the cancel goes out here, and `wakeOnStop` settles the turn without waiting for the poll.
+   * Whatever that poll eventually answers is dropped: `turn` races the two and a race settles once,
+   * so an answer landing after a stop cannot turn a stopped turn into an answered one. (gemini and
+   * codex, the plan round, independently.)</p>
+   */
+  stop(): void {
+    if (this.disposed || !this.running) {
+      // Nothing is in flight — an idle session, or a stop that lost a race with the answer it meant
+      // to prevent. Cancelling a job id this session no longer owns would be cancelling somebody's
+      // finished work for nothing.
+      return;
+    }
+    this.stopped = true;
+    const id = this.inFlight;
+    this.inFlight = '';
+    if (id.length > 0) {
+      void this.transport.cancel(id);
+    }
+    // Undefined in the window between `submit` going out and its id coming back. That window is not
+    // lost: `turn` checks `stopped` where the id first exists, exactly as it already checks
+    // `disposed` there, and cancels then.
+    this.wakeOnStop?.();
+  }
+
   dispose(): void {
     this.disposed = true;
     const id = this.inFlight;
@@ -100,6 +158,21 @@ export class RemoteChatSession implements ChatSession {
     if (this.disposed) {
       return { ok: false, failure: 'the conversation was closed' };
     }
+    // A NEW turn, so last turn's stop is spent. Reset here rather than in `stop` itself, because
+    // between the two is exactly where a person decides whether to ask again.
+    this.stopped = false;
+    this.running = true;
+    try {
+      return await this.submitAndWait(text, onWaiting);
+    } finally {
+      this.running = false;
+      this.wakeOnStop = undefined;
+      this.inFlight = '';
+    }
+  }
+
+  /** The turn proper, with `running` already true so a stop arriving mid-flight is not a no-op. */
+  private async submitAndWait(text: string, onWaiting?: (position: number) => void): Promise<TurnResult> {
     const deadline = this.now() + this.budgets.turnMs;
     const seconds = Math.max(1, Math.floor(this.budgets.turnMs / 1000));
     // One name for this TURN — the SAME one when this is the person retrying a turn that failed,
@@ -134,13 +207,29 @@ export class RemoteChatSession implements ChatSession {
 
       return { ok: false, failure: 'the conversation was closed' };
     }
+    // The same window, for the same reason, for a stop instead of a close: `stop` ran while the POST
+    // was in flight, found no id to cancel and settled nothing. Checked HERE because this is the
+    // first moment the job has a name. (The dispose case above is the precedent; a stop needed it
+    // too and would otherwise have left the job running for the sweep to find.)
+    if (this.stopped) {
+      void this.transport.cancel(id);
+
+      return STOPPED;
+    }
     this.inFlight = id;
 
-    try {
-      return await this.waitFor(id, deadline, onWaiting);
-    } finally {
-      this.inFlight = '';
-    }
+    const waiting = this.waitFor(id, deadline, onWaiting);
+    // Attached BEFORE the race. If the stop wins, this promise still settles later with nobody
+    // reading it, and a rejection nobody handles is an unhandled rejection that takes the window
+    // down rather than the turn.
+    waiting.catch(() => undefined);
+
+    return Promise.race([
+      waiting,
+      new Promise<TurnResult>((resolve) => {
+        this.wakeOnStop = () => resolve(STOPPED);
+      }),
+    ]);
   }
 
   /** Poll until it answers, fails, or the deadline passes. */
@@ -150,7 +239,9 @@ export class RemoteChatSession implements ChatSession {
     onWaiting?: (position: number) => void,
   ): Promise<TurnResult> {
     let refusals = 0;
-    while (!this.disposed) {
+    // `stopped` as well as `disposed`: the race has already settled the turn, and this loop carrying
+    // on would keep polling a job the server has been told to cancel.
+    while (!this.disposed && !this.stopped) {
       const remaining = deadline - this.now();
       if (remaining <= 0) {
         void this.transport.cancel(id);

--- a/src_vs_code/src/test/chatMessages.test.ts
+++ b/src_vs_code/src/test/chatMessages.test.ts
@@ -83,24 +83,21 @@ test('a stop carries the turn it means to stop', () => {
   );
 });
 
-test('a stop from a page too old to name a turn still stops the running one', () => {
-  // A webview retained across a reload can be older than the extension talking to it — the reason
-  // this module ignores what it does not know rather than refusing it. An older page posts no turn,
-  // and zero means "whichever is running", which is what that page was built to mean.
-  assert.deepStrictEqual(
-    chatCommandOf({ type: 'command', command: 'stop' }),
-    { kind: 'stop', turn: 0 },
-  );
+test('a stop that names no turn is not a stop', () => {
+  // There is no wildcard. The first version let a missing number mean "whichever is running", which
+  // hands back the exact defect the number exists to prevent — and no such page can exist, because
+  // `stop` and its turn number ship in the same release. (codex and gemini, the code round.)
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'stop' }), { kind: 'ignore' });
 });
 
-test('a stop naming a turn that is not a whole positive number names no turn at all', () => {
-  // Same rule the zoom delta follows: a value from a surface the host does not control is clamped to
-  // something meaningful rather than trusted into an index.
-  for (const turn of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 'two', null]) {
+test('a stop naming something that is not a turn is refused, not applied to whatever is running', () => {
+  // The boundary rule: a value from a surface the host does not control is validated before it
+  // reaches anything that acts on it. Every one of these used to become "stop whatever is running".
+  for (const turn of [-1, 0, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 2, 'two', null, {}]) {
     assert.deepStrictEqual(
       chatCommandOf({ type: 'command', command: 'stop', turn }),
-      { kind: 'stop', turn: 0 },
-      `a turn of ${String(turn)} should have been read as no turn`,
+      { kind: 'ignore' },
+      `a turn of ${String(turn)} should have been refused outright`,
     );
   }
 });

--- a/src_vs_code/src/test/chatMessages.test.ts
+++ b/src_vs_code/src/test/chatMessages.test.ts
@@ -73,3 +73,34 @@ test('a message whose fields are the wrong types cannot become a command', () =>
   assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'pick', id: { id: 'x' } }), { kind: 'ignore' });
   assert.deepStrictEqual(chatCommandOf({ type: 42, command: 'send', text: 'hi' }), { kind: 'ignore' });
 });
+
+test('a stop carries the turn it means to stop', () => {
+  // The number is what keeps a late stop from ending the turn AFTER the one it was pressed for: the
+  // page renders the control against a turn, and the host refuses a number that is no longer running.
+  assert.deepStrictEqual(
+    chatCommandOf({ type: 'command', command: 'stop', turn: 3 }),
+    { kind: 'stop', turn: 3 },
+  );
+});
+
+test('a stop from a page too old to name a turn still stops the running one', () => {
+  // A webview retained across a reload can be older than the extension talking to it — the reason
+  // this module ignores what it does not know rather than refusing it. An older page posts no turn,
+  // and zero means "whichever is running", which is what that page was built to mean.
+  assert.deepStrictEqual(
+    chatCommandOf({ type: 'command', command: 'stop' }),
+    { kind: 'stop', turn: 0 },
+  );
+});
+
+test('a stop naming a turn that is not a whole positive number names no turn at all', () => {
+  // Same rule the zoom delta follows: a value from a surface the host does not control is clamped to
+  // something meaningful rather than trusted into an index.
+  for (const turn of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 'two', null]) {
+    assert.deepStrictEqual(
+      chatCommandOf({ type: 'command', command: 'stop', turn }),
+      { kind: 'stop', turn: 0 },
+      `a turn of ${String(turn)} should have been read as no turn`,
+    );
+  }
+});

--- a/src_vs_code/src/test/chatWiring.test.ts
+++ b/src_vs_code/src/test/chatWiring.test.ts
@@ -148,7 +148,7 @@ test('a stop reaches the thread it names, and only while that thread is running'
   );
   assert.match(
     text,
-    /turn !== 0 && turn !== thread\.turn/,
+    /turn !== thread\.turn/,
     'a stop naming a turn other than the running one is not refused',
   );
 });

--- a/src_vs_code/src/test/chatWiring.test.ts
+++ b/src_vs_code/src/test/chatWiring.test.ts
@@ -143,7 +143,7 @@ test('a stop reaches the thread it names, and only while that thread is running'
   );
   assert.match(
     text,
-    /thread\.running/,
+    /thread\??\.running/,
     'a stop is applied without checking that the thread has a turn to stop',
   );
   assert.match(

--- a/src_vs_code/src/test/chatWiring.test.ts
+++ b/src_vs_code/src/test/chatWiring.test.ts
@@ -129,3 +129,46 @@ test('a closed tab is forgotten, not merely disposed', () => {
     'closing a tab leaves its conversation in the registry forever',
   );
 });
+
+test('a stop reaches the thread it names, and only while that thread is running', () => {
+  // The guarantee the plan states as "a double press cannot stop the NEXT turn". The session refuses
+  // a stop that names nothing, but the host must refuse one that names the WRONG thing: a bridge
+  // message can be late, and by the time it lands the next turn may already be in flight.
+  const text = read(join('src', 'chatCommand.ts'));
+
+  assert.match(
+    text,
+    /onStop:[\s\S]{0,600}?panels\.entryOf\(id\)/,
+    'a stop is routed by the page id, so it can reach a thread that is not the one that sent it',
+  );
+  assert.match(
+    text,
+    /thread\.running/,
+    'a stop is applied without checking that the thread has a turn to stop',
+  );
+  assert.match(
+    text,
+    /turn !== 0 && turn !== thread\.turn/,
+    'a stop naming a turn other than the running one is not refused',
+  );
+});
+
+test('a stopped turn is written into the transcript before the conversation is carried', () => {
+  // The finding that ordering is load-bearing. The question is appended BEFORE the turn is sent, so a
+  // turn that ends without an answer leaves the transcript ending on a dangling question. Carrying
+  // that into a fresh process hands the next model a question nobody answered and no sign that it was
+  // abandoned — and the turn after it appends a second `you` on top of the first. (gemini, the plan
+  // round, Blocking.)
+  const text = read(join('src', 'chatCommand.ts'));
+
+  assert.match(
+    text,
+    /result\.stopped[\s\S]{0,500}?thread\.messages = \[\.\.\.thread\.messages,/,
+    'a stopped turn leaves the transcript ending on a question nobody answered',
+  );
+  assert.match(
+    text,
+    /result\.stopped === true[\s\S]{0,900}?thread\.carry = \[\.\.\.thread\.messages\]/,
+    'the carry is taken BEFORE the stop is recorded, so it carries the dangling question',
+  );
+});

--- a/src_vs_code/src/test/cliChatSession.test.ts
+++ b/src_vs_code/src/test/cliChatSession.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { CliChatSession, Timers } from '../cliChatSession';
 import { ProcessHandle } from '../processLauncher';
-import { TurnBudgets } from '../chatSession';
+import { TurnBudgets, TurnResult } from '../chatSession';
 
 /**
  * The four ways a long-lived vendor process ends, and the one way it answers.
@@ -174,7 +174,7 @@ async function asking(
   session: CliChatSession,
   child: FakeChild,
   text: string,
-): Promise<{ answering: Promise<unknown> }> {
+): Promise<{ answering: Promise<TurnResult> }> {
   const answering = session.send(text);
   child.say(INIT);
   await flush();
@@ -656,4 +656,121 @@ test('a death after a question, before any answer, still counts as a lost conver
   current.say(ok('answer two'));
 
   assert.deepStrictEqual(await second, { ok: true, answer: 'answer two', contextLost: true });
+});
+
+/**
+ * Stopping a turn, and what the conversation looks like afterwards.
+ *
+ * <p>A turn is 9.4 s measured and a long one is much more, so a question sent by accident is waited
+ * out and billed. The kill was always built — `dispose` has used it since the first version. What was
+ * missing is a stop that ends the TURN without ending the CONVERSATION, and for a vendor that holds
+ * the conversation inside its own process those are the same kill with two different sequels.</p>
+ */
+
+test('a turn stopped while it runs ends as stopped rather than waiting out its budget', async () => {
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering } = await asking(session, child, 'why is it pinned?');
+  session.stop();
+
+  const result = await answering;
+  assert.strictEqual(result.ok, false, 'a stopped turn is not an answer');
+  assert.match(
+    result.ok === false ? result.failure : '',
+    /stopped/i,
+    'the sentence must say the person stopped it, not that something went wrong',
+  );
+  assert.strictEqual(child.killed(), 1, 'the process must actually be killed, not merely abandoned');
+});
+
+test('a turn stopped on a vendor that keeps the conversation says the next question re-sends it', async () => {
+  // The trap this plan is really about. `claude` and `agy` hold the conversation IN the process, so
+  // the kill that stops the turn takes the memory with it. The caller must be TOLD, because it is
+  // the caller that carries the transcript into the next turn.
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering } = await asking(session, child, 'why is it pinned?');
+  session.stop();
+
+  const result = await answering;
+  assert.strictEqual(result.ok, false);
+  assert.strictEqual(
+    result.ok === false ? result.contextLost : undefined,
+    true,
+    'a persistent vendor loses the conversation with the process; the caller carries it or it is gone',
+  );
+  assert.strictEqual(
+    result.ok === false ? result.stopped : undefined,
+    true,
+    'the caller has to tell a stop from a crash: one is the person, the other is a defect',
+  );
+});
+
+test('the turn after a stop is answered by a new process', async () => {
+  const first = fakeChild();
+  const second = fakeChild();
+  let handed = 0;
+  const session = new CliChatSession(
+    () => {
+      handed += 1;
+
+      return handed === 1 ? first.handle : second.handle;
+    },
+    BUDGETS,
+    fakeTimers(),
+  );
+
+  const { answering } = await asking(session, first, 'one');
+  session.stop();
+  await answering;
+
+  const next = session.send('two');
+  await flush();
+  second.say(INIT);
+  await flush();
+  second.say(ok('answer two'));
+
+  assert.deepStrictEqual(
+    await next,
+    { ok: true, answer: 'answer two', contextLost: true },
+    'the next turn must work, and must still say the process answering it never heard the first',
+  );
+  assert.strictEqual(handed, 2, 'a stop must not leave the session unable to start again');
+});
+
+test('a stop with nothing running kills nothing', async () => {
+  // A stop can arrive late — a queued bridge message, a second press, a keybinding while the turn
+  // has just landed. Killing a healthy idle process for it would cost the conversation for nothing.
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  session.stop();
+  assert.strictEqual(child.killed(), 0, 'nothing was running, so nothing should have been killed');
+
+  const { answering } = await asking(session, child, 'one');
+  child.say(ok('answer one'));
+  await answering;
+
+  session.stop();
+  assert.strictEqual(child.killed(), 0, 'the turn had already finished; a late stop must be a no-op');
+});
+
+test('a stop that arrives after the next turn has started does not stop that one', async () => {
+  // The guarantee the plan states as "a double press cannot stop the NEXT turn". The page disables
+  // its button, but a keybinding does not go through the button and a bridge message can be late.
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const { answering: one } = await asking(session, child, 'one');
+  child.say(ok('answer one'));
+  await one;
+
+  const { answering: two } = await asking(session, child, 'two');
+  session.stop();
+  const result = await two;
+
+  assert.strictEqual(result.ok, false, 'this stop names the turn that IS running, and stops it');
+  assert.strictEqual(child.killed(), 1, 'exactly one kill, for the turn that was actually running');
 });

--- a/src_vs_code/src/test/cliChatSession.test.ts
+++ b/src_vs_code/src/test/cliChatSession.test.ts
@@ -774,3 +774,52 @@ test('a stop that arrives after the next turn has started does not stop that one
   assert.strictEqual(result.ok, false, 'this stop names the turn that IS running, and stops it');
   assert.strictEqual(child.killed(), 1, 'exactly one kill, for the turn that was actually running');
 });
+
+test('a stop while the process is still starting ends the turn instead of being ignored', async () => {
+  // The code round's clearest signal: four reviewers across three vendors, independently. Startup is
+  // 3.6-6.6 s measured — a large share of the wait a person presses stop to end — and the first
+  // version installed the stop handle only AFTER the question was written, so a stop during launch
+  // was a silent no-op: the process went on starting, took the question and answered it.
+  const child = fakeChild();
+  const session = new CliChatSession(() => child.handle, BUDGETS, fakeTimers());
+
+  const answering = session.send('why is it pinned?');
+  await flush();
+  // Deliberately NO init: the child is still starting, which is the whole case.
+  session.stop();
+
+  const result = await answering;
+  assert.strictEqual(result.ok, false, 'a stop during startup must end the turn');
+  assert.strictEqual(result.ok === false ? result.stopped : undefined, true);
+  assert.strictEqual(child.killed(), 1, 'the starting process must be killed, not left to run on');
+  assert.strictEqual(child.written.length, 0, 'the question must never be written after a stop');
+});
+
+test('a stop during startup does not leave the next question waiting on the dead one', async () => {
+  const first = fakeChild();
+  const second = fakeChild();
+  let handed = 0;
+  const session = new CliChatSession(
+    () => {
+      handed += 1;
+
+      return handed === 1 ? first.handle : second.handle;
+    },
+    BUDGETS,
+    fakeTimers(),
+  );
+
+  const stopped = session.send('one');
+  await flush();
+  session.stop();
+  await stopped;
+
+  const next = session.send('two');
+  await flush();
+  second.say(INIT);
+  await flush();
+  second.say(ok('answer two'));
+
+  assert.strictEqual((await next).ok, true, 'the session must still answer after a stop during startup');
+  assert.strictEqual(handed, 2, 'the next question must start its own process');
+});

--- a/src_vs_code/src/test/perTurnSession.test.ts
+++ b/src_vs_code/src/test/perTurnSession.test.ts
@@ -396,3 +396,45 @@ test('a thread that cannot be resumed is dropped, rather than failing every turn
   assert.ok(result.ok);
   assert.strictEqual(result.contextLost, true, 'the new conversation did not say it was new');
 });
+
+test('stopping a per-turn turn keeps the thread, so the next question resumes the same conversation', async () => {
+  // The inversion, at the one moment it is most likely to be got wrong. For `claude` and `agy` a
+  // stop kills the conversation and the caller must carry the transcript; here the conversation is
+  // in the vendor's own store, the thread id survives the killed process, and carrying anything
+  // would re-send a conversation the model already has. A reviewer asked for this to be PROVEN
+  // rather than asserted in a comment. (codex, the plan round.)
+  const launcher = perTurnLauncher();
+  const session = new CliChatSession(launcher.start, BUDGETS, NEVER, codexAdapter);
+
+  const first = session.send('what does this mean?');
+  await flush();
+  launcher.turns[0]!.say(started('01a0851c-488c-7be0-9e51-e35c5fb2ce5c'));
+  launcher.turns[0]!.say(answered('it means this'));
+  launcher.turns[0]!.exit();
+  await first;
+
+  const stopped = session.send('and in the north?');
+  await flush();
+  launcher.turns[1]!.say(started('01a0851c-488c-7be0-9e51-e35c5fb2ce5c'));
+  session.stop();
+
+  const result = await stopped;
+  assert.strictEqual(result.ok, false, 'a stopped turn is not an answer');
+  assert.strictEqual(result.ok === false ? result.stopped : undefined, true);
+  assert.strictEqual(
+    result.ok === false ? result.contextLost : undefined,
+    undefined,
+    'a per-turn vendor keeps the conversation in its own store; a stop loses nothing to report',
+  );
+
+  const third = session.send('try again');
+  await flush();
+  assert.strictEqual(
+    launcher.turns[2]!.resume,
+    '01a0851c-488c-7be0-9e51-e35c5fb2ce5c',
+    'the turn after a stop must resume the SAME thread, not open a new conversation',
+  );
+  launcher.turns[2]!.say(answered('there it is different'));
+  launcher.turns[2]!.exit();
+  assert.deepStrictEqual(await third, { ok: true, answer: 'there it is different' });
+});

--- a/src_vs_code/src/test/remoteChat.test.ts
+++ b/src_vs_code/src/test/remoteChat.test.ts
@@ -626,3 +626,83 @@ test('a stop with no remote turn running tells the server nothing', async () => 
   session.stop();
   assert.deepStrictEqual(server.cancelled, [], 'the turn had finished; a late stop must be a no-op');
 });
+
+test('a stop while the question is still being submitted settles the turn at once', async () => {
+  // The stop signal used to be armed only after `submit` returned an id, so a stop pressed while the
+  // POST was in flight had no resolver to call — and a submit can take twenty seconds. (codex, the
+  // code round, twice.)
+  let releaseSubmit = (): void => undefined;
+  const held = new Promise<void>((resolve) => {
+    releaseSubmit = resolve;
+  });
+  const server = fakeServer([{ body: answered('too late') }], held);
+  const session = new RemoteChatSession(server.transport, vendor, BUDGETS, AT_ONCE);
+
+  const answering = session.send('explain this');
+  await new Promise((resolve) => setImmediate(resolve));
+  session.stop();
+
+  const result = await answering;
+  assert.strictEqual(result.ok, false, 'a stop during submission must end the turn, not wait it out');
+  assert.strictEqual(result.ok === false ? result.stopped : undefined, true);
+
+  // And when the submission finally lands, the job it created is cancelled rather than left running.
+  releaseSubmit();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepStrictEqual(
+    server.cancelled,
+    ['review-1'],
+    'a job whose submission finished after the stop must still be dropped',
+  );
+});
+
+test('a poll belonging to a stopped turn cannot come back to life during the next one', async () => {
+  // The defect three reviewers found in the first version. It used a `stopped` flag that the NEXT
+  // turn reset — so turn A's poll, sitting in an await when A was stopped, woke up after turn B had
+  // cleared the flag, decided it was not stopped after all, and carried on polling A's cancelled job
+  // and pushing A's queue positions into B's tab. A generation cannot be un-stopped.
+  let releasePoll = (): void => undefined;
+  const held = new Promise<void>((resolve) => {
+    releasePoll = resolve;
+  });
+  let firstPoll = true;
+  const positions: number[] = [];
+  const server = fakeServer([{ body: answered('the second answer') }]);
+  const racy: RemoteTransport = {
+    ...server.transport,
+    poll: async (id, waitSeconds) => {
+      server.polls.push({ id, waitSeconds });
+      if (firstPoll) {
+        firstPoll = false;
+        await held;
+
+        return { body: { status: 'queued', position: 9 }, failure: '', status: 200 };
+      }
+
+      return { body: answered('the second answer'), failure: '', status: 200 };
+    },
+  };
+  const session = new RemoteChatSession(racy, vendor, BUDGETS, AT_ONCE);
+
+  const first = session.send('one', (position) => positions.push(position));
+  await new Promise((resolve) => setImmediate(resolve));
+  session.stop();
+  await first;
+
+  // Turn two starts and finishes while turn one's poll is still held.
+  const second = await session.send('two');
+  assert.deepStrictEqual(second, { ok: true, answer: 'the second answer' });
+
+  // Now turn one's poll finally comes back. It must find itself stale and stop, not resume.
+  const pollsBefore = server.polls.length;
+  releasePoll();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(positions, [], 'a stopped turn must not push a queue position afterwards');
+  assert.strictEqual(
+    server.polls.length,
+    pollsBefore,
+    'the abandoned poll loop must not issue another poll once its turn is stale',
+  );
+});

--- a/src_vs_code/src/test/remoteChat.test.ts
+++ b/src_vs_code/src/test/remoteChat.test.ts
@@ -550,3 +550,79 @@ test('a turn that was ACCEPTED leaves no key to reuse', async () => {
   assert.notStrictEqual(submitted[1]?.['idempotencyKey'], submitted[0]?.['idempotencyKey']);
   assert.strictEqual(minted, 2);
 });
+
+/**
+ * Stopping a turn a SERVER is running.
+ *
+ * <p>The remote half has no process to kill and no conversation to lose. What it has is a job on
+ * somebody else's machine, holding a slot on a shared vendor account, and a poll that may be holding
+ * a connection open for another eight seconds. So a stop here is two obligations that pull apart: the
+ * person must see it took AT ONCE, and the server must be told so the slot is freed rather than left
+ * to the drop-on-no-poll sweep three minutes later.</p>
+ */
+
+test('stopping a remote turn settles it at once, without waiting for the poll in flight', async () => {
+  // The finding two reviewers raised independently: a poll holds the connection for up to eight
+  // seconds, and a person who pressed stop is not waiting eight seconds to learn it worked.
+  let releasePoll = (): void => undefined;
+  const held = new Promise<void>((resolve) => {
+    releasePoll = resolve;
+  });
+  const server = fakeServer([{ body: { status: 'queued', position: 2 } }]);
+  const slowPoll: RemoteTransport = {
+    ...server.transport,
+    poll: async (id, waitSeconds) => {
+      server.polls.push({ id, waitSeconds });
+      await held;
+
+      return { body: answered('too late to matter'), failure: '', status: 200 };
+    },
+  };
+  const session = new RemoteChatSession(slowPoll, vendor, BUDGETS, AT_ONCE);
+
+  const answering = session.send('explain this');
+  await new Promise((resolve) => setImmediate(resolve));
+  session.stop();
+
+  const result = await answering;
+  assert.strictEqual(result.ok, false, 'a stopped turn is not an answer');
+  assert.strictEqual(result.ok === false ? result.stopped : undefined, true);
+  assert.deepStrictEqual(server.cancelled, ['review-1'], 'the server must be told, not left to its sweep');
+
+  // And the answer that arrives afterwards is dropped rather than resolving the turn a second time.
+  releasePoll();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.strictEqual(
+    (await answering).ok,
+    false,
+    'a poll landing after a stop must not turn a stopped turn into an answered one',
+  );
+});
+
+test('a remote conversation still works after a turn is stopped', async () => {
+  // `stop` is not `dispose`: the session stays open. A server holds no conversation anyway, so the
+  // only thing that must survive is the session's own ability to submit again.
+  const server = fakeServer([{ body: answered('the second answer') }]);
+  const session = new RemoteChatSession(server.transport, vendor, BUDGETS, AT_ONCE);
+
+  const first = session.send('one');
+  await new Promise((resolve) => setImmediate(resolve));
+  session.stop();
+  await first;
+
+  const second = await session.send('two');
+  assert.deepStrictEqual(second, { ok: true, answer: 'the second answer' });
+  assert.strictEqual(server.submitted.length, 2, 'the session must still be able to ask');
+});
+
+test('a stop with no remote turn running tells the server nothing', async () => {
+  const server = fakeServer([{ body: answered('done') }]);
+  const session = new RemoteChatSession(server.transport, vendor, BUDGETS, AT_ONCE);
+
+  session.stop();
+  assert.deepStrictEqual(server.cancelled, [], 'nothing was running, so nothing should be cancelled');
+
+  await session.send('one');
+  session.stop();
+  assert.deepStrictEqual(server.cancelled, [], 'the turn had finished; a late stop must be a no-op');
+});

--- a/todo/PLAN_a_turn_nobody_can_stop.md
+++ b/todo/PLAN_a_turn_nobody_can_stop.md
@@ -1,6 +1,11 @@
 # PLAN — a turn nobody can stop
 
-> Status: **plan only, nothing implemented yet.** Kind: **bug** (accepted 2026-09-09). Scope: the
+> Status: **the SEAM half is implemented (2026-09-09, branch `fix/a-turn-nobody-can-stop-seam`); the
+> PAGE half — the Stop button in `chatStatusHtml` — is not yet built.** `ChatSession.stop()` exists on
+> the seam and in both implementations, the three session shapes behave as this plan describes, and
+> `chatCommand.ts` routes a `stop` message to the right thread and refuses one naming a turn that is
+> no longer running. What remains is the button that posts it, which belongs to the chat-page lane
+> because that lane owns `chatPage.ts`. Kind: **bug** (accepted 2026-09-09). Scope: the
 > chat session seam and the page — `src_vs_code/src/chatSession.ts`, `cliChatSession.ts`,
 > `remoteChatSession.ts`, `chatCommand.ts`, `chatPage.ts` (the thinking line only). Origin:
 > [BUGS_2026-09-09.md](BUGS_2026-09-09.md), entry 15.


### PR DESCRIPTION
The seam half of [PLAN_a_turn_nobody_can_stop.md](todo/PLAN_a_turn_nobody_can_stop.md).

## What was asked

A chat turn is 9.4 s measured and a long one much more. `ChatSession` offered `send` and `dispose` and nothing between them, so a question sent by accident — or one you can see is wrong the moment it leaves — could only be waited out, and billed.

## What shipped

`ChatSession.stop()` ends the turn that is running now and leaves the conversation able to take another. **A stop that names nothing does nothing**: with no turn in flight it neither kills an idle process nor marks a conversation lost. The turn's identity is a closure created by that turn and cleared the moment it settles by any route, so a stop one tick late finds nothing — and the host checks the turn NUMBER before calling it at all.

What a stop costs differs by session shape, and each was proven rather than asserted:

| shape | vendor | the kill costs | the next turn |
|---|---|---|---|
| persistent | `claude`, `agy` | the conversation — it lived in that process | re-sends the transcript (`contextLost: true`) |
| per-turn | `codex` | the answer only | resumes the same thread id |
| remote | a Team server | nothing | submits as usual; the job is cancelled at once |

`contextLost` is set for a stop and **not** for a crash: a stop is the person's decision, whereas silently re-sending a transcript because a third-party CLI fell over would bill somebody for an accident. That case is [its own plan](todo/PLAN_a_dead_process_could_carry_the_conversation_too.md), gated on a measurement.

## What is deliberately NOT here

**The Stop button.** It lives in `chatStatusHtml` in `chatPage.ts`, which a parallel session owns on another branch — two sessions editing one file is a failure this repository has already measured and written a rule about. The seam is complete and tested without it, and the host route already accepts the message the button will post. Nothing a person can see changed in this branch, which is why there is no help article, no README change and no CHANGELOG entry; the page-lane pull request that adds the button carries those. The plan's status line says exactly which half shipped.

## What the tests showed

RED first, watched failing with the real symptom: the CLI tests failed with `Property 'stop' is private and only accessible within class 'CliChatSession'`, the bridge tests with `{ kind: 'ignore' }` against `{ kind: 'stop', turn: 3 }`.

Teeth checked rather than assumed. With the startup arming and the generation check reverted, **seven stop tests go red** — the CLI ones by HANGING, which is the true symptom (the turn never settles because the stop was ignored), the two remote ones failing fast. Both fixes restored.

`npm test`: **1077 tests, 1076 pass, 0 fail, 1 skipped.** `plan-lifecycle.mjs` and `pin-check.mjs` clean.

## The review gate

Plan round: `good_enough`, all 3 reviewers, 14 gating findings — 13 accepted, 3 rejected with reasons.

Code round 1: `revise`, all 12 reviewers, 29 gating findings. **Three were real defects** and are fixed here:

- **A stop during CLI startup was a silent no-op.** The handle was armed after the question was written, and startup is 3.6–6.6 s measured — a large share of the wait a person presses stop to end. Four reviewers across three vendors found it independently.
- **A stop during the remote submit could not settle the turn**, because the signal was armed only after the POST returned an id — and a POST can take twenty seconds.
- **An abandoned remote poll could come back to life during the next turn.** The session held a `stopped` flag each new turn reset, so turn A's poll — asleep in an await when A was stopped — woke after turn B cleared it and went on polling A's cancelled job and pushing A's queue positions into B's tab. It is a per-turn generation now, which cannot be un-stopped.

Also from that round: the `turn: 0` stop wildcard is gone (it handed back the exact defect the turn number exists to prevent), `transport.cancel` can no longer become an unhandled rejection, and `submitAndWait` is back under fifty lines.

Code round 2: `good_enough`, all 3 reviewers, 6 gating findings — 1 accepted (a doc comment still describing the removed wildcard, which would have misled the page lane), 5 rejected with reasons. Four of those five reported races between adjacent synchronous statements with no suspension point between them; one proposed a fix that would have left the remote session permanently marked `running` after a stop.

Every finding in all three rounds was resolved with an accept or a reasoned rejection.
