### PR TITLE
feat(chat): the tab wears this product's own glyph

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -787,6 +787,49 @@ because it could override the value out of sight. A second test in the file driv
 guard that cannot be described in a fixture is a guard nobody can trust. The discovery walks `.ts`,
 `.tsx`, `.mts` and `.cts`, so a panel arriving as a `.tsx` is not a panel nobody scans.
 
+## The chat tab wears its own glyph (2026-09-09)
+
+Every chat tab wore the generic `≡`, because `createWebviewPanel` never set `iconPath` — there was
+not one in the whole extension. A person with three conversations open had three tabs that looked
+like everything else in the editor.
+
+`media/chat.svg` and `media/chat-light.svg` are the activity-bar glyph (`panel.svg`: three nodes
+around a hub) with three things changed for a tab. The colour is BAKED IN, twice, because a tab icon
+is workbench chrome and no theme reaches it: `var(--vscode-…)` is unavailable and `iconPath` takes a
+`Uri` or a `{ light, dark }` pair — `#5CC46F`, palette slot 5, on a dark ground, and `#2E8B3E`, the
+same hue darkened, on a light one, because a bright green on white reads pale. Measured against the
+grounds they sit on: 4.30:1 on white, 3.64:1 on a Light+ tab, 7.61:1 on Dark+, 8.10:1 on Dark
+Modern — every one past the 3:1 WCAG asks of a graphical object. And the viewBox is cut to the
+content (`2.7 0.85 18.6 18.6`, centred on the hub's visual centre at y 10.15 rather than the box's
+12) with the strokes taken from 0.95/1.15 to 1.7/1.8, because "big" is not a size the workbench lets
+you ask for: it draws a tab icon at its own fixed size, and the Welcome tab's looks big only because
+its glyph fills the box edge to edge.
+
+**The line was the small half.** `createChatPanel` took no context and no URI, and neither did
+`newConversation` or `chatWithOtherAi`; `context` exists only in `activate`. The URI is threaded
+through all three — the URI, not the `ExtensionContext`, because a function that needs a media folder
+should say that and this one needs neither storage nor subscriptions. `PanelProvider` holding a whole
+context is the precedent for the other choice and it is the right one there: it uses `globalState`
+and `globalStorageUri`.
+
+**Where the path lives, and why it is not in `chatPanel.ts`.** `chatIcon.ts` holds the two file names
+as path segments and imports nothing. The only failure mode an icon has is a path that names a file
+nobody shipped — nothing type-checks a `Uri`, and a wrong one produces the generic icon and no error
+anywhere — so the segments the panel joins are the segments a test opens on disk. A regex over the
+source could only have proved that some string was written down. The tests also assert the two
+colours, the viewBox and the stroke weights, and that `.vscodeignore` excludes nothing under
+`media/`; `vsce ls` was run and lists both files.
+
+**Not verified here.** The side-by-side against the Welcome tab needs a running workbench and a human
+eye. The geometry matches the numbers the plan measured, but "indistinguishable in size" is recorded
+as unverified rather than claimed.
+
+**The open tail, named by the plan round.** A panel restored by a `WebviewPanelSerializer` would not
+pass through `chatWithOtherAi`, so it would come back without an icon. There is no serializer in this
+extension today — `registerWebviewPanelSerializer` appears nowhere — but the plan that adds one
+(`a_conversation_survives_a_reload`) must route its restored panel through `createChatPanel`, or its
+tabs will wear the generic glyph again.
+
 ## The update check can trust `…/releases` again (2026-09-08)
 
 `installer.ts` asks GitHub for the newest release and offers its asset. That was safe only while a

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -813,22 +813,38 @@ context is the precedent for the other choice and it is the right one there: it 
 and `globalStorageUri`.
 
 **Where the path lives, and why it is not in `chatPanel.ts`.** `chatIcon.ts` holds the two file names
-as path segments and imports nothing. The only failure mode an icon has is a path that names a file
-nobody shipped — nothing type-checks a `Uri`, and a wrong one produces the generic icon and no error
-anywhere — so the segments the panel joins are the segments a test opens on disk. A regex over the
-source could only have proved that some string was written down. The tests also assert the two
-colours, the viewBox and the stroke weights, and that `.vscodeignore` excludes nothing under
-`media/`; `vsce ls` was run and lists both files.
+and imports nothing. The only failure mode an icon has is a path that names a file nobody shipped —
+nothing type-checks a `Uri`, and a wrong one produces the generic icon and no error anywhere. The
+code round refused a regex over `chatPanel.ts` for this, and it was right: a regex proves that
+somebody wrote a string down. So the RESOLUTION is a pure function, `chatTabIcon(join)` — the panel
+hands it `vscode.Uri.joinPath` and the test hands it a joiner of its own, and both observe the same
+two paths, which the test then opens on disk. One structural assertion survives, for the one thing no
+test here can reach: that `chatPanel.ts` assigns `panel.iconPath` at all.
+
+That assignment mutates a live object, which the immutability rule would ordinarily refuse. The rule
+governs OUR data; this handle is VS Code's, `iconPath` is settable only after creation, and every
+webview in this extension is configured the same way. Recorded at the line rather than worked around,
+because the alternative is a creation API that does not exist.
+
+**What the packaging test had to become.** Asserting that no `.vscodeignore` line STARTS with `media`
+was the first version, and it was green with `**/*.svg` sitting in the file — measured, not supposed.
+Each pattern is now expanded into the regex the packager's glob means by it, in one character-by-character
+pass, and run against the paths the panel actually asks for. A chain of `.replace` calls cannot do
+that job: the `.*` that `**/` expands to contains a `*`, which the later `*` rule rewrites into
+`[^/]*`. It was checked against `**/*.svg`, `media/**`, `**/media/**` and `media`, all four of which
+now fail it. `vsce ls` was also run and lists both files.
 
 **Not verified here.** The side-by-side against the Welcome tab needs a running workbench and a human
 eye. The geometry matches the numbers the plan measured, but "indistinguishable in size" is recorded
 as unverified rather than claimed.
 
-**The open tail, named by the plan round.** A panel restored by a `WebviewPanelSerializer` would not
-pass through `chatWithOtherAi`, so it would come back without an icon. There is no serializer in this
-extension today — `registerWebviewPanelSerializer` appears nowhere — but the plan that adds one
-(`a_conversation_survives_a_reload`) must route its restored panel through `createChatPanel`, or its
-tabs will wear the generic glyph again.
+**The tail is held by a test, not by a paragraph.** A panel restored by a `WebviewPanelSerializer`
+would not pass through `chatWithOtherAi`, so it would come back without an icon. There is no
+serializer in this extension today — `registerWebviewPanelSerializer` appears nowhere — so no tab
+loses anything yet; the plan that adds one (`a_conversation_survives_a_reload`) must route its
+restored panel through `createChatPanel`. `theTabWearsAnIcon.test.ts` walks `src/` and fails any file
+that registers a serializer without reaching `createChatPanel`, so the requirement arrives with the
+change that needs it rather than being remembered.
 
 ## The update check can trust `…/releases` again (2026-09-08)
 

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Extension 0.31.21 — 2026-09-09
+
+**A chat tab looks like a chat tab.** It wore the same generic icon as everything else in the editor,
+which is no help at all when three conversations are open side by side. It carries this product's own
+green glyph now, in a light and a dark version, because a tab icon cannot read your theme.
+
+
 ## Extension 0.31.19 — 2026-09-09
 
 **Ctrl+F works.** The chat tab, the rounds log and the help page each open with the editor's own find

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -7,6 +7,14 @@ which is no help at all when three conversations are open side by side. It carri
 green glyph now, in a light and a dark version, because a tab icon cannot read your theme.
 
 
+## Extension 0.31.20 — 2026-09-09
+
+**The prompt you type into the sidebar now stays typed.** *What to ask about the selection* was
+saving only when you clicked away, and the panel rebuilds itself whenever a probe, a version check or
+any other setting moves — several times a minute, none of it your doing. Whatever you had typed died
+with the page. It is written as you type now, and the panel will not rebuild itself underneath a box
+you are working in.
+
 ## Extension 0.31.19 — 2026-09-09
 
 **Ctrl+F works.** The chat tab, the rounds log and the help page each open with the editor's own find

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.20",
+  "version": "0.31.21",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -541,6 +541,7 @@ function newConversation(
   state: { readonly title: string; readonly passage: string; readonly draft: string },
   resolved: string,
   remote: ChatSession | undefined,
+  extensionUri: vscode.Uri,
 ): ChatEntry {
   const first = started(ready.vendor, resolved, remote);
   const session = first.session;
@@ -611,6 +612,7 @@ function newConversation(
         void vscode.window.showWarningMessage(`The chat page reported: ${message}`);
       },
     },
+    extensionUri,
   );
   // Recorded against the entry's OWN id, which `createChatPanel` made — not against the tab key,
   // which can move under a live conversation. That distinction cost a whole code round.
@@ -639,7 +641,11 @@ function newConversation(
  * @param panels the registry of open conversations
  * @param args what VS Code handed it — a menu item passes the webview, a keybinding passes nothing
  */
-export async function chatWithOtherAi(panels: ChatPanels, args: readonly unknown[]): Promise<void> {
+export async function chatWithOtherAi(
+  panels: ChatPanels,
+  extensionUri: vscode.Uri,
+  args: readonly unknown[],
+): Promise<void> {
   const config = vscode.workspace.getConfiguration('coai');
   const settings = chatSettingsFrom((key) => config.get(key));
   const ready = readyToChat(config, settings.model);
@@ -699,7 +705,7 @@ export async function chatWithOtherAi(panels: ChatPanels, args: readonly unknown
     title: match.label,
     passage: passage.text,
     draft: plan.send ? '' : turn,
-  }, cli.resolved, remote.session));
+  }, cli.resolved, remote.session, extensionUri));
 
   opened.entry.panel.reveal();
   if (plan.send) {

--- a/src_vs_code/src/chatIcon.ts
+++ b/src_vs_code/src/chatIcon.ts
@@ -1,25 +1,42 @@
 /**
- * Where the chat tab's icon lives, as path segments and nothing else.
+ * Where the chat TAB's icon lives, as path segments and nothing else.
  *
  * <p>Its own module because `chatPanel.ts` imports `vscode`, which does not exist outside the
  * extension host — so a constant declared there could not be read by a test, and the one failure
  * mode an icon has is a path that names a file nobody shipped. Nothing type-checks a `Uri`: it is
  * built from strings, joined, handed to the workbench, and a wrong one produces the generic tab icon
- * and no error anywhere. Here the SAME segments the panel joins are what the test opens on disk.</p>
+ * and no error anywhere. Here the SAME segments the panel joins are what a test opens on disk.</p>
+ *
+ * <p>The TAB, not the activity bar: `media/panel.svg` is the activity-bar glyph, drawn in
+ * `currentColor` so the workbench can recolour it. These two are its descendants and cannot be
+ * recoloured — see below.</p>
  *
  * <p>Two files rather than one, because a tab icon cannot read the theme: it is workbench chrome,
  * `var(--vscode-…)` never reaches it, and `iconPath` takes a `Uri` or a `{ light, dark }` pair. The
  * colour is baked into each file, which is why `help-yellow.svg` / `help-yellow-light.svg` is a pair
  * already.</p>
  */
-export interface IconFiles {
+export interface ThemedIcon<T> {
   /** Drawn on a light ground: `#2E8B3E`, the same hue darkened, because a bright green on white reads pale. */
-  readonly light: readonly string[];
+  readonly light: T;
   /** Drawn on a dark ground: `#5CC46F`, palette slot 5 — the green `gemini` wears. */
-  readonly dark: readonly string[];
+  readonly dark: T;
 }
 
-export const CHAT_ICON: IconFiles = {
+/** The two files, relative to the extension's own folder. */
+export const CHAT_TAB_ICON: ThemedIcon<readonly string[]> = {
   light: ['media', 'chat-light.svg'],
   dark: ['media', 'chat.svg'],
 };
+
+/**
+ * The pair, resolved by whatever knows how to join a path.
+ *
+ * <p>A function rather than the constant alone so that the RESOLUTION can be tested: the panel hands
+ * it `vscode.Uri.joinPath` and a test hands it a joiner of its own, and both then observe the same
+ * two paths. Asserting the panel's source text instead would only have proved that somebody wrote a
+ * string down.</p>
+ */
+export function chatTabIcon<T>(join: (...segments: readonly string[]) => T): ThemedIcon<T> {
+  return { light: join(...CHAT_TAB_ICON.light), dark: join(...CHAT_TAB_ICON.dark) };
+}

--- a/src_vs_code/src/chatIcon.ts
+++ b/src_vs_code/src/chatIcon.ts
@@ -1,0 +1,25 @@
+/**
+ * Where the chat tab's icon lives, as path segments and nothing else.
+ *
+ * <p>Its own module because `chatPanel.ts` imports `vscode`, which does not exist outside the
+ * extension host — so a constant declared there could not be read by a test, and the one failure
+ * mode an icon has is a path that names a file nobody shipped. Nothing type-checks a `Uri`: it is
+ * built from strings, joined, handed to the workbench, and a wrong one produces the generic tab icon
+ * and no error anywhere. Here the SAME segments the panel joins are what the test opens on disk.</p>
+ *
+ * <p>Two files rather than one, because a tab icon cannot read the theme: it is workbench chrome,
+ * `var(--vscode-…)` never reaches it, and `iconPath` takes a `Uri` or a `{ light, dark }` pair. The
+ * colour is baked into each file, which is why `help-yellow.svg` / `help-yellow-light.svg` is a pair
+ * already.</p>
+ */
+export interface IconFiles {
+  /** Drawn on a light ground: `#2E8B3E`, the same hue darkened, because a bright green on white reads pale. */
+  readonly light: readonly string[];
+  /** Drawn on a dark ground: `#5CC46F`, palette slot 5 — the green `gemini` wears. */
+  readonly dark: readonly string[];
+}
+
+export const CHAT_ICON: IconFiles = {
+  light: ['media', 'chat-light.svg'],
+  dark: ['media', 'chat.svg'],
+};

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -12,7 +12,7 @@ import {
   chatPickerHtml,
   chatStatusHtml,
 } from './chatPage';
-import { CHAT_ICON } from './chatIcon';
+import { chatTabIcon } from './chatIcon';
 import { escapeHtml } from './webviewHtml';
 import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
 
@@ -120,13 +120,16 @@ export function createChatPanel(
     },
   );
   // A pair, because a tab icon is workbench chrome and no theme reaches it — `var(--vscode-…)` is
-  // unavailable there, and the colour has to be baked into the file. The segments come from
-  // `chatIcon.ts` rather than being spelled out here: a path written twice is a path that goes stale
-  // on the first rename, and nothing type-checks a `Uri`.
-  panel.iconPath = {
-    light: vscode.Uri.joinPath(extensionUri, ...CHAT_ICON.light),
-    dark: vscode.Uri.joinPath(extensionUri, ...CHAT_ICON.dark),
-  };
+  // unavailable there, and the colour has to be baked into the file. The paths are resolved by
+  // `chatTabIcon` rather than spelled out here: a path written twice is a path that goes stale on the
+  // first rename, and nothing type-checks a `Uri`.
+  //
+  // An assignment onto a live object, which the immutability rule would ordinarily refuse. The rule
+  // governs OUR data; this handle is VS Code's, `iconPath` is settable only after creation, and every
+  // webview in this extension is configured the same way (`panel.webview.html = …`,
+  // `view.webview.options = …`). Raised by two reviewers on the code round; recorded rather than
+  // worked around, because the alternative is a creation API the API does not have.
+  panel.iconPath = chatTabIcon((...segments) => vscode.Uri.joinPath(extensionUri, ...segments));
   panel.webview.html = chatPageHtml(state, crypto.randomBytes(16).toString('hex'));
 
   const scale = pushUiScaleTo(panel.webview);

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -12,6 +12,7 @@ import {
   chatPickerHtml,
   chatStatusHtml,
 } from './chatPage';
+import { CHAT_ICON } from './chatIcon';
 import { escapeHtml } from './webviewHtml';
 import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
 
@@ -89,11 +90,13 @@ export interface ChatPushState {
  * map, and handing back a `WebviewPanel` would invite a second place that knows how to dispose one.</p>
  *
  * @param known whether a model id the page asks for is one this conversation was actually offered
+ * @param extensionUri where this extension was installed — the only way to name a file it ships
  */
 export function createChatPanel(
   state: ChatPageState,
   session: DisposableSession,
   hooks: ChatPanelHooks,
+  extensionUri: vscode.Uri,
 ): ChatEntry {
   // The conversation's own identity, created once and never replaced. See the module comment.
   const id = { conversation: state.title };
@@ -116,6 +119,14 @@ export function createChatPanel(
       localResourceRoots: [],
     },
   );
+  // A pair, because a tab icon is workbench chrome and no theme reaches it — `var(--vscode-…)` is
+  // unavailable there, and the colour has to be baked into the file. The segments come from
+  // `chatIcon.ts` rather than being spelled out here: a path written twice is a path that goes stale
+  // on the first rename, and nothing type-checks a `Uri`.
+  panel.iconPath = {
+    light: vscode.Uri.joinPath(extensionUri, ...CHAT_ICON.light),
+    dark: vscode.Uri.joinPath(extensionUri, ...CHAT_ICON.dark),
+  };
   panel.webview.html = chatPageHtml(state, crypto.randomBytes(16).toString('hex'));
 
   const scale = pushUiScaleTo(panel.webview);

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -161,7 +161,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // 'Chat with other AI' item in Claude Code's own right-click menu — and the command tells them
     // apart by what VS Code hands it, because only one of them can copy the selection itself.
     vscode.commands.registerCommand('coai.chatWithOtherAi', (...args: unknown[]) => {
-      void chatWithOtherAi(chatPanels, args);
+      void chatWithOtherAi(chatPanels, context.extensionUri, args);
     }),
     // Deactivation is not a tab closing: nobody has told VS Code about these panels, so both the
     // panel and the vendor process behind it have to be ended here or they outlive the extension.

--- a/src_vs_code/src/test/theTabWearsAnIcon.test.ts
+++ b/src_vs_code/src/test/theTabWearsAnIcon.test.ts
@@ -136,7 +136,10 @@ test('nothing excludes the icons from the package a person installs', () => {
       } else if (here === '?') {
         out += '[^/]';
       } else {
-        out += here.replace(/[.+^${}()|[\]\\]/, '\\$&');
+        // Global, although `here` is one character: a sanitiser that escapes only the first match is
+        // a sanitiser that is wrong the day its input grows, and CodeQL is right to refuse to reason
+        // about which of those two this is.
+        out += here.replace(/[.+^${}()|[\]\\]/g, '\\$&');
       }
     }
 

--- a/src_vs_code/src/test/theTabWearsAnIcon.test.ts
+++ b/src_vs_code/src/test/theTabWearsAnIcon.test.ts
@@ -1,0 +1,89 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { CHAT_ICON } from '../chatIcon';
+
+/**
+ * The chat tab wears this product's own glyph, in green, in both themes.
+ *
+ * <p>2026-09-09: every chat tab wore the generic `≡`, because `createWebviewPanel` never set
+ * `iconPath` — a search of `src_vs_code/src` found not one. A person with three conversations open
+ * had three tabs that looked like everything else.</p>
+ *
+ * <p>Structural where it has to be: `chatPanel.ts` imports `vscode`, so no test here can call it.
+ * But the failure mode of an icon is not logic, it is a PATH — nothing type-checks a `Uri`, a wrong
+ * one produces the generic icon and no error anywhere — so the segments the panel joins live in
+ * `chatIcon.ts`, with no `vscode` import, and this file opens them on disk. A regex over the source
+ * could only have proved that some string was written down.</p>
+ */
+
+const EXTENSION_ROOT = path.join(__dirname, '..', '..');
+const read = (file: string): string => fs.readFileSync(path.join(EXTENSION_ROOT, file), 'utf8');
+
+test('both icon files are where the panel will look for them', () => {
+  for (const segments of [CHAT_ICON.light, CHAT_ICON.dark]) {
+    const file = path.join(EXTENSION_ROOT, ...segments);
+
+    assert.ok(fs.existsSync(file), `${segments.join('/')} is named by the panel and is not in the tree`);
+    assert.match(fs.readFileSync(file, 'utf8'), /^<svg /, `${segments.join('/')} is not an svg`);
+  }
+});
+
+test('each icon is drawn for the ground it sits on, full bleed', () => {
+  // The colours are the decision, so they are the assertion. `#5CC46F` is palette slot 5 — the green
+  // `gemini` wears, picked with eleven others to stay apart in a light theme as well as a dark one;
+  // `#2E8B3E` is the same hue darkened, derived the way `help-yellow-light.svg` was from
+  // `help-yellow.svg`, because a bright colour on white reads pale. Measured against the grounds they
+  // actually sit on: 4.30:1 on white and 3.64:1 on a Light+ tab, 7.61:1 on Dark+ and 8.10:1 on Dark
+  // Modern — every one of them past the 3:1 that WCAG asks of a graphical object.
+  const dark = read(path.join(...CHAT_ICON.dark));
+  const light = read(path.join(...CHAT_ICON.light));
+
+  assert.match(dark, /fill="#5CC46F"/);
+  assert.match(light, /fill="#2E8B3E"/);
+  assert.ok(!light.includes('#5CC46F'), 'the light icon still carries the dark theme’s green');
+
+  // "Big" is not a size the workbench lets you ask for: it draws a tab icon at its own fixed size, and
+  // the Welcome tab's looks big because its glyph fills the box edge to edge. So the viewBox is cut to
+  // the content and the strokes are heavy — a hairline at 16 px is a smudge.
+  for (const svg of [dark, light]) {
+    assert.match(svg, /viewBox="2\.7 0\.85 18\.6 18\.6"/, 'the viewBox is not cut to the glyph');
+    assert.match(svg, /stroke-width="1\.7"/, 'the lines are back to the activity bar’s hairline');
+    assert.match(svg, /stroke-width="1\.8"/, 'the rings are back to the activity bar’s hairline');
+  }
+});
+
+test('the chat tab asks for that icon, in both variants, from the extension’s own folder', () => {
+  const source = read(path.join('src', 'chatPanel.ts'));
+
+  assert.match(source, /panel\.iconPath = \{/, 'no iconPath is set, so the tab wears the generic glyph');
+  assert.match(source, /light: vscode\.Uri\.joinPath\(extensionUri, \.\.\.CHAT_ICON\.light\)/);
+  assert.match(source, /dark: vscode\.Uri\.joinPath\(extensionUri, \.\.\.CHAT_ICON\.dark\)/);
+  // Built from the SHARED segments, not from a path written out a second time here — the second copy
+  // is the one that goes stale when a file is renamed, and nothing would say so.
+  assert.ok(!/['"]media\/chat/.test(source), 'the panel spells the icon path out instead of sharing it');
+});
+
+test('the extension URI is handed to the panel rather than invented by it', () => {
+  // `createChatPanel` had no context and no URI, and neither did either of its callers; `context`
+  // exists only in `activate`. The URI is threaded, not the whole `ExtensionContext`: a function that
+  // needs a media folder should say that, and this one needs neither storage nor subscriptions.
+  assert.match(read(path.join('src', 'chatPanel.ts')), /extensionUri: vscode\.Uri/);
+  assert.match(read(path.join('src', 'chatCommand.ts')), /extensionUri: vscode\.Uri/);
+  assert.match(read(path.join('src', 'extension.ts')), /chatWithOtherAi\(chatPanels, context\.extensionUri, args\)/);
+});
+
+test('nothing excludes the icons from the package a person installs', () => {
+  // The tests run against the source tree; a person runs a `.vsix`. `media/` is not excluded today,
+  // and this is what says so the day somebody tidies the ignore file — a shipped extension whose icon
+  // files were left out looks exactly like an extension that never set `iconPath`.
+  const ignored = read('.vscodeignore').split(/\r?\n/).map((line) => line.trim());
+
+  for (const line of ignored) {
+    assert.ok(
+      line.length === 0 || line.startsWith('#') || !line.startsWith('media'),
+      `.vscodeignore excludes the icons the tab needs: ${line}`,
+    );
+  }
+});

--- a/src_vs_code/src/test/theTabWearsAnIcon.test.ts
+++ b/src_vs_code/src/test/theTabWearsAnIcon.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { CHAT_ICON } from '../chatIcon';
+import { CHAT_TAB_ICON, chatTabIcon } from '../chatIcon';
 
 /**
  * The chat tab wears this product's own glyph, in green, in both themes.
@@ -11,22 +11,38 @@ import { CHAT_ICON } from '../chatIcon';
  * `iconPath` — a search of `src_vs_code/src` found not one. A person with three conversations open
  * had three tabs that looked like everything else.</p>
  *
- * <p>Structural where it has to be: `chatPanel.ts` imports `vscode`, so no test here can call it.
- * But the failure mode of an icon is not logic, it is a PATH — nothing type-checks a `Uri`, a wrong
- * one produces the generic icon and no error anywhere — so the segments the panel joins live in
- * `chatIcon.ts`, with no `vscode` import, and this file opens them on disk. A regex over the source
- * could only have proved that some string was written down.</p>
+ * <p>The failure mode of an icon is not logic, it is a PATH: nothing type-checks a `Uri`, and a wrong
+ * one produces the generic icon and no error anywhere. So the resolution is a pure function —
+ * `chatTabIcon` takes a joiner, the panel hands it `vscode.Uri.joinPath` and this file hands it one of
+ * its own — and the paths it produces are opened on disk here. The code round refused the first
+ * version's regex over `chatPanel.ts`, correctly: a regex could only have proved that somebody wrote
+ * a string down.</p>
  */
 
 const EXTENSION_ROOT = path.join(__dirname, '..', '..');
 const read = (file: string): string => fs.readFileSync(path.join(EXTENSION_ROOT, file), 'utf8');
+/** The joiner a test can watch, standing where `vscode.Uri.joinPath` stands in the panel. */
+const asPath = (...segments: readonly string[]): string => segments.join('/');
 
-test('both icon files are where the panel will look for them', () => {
-  for (const segments of [CHAT_ICON.light, CHAT_ICON.dark]) {
-    const file = path.join(EXTENSION_ROOT, ...segments);
+test('the icon resolves to two files, and both are in the tree', () => {
+  const resolved = chatTabIcon(asPath);
 
-    assert.ok(fs.existsSync(file), `${segments.join('/')} is named by the panel and is not in the tree`);
-    assert.match(fs.readFileSync(file, 'utf8'), /^<svg /, `${segments.join('/')} is not an svg`);
+  assert.deepEqual(resolved, { light: 'media/chat-light.svg', dark: 'media/chat.svg' });
+
+  for (const file of [resolved.light, resolved.dark]) {
+    const full = path.join(EXTENSION_ROOT, file);
+
+    assert.ok(fs.existsSync(full), `${file} is what the panel asks the workbench for, and is not here`);
+    assert.match(fs.readFileSync(full, 'utf8'), /^<svg /, `${file} is not an svg`);
+  }
+});
+
+test('the icon cannot name anything outside the folder this extension shipped', () => {
+  for (const segments of [CHAT_TAB_ICON.light, CHAT_TAB_ICON.dark]) {
+    for (const segment of segments) {
+      assert.ok(segment !== '..' && !/[\\/]/.test(segment),
+        `an icon segment that walks the tree resolves somewhere nobody meant: ${segment}`);
+    }
   }
 });
 
@@ -37,8 +53,9 @@ test('each icon is drawn for the ground it sits on, full bleed', () => {
   // `help-yellow.svg`, because a bright colour on white reads pale. Measured against the grounds they
   // actually sit on: 4.30:1 on white and 3.64:1 on a Light+ tab, 7.61:1 on Dark+ and 8.10:1 on Dark
   // Modern — every one of them past the 3:1 that WCAG asks of a graphical object.
-  const dark = read(path.join(...CHAT_ICON.dark));
-  const light = read(path.join(...CHAT_ICON.light));
+  const icons = chatTabIcon(asPath);
+  const dark = read(icons.dark);
+  const light = read(icons.light);
 
   assert.match(dark, /fill="#5CC46F"/);
   assert.match(light, /fill="#2E8B3E"/);
@@ -54,36 +71,83 @@ test('each icon is drawn for the ground it sits on, full bleed', () => {
   }
 });
 
-test('the chat tab asks for that icon, in both variants, from the extension’s own folder', () => {
+test('the chat tab asks the workbench for that pair', () => {
+  // The one thing no test in this suite can observe: `chatPanel.ts` imports `vscode`, which does not
+  // exist outside the extension host. Everything else about the icon is a call away, above.
   const source = read(path.join('src', 'chatPanel.ts'));
 
-  assert.match(source, /panel\.iconPath = \{/, 'no iconPath is set, so the tab wears the generic glyph');
-  assert.match(source, /light: vscode\.Uri\.joinPath\(extensionUri, \.\.\.CHAT_ICON\.light\)/);
-  assert.match(source, /dark: vscode\.Uri\.joinPath\(extensionUri, \.\.\.CHAT_ICON\.dark\)/);
-  // Built from the SHARED segments, not from a path written out a second time here — the second copy
-  // is the one that goes stale when a file is renamed, and nothing would say so.
-  assert.ok(!/['"]media\/chat/.test(source), 'the panel spells the icon path out instead of sharing it');
+  assert.match(source, /panel\.iconPath = chatTabIcon\(/,
+    'no iconPath is set, so the tab wears the generic glyph');
+  assert.match(read(path.join('src', 'extension.ts')),
+    /chatWithOtherAi\(chatPanels, context\.extensionUri, args\)/,
+    'the extension URI never leaves activate, so the panel has nothing to join');
 });
 
-test('the extension URI is handed to the panel rather than invented by it', () => {
-  // `createChatPanel` had no context and no URI, and neither did either of its callers; `context`
-  // exists only in `activate`. The URI is threaded, not the whole `ExtensionContext`: a function that
-  // needs a media folder should say that, and this one needs neither storage nor subscriptions.
-  assert.match(read(path.join('src', 'chatPanel.ts')), /extensionUri: vscode\.Uri/);
-  assert.match(read(path.join('src', 'chatCommand.ts')), /extensionUri: vscode\.Uri/);
-  assert.match(read(path.join('src', 'extension.ts')), /chatWithOtherAi\(chatPanels, context\.extensionUri, args\)/);
+test('a panel restored after a reload must be built the same way', () => {
+  // The code round's open tail, held rather than written down. There is no `WebviewPanelSerializer`
+  // in this extension today, so no tab loses its icon — but the plan that adds one restores a panel
+  // WITHOUT passing through `chatWithOtherAi`, and would hand back tabs wearing the generic glyph
+  // again. The day a serializer appears, the file that registers it has to reach `createChatPanel`.
+  const root = path.join(EXTENSION_ROOT, 'src');
+  const walk = (dir: string): string[] => fs.readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return entry.name === 'test' ? [] : walk(full);
+      }
+
+      return entry.name.endsWith('.ts') ? [full] : [];
+    });
+
+  for (const file of walk(root)) {
+    const source = fs.readFileSync(file, 'utf8');
+    if (!source.includes('registerWebviewPanelSerializer')) {
+      continue;
+    }
+
+    assert.match(source, /createChatPanel/,
+      `${path.basename(file)} restores a chat panel without building it the way an opened one is built`);
+  }
 });
 
 test('nothing excludes the icons from the package a person installs', () => {
-  // The tests run against the source tree; a person runs a `.vsix`. `media/` is not excluded today,
-  // and this is what says so the day somebody tidies the ignore file — a shipped extension whose icon
-  // files were left out looks exactly like an extension that never set `iconPath`.
-  const ignored = read('.vscodeignore').split(/\r?\n/).map((line) => line.trim());
+  // The tests run against the source tree; a person runs a `.vsix`. Checking that no line STARTS with
+  // `media` was the first version and the code round was right about it: `**/*.svg` or `**/media/**`
+  // would exclude the icons and leave this green. Each pattern is turned into the regex the packager's
+  // glob means by it and run against the paths the panel actually asks for.
+  const patterns = read('.vscodeignore').split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#') && !line.startsWith('!'));
+  // One pass, character by character. A chain of `.replace` calls cannot do this: the `.*` that `**/`
+  // expands to contains a `*`, which the later `*` rule then rewrites into `[^/]*` — and the first
+  // version of this test passed happily while `**/*.svg` sat in the ignore file.
+  const asRegex = (pattern: string): RegExp => {
+    let out = '';
+    for (let i = 0; i < pattern.length; i += 1) {
+      const here = pattern[i];
+      if (here === '*' && pattern[i + 1] === '*' && pattern[i + 2] === '/') {
+        out += '(?:.*/)?';
+        i += 2;
+      } else if (here === '*' && pattern[i + 1] === '*') {
+        out += '.*';
+        i += 1;
+      } else if (here === '*') {
+        out += '[^/]*';
+      } else if (here === '?') {
+        out += '[^/]';
+      } else {
+        out += here.replace(/[.+^${}()|[\]\\]/, '\\$&');
+      }
+    }
 
-  for (const line of ignored) {
-    assert.ok(
-      line.length === 0 || line.startsWith('#') || !line.startsWith('media'),
-      `.vscodeignore excludes the icons the tab needs: ${line}`,
-    );
+    return new RegExp(`^${out}(?:/.*)?$`);
+  };
+  const icons = chatTabIcon(asPath);
+
+  for (const pattern of patterns) {
+    for (const icon of [icons.light, icons.dark]) {
+      assert.ok(!asRegex(pattern).test(icon),
+        `.vscodeignore keeps ${icon} out of the package, so an installed tab wears the generic glyph: ${pattern}`);
+    }
   }
 });


### PR DESCRIPTION
Every chat tab wore the generic `≡`, because `createWebviewPanel` never set `iconPath` — there was
not one in the whole extension. A person with three conversations open had three tabs that looked
like everything else in the editor.

## The asset

`media/chat.svg` and `media/chat-light.svg` are the activity-bar glyph (`panel.svg`: three nodes
around a hub) with three things changed for a tab.

**The colour is baked in, twice**, because a tab icon is workbench chrome and no theme reaches it:
`var(--vscode-…)` is unavailable there and `iconPath` takes a `Uri` or a `{ light, dark }` pair.
`#5CC46F` — palette slot 5, the green `gemini` wears — on a dark ground; `#2E8B3E`, the same hue
darkened, on a light one, because a bright green on white reads pale. Measured against the grounds
they actually sit on: **4.30:1** on white, **3.64:1** on a Light+ tab, **7.61:1** on Dark+, **8.10:1**
on Dark Modern — every one past the 3:1 WCAG asks of a graphical object.

**The viewBox is cut to the glyph** (`2.7 0.85 18.6 18.6`, centred on the hub's visual centre at
y 10.15 rather than the box's 12) and the strokes go 0.95→1.7 and 1.15→1.8, because "big" is not a
size the workbench lets you ask for: it draws a tab icon at its own fixed size, and the Welcome tab's
looks big only because its glyph fills the box edge to edge.

## The line was the small half

`createChatPanel` had no context and no URI, and neither had `newConversation` or `chatWithOtherAi`;
`context` exists only in `activate`. The URI is threaded through all three — the URI, not the whole
`ExtensionContext`, because a function that needs a media folder should say so and this one needs
neither storage nor subscriptions. (`PanelProvider` holding a whole context is the precedent for the
other choice, and is right there: it uses `globalState` and `globalStorageUri`.)

## How it is tested, after the code round rewrote it

The first version asserted `iconPath` with a regex over `chatPanel.ts`. Reviewers refused that,
quoting this plan's own sentence back at it, and they were right: a regex proves somebody wrote a
string down. So the **resolution is a pure function** — `chatTabIcon(join)`, handed
`vscode.Uri.joinPath` by the panel and a joiner of its own by the test — and both observe the same two
paths, which the test then opens on disk. One structural assertion survives, for the only thing no
test here can reach: that `panel.iconPath` is assigned at all.

**The packaging guard was green over its own defect.** It asserted that no `.vscodeignore` line starts
with `media`; adding `**/*.svg` to the file left it passing. Each pattern is now expanded into the
regex the packager's glob means by it, in one character-by-character pass — a chain of `.replace`
calls cannot do that job, because the `.*` that `**/` expands to contains a `*` the later `*` rule
rewrites. Checked against `**/*.svg`, `media/**`, `**/media/**` and `media`; all four fail it now.
`npx vsce ls` was also run and lists both files.

**The open tail is held by a test.** A panel restored by a `WebviewPanelSerializer` would not pass
through `chatWithOtherAi` and would come back without an icon. There is no serializer in this
extension today, so nothing loses anything — but the suite now walks `src/` and fails any file that
registers one without reaching `createChatPanel`. Watched failing with one planted in `chatModels.ts`.

## Evidence

- RED first: `no iconPath is set, so the tab wears the generic glyph`.
- Whole suite: **1064 pass, 1 skipped, 0 fail**. `plan-lifecycle.mjs` clean; `pin-check.mjs` OK.

## The gate

Plan round `good_enough` — 3 reviewers, 12 findings, 8 accepted, 4 rejected with reasons. Code round
`proceed` — 12 reviewers, 18 findings, 6 accepted and built, 12 rejected with reasons (a `try/catch`
around `Uri.joinPath`, which does not throw; a runtime `fs` check asking whether we shipped our own
files; and a demand that this pull request also add the serializer, which is the next plan in this
lane and is held by the test above).

One Blocking finding was rejected on the immutability rule: setting `iconPath` mutates a live object.
That rule governs our data; the handle is VS Code's, `iconPath` is settable only after creation, and
every webview here is configured the same way. The reason is recorded at the line rather than worked
around, because the alternative is a creation API that does not exist.

## Not claimed

The side-by-side against the Welcome tab needs a running workbench and a human eye. The geometry
matches the numbers the plan measured, but "indistinguishable in size" is **unverified**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)