### PR TITLE
fix(chat): the composer stays put, the page scrolls once, and it follows only from the bottom

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -138,8 +138,15 @@ call rather than a hope.
 that rule 2 refuses IS the right instrument: a reader at the bottom did not scroll — the region
 shrank underneath them — so re-measuring would call them scrolled away and leave the last answer
 behind the box they are typing into. What they WERE is the only measurement that survives the resize.
-A `ResizeObserver` on `#composer` re-pins them through `landOnNewest()`; a host without one keeps
-today's behaviour rather than breaking.
+A `ResizeObserver` on `#composer` re-pins them through `landOnNewest()`, and where the host has none
+the fallback that sized the box says so itself — those are the same hosts, since an engine without
+`field-sizing` is an old engine, and the promise was made to them too. Whoever changed the height
+reports it; the pin is one function.
+
+**A follow the reader cancels hands them the jump control instead.** An answer can arrive while
+somebody is at the bottom — so a follow is scheduled rather than done — and they can scroll up inside
+that frame. Cancelling is right; leaving them scrolled up with an answer they were never taken to and
+nothing on screen saying it came is not.
 
 **A write is compared against what was LAST WRITTEN, not against the element.** Reading `innerHTML`
 back makes the browser serialise the whole subtree on every push, and what comes back is normalised —

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -24,6 +24,42 @@ local model` the page would otherwise still show the remote one as selected whil
 somewhere else), a pushed state that has not changed is not sent at all, a `pick` naming a model the
 conversation was never offered is refused at the host boundary rather than trusted, and the
 composer takes focus back when a turn ends — without which every follow-up costs a mouse click.
+### The chat page's layout: one scrolling region, a pinned footer (2026-09-09)
+
+`chatPage.ts` renders two children of `body` and nothing else at the top level: `<main id="scroll">`
+holds the header, the passage, the failure box, the messages, the thinking line and the capped
+notice; `<footer id="composer">` holds the picker row, the textarea, the **Send** button and the
+hint. `body` is a flex column with `overflow: hidden`, so **the page itself never scrolls** — only
+the region does.
+
+`#scroll` carries `flex: 1 1 auto; min-height: 0; overflow-y: auto`, and the `min-height: 0` is the
+load-bearing line: a flex child refuses to shrink below its content without it, so the region would
+never scroll, the body would instead, and the composer would leave the screen — which is the exact
+symptom the layout exists to end.
+
+**The passage is no longer capped.** It used to carry `max-height: 180px; overflow-y: auto` — a
+second scrollbar on the same page — because a fifty-line selection would otherwise push the composer
+off screen on open. Pinning the composer retires that reason: what a long selection pushes down is
+the conversation. The block itself stays, for the reason it always had — a person must see a stale
+clipboard before they discover it in the answer.
+
+**One send, two callers, one lock.** `send()` is the only path; the Send button's listener is
+attached inside the nonced script (the page's CSP is `script-src 'nonce-…'`, so an inline handler
+would be a dead button) and Enter's keydown handler calls the same function. `send()` locks BOTH
+controls the moment it has posted, through a single `lock()` — not when the host's `running: true`
+comes back. That window was small and real: two vendors found it independently in the code round,
+and a second Enter inside it put a second turn down a pipe that carries one. Nothing focuses the box
+on send, because focusing a control you have just disabled is how a caret ends up somewhere nobody
+can type; the existing unlock path hands focus back when the turn ends, whichever way it went.
+
+**A defect fixed on the way in: the page's `body` rule had never applied.** The stylesheet opened
+with the zoom as a bare `font-size: 13px;` outside any rule. CSS has no such thing at the top level
+— a parser consuming a qualified rule appends every token to the prelude until it meets `{`, and `;`
+does not end one — so the selector became `font-size: 13px; body` and the whole rule was dropped:
+no margin, no padding, no font-family, no background, and the chosen text size never applied until
+an unrelated push set it. The zoom now sits inside the rule, as `helpPage.ts` always had it, and a
+structural test fails the build if any rule on this page is swallowed again.
+
 ### One webview per SESSION, which no other page in here does (2026-09-08)
 
 Every other webview in this extension is a singleton — the rounds log and the help page each keep

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -96,10 +96,28 @@ agree by accident.
 **A deferred follow is cancelled by the reader, not by re-measuring.** The reader can move between
 the frame being asked for and the frame arriving, and re-measuring in the callback cannot tell: the
 content is already in, so a reader who *was* at the bottom now measures short of it. Only the reader
-knows they moved, so their scroll event invalidates the pending token. The page's own scroll is told
-apart by POSITION — `scrolledItselfTo`, recorded as what the browser clamped to — rather than by a
-flag cleared on a later frame, which stays raised for as long as that frame has not come and makes
-every scroll in between read as the page's own.
+knows they moved, so their scroll event invalidates the pending token.
+
+**Telling the page's own scroll from the reader's took three shapes, and the first two were wrong.**
+A flag cleared on a later frame stays raised for as long as that frame has not come, so every scroll
+in between reads as the page's own. A position kept indefinitely turns the bottom into a magic pixel:
+a reader who scrolls away and comes back to it — which is what *scroll back down* is — was still
+being read as the page for the rest of the tab's life. What is there now is a ONE-SHOT arming:
+`landOnNewest` records the position it actually reached (what the browser clamped to, and `null` when
+nothing moved, since then no event is coming to consume it), and the first scroll event matching it
+consumes the arming. Everything after that is the reader.
+
+**The fonts-settled correction belongs to the opening follow and dies with it.** Scheduling it
+unconditionally made a fresh token, so a cancelled open came back to life whenever the fonts happened
+to settle, and a person who opened a tab and started reading upward was dragged down by a font. It
+captures the generation at open and skips if a reader's scroll has moved it.
+
+**A write is compared against what was LAST WRITTEN, not against the element.** Reading `innerHTML`
+back makes the browser serialise the whole subtree on every push, and what comes back is normalised —
+attributes reordered, entities decoded — so an unchanged push can read as different and a changed one
+as the same. `cappedHtml` and `failureHtml` clear when they are not mentioned, which the protocol has
+always meant: a cap notice or a failure left on screen after it stopped being true is one a person
+acts on.
 
 ### One webview per SESSION, which no other page in here does (2026-09-08)
 

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -60,6 +60,47 @@ no margin, no padding, no font-family, no background, and the chosen text size n
 an unrelated push set it. The zoom now sits inside the rule, as `helpPage.ts` always had it, and a
 structural test fails the build if any rule on this page is swallowed again.
 
+### The chat page's scroll rule, decided once (2026-09-09)
+
+Three separate fixes move this page — the pinned composer, the *jump to newest* control, the growing
+composer — so the rule the operator decided (entry 23 of the bug list of 2026-09-09) is implemented
+ONCE and the others obey it. Deciding it three times is how a page ends up behaving differently
+depending on which change you provoked.
+
+1. **On open the tab looks at the last message.** The passage stays above it, reached by scrolling up.
+2. **A new answer scrolls to itself only if the reader was already at the bottom** — within
+   `FOLLOW_SLACK_PX` (48) of it, measured BEFORE the content is inserted.
+3. A reader who is scrolled up gets a *jump to newest* control (its own story).
+
+**`shouldFollow` is exported and its SOURCE is embedded into the page** by `toString()`, bound by
+assignment. That is the rounds log's idiom and it is not decoration: a function referenced only from
+a template string is one the minifier renames out from under the page, which shipped dead there
+twice. It references nothing outside itself — the slack is a parameter for that reason — and it is
+written as `!(distance > slack)` rather than `distance <= slack` so that an unmeasurable page (NaN,
+every comparison with which is false) follows: a page whose numbers cannot be read is a page whose
+reader has not scrolled away from anything.
+
+**The snapshot is the first statement of the one state handler.** Read after a write, `scrollHeight`
+already includes what arrived, so a reader who was at the bottom measures a screen short of it and
+is never followed — rule 2 becomes "never follow", silently, and only the real webview shows it.
+Every region arrives through that one handler, which is what makes the ordering true by construction
+rather than by remembering it in five places. A write counts only when the value actually CHANGED: a
+retry that assigns the same html is not an insertion, and scrolling for it moves a reader for content
+already in front of them.
+
+**Two entry points, and they are the contract.** `landOnNewest()` scrolls now; `scheduleFollow()`
+scrolls on the next frame and can be cancelled. Nothing else in this page may write `scrollTop` —
+the jump control and the composer's resize both go through these, or the one rule becomes four that
+agree by accident.
+
+**A deferred follow is cancelled by the reader, not by re-measuring.** The reader can move between
+the frame being asked for and the frame arriving, and re-measuring in the callback cannot tell: the
+content is already in, so a reader who *was* at the bottom now measures short of it. Only the reader
+knows they moved, so their scroll event invalidates the pending token. The page's own scroll is told
+apart by POSITION — `scrolledItselfTo`, recorded as what the browser clamped to — rather than by a
+flag cleared on a later frame, which stays raised for as long as that frame has not come and makes
+every scroll in between read as the page's own.
+
 ### One webview per SESSION, which no other page in here does (2026-09-08)
 
 Every other webview in this extension is a singleton — the rounds log and the help page each keep

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -112,12 +112,25 @@ unconditionally made a fresh token, so a cancelled open came back to life whenev
 to settle, and a person who opened a tab and started reading upward was dragged down by a font. It
 captures the generation at open and skips if a reader's scroll has moved it.
 
+**Rule 3 is an OVERLAY, and that is structural rather than styling.** The *jump to newest* control
+hangs above the composer out of flow (`.jump { position: absolute }` against a positioned
+`#composer`). In the flow it would take room in the footer, which shrinks the scrolling region,
+which changes `clientHeight` — one of the three numbers the follow decision is made from. A control
+that appears BECAUSE a reader was not followed must not alter what "at the bottom" means. It is
+shown only when an insertion happened and the reader was not taken to it, and it is retired two
+ways: by its own click, and by the reader arriving under their own steam, which has answered the
+question it was asking. Its click goes through `landOnNewest()`, the same entry point everything
+else uses, and it hands the box back the focus unless a turn is running — focusing a disabled
+control puts the caret where nobody can type.
+
 **A write is compared against what was LAST WRITTEN, not against the element.** Reading `innerHTML`
 back makes the browser serialise the whole subtree on every push, and what comes back is normalised —
 attributes reordered, entities decoded — so an unchanged push can read as different and a changed one
 as the same. `cappedHtml` and `failureHtml` clear when they are not mentioned, which the protocol has
 always meant: a cap notice or a failure left on screen after it stopped being true is one a person
-acts on.
+acts on. The record is SEEDED from what the markup holds — `regionsOf`, the one function both the
+markup and the script take their four strings from — or the first push would compare against nothing,
+read as a change, and scroll a reader for content already on their screen.
 
 ### One webview per SESSION, which no other page in here does (2026-09-08)
 

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -123,6 +123,24 @@ question it was asking. Its click goes through `landOnNewest()`, the same entry 
 else uses, and it hands the box back the focus unless a turn is running — focusing a disabled
 control puts the caret where nobody can type.
 
+**The composer sizes itself to its text, under one ceiling, on either kind of host.** `field-sizing:
+content` with `max-height: 30vh` does it in CSS where the engine has it; the page ASKS
+(`CSS.supports('field-sizing', 'content')`) and falls back to an `input` handler that sets the height
+from `scrollHeight`, with the SAME CSS ceiling capping it — the 30 % lives in one rule so the two
+paths cannot disagree about where the top is. Asking rather than assuming is the point: the property
+is Chromium-only and the manifest declares support back to VS Code 1.85, whose engine has never heard
+of it, so a page that took it on faith would work on the machine it was written on and silently never
+grow anywhere else, which is the one failure a person cannot report because nothing happens. The
+fallback is also called after a send empties the box and after a pushed draft, so shrinking back is a
+call rather than a hope.
+
+**A footer whose height changes takes the room from the conversation above it**, and here the flag
+that rule 2 refuses IS the right instrument: a reader at the bottom did not scroll — the region
+shrank underneath them — so re-measuring would call them scrolled away and leave the last answer
+behind the box they are typing into. What they WERE is the only measurement that survives the resize.
+A `ResizeObserver` on `#composer` re-pins them through `landOnNewest()`; a host without one keeps
+today's behaviour rather than breaking.
+
 **A write is compared against what was LAST WRITTEN, not against the element.** Reading `innerHTML`
 back makes the browser serialise the whole subtree on every push, and what comes back is normalised —
 attributes reordered, entities decoded — so an unchanged push can read as different and a changed one

--- a/research/module_tests.md
+++ b/research/module_tests.md
@@ -89,6 +89,7 @@ real and named here rather than implied:
 
 | Flow | Covered | By |
 |---|---|---|
+| The chat tab's page | yes, as it ships | `bundledPage.test.ts` runs the bundled, minified page and drives its **Send** button through to the one posted turn, asserting the composer locks on the way — the flow the pinned composer added. `chatPage.test.ts` runs the same script from source through `runChatPage()`, which answers only the ids the page actually renders, so a control that stops being rendered stops being testable rather than silently passing |
 | The rounds log page | yes, as it ships | `bundledPage.test.ts` bundles and minifies the real module and runs the page script — the only test that catches a minifier-renamed binding, which shipped twice |
 | Install / update the server | decisions only | `install.test.ts` (RID choice, asset names, companion policy, the release workflow's own guarantees) |
 | Copy the config block / the CLAUDE.md snippet | decisions only | `install.test.ts`, `panelServerPromptAgreement.test.ts` |

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -13,6 +13,10 @@ last thing said rather than at the top, and an answer that arrives scrolls itsel
 you were already at the bottom. Scroll up to re-read something and the conversation stays where you
 put it — including if the answer lands in the moment between your scroll and the screen redrawing.
 
+**And when it stays put, it tells you something arrived.** A *Jump to newest* button appears over
+the composer when an answer lands while you are reading further up, takes you there in one press,
+and disappears again — either when you press it or when you scroll back down yourself.
+
 **The captured text no longer has a scrollbar of its own.** There were two on the page. The passage
 was boxed in because a long selection would otherwise push the composer off the screen when the tab
 opened; with the composer pinned, nothing can push it anywhere.

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -8,6 +8,11 @@ the hint are pinned to the bottom of the tab now, the conversation scrolls above
 a **Send** button beside the box for anyone who would rather click than press Enter — locked at the
 same moments the box is, because a second turn down the same pipe would interleave with the first.
 
+**A new answer no longer drags you away from what you were reading.** The tab opens looking at the
+last thing said rather than at the top, and an answer that arrives scrolls itself into view only if
+you were already at the bottom. Scroll up to re-read something and the conversation stays where you
+put it — including if the answer lands in the moment between your scroll and the screen redrawing.
+
 **The captured text no longer has a scrollbar of its own.** There were two on the page. The passage
 was boxed in because a long selection would otherwise push the composer off the screen when the tab
 opened; with the composer pinned, nothing can push it anywhere.

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -17,6 +17,11 @@ put it — including if the answer lands in the moment between your scroll and t
 the composer when an answer lands while you are reading further up, takes you there in one press,
 and disappears again — either when you press it or when you scroll back down yourself.
 
+**The box grows with your question.** It starts at three lines and stretches as you type, up to
+about a third of the tab's height, and only then scrolls inside itself; it shrinks back when you send
+or delete. If it grows while you are reading the last answer, the answer stays in view rather than
+sliding behind the box.
+
 **The captured text no longer has a scrollbar of its own.** There were two on the page. The passage
 was boxed in because a long selection would otherwise push the composer off the screen when the tab
 opened; with the composer pinned, nothing can push it anywhere.

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+**The box you type in stays where you put it.** It used to scroll away with the conversation, so
+asking a second question meant scrolling back down to find it. The composer, the model picker and
+the hint are pinned to the bottom of the tab now, the conversation scrolls above them, and there is
+a **Send** button beside the box for anyone who would rather click than press Enter — locked at the
+same moments the box is, because a second turn down the same pipe would interleave with the first.
+
+**The captured text no longer has a scrollbar of its own.** There were two on the page. The passage
+was boxed in because a long selection would otherwise push the composer off the screen when the tab
+opened; with the composer pinned, nothing can push it anywhere.
+
+**The chat tab had never used its own styles.** Its stylesheet began with a line that CSS does not
+allow where it stood, and a browser reading it threw away the rule that followed — the tab's
+margins, its font, its background and the text size you had chosen, all of it, on every open. The
+size only appeared when something unrelated happened to push it. Fixed, with a test that fails the
+build if any rule on that page is ever swallowed again.
+
 ## Extension 0.31.21 — 2026-09-09
 
 **A chat tab looks like a chat tab.** It wore the same generic icon as everything else in the editor,

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -264,15 +264,38 @@ function chatScript(state: ChatPageState): string {
   // the source is also what makes the function the tests exercise the function the page runs.
   var shouldFollow = ${shouldFollow.toString()};
   var SLACK = ${FOLLOW_SLACK_PX};
+  var pendingFollow = 0;
+  // Where the PAGE last put the reader. A flag cleared on a later frame looked simpler and was
+  // wrong: it stays raised for as long as that frame has not arrived, and every scroll in between
+  // reads as the page's own. A position cannot get stuck. If a reader happens to land exactly where
+  // we did, they are at the bottom, which is the case where not cancelling is right anyway.
+  var scrolledItselfTo = -1;
   // A scroll set in the same tick as the write scrolls to a height the browser has not laid out yet
   // and lands short. The next frame has the real height, and setTimeout is the fallback for a host
   // that has no requestAnimationFrame - the bundled page runs in exactly such a stub.
   function afterLayout(fn) {
     if (typeof requestAnimationFrame === 'function') { requestAnimationFrame(fn); } else { setTimeout(fn, 0); }
   }
+  // THE TWO ENTRY POINTS for moving this page, and the contract stories 3 and 4 are held to: the
+  // jump control and the composer's resize go through scheduleFollow or landOnNewest, never through
+  // scrollTop of their own. One place decides, or the rule is four rules that agree by accident.
   function landOnNewest() {
     const scroll = document.getElementById('scroll');
-    if (scroll) { scroll.scrollTop = scroll.scrollHeight; }
+    if (!scroll) { return; }
+    // Our own write fires a scroll event. Without this flag the page would cancel its own next
+    // follow, and the rule would work exactly once per tab.
+    scroll.scrollTop = scroll.scrollHeight;
+    // What it CLAMPED to, not what we asked for: a browser answers scrollHeight - clientHeight.
+    scrolledItselfTo = scroll.scrollTop;
+  }
+  // Deferred to the next frame, and CANCELLABLE. The reader can move between the frame being asked
+  // for and the frame arriving - a drag, a wheel, Page Up - and a scroll that was right when it was
+  // scheduled is a hijack by the time it runs. Re-measuring in the callback cannot tell: the content
+  // is already in, so a reader who WAS at the bottom now measures short of it. Only the reader knows
+  // they moved, so the cancel is their scroll event. (Two vendors raised this on the plan round.)
+  function scheduleFollow() {
+    const token = ++pendingFollow;
+    afterLayout(function () { if (token === pendingFollow) { landOnNewest(); } });
   }
   function send() {
     const box = document.getElementById('say');
@@ -340,9 +363,17 @@ function chatScript(state: ChatPageState): string {
   // after layout, and after the fonts settle where the host reports them. Idempotent, so the two
   // extra calls cost nothing on a page that was already there.
   landOnNewest();
-  afterLayout(landOnNewest);
+  scheduleFollow();
   if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
-    document.fonts.ready.then(landOnNewest);
+    // Through the schedule, not straight to the scroll: fonts settle after the first paint, and a
+    // person who opened the tab and started reading upward in that gap must not be dragged back.
+    document.fonts.ready.then(scheduleFollow);
+  }
+  const scrollRegion = document.getElementById('scroll');
+  if (scrollRegion) {
+    scrollRegion.addEventListener('scroll', function () {
+      if (scrollRegion.scrollTop !== scrolledItselfTo) { pendingFollow++; }
+    });
   }
   window.addEventListener('message', function (event) {
     const data = event.data || {};
@@ -355,21 +386,41 @@ function chatScript(state: ChatPageState): string {
     const scroll = document.getElementById('scroll');
     const follow = !scroll || shouldFollow(scroll.scrollTop, scroll.clientHeight, scroll.scrollHeight, SLACK);
     let wrote = false;
+    // A CHANGE, not an assignment. A retry, or a poll that pushes the state again, assigns the same
+    // html - and counting that as an insertion scrolls a reader for content already in front of
+    // them. Compared against the element rather than a remembered copy: what the page is showing is
+    // the honest question, and our own generated markup round-trips through innerHTML unchanged.
     const messages = document.getElementById('messages');
-    if (messages && typeof data.messagesHtml === 'string') { messages.innerHTML = data.messagesHtml; wrote = true; }
+    if (messages && typeof data.messagesHtml === 'string' && messages.innerHTML !== data.messagesHtml) {
+      messages.innerHTML = data.messagesHtml;
+      wrote = true;
+    }
     const thinking = document.getElementById('thinking');
-    if (thinking && typeof data.thinkingHtml === 'string') { thinking.innerHTML = data.thinkingHtml; wrote = true; }
+    if (thinking && typeof data.thinkingHtml === 'string' && thinking.innerHTML !== data.thinkingHtml) {
+      thinking.innerHTML = data.thinkingHtml;
+      wrote = true;
+    }
     const capped = document.getElementById('capped');
-    if (capped && typeof data.cappedHtml === 'string') { capped.innerHTML = data.cappedHtml; wireCapped(); wrote = true; }
+    if (capped && typeof data.cappedHtml === 'string' && capped.innerHTML !== data.cappedHtml) {
+      capped.innerHTML = data.cappedHtml;
+      wireCapped();
+      wrote = true;
+    }
     // The picker is re-rendered rather than nudged: after "continue with a local model" the whole
     // list can be different, and a select that only had its value set would show a model it no
     // longer offers.
     const pickerBox = document.getElementById('pickerBox');
     if (pickerBox && typeof data.pickerHtml === 'string') { pickerBox.innerHTML = data.pickerHtml; wirePicker(); }
     const failure = document.getElementById('failure');
-    if (failure && typeof data.failureHtml === 'string') { failure.innerHTML = data.failureHtml; wrote = true; }
+    if (failure && typeof data.failureHtml === 'string' && failure.innerHTML !== data.failureHtml) {
+      failure.innerHTML = data.failureHtml;
+      wrote = true;
+    }
     const passage = document.getElementById('passage');
-    if (passage && typeof data.passage === 'string') { passage.textContent = data.passage; wrote = true; }
+    if (passage && typeof data.passage === 'string' && passage.textContent !== data.passage) {
+      passage.textContent = data.passage;
+      wrote = true;
+    }
     // A draft pushed into an OPEN tab. Appended rather than assigned, so a half-typed follow-up
     // is never thrown away by a second invocation - losing what somebody typed is the one thing
     // the queue in the session was also built to avoid.
@@ -393,7 +444,7 @@ function chatScript(state: ChatPageState): string {
     }
     // Rule 2, applied once for whatever this push contained - an answer, a failure, a thinking line
     // or a capped notice. There is one rule, not one per outcome.
-    if (wrote && follow) { afterLayout(landOnNewest); }
+    if (wrote && follow) { scheduleFollow(); }
   });
 }());`;
 }

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -265,16 +265,22 @@ function chatScript(state: ChatPageState): string {
   var shouldFollow = ${shouldFollow.toString()};
   var SLACK = ${FOLLOW_SLACK_PX};
   var pendingFollow = 0;
-  // Where the PAGE last put the reader. A flag cleared on a later frame looked simpler and was
-  // wrong: it stays raised for as long as that frame has not arrived, and every scroll in between
-  // reads as the page's own. A position cannot get stuck. If a reader happens to land exactly where
-  // we did, they are at the bottom, which is the case where not cancelling is right anyway.
-  var scrolledItselfTo = -1;
+  // What was last PUT into each region, so a repeat can be told from a change without asking the
+  // browser to serialise the DOM back to us on every push.
+  var lastWritten = { messages: null, thinking: null, capped: null, failure: null };
+  // The ONE scroll event the page owes itself, armed by its own write and consumed by the event it
+  // causes. Two shapes were tried and both were wrong: a flag cleared on a later frame stays raised
+  // until that frame comes, so every scroll in between reads as the page's own; and a position kept
+  // indefinitely turns the bottom into a magic pixel - a reader who scrolls away and comes back to
+  // it, which is what "scroll back down" IS, was still being read as the page for the rest of the
+  // tab's life. Armed only when the write actually moved anything, or nothing would consume it.
+  var selfScrollTo = null;
   // A scroll set in the same tick as the write scrolls to a height the browser has not laid out yet
   // and lands short. The next frame has the real height, and setTimeout is the fallback for a host
   // that has no requestAnimationFrame - the bundled page runs in exactly such a stub.
   function afterLayout(fn) {
-    if (typeof requestAnimationFrame === 'function') { requestAnimationFrame(fn); } else { setTimeout(fn, 0); }
+    if (typeof requestAnimationFrame === 'function') { requestAnimationFrame(fn); }
+    else if (typeof setTimeout === 'function') { setTimeout(fn, 0); }
   }
   // THE TWO ENTRY POINTS for moving this page, and the contract stories 3 and 4 are held to: the
   // jump control and the composer's resize go through scheduleFollow or landOnNewest, never through
@@ -284,9 +290,11 @@ function chatScript(state: ChatPageState): string {
     if (!scroll) { return; }
     // Our own write fires a scroll event. Without this flag the page would cancel its own next
     // follow, and the rule would work exactly once per tab.
+    const was = scroll.scrollTop;
     scroll.scrollTop = scroll.scrollHeight;
-    // What it CLAMPED to, not what we asked for: a browser answers scrollHeight - clientHeight.
-    scrolledItselfTo = scroll.scrollTop;
+    // What it CLAMPED to, not what we asked for: a browser answers scrollHeight - clientHeight. And
+    // null when nothing moved, because then no scroll event is coming to consume the arming.
+    selfScrollTo = scroll.scrollTop === was ? null : scroll.scrollTop;
   }
   // Deferred to the next frame, and CANCELLABLE. The reader can move between the frame being asked
   // for and the frame arriving - a drag, a wheel, Page Up - and a scroll that was right when it was
@@ -365,14 +373,23 @@ function chatScript(state: ChatPageState): string {
   landOnNewest();
   scheduleFollow();
   if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
-    // Through the schedule, not straight to the scroll: fonts settle after the first paint, and a
-    // person who opened the tab and started reading upward in that gap must not be dragged back.
-    document.fonts.ready.then(scheduleFollow);
+    // The correction belongs to the OPENING follow and dies with it. Scheduling unconditionally
+    // here made a fresh token, so a cancelled open came back to life whenever the fonts happened to
+    // settle - a reader who opened the tab and started reading upward was dragged down by a font.
+    // Three findings from one vendor said this, and they were right.
+    const openedAt = pendingFollow;
+    document.fonts.ready.then(function () {
+      if (pendingFollow === openedAt) { scheduleFollow(); }
+    });
   }
   const scrollRegion = document.getElementById('scroll');
   if (scrollRegion) {
     scrollRegion.addEventListener('scroll', function () {
-      if (scrollRegion.scrollTop !== scrolledItselfTo) { pendingFollow++; }
+      if (selfScrollTo !== null && scrollRegion.scrollTop === selfScrollTo) {
+        selfScrollTo = null;
+      } else {
+        pendingFollow++;
+      }
     });
   }
   window.addEventListener('message', function (event) {
@@ -386,23 +403,33 @@ function chatScript(state: ChatPageState): string {
     const scroll = document.getElementById('scroll');
     const follow = !scroll || shouldFollow(scroll.scrollTop, scroll.clientHeight, scroll.scrollHeight, SLACK);
     let wrote = false;
+    const messages = document.getElementById('messages');
+    const thinking = document.getElementById('thinking');
+    const capped = document.getElementById('capped');
+    const failure = document.getElementById('failure');
     // A CHANGE, not an assignment. A retry, or a poll that pushes the state again, assigns the same
     // html - and counting that as an insertion scrolls a reader for content already in front of
-    // them. Compared against the element rather than a remembered copy: what the page is showing is
-    // the honest question, and our own generated markup round-trips through innerHTML unchanged.
-    const messages = document.getElementById('messages');
-    if (messages && typeof data.messagesHtml === 'string' && messages.innerHTML !== data.messagesHtml) {
+    // them. Compared against what we LAST WROTE rather than against the element: reading innerHTML
+    // back makes the browser serialise the whole subtree on every push, and what comes back is
+    // normalised - attributes reordered, entities decoded - so an unchanged push can read as
+    // different and a changed one as the same.
+    if (messages && typeof data.messagesHtml === 'string' && lastWritten.messages !== data.messagesHtml) {
       messages.innerHTML = data.messagesHtml;
+      lastWritten.messages = data.messagesHtml;
       wrote = true;
     }
-    const thinking = document.getElementById('thinking');
-    if (thinking && typeof data.thinkingHtml === 'string' && thinking.innerHTML !== data.thinkingHtml) {
+    if (thinking && typeof data.thinkingHtml === 'string' && lastWritten.thinking !== data.thinkingHtml) {
       thinking.innerHTML = data.thinkingHtml;
+      lastWritten.thinking = data.thinkingHtml;
       wrote = true;
     }
-    const capped = document.getElementById('capped');
-    if (capped && typeof data.cappedHtml === 'string' && capped.innerHTML !== data.cappedHtml) {
-      capped.innerHTML = data.cappedHtml;
+    // These two clear when they are NOT mentioned - the protocol has always meant that, and a
+    // capped notice or a failure left on screen after it stopped being true is one a person acts on.
+    // Requiring a string here was this branch's own regression; the gate caught it.
+    const nextCapped = typeof data.cappedHtml === 'string' ? data.cappedHtml : '';
+    if (capped && lastWritten.capped !== nextCapped) {
+      capped.innerHTML = nextCapped;
+      lastWritten.capped = nextCapped;
       wireCapped();
       wrote = true;
     }
@@ -411,9 +438,10 @@ function chatScript(state: ChatPageState): string {
     // longer offers.
     const pickerBox = document.getElementById('pickerBox');
     if (pickerBox && typeof data.pickerHtml === 'string') { pickerBox.innerHTML = data.pickerHtml; wirePicker(); }
-    const failure = document.getElementById('failure');
-    if (failure && typeof data.failureHtml === 'string' && failure.innerHTML !== data.failureHtml) {
-      failure.innerHTML = data.failureHtml;
+    const nextFailure = typeof data.failureHtml === 'string' ? data.failureHtml : '';
+    if (failure && lastWritten.failure !== nextFailure) {
+      failure.innerHTML = nextFailure;
+      lastWritten.failure = nextFailure;
       wrote = true;
     }
     const passage = document.getElementById('passage');

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -134,7 +134,7 @@ function chatStyle(uiScale: number): string {
   // did it this way (`helpPage.ts`); this one did not.
   return `  html, body { height: 100%; }
   body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); background: var(--vscode-editor-background); margin: 0; padding: 0; display: flex; flex-direction: column; overflow: hidden; ${zoomStyle(uiScale)} }
-  /* The conversation scrolls; the page does not. \`min-height: 0\` is what makes that true: a flex
+  /* The conversation scrolls; the page does not. The min-height of 0 is what makes that true: a flex
      child refuses to shrink below its content without it, so the region would never scroll, the
      body would instead, and the composer would leave the screen — the symptom this layout exists
      to end. (The gate raised it, and it is invisible to every test but a reading of this rule.) */
@@ -232,9 +232,22 @@ function chatScript(state: ChatPageState): string {
     if (text.length === 0) { return; }
     box.value = '';
     vscode.postMessage({ type: 'command', command: 'send', text: text });
-    // Clicking the button moves focus to the button. Without this every follow-up costs a mouse
-    // click back into the box - the same reason the lock below returns focus when a turn ends.
-    if (typeof box.focus === 'function') { box.focus(); }
+    // Locked HERE, not when the host gets round to saying so. Between the post and the state that
+    // comes back there was a window - small, and the width of a second Enter - in which a second
+    // turn went down a pipe that carries one. Two vendors found it independently; the page did not
+    // need telling that it had just sent something.
+    lock(true);
+    // And no focus call: focusing a control you have just disabled is how a caret ends up in a box
+    // nobody can type in. The unlock below already hands focus back when the turn ends, whichever
+    // way it went, and one place deciding that is the point.
+  }
+  // The one place either control's lock is written. Two controls deciding the same thing from the
+  // same inputs is two chances to disagree, and the one that disagrees is the one that sends.
+  function lock(locked) {
+    const box = document.getElementById('say');
+    const button = document.getElementById('send');
+    if (box) { box.disabled = locked; }
+    if (button) { button.disabled = locked; }
   }
   const say = document.getElementById('say');
   if (say) {
@@ -307,12 +320,7 @@ function chatScript(state: ChatPageState): string {
     // it while a turn is still in flight. (local, the second code round.)
     if (box && typeof data.running === 'boolean' && typeof data.capped === 'boolean') {
       const wasLocked = box.disabled;
-      box.disabled = data.running || data.capped;
-      // The button takes the box's lock rather than recomputing it. Two controls deciding the same
-      // thing from the same inputs is two chances to disagree, and the one that disagrees is the one
-      // that sends a second turn down a pipe that carries one.
-      const button = document.getElementById('send');
-      if (button) { button.disabled = box.disabled; }
+      lock(data.running || data.capped);
       // Back to the box when the turn ends. Without this every single follow-up costs a mouse click,
       // nine seconds after the last one — which is the whole conversation, one click at a time.
       if (wasLocked && !box.disabled && typeof box.focus === 'function') { box.focus(); }

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -19,8 +19,13 @@ import { ZOOM_CSS, zoomControlHtml, zoomScript, zoomStyle } from './zoomControl'
  * <p><b>The passage is at the top and it is not decoration.</b> The menu path takes whatever is in
  * the clipboard and cannot know whether it is the passage just selected or something copied an hour
  * ago — the gate raised that three times. Showing the text the conversation is ABOUT is how a person
- * sees a stale clipboard instead of discovering it in the answer. It is capped in height and scrolls:
- * a fifty-line selection would otherwise push the composer off the screen on open.</p>
+ * sees a stale clipboard instead of discovering it in the answer.</p>
+ *
+ * <p><b>It used to be capped in height with a scrollbar of its own, and is not any more.</b> The cap
+ * existed because "a fifty-line selection would otherwise push the composer off the screen on open"
+ * — and the composer is pinned now, so nothing can push it anywhere. What a long selection pushes
+ * down is the conversation, which is what the page scrolls to anyway. Two scrollbars on one page was
+ * the price of the old arrangement and the operator named it.</p>
  *
  * <p><b>The composer is disabled while a turn runs, and that is a feature.</b> A real explanation
  * took 9.4 s when it was measured, and eight of those seconds are silent. Two turns down one NDJSON
@@ -121,11 +126,24 @@ export function chatCappedHtml(capped: boolean): string {
 
 /** The page's own styles. Its own function so the document below stays readable. */
 function chatStyle(uiScale: number): string {
-  return `  ${zoomStyle(uiScale)}
-  body { font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground); background: var(--vscode-editor-background); margin: 0; padding: 16px 20px; }
+  // The zoom goes INSIDE the body rule, and that is not a tidiness preference. It used to sit above
+  // it, where CSS has no such thing as a declaration: a parser consuming a qualified rule appends
+  // every token to the prelude until it meets `{`, and `;` does not end one — so the selector became
+  // `font-size: 13px; body`, and the whole body rule was dropped. The page had no margin, no
+  // padding, no font and no background of its own for as long as that stood. The help page always
+  // did it this way (`helpPage.ts`); this one did not.
+  return `  html, body { height: 100%; }
+  body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); background: var(--vscode-editor-background); margin: 0; padding: 0; display: flex; flex-direction: column; overflow: hidden; ${zoomStyle(uiScale)} }
+  /* The conversation scrolls; the page does not. \`min-height: 0\` is what makes that true: a flex
+     child refuses to shrink below its content without it, so the region would never scroll, the
+     body would instead, and the composer would leave the screen — the symptom this layout exists
+     to end. (The gate raised it, and it is invisible to every test but a reading of this rule.) */
+  #scroll { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 16px 20px 0; }
+  #composer { flex: 0 0 auto; padding: 8px 20px 12px; }
+  .compose { display: flex; gap: 8px; align-items: flex-end; }
   header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; }
   h1 { font-size: 1.2em; margin: 0; }
-  .passage { border-left: 3px solid var(--vscode-panel-border); padding: 6px 0 6px 12px; margin: 0 0 16px; white-space: pre-wrap; opacity: .85; max-height: 180px; overflow-y: auto; }
+  .passage { border-left: 3px solid var(--vscode-panel-border); padding: 6px 0 6px 12px; margin: 0 0 16px; white-space: pre-wrap; opacity: .85; }
   .msg { margin: 0 0 14px; }
   .msg .who { font-size: .85em; opacity: .7; margin-bottom: 3px; }
   .msg .what { white-space: pre-wrap; }
@@ -138,8 +156,11 @@ function chatStyle(uiScale: number): string {
   .capped p { margin: 0 0 8px; }
   .picker { display: flex; gap: 8px; align-items: center; margin: 0 0 8px; }
   .caption { font-size: .85em; opacity: .7; }
-  textarea { width: 100%; box-sizing: border-box; min-height: 64px; font: inherit; color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 4px; padding: 8px; }
+  textarea { flex: 1 1 auto; min-width: 0; box-sizing: border-box; min-height: 64px; font: inherit; color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 4px; padding: 8px; }
   textarea[disabled] { opacity: .6; }
+  #send { flex: 0 0 auto; font: inherit; color: var(--vscode-button-foreground); background: var(--vscode-button-background); border: none; border-radius: 4px; padding: 8px 14px; cursor: pointer; }
+  #send:hover:not([disabled]) { background: var(--vscode-button-hoverBackground); }
+  #send[disabled] { opacity: .6; cursor: default; }
   .hint { font-size: .85em; opacity: .6; margin-top: 4px; }
 ${ZOOM_CSS}`;
 }
@@ -171,15 +192,22 @@ export function chatStatusHtml(running: boolean, position: number): string {
 function chatBody(state: ChatPageState): string {
   const locked = state.running || state.capped;
 
-  return `<header><h1>${escapeHtml(state.title)}</h1>${zoomControlHtml(state.uiScale)}</header>
+  return `<main id="scroll">
+<header><h1>${escapeHtml(state.title)}</h1>${zoomControlHtml(state.uiScale)}</header>
 <div class="passage" id="passage">${escapeHtml(state.passage)}</div>
 <div id="failure">${state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`}</div>
 <div id="messages">${chatMessagesHtml(state.messages)}</div>
 <div id="thinking">${chatStatusHtml(state.running, 0)}</div>
 <div id="capped">${chatCappedHtml(state.capped)}</div>
+</main>
+<footer id="composer">
 <div id="pickerBox">${chatPickerHtml(state.models, state.modelId)}</div>
+<div class="compose">
 <textarea id="say" rows="3" placeholder="Ask about the text above…"${locked ? ' disabled' : ''}>${escapeHtml(state.draft)}</textarea>
-<div class="hint">Enter sends · Shift+Enter for a new line</div>`;
+<button type="button" id="send"${locked ? ' disabled' : ''}>Send</button>
+</div>
+<div class="hint">Enter sends · Shift+Enter for a new line</div>
+</footer>`;
 }
 
 /** The page's behaviour. Its own function for the same reason the styles are. */
@@ -204,12 +232,21 @@ function chatScript(state: ChatPageState): string {
     if (text.length === 0) { return; }
     box.value = '';
     vscode.postMessage({ type: 'command', command: 'send', text: text });
+    // Clicking the button moves focus to the button. Without this every follow-up costs a mouse
+    // click back into the box - the same reason the lock below returns focus when a turn ends.
+    if (typeof box.focus === 'function') { box.focus(); }
   }
   const say = document.getElementById('say');
   if (say) {
     say.addEventListener('keydown', function (event) {
       if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); send(); }
     });
+  }
+  // The second caller of the ONE send. Attached here rather than as an onclick attribute: the page's
+  // CSP is script-src 'nonce-...', so an inline handler is not merely untidy, it is a dead button.
+  const sendButton = document.getElementById('send');
+  if (sendButton) {
+    sendButton.addEventListener('click', function () { send(); });
   }
   function wirePicker() {
     const model = document.getElementById('model');
@@ -271,6 +308,11 @@ function chatScript(state: ChatPageState): string {
     if (box && typeof data.running === 'boolean' && typeof data.capped === 'boolean') {
       const wasLocked = box.disabled;
       box.disabled = data.running || data.capped;
+      // The button takes the box's lock rather than recomputing it. Two controls deciding the same
+      // thing from the same inputs is two chances to disagree, and the one that disagrees is the one
+      // that sends a second turn down a pipe that carries one.
+      const button = document.getElementById('send');
+      if (button) { button.disabled = box.disabled; }
       // Back to the box when the turn ends. Without this every single follow-up costs a mouse click,
       // nine seconds after the last one — which is the whole conversation, one click at a time.
       if (wasLocked && !box.disabled && typeof box.focus === 'function') { box.focus(); }

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -209,7 +209,9 @@ export function chatStatusHtml(running: boolean, position: number): string {
  * change from a repeat. Two copies of these expressions would drift on the day one of them gains a
  * condition, and the symptom would be a page that scrolls on a push that changed nothing.</p>
  */
-function regionsOf(state: ChatPageState): Record<'messages' | 'thinking' | 'capped' | 'failure', string> {
+type Regions = Record<'messages' | 'thinking' | 'capped' | 'failure', string>;
+
+function regionsOf(state: ChatPageState): Regions {
   return {
     messages: chatMessagesHtml(state.messages),
     thinking: chatStatusHtml(state.running, 0),
@@ -219,9 +221,8 @@ function regionsOf(state: ChatPageState): Record<'messages' | 'thinking' | 'capp
 }
 
 /** The document, without its head or its script. */
-function chatBody(state: ChatPageState): string {
+function chatBody(state: ChatPageState, regions: Regions): string {
   const locked = state.running || state.capped;
-  const regions = regionsOf(state);
 
   return `<main id="scroll">
 <header><h1>${escapeHtml(state.title)}</h1>${zoomControlHtml(state.uiScale)}</header>
@@ -277,7 +278,7 @@ export function shouldFollow(
 }
 
 /** The page's behaviour. Its own function for the same reason the styles are. */
-function chatScript(state: ChatPageState): string {
+function chatScript(state: ChatPageState, regions: Regions): string {
   return `(function () {
   const vscode = acquireVsCodeApi();
   let captions = ${jsonForScript(Object.fromEntries(state.models.map((model) => [model.id, model.caption])))};
@@ -309,7 +310,7 @@ function chatScript(state: ChatPageState): string {
   // browser to serialise the DOM back to us on every push. Seeded with what the MARKUP holds, or the
   // first push would compare against nothing, read as a change, and scroll a reader for content that
   // was already on their screen.
-  var lastWritten = ${jsonForScript(regionsOf(state))};
+  var lastWritten = ${jsonForScript(regions)};
   // The ONE scroll event the page owes itself, armed by its own write and consumed by the event it
   // causes. Two shapes were tried and both were wrong: a flag cleared on a later frame stays raised
   // until that frame comes, so every scroll in between reads as the page's own; and a position kept
@@ -334,9 +335,15 @@ function chatScript(state: ChatPageState): string {
     // follow, and the rule would work exactly once per tab.
     const was = scroll.scrollTop;
     scroll.scrollTop = scroll.scrollHeight;
+    // Whoever brought them here, they are here: the control has nothing left to offer. Retiring it
+    // in the click handler alone left it standing for every other path that lands on the newest.
+    offerJump(false);
     // What it CLAMPED to, not what we asked for: a browser answers scrollHeight - clientHeight. And
     // null when nothing moved, because then no scroll event is coming to consume the arming.
     selfScrollTo = scroll.scrollTop === was ? null : scroll.scrollTop;
+    // Known NOW rather than sampled next frame. A run of keystrokes calls the re-pin several times
+    // before any frame arrives, and each one was reading a flag that had not been updated yet.
+    wasAtBottom = true;
   }
   // Deferred to the next frame, and CANCELLABLE. The reader can move between the frame being asked
   // for and the frame arriving - a drag, a wheel, Page Up - and a scroll that was right when it was
@@ -356,17 +363,24 @@ function chatScript(state: ChatPageState): string {
     if (!box || !box.style) { return; }
     box.style.height = 'auto';
     box.style.height = box.scrollHeight + 'px';
-    // The footer just changed height and nothing else is watching on this host - the engines without
-    // field-sizing are the ones this fallback exists for, and requirement 8 was promised to them
-    // too. Whoever changed the height says so; the pin itself is one function.
-    repinIfTheyWereAtTheBottom();
+    // Only where nothing else is watching. On a host WITH ResizeObserver this same height change
+    // reaches the observer too, and both firing means two re-pins and two queued samplings racing
+    // over one event. The engines without field-sizing are the ones this fallback exists for, and
+    // requirement 8 was promised to them as well. (gemini, the code round.)
+    if (typeof ResizeObserver !== 'function') { repinIfTheyWereAtTheBottom(); }
   }
   // A height change nobody asked for must not move the conversation out from under a reader. The
   // remembered flag is right here where re-measuring is not: they did NOT scroll, the region shrank
   // underneath them, so measuring now would call them scrolled away and leave the last answer behind
   // the box they are typing into.
   function repinIfTheyWereAtTheBottom() {
-    if (wasAtBottom) { landOnNewest(); }
+    if (wasAtBottom) {
+      landOnNewest();
+
+      return;
+    }
+    // Not at the bottom, so nothing moves - but the resize changed the numbers under them, and the
+    // next frame is when they can be read again.
     afterLayout(rememberWhereTheyAre);
   }
   function rememberWhereTheyAre() {
@@ -605,6 +619,11 @@ function chatScript(state: ChatPageState): string {
 }
 
 export function chatPageHtml(state: ChatPageState, nonce: string): string {
+  // Built once and handed to both. The markup writes these four strings and the script remembers
+  // them; serialising a long conversation twice per render is a cost that grows with the thing a
+  // person is most likely to have a lot of. (local, the code round.)
+  const regions = regionsOf(state);
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -617,9 +636,9 @@ ${chatStyle(state.uiScale)}
 </style>
 </head>
 <body>
-${chatBody(state)}
+${chatBody(state, regions)}
 <script nonce="${nonce}">
-${chatScript(state)}
+${chatScript(state, regions)}
 </script>
 </body>
 </html>`;

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -297,6 +297,14 @@ function chatScript(state: ChatPageState): string {
   var shouldFollow = ${shouldFollow.toString()};
   var SLACK = ${FOLLOW_SLACK_PX};
   var pendingFollow = 0;
+  // Whether the reader was at the bottom BEFORE the last thing that moved the layout under them.
+  // Recomputed on every scroll, which is the only event that means the READER moved; a resize or a
+  // growing composer must ask what this remembers, because after one the numbers no longer describe
+  // where the person put themselves.
+  var wasAtBottom = true;
+  // A follow is out and has not run yet. If the reader cancels it, they are left scrolled up with an
+  // answer nobody took them to - so the cancel hands them the jump control instead.
+  var followOutstanding = false;
   // What was last PUT into each region, so a repeat can be told from a change without asking the
   // browser to serialise the DOM back to us on every push. Seeded with what the MARKUP holds, or the
   // first push would compare against nothing, read as a change, and scroll a reader for content that
@@ -348,6 +356,24 @@ function chatScript(state: ChatPageState): string {
     if (!box || !box.style) { return; }
     box.style.height = 'auto';
     box.style.height = box.scrollHeight + 'px';
+    // The footer just changed height and nothing else is watching on this host - the engines without
+    // field-sizing are the ones this fallback exists for, and requirement 8 was promised to them
+    // too. Whoever changed the height says so; the pin itself is one function.
+    repinIfTheyWereAtTheBottom();
+  }
+  // A height change nobody asked for must not move the conversation out from under a reader. The
+  // remembered flag is right here where re-measuring is not: they did NOT scroll, the region shrank
+  // underneath them, so measuring now would call them scrolled away and leave the last answer behind
+  // the box they are typing into.
+  function repinIfTheyWereAtTheBottom() {
+    if (wasAtBottom) { landOnNewest(); }
+    afterLayout(rememberWhereTheyAre);
+  }
+  function rememberWhereTheyAre() {
+    const scroll = document.getElementById('scroll');
+    if (scroll) {
+      wasAtBottom = shouldFollow(scroll.scrollTop, scroll.clientHeight, scroll.scrollHeight, SLACK);
+    }
   }
   function offerJump(show) {
     const control = document.getElementById('jump');
@@ -355,7 +381,13 @@ function chatScript(state: ChatPageState): string {
   }
   function scheduleFollow() {
     const token = ++pendingFollow;
-    afterLayout(function () { if (token === pendingFollow) { landOnNewest(); } });
+    followOutstanding = true;
+    afterLayout(function () {
+      if (token === pendingFollow) {
+        landOnNewest();
+        followOutstanding = false;
+      }
+    });
   }
   function send() {
     const box = document.getElementById('say');
@@ -443,7 +475,14 @@ function chatScript(state: ChatPageState): string {
         selfScrollTo = null;
       } else {
         pendingFollow++;
+        // They cancelled a follow that had not run. An answer arrived, they were not taken to it,
+        // and without this nothing on the page would say so. (codex, the plan round.)
+        if (followOutstanding) {
+          followOutstanding = false;
+          offerJump(true);
+        }
       }
+      rememberWhereTheyAre();
       // A reader who came back under their own steam has answered the question the control was
       // asking. One that stays up after that is one nobody trusts.
       if (shouldFollow(scrollRegion.scrollTop, scrollRegion.clientHeight, scrollRegion.scrollHeight, SLACK)) {
@@ -457,21 +496,12 @@ function chatScript(state: ChatPageState): string {
   // the other side. What they WERE is the only measurement that survives the resize, so it is taken
   // before the layout changes and acted on after. A host without ResizeObserver keeps today's
   // behaviour rather than breaking.
-  if (typeof ResizeObserver === 'function' && scrollRegion) {
-    let wasAtBottom = true;
+  // Where the host has one, it catches every way the composer's height can change, including the
+  // CSS path where no script of ours runs at all. Where it has none, fitComposer says so instead -
+  // and those are the same hosts, since an engine without field-sizing is an old engine.
+  if (typeof ResizeObserver === 'function') {
     const composer = document.getElementById('composer');
-    const watcher = new ResizeObserver(function () {
-      if (wasAtBottom) { landOnNewest(); }
-      afterLayout(function () {
-        wasAtBottom = shouldFollow(
-          scrollRegion.scrollTop, scrollRegion.clientHeight, scrollRegion.scrollHeight, SLACK);
-      });
-    });
-    if (composer) { watcher.observe(composer); }
-    scrollRegion.addEventListener('scroll', function () {
-      wasAtBottom = shouldFollow(
-        scrollRegion.scrollTop, scrollRegion.clientHeight, scrollRegion.scrollHeight, SLACK);
-    });
+    if (composer) { new ResizeObserver(repinIfTheyWereAtTheBottom).observe(composer); }
   }
   const jump = document.getElementById('jump');
   if (jump) {

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -139,7 +139,15 @@ function chatStyle(uiScale: number): string {
      body would instead, and the composer would leave the screen — the symptom this layout exists
      to end. (The gate raised it, and it is invisible to every test but a reading of this rule.) */
   #scroll { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 16px 20px 0; }
-  #composer { flex: 0 0 auto; padding: 8px 20px 12px; }
+  /* Positioned, because the jump control hangs above it. */
+  #composer { flex: 0 0 auto; padding: 8px 20px 12px; position: relative; }
+  /* OUT OF FLOW, and that is the point rather than the styling. In the flow it would take room in
+     the footer, which shrinks the scrolling region, which changes clientHeight - one of the three
+     numbers the follow decision is made from. A control that appears BECAUSE a reader was not
+     followed must not alter what "at the bottom" means. No display property either, so the hidden
+     attribute keeps working. */
+  .jump { position: absolute; bottom: calc(100% + 6px); left: 50%; transform: translateX(-50%); font: inherit; color: var(--vscode-button-foreground); background: var(--vscode-button-background); border: none; border-radius: 12px; padding: 4px 12px; cursor: pointer; box-shadow: 0 2px 6px rgba(0, 0, 0, .35); }
+  .jump:hover { background: var(--vscode-button-hoverBackground); }
   .compose { display: flex; gap: 8px; align-items: flex-end; }
   header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; }
   h1 { font-size: 1.2em; margin: 0; }
@@ -188,19 +196,38 @@ export function chatStatusHtml(running: boolean, position: number): string {
   return `<p class="thinking">Thinking…${where}</p>`;
 }
 
+/**
+ * What each pushed region holds, for the page as it is first rendered.
+ *
+ * <p>One function because two callers need the SAME four strings: the markup writes them, and the
+ * script remembers them as "what is already on screen" so that the first pushed state can tell a
+ * change from a repeat. Two copies of these expressions would drift on the day one of them gains a
+ * condition, and the symptom would be a page that scrolls on a push that changed nothing.</p>
+ */
+function regionsOf(state: ChatPageState): Record<'messages' | 'thinking' | 'capped' | 'failure', string> {
+  return {
+    messages: chatMessagesHtml(state.messages),
+    thinking: chatStatusHtml(state.running, 0),
+    capped: chatCappedHtml(state.capped),
+    failure: state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`,
+  };
+}
+
 /** The document, without its head or its script. */
 function chatBody(state: ChatPageState): string {
   const locked = state.running || state.capped;
+  const regions = regionsOf(state);
 
   return `<main id="scroll">
 <header><h1>${escapeHtml(state.title)}</h1>${zoomControlHtml(state.uiScale)}</header>
 <div class="passage" id="passage">${escapeHtml(state.passage)}</div>
-<div id="failure">${state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`}</div>
-<div id="messages">${chatMessagesHtml(state.messages)}</div>
-<div id="thinking">${chatStatusHtml(state.running, 0)}</div>
-<div id="capped">${chatCappedHtml(state.capped)}</div>
+<div id="failure">${regions.failure}</div>
+<div id="messages">${regions.messages}</div>
+<div id="thinking">${regions.thinking}</div>
+<div id="capped">${regions.capped}</div>
 </main>
 <footer id="composer">
+<button type="button" id="jump" class="jump" hidden>Jump to newest ↓</button>
 <div id="pickerBox">${chatPickerHtml(state.models, state.modelId)}</div>
 <div class="compose">
 <textarea id="say" rows="3" placeholder="Ask about the text above…"${locked ? ' disabled' : ''}>${escapeHtml(state.draft)}</textarea>
@@ -266,8 +293,10 @@ function chatScript(state: ChatPageState): string {
   var SLACK = ${FOLLOW_SLACK_PX};
   var pendingFollow = 0;
   // What was last PUT into each region, so a repeat can be told from a change without asking the
-  // browser to serialise the DOM back to us on every push.
-  var lastWritten = { messages: null, thinking: null, capped: null, failure: null };
+  // browser to serialise the DOM back to us on every push. Seeded with what the MARKUP holds, or the
+  // first push would compare against nothing, read as a change, and scroll a reader for content that
+  // was already on their screen.
+  var lastWritten = ${jsonForScript(regionsOf(state))};
   // The ONE scroll event the page owes itself, armed by its own write and consumed by the event it
   // causes. Two shapes were tried and both were wrong: a flag cleared on a later frame stays raised
   // until that frame comes, so every scroll in between reads as the page's own; and a position kept
@@ -301,6 +330,10 @@ function chatScript(state: ChatPageState): string {
   // scheduled is a hijack by the time it runs. Re-measuring in the callback cannot tell: the content
   // is already in, so a reader who WAS at the bottom now measures short of it. Only the reader knows
   // they moved, so the cancel is their scroll event. (Two vendors raised this on the plan round.)
+  function offerJump(show) {
+    const control = document.getElementById('jump');
+    if (control) { control.hidden = !show; }
+  }
   function scheduleFollow() {
     const token = ++pendingFollow;
     afterLayout(function () { if (token === pendingFollow) { landOnNewest(); } });
@@ -390,6 +423,22 @@ function chatScript(state: ChatPageState): string {
       } else {
         pendingFollow++;
       }
+      // A reader who came back under their own steam has answered the question the control was
+      // asking. One that stays up after that is one nobody trusts.
+      if (shouldFollow(scrollRegion.scrollTop, scrollRegion.clientHeight, scrollRegion.scrollHeight, SLACK)) {
+        offerJump(false);
+      }
+    });
+  }
+  const jump = document.getElementById('jump');
+  if (jump) {
+    jump.addEventListener('click', function () {
+      landOnNewest();
+      offerJump(false);
+      // The box, unless a turn is running - focusing a disabled control puts the caret where
+      // nobody can type, which is the same rule send() follows.
+      const box = document.getElementById('say');
+      if (box && !box.disabled && typeof box.focus === 'function') { box.focus(); }
     });
   }
   window.addEventListener('message', function (event) {
@@ -470,9 +519,13 @@ function chatScript(state: ChatPageState): string {
       // nine seconds after the last one — which is the whole conversation, one click at a time.
       if (wasLocked && !box.disabled && typeof box.focus === 'function') { box.focus(); }
     }
-    // Rule 2, applied once for whatever this push contained - an answer, a failure, a thinking line
-    // or a capped notice. There is one rule, not one per outcome.
-    if (wrote && follow) { scheduleFollow(); }
+    // Rules 2 and 3, applied once for whatever this push contained - an answer, a failure, a
+    // thinking line or a capped notice. There is one rule, not one per outcome, and the two halves
+    // are exclusive by construction: something arrived, and either the reader was taken to it or
+    // they are told it is there.
+    if (wrote) {
+      if (follow) { scheduleFollow(); } else { offerJump(true); }
+    }
   });
 }());`;
 }

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -164,7 +164,12 @@ function chatStyle(uiScale: number): string {
   .capped p { margin: 0 0 8px; }
   .picker { display: flex; gap: 8px; align-items: center; margin: 0 0 8px; }
   .caption { font-size: .85em; opacity: .7; }
-  textarea { flex: 1 1 auto; min-width: 0; box-sizing: border-box; min-height: 64px; font: inherit; color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 4px; padding: 8px; }
+  /* The 30 % lives HERE and only here, so the CSS path and the JavaScript fallback below cannot
+     disagree about where the ceiling is: the fallback sets a height and this caps it. field-sizing
+     is Chromium-only, which is not a limitation in a page that renders nowhere but VS Code's own
+     webview - but the manifest declares support back to 1.85, whose engine has never heard of it,
+     and there the fallback does the growing. */
+  textarea { flex: 1 1 auto; min-width: 0; box-sizing: border-box; min-height: 64px; max-height: 30vh; field-sizing: content; overflow-y: auto; resize: none; font: inherit; color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border, var(--vscode-panel-border)); border-radius: 4px; padding: 8px; }
   textarea[disabled] { opacity: .6; }
   #send { flex: 0 0 auto; font: inherit; color: var(--vscode-button-foreground); background: var(--vscode-button-background); border: none; border-radius: 4px; padding: 8px 14px; cursor: pointer; }
   #send:hover:not([disabled]) { background: var(--vscode-button-hoverBackground); }
@@ -330,6 +335,20 @@ function chatScript(state: ChatPageState): string {
   // scheduled is a hijack by the time it runs. Re-measuring in the callback cannot tell: the content
   // is already in, so a reader who WAS at the bottom now measures short of it. Only the reader knows
   // they moved, so the cancel is their scroll event. (Two vendors raised this on the plan round.)
+  // ASKED, not assumed. The gate's blocking finding on the plan: a page that takes field-sizing on
+  // faith works on the machine it was written on and silently never grows anywhere else, which is
+  // the one failure mode a person cannot report because nothing happens.
+  var sizesItself = typeof CSS !== 'undefined' && typeof CSS.supports === 'function'
+    && CSS.supports('field-sizing', 'content');
+  // Height from content, ceiling from the CSS. Called on input, after a send has emptied the box and
+  // after a draft is pushed into it - shrinking back is a call, not a hope.
+  function fitComposer() {
+    if (sizesItself) { return; }
+    const box = document.getElementById('say');
+    if (!box || !box.style) { return; }
+    box.style.height = 'auto';
+    box.style.height = box.scrollHeight + 'px';
+  }
   function offerJump(show) {
     const control = document.getElementById('jump');
     if (control) { control.hidden = !show; }
@@ -345,6 +364,7 @@ function chatScript(state: ChatPageState): string {
     if (text.length === 0) { return; }
     box.value = '';
     vscode.postMessage({ type: 'command', command: 'send', text: text });
+    fitComposer();
     // Locked HERE, not when the host gets round to saying so. Between the post and the state that
     // comes back there was a window - small, and the width of a second Enter - in which a second
     // turn went down a pipe that carries one. Two vendors found it independently; the page did not
@@ -367,6 +387,7 @@ function chatScript(state: ChatPageState): string {
     say.addEventListener('keydown', function (event) {
       if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); send(); }
     });
+    say.addEventListener('input', fitComposer);
   }
   // The second caller of the ONE send. Attached here rather than as an onclick attribute: the page's
   // CSP is script-src 'nonce-...', so an inline handler is not merely untidy, it is a dead button.
@@ -428,6 +449,28 @@ function chatScript(state: ChatPageState): string {
       if (shouldFollow(scrollRegion.scrollTop, scrollRegion.clientHeight, scrollRegion.scrollHeight, SLACK)) {
         offerJump(false);
       }
+    });
+  }
+  // A footer whose height changes takes the room from the conversation above it. A reader who was at
+  // the bottom did NOT scroll - the region shrank underneath them - so re-measuring would call them
+  // scrolled away and leave the last answer behind the box they are typing into: rule 2 broken from
+  // the other side. What they WERE is the only measurement that survives the resize, so it is taken
+  // before the layout changes and acted on after. A host without ResizeObserver keeps today's
+  // behaviour rather than breaking.
+  if (typeof ResizeObserver === 'function' && scrollRegion) {
+    let wasAtBottom = true;
+    const composer = document.getElementById('composer');
+    const watcher = new ResizeObserver(function () {
+      if (wasAtBottom) { landOnNewest(); }
+      afterLayout(function () {
+        wasAtBottom = shouldFollow(
+          scrollRegion.scrollTop, scrollRegion.clientHeight, scrollRegion.scrollHeight, SLACK);
+      });
+    });
+    if (composer) { watcher.observe(composer); }
+    scrollRegion.addEventListener('scroll', function () {
+      wasAtBottom = shouldFollow(
+        scrollRegion.scrollTop, scrollRegion.clientHeight, scrollRegion.scrollHeight, SLACK);
     });
   }
   const jump = document.getElementById('jump');
@@ -505,6 +548,7 @@ function chatScript(state: ChatPageState): string {
       const box2 = document.getElementById('say');
       if (box2) {
         box2.value = box2.value.length > 0 ? box2.value + '\\n\\n' + data.draft : data.draft;
+        fitComposer();
         if (typeof box2.focus === 'function') { box2.focus(); }
       }
     }

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -210,6 +210,40 @@ function chatBody(state: ChatPageState): string {
 </footer>`;
 }
 
+/**
+ * How close to the bottom still counts as being AT the bottom, in pixels.
+ *
+ * <p>The operator's rule says "a line or two of slack"; the gate asked for a number, and it is right
+ * to — a boundary a reader can land on is a boundary a test has to name. 48 is about two lines at
+ * the base size and three at the largest zoom step down. It is a constant rather than something
+ * derived from the font size on purpose: a reader a hair short of the bottom considers themselves at
+ * the bottom whatever size they are reading at, and a slack that shrinks with the text would make
+ * the rule behave differently for the people most likely to have scrolled.</p>
+ */
+export const FOLLOW_SLACK_PX = 48;
+
+/**
+ * Was the reader at the bottom — and therefore should a new answer be scrolled to?
+ *
+ * <p>Rule 2 of the decided scroll behaviour (entry 23, settled 2026-09-09). Pure, and taking its
+ * slack as a parameter rather than reading the constant, because its SOURCE is embedded into the
+ * page: it must reference nothing outside itself or the page gets a function whose free variable
+ * does not exist there.</p>
+ *
+ * <p>Written as `!(distance > slack)` rather than `distance <= slack` for the case that reaches it
+ * most rarely and matters anyway: a page that cannot measure itself yields NaN, every comparison
+ * with NaN is false, and the negation turns that into "follow". A page whose numbers are unreadable
+ * is a page whose reader has not scrolled away from anything.</p>
+ */
+export function shouldFollow(
+  scrollTop: number,
+  clientHeight: number,
+  scrollHeight: number,
+  slack: number,
+): boolean {
+  return !(scrollHeight - (scrollTop + clientHeight) > slack);
+}
+
 /** The page's behaviour. Its own function for the same reason the styles are. */
 function chatScript(state: ChatPageState): string {
   return `(function () {
@@ -225,6 +259,21 @@ function chatScript(state: ChatPageState): string {
     vscode.postMessage({ type: 'pageError', message: String(message) });
   };
   ${zoomScript()}
+  // Bound by ASSIGNMENT, not declared: the minifier renames a declaration and leaves the name in the
+  // template string that calls it, which is how the rounds log shipped a dead page twice. Embedding
+  // the source is also what makes the function the tests exercise the function the page runs.
+  var shouldFollow = ${shouldFollow.toString()};
+  var SLACK = ${FOLLOW_SLACK_PX};
+  // A scroll set in the same tick as the write scrolls to a height the browser has not laid out yet
+  // and lands short. The next frame has the real height, and setTimeout is the fallback for a host
+  // that has no requestAnimationFrame - the bundled page runs in exactly such a stub.
+  function afterLayout(fn) {
+    if (typeof requestAnimationFrame === 'function') { requestAnimationFrame(fn); } else { setTimeout(fn, 0); }
+  }
+  function landOnNewest() {
+    const scroll = document.getElementById('scroll');
+    if (scroll) { scroll.scrollTop = scroll.scrollHeight; }
+  }
   function send() {
     const box = document.getElementById('say');
     if (!box || box.disabled) { return; }
@@ -286,24 +335,41 @@ function chatScript(state: ChatPageState): string {
   }
   wirePicker();
   wireCapped();
+  // Rule 1: the tab opens looking at the last thing said, not at the passage above it. Three times,
+  // because the height is not final until the fonts are: now (the first paint is already close),
+  // after layout, and after the fonts settle where the host reports them. Idempotent, so the two
+  // extra calls cost nothing on a page that was already there.
+  landOnNewest();
+  afterLayout(landOnNewest);
+  if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
+    document.fonts.ready.then(landOnNewest);
+  }
   window.addEventListener('message', function (event) {
     const data = event.data || {};
     if (data.type !== 'state') { return; }
+    // BEFORE any write. Read after one, scrollHeight already includes what just arrived, so a reader
+    // who was at the bottom measures as a screen short of it and is never followed - rule 2 turns
+    // silently into "never follow", and the only place that shows is the real webview. One snapshot
+    // at the head of the one handler every region arrives through is what makes it true by
+    // construction rather than by remembering to do it in five places.
+    const scroll = document.getElementById('scroll');
+    const follow = !scroll || shouldFollow(scroll.scrollTop, scroll.clientHeight, scroll.scrollHeight, SLACK);
+    let wrote = false;
     const messages = document.getElementById('messages');
-    if (messages && typeof data.messagesHtml === 'string') { messages.innerHTML = data.messagesHtml; }
+    if (messages && typeof data.messagesHtml === 'string') { messages.innerHTML = data.messagesHtml; wrote = true; }
     const thinking = document.getElementById('thinking');
-    if (thinking && typeof data.thinkingHtml === 'string') { thinking.innerHTML = data.thinkingHtml; }
+    if (thinking && typeof data.thinkingHtml === 'string') { thinking.innerHTML = data.thinkingHtml; wrote = true; }
     const capped = document.getElementById('capped');
-    if (capped) { capped.innerHTML = data.cappedHtml || ''; wireCapped(); }
+    if (capped && typeof data.cappedHtml === 'string') { capped.innerHTML = data.cappedHtml; wireCapped(); wrote = true; }
     // The picker is re-rendered rather than nudged: after "continue with a local model" the whole
     // list can be different, and a select that only had its value set would show a model it no
     // longer offers.
     const pickerBox = document.getElementById('pickerBox');
     if (pickerBox && typeof data.pickerHtml === 'string') { pickerBox.innerHTML = data.pickerHtml; wirePicker(); }
     const failure = document.getElementById('failure');
-    if (failure) { failure.innerHTML = data.failureHtml || ''; }
+    if (failure && typeof data.failureHtml === 'string') { failure.innerHTML = data.failureHtml; wrote = true; }
     const passage = document.getElementById('passage');
-    if (passage && typeof data.passage === 'string') { passage.textContent = data.passage; }
+    if (passage && typeof data.passage === 'string') { passage.textContent = data.passage; wrote = true; }
     // A draft pushed into an OPEN tab. Appended rather than assigned, so a half-typed follow-up
     // is never thrown away by a second invocation - losing what somebody typed is the one thing
     // the queue in the session was also built to avoid.
@@ -325,6 +391,9 @@ function chatScript(state: ChatPageState): string {
       // nine seconds after the last one — which is the whole conversation, one click at a time.
       if (wasLocked && !box.disabled && typeof box.focus === 'function') { box.focus(); }
     }
+    // Rule 2, applied once for whatever this push contained - an answer, a failure, a thinking line
+    // or a capped notice. There is one rule, not one per outcome.
+    if (wrote && follow) { afterLayout(landOnNewest); }
   });
 }());`;
 }

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -296,6 +296,57 @@ function bundledChatPage(): { bundle: string; html: string } {
   return { bundle, html };
 }
 
+test('the chat page the bundle produces runs, and its Send button sends exactly one turn', () => {
+  // The rounds log has had this since a minifier renamed a binding out from under it — twice. The
+  // chat page had only ever been READ here, and story 2 of this plan is about to embed a function
+  // by `toString()` into its script, which is precisely the shape that broke there. So the page is
+  // run as it SHIPS: bundled, minified, then executed against a stub DOM.
+  const { html } = bundledChatPage();
+  const script = html.split('<script nonce="n0nce">')[1].split('</script>')[0];
+  const posted: Array<Record<string, unknown>> = [];
+  const rendered = new Map(
+    [...html.matchAll(/<[a-z]+[^>]*\bid="([^"]+)"[^>]*>/g)].map((match) => [match[1], match[0]]),
+  );
+  const listeners: Record<string, Record<string, Array<() => void>>> = {};
+  const nodes: Record<string, Record<string, unknown>> = {};
+  const node = (id: string) => (nodes[id] ??= {
+    innerHTML: '', textContent: '', hidden: false, value: '', className: '',
+    disabled: / disabled(?=[ >])/.test(rendered.get(id) ?? ''),
+    addEventListener(type: string, fn: () => void) { ((listeners[id] ??= {})[type] ??= []).push(fn); },
+    focus() { /* the stub is focusable */ },
+    getAttribute: () => null,
+    setAttribute() { /* the page sets none */ },
+    querySelectorAll: () => [],
+  });
+
+  assert.doesNotThrow(
+    () => new Function('document', 'window', 'acquireVsCodeApi', script)(
+      {
+        getElementById: (id: string) => (rendered.has(id) ? node(id) : null),
+        querySelectorAll: () => [],
+        addEventListener() { /* the page listens on window */ },
+        body: { style: {} },
+      },
+      { addEventListener() { /* no host push in this test */ } },
+      () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message) }),
+    ),
+    'the minified chat page script threw on its first render',
+  );
+
+  // The button exists in the shipped markup, its listener survived minification, and it reaches the
+  // one send. A page whose button was renamed away would attach nothing and post nothing here.
+  assert.ok(rendered.has('send'), 'the shipped chat page has no Send button');
+  nodes['say']['value'] = 'does the shipped button work';
+  for (const fire of listeners['send']?.['click'] ?? []) {
+    fire();
+  }
+
+  const sends = posted.filter((message) => message['command'] === 'send');
+  assert.strictEqual(sends.length, 1, 'the shipped Send button did not send exactly one turn');
+  assert.strictEqual(sends[0]?.['text'], 'does the shipped button work');
+  assert.strictEqual(nodes['say']['disabled'], true, 'the shipped page left the composer open after a send');
+});
+
 test('the chat page carries nothing from the host into the webview', () => {
   const { bundle } = bundledChatPage();
 

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -311,6 +311,7 @@ test('the chat page the bundle produces runs, and its Send button sends exactly 
   const nodes: Record<string, Record<string, unknown>> = {};
   const node = (id: string) => (nodes[id] ??= {
     innerHTML: '', textContent: '', hidden: false, value: '', className: '',
+    scrollTop: 0, clientHeight: 0, scrollHeight: 0,
     disabled: / disabled(?=[ >])/.test(rendered.get(id) ?? ''),
     addEventListener(type: string, fn: () => void) { ((listeners[id] ??= {})[type] ??= []).push(fn); },
     focus() { /* the stub is focusable */ },
@@ -319,19 +320,30 @@ test('the chat page the bundle produces runs, and its Send button sends exactly 
     querySelectorAll: () => [],
   });
 
+  const onWindow: Record<string, Array<(event: { data: unknown }) => void>> = {};
+  const frames: Array<() => void> = [];
+
   assert.doesNotThrow(
-    () => new Function('document', 'window', 'acquireVsCodeApi', script)(
+    () => new Function('document', 'window', 'acquireVsCodeApi', 'requestAnimationFrame', script)(
       {
         getElementById: (id: string) => (rendered.has(id) ? node(id) : null),
         querySelectorAll: () => [],
         addEventListener() { /* the page listens on window */ },
         body: { style: {} },
       },
-      { addEventListener() { /* no host push in this test */ } },
+      {
+        addEventListener(type: string, fn: (event: { data: unknown }) => void) {
+          (onWindow[type] ??= []).push(fn);
+        },
+      },
       () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message) }),
+      (fn: () => void) => { frames.push(fn); },
     ),
     'the minified chat page script threw on its first render',
   );
+  for (const fn of frames.splice(0)) {
+    fn();
+  }
 
   // The button exists in the shipped markup, its listener survived minification, and it reaches the
   // one send. A page whose button was renamed away would attach nothing and post nothing here.
@@ -345,6 +357,27 @@ test('the chat page the bundle produces runs, and its Send button sends exactly 
   assert.strictEqual(sends.length, 1, 'the shipped Send button did not send exactly one turn');
   assert.strictEqual(sends[0]?.['text'], 'does the shipped button work');
   assert.strictEqual(nodes['say']['disabled'], true, 'the shipped page left the composer open after a send');
+
+  // And a real push, which is what exercises the function the page carries as EMBEDDED SOURCE. A
+  // free identifier in it — a default parameter, a transpiler helper, a constant it closed over —
+  // does not exist in the page's scope and throws a ReferenceError only here, on the shipped
+  // bundle, with a state arriving. The gate raised exactly that hazard.
+  const scroll = nodes['scroll'];
+  assert.ok(scroll, 'the shipped page has no scrolling region');
+  scroll['clientHeight'] = 500;
+  scroll['scrollHeight'] = 2000;
+  scroll['scrollTop'] = 1500;
+  const push = onWindow['message'] ?? [];
+  assert.ok(push.length > 0, 'the shipped page is not listening for host state');
+  for (const fire of push) {
+    fire({ data: { type: 'state', messagesHtml: '<p>an answer</p>' } });
+  }
+  for (const fn of frames.splice(0)) {
+    fn();
+  }
+
+  assert.strictEqual(scroll['scrollTop'], 2000,
+    'the shipped page did not follow a reader who was at the bottom — the embedded rule did not run');
 });
 
 test('the chat page carries nothing from the host into the webview', () => {

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -329,8 +329,14 @@ function growsTheRegion(region: Fake, by: number): (value: string) => void {
   };
 }
 
-function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
-  const html = chatPageHtml(state(over), 'n0nce');
+interface RunOptions extends Partial<ChatPageState> {
+  /** Model an older engine: the same hosts that lack `field-sizing` are the case this guards. */
+  readonly withoutResizeObserver?: boolean;
+}
+
+function runChatPage(over: RunOptions = {}): RunningPage {
+  const { withoutResizeObserver, ...state_ } = over;
+  const html = chatPageHtml(state(state_), 'n0nce');
   const body = html.split('<script nonce="n0nce">')[1].split('</script>')[0];
   const seen: Record<string, Fake> = {};
   const posted: Array<Record<string, unknown>> = [];
@@ -389,7 +395,7 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
     window_,
     () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message) }),
     (fn: () => void) => { pending.push(fn); },
-    FakeResizeObserver,
+    withoutResizeObserver === true ? undefined : FakeResizeObserver,
   );
 
   const region = () => {
@@ -991,4 +997,40 @@ test('a composer that grows leaves a reader who scrolled up where they were', ()
   page.frames();
 
   assert.strictEqual(scroll.scrollTop, 200, 'a growing composer moved a reader who was reading something else');
+});
+
+test('a follow the reader cancels leaves the jump control behind it', () => {
+  // The narrow race the gate found: an answer arrives while the reader is at the bottom, so a follow
+  // is scheduled rather than done — and the reader scrolls up inside that frame. The follow is
+  // correctly cancelled, and without this the reader is left scrolled up, with an answer they were
+  // never taken to and nothing on screen saying it came.
+  const page = runChatPage();
+  const scroll = page.scrolledToBottom();
+
+  page.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+  scroll.scrollTop = 100;
+  page.fire('scroll', 'scroll');
+  page.frames();
+
+  assert.strictEqual(scroll.scrollTop, 100, 'the cancelled follow ran anyway');
+  assert.strictEqual(page.seen['jump'].hidden, false, 'an answer arrived, nobody was taken to it, and nobody was told');
+});
+
+test('a composer that grows re-pins the reader even where nothing observes it', () => {
+  // Requirement 8 was promised unconditionally and delivered only through ResizeObserver. Where the
+  // host has none — the same older engines that lack field-sizing — the box grows, the footer eats
+  // the room, and the last answer slides behind it with nothing to notice. The fallback that sizes
+  // the box knows it changed the height, so it is the one place that can say so.
+  const page = runChatPage({ withoutResizeObserver: true });
+  const scroll = page.scrolledToBottom();
+  scroll.scrollTop = scroll.scrollHeight - scroll.clientHeight;
+
+  page.seen['say'].value = 'one\ntwo\nthree';
+  page.seen['say'].scrollHeight = 180;
+  scroll.clientHeight -= 100;
+  page.fire('say', 'input');
+  page.frames();
+
+  assert.strictEqual(scroll.scrollTop, scroll.scrollHeight,
+    'the growing box pushed the last answer out of view on a host with no ResizeObserver');
 });

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -310,6 +310,8 @@ interface RunningPage {
   scrolledToBottom(): Fake;
   /** Put the reader a screen above the bottom, same page. */
   scrolledUp(): Fake;
+  /** Resolve `document.fonts.ready`. Await it: what it queued runs on the microtask queue. */
+  fontsSettle(): Promise<void>;
 }
 
 /**
@@ -341,6 +343,10 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
   const rendered = new Map(
     [...html.matchAll(/<[a-z]+[^>]*\bid="([^"]+)"[^>]*>/g)].map((match) => [match[1], match[0]]),
   );
+  // The page corrects its opening scroll once the fonts have settled. A test that cannot say WHEN
+  // that happens cannot show what a reader who moved in the meantime experiences.
+  let settleFonts = () => { /* replaced by the promise below */ };
+  const fontsReady = new Promise<void>((resolve) => { settleFonts = () => { resolve(); }; });
   const document_ = {
     getElementById: (id: string) => {
       const tag = rendered.get(id);
@@ -357,10 +363,12 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
     querySelectorAll: () => [],
     addEventListener() { /* the page listens on window */ },
     body: { style: emptyStyle() },
+    fonts: { ready: fontsReady },
   };
   const window_ = {
     addEventListener(type: string, fn: (event: unknown) => void) { (onWindow[type] ??= []).push(fn); },
   };
+
 
   new Function('document', 'window', 'acquireVsCodeApi', 'requestAnimationFrame', body)(
     document_,
@@ -404,6 +412,13 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
       scroll.scrollTop = 200;
 
       return scroll;
+    },
+    fontsSettle() {
+      settleFonts();
+      // Awaited by the caller: the page registered its own `.then` first, so by the time this
+      // resolves for us it has already run. A synchronous "drain" does not drain anything, and a
+      // test written that way passes because the callback never ran at all.
+      return fontsReady;
     },
     fire(id, type, event = {}) {
       assert.ok(seen[id], `the page never asked for #${id}, so nothing is listening on it`);
@@ -724,4 +739,62 @@ test('a push that changes nothing scrolls nobody, however many times it arrives'
   page.frames();
 
   assert.strictEqual(scroll.scrollTop, after - 300, 'an identical push moved the reader');
+});
+
+
+test('a reader who leaves and comes back to where the page left them still cancels the follow', () => {
+  // The position marker was permanent, and that is a magic pixel: a reader who scrolls away and
+  // returns to it — which is exactly what "scroll back down to the bottom" is — read as the page's
+  // own scroll for the rest of the tab's life, so their next movement never cancelled anything.
+  // It is one-shot now: our own scroll event consumes it, and everything after is the reader.
+  const page = runChatPage();
+  const scroll = page.scrolledToBottom();
+
+  page.deliver({ type: 'state', messagesHtml: '<p>first</p>' });
+  page.frames();
+  const wherePageLeftThem = scroll.scrollTop;
+  page.fire('scroll', 'scroll');
+
+  page.deliver({ type: 'state', messagesHtml: '<p>second</p>' });
+  scroll.scrollTop = wherePageLeftThem;
+  page.fire('scroll', 'scroll');
+  page.frames();
+
+  assert.strictEqual(scroll.scrollTop, wherePageLeftThem,
+    'a reader standing where the page had left them was moved by a follow they had cancelled');
+});
+
+test('the fonts settling does not undo a reader who has already scrolled away', async () => {
+  // Three findings from one vendor said the same thing: the opening follow is cancellable, and the
+  // fonts-settled correction was not — it made a FRESH token, so a cancelled open came back to life
+  // whenever the fonts happened to settle. A reader who opened a tab and started reading upward was
+  // dragged to the bottom by a font.
+  const page = runChatPage({ messages: [{ role: 'model', text: 'something long' }] });
+  const scroll = page.seen['scroll'];
+  assert.ok(scroll, 'the page has no scrolling region');
+  scroll.clientHeight = 500;
+  scroll.scrollHeight = 3000;
+
+  scroll.scrollTop = 200;
+  page.fire('scroll', 'scroll');
+  await page.fontsSettle();
+  page.frames();
+
+  assert.strictEqual(scroll.scrollTop, 200, 'the fonts settling yanked a reader who had scrolled up');
+});
+
+test('a state that omits the capped notice clears it, as it always did', () => {
+  // A regression this branch introduced and the gate caught: requiring a string before writing meant
+  // an omitted field left the old notice on screen. The protocol has always treated "not mentioned"
+  // as "gone" for these two regions, and a stale cap notice is one a person acts on.
+  const page = runChatPage();
+
+  page.deliver({ type: 'state', cappedHtml: '<div class="capped">no more turns</div>', failureHtml: '<p>it broke</p>' });
+  assert.match(page.seen['capped'].innerHTML, /no more turns/, 'the capped notice was never shown');
+  assert.match(page.seen['failure'].innerHTML, /it broke/, 'the failure was never shown');
+
+  page.deliver({ type: 'state', running: false, capped: false });
+
+  assert.strictEqual(page.seen['capped'].innerHTML, '', 'an omitted capped notice stayed on screen');
+  assert.strictEqual(page.seen['failure'].innerHTML, '', 'an omitted failure stayed on screen');
 });

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -243,9 +243,13 @@ test('the text size the person chose is inside the body rule, so it applies befo
  *
  * <p>Every test above reads the page as a string, which is the right shape for markup and escaping
  * and the wrong one for a lock, a focus or a scroll — those are behaviour, and a string match on
- * behaviour asserts that a line was written rather than that it works. Nothing in this repository
- * executed the chat page's script before this: `bundledPage.test.ts` runs the ROUNDS LOG page (it
- * asserts on `seen['rows']`) and only reads the chat page's bundle text.</p>
+ * behaviour asserts that a line was written rather than that it works.</p>
+ *
+ * <p>`bundledPage.test.ts` already RUNS the shipped script — bundled and minified, which is the only
+ * place a minifier-renamed binding shows up — but against a stub that answers every id and records
+ * nothing. This harness is the other half: the script from source, elements only where the page
+ * renders one, listeners captured by name, and host messages delivered through the same `window`
+ * listener the webview uses. Neither replaces the other and both are cheap.</p>
  *
  * <p>Modelled on `runPage()` in `theLogLosesItsFirstPush.test.ts`. The fakes record what the page
  * did — listeners by event name, focus calls, the three scroll numbers — and `deliver` pushes a
@@ -270,10 +274,15 @@ interface Fake {
   querySelectorAll(): never[];
 }
 
+/** A style bag the page writes into. Its own function so no fixture needs an `as` cast. */
+function emptyStyle(): Record<string, string> {
+  return {};
+}
+
 function fake(): Fake {
   return {
     innerHTML: '', textContent: '', hidden: false, value: '', disabled: false, focused: 0,
-    scrollTop: 0, clientHeight: 0, scrollHeight: 0, style: {}, listeners: {},
+    scrollTop: 0, clientHeight: 0, scrollHeight: 0, style: emptyStyle(), listeners: {},
     addEventListener(type, fn) { (this.listeners[type] ??= []).push(fn); },
     focus() { this.focused += 1; },
     getAttribute: () => null,
@@ -297,11 +306,31 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
   const posted: Array<Record<string, unknown>> = [];
   const pending: Array<() => void> = [];
   const onWindow: Record<string, Array<(event: unknown) => void>> = {};
+  // Only the ids the page actually RENDERS answer, and each starts in the state the markup gives it.
+  // A registry that fabricates an element for any id asked of it lets a test pass against a page
+  // that has nothing to click — the listener is attached to a fake, the behaviour is asserted on a
+  // fake, and the shipped webview is inert. (The gate raised this looking ahead to story 3's jump
+  // control.) The `disabled` attribute is read across for the same reason: a page rendered locked
+  // whose fakes start unlocked is a page the tests cannot see the lock on.
+  const rendered = new Map(
+    [...html.matchAll(/<[a-z]+[^>]*\bid="([^"]+)"[^>]*>/g)].map((match) => [match[1], match[0]]),
+  );
   const document_ = {
-    getElementById: (id: string) => (seen[id] ??= fake()),
+    getElementById: (id: string) => {
+      const tag = rendered.get(id);
+      if (tag === undefined) {
+        return null;
+      }
+      if (seen[id] === undefined) {
+        seen[id] = fake();
+        seen[id].disabled = / disabled(?=[ >])/.test(tag);
+      }
+
+      return seen[id];
+    },
     querySelectorAll: () => [],
     addEventListener() { /* the page listens on window */ },
-    body: { style: {} as Record<string, string> },
+    body: { style: emptyStyle() },
   };
   const window_ = {
     addEventListener(type: string, fn: (event: unknown) => void) { (onWindow[type] ??= []).push(fn); },
@@ -318,6 +347,7 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
     seen,
     posted,
     fire(id, type, event = {}) {
+      assert.ok(seen[id], `the page never asked for #${id}, so nothing is listening on it`);
       for (const fn of seen[id]?.listeners[type] ?? []) {
         fn({ preventDefault() { /* the page calls this on Enter */ }, ...event });
       }
@@ -399,28 +429,65 @@ test('the Send button and Enter share one send, wired inside the nonced script',
   // dead. Every listener is attached in the nonced script.
   assert.doesNotMatch(body, / on[a-z]+="/, 'a control carries an inline handler the CSP will block');
 
+  // Both paths reach that one send — with the turn between them finished, because a send now locks
+  // the composer until the host says the turn is over. Firing them back to back would be asserting
+  // the defect the gate found rather than the two callers.
   const page = runChatPage();
   page.seen['say'].value = 'what does this do';
   page.fire('send', 'click');
+  page.deliver({ type: 'state', running: false, capped: false });
   page.seen['say'].value = 'and this';
   page.fire('say', 'keydown', { key: 'Enter', shiftKey: false });
 
-  const sends = page.posted.filter((m) => m['command'] === 'send');
+  const sends = page.posted.filter((message) => message['command'] === 'send');
   assert.strictEqual(sends.length, 2, 'the button and Enter did not both send');
-  assert.deepStrictEqual(sends.map((m) => m['text']), ['what does this do', 'and this']);
+  assert.deepStrictEqual(sends.map((message) => message['text']), ['what does this do', 'and this']);
 });
 
-test('a send hands focus back to the textarea, and a locked composer posts nothing', () => {
-  // Clicking a button moves focus to the button. Without this, every follow-up costs a mouse click
-  // back into the box — the same reason the lock already returns focus when a turn ends.
+test('a send locks the composer at once, before the host has said anything', () => {
+  // The gap the gate found, raised by two vendors independently: between posting and the host's
+  // `running: true` the composer stayed open, so a second Enter — or a click, now that there is a
+  // button — put a second turn down a pipe that carries one. Nothing on the host end had gone wrong
+  // yet; the page simply had not been told, and it did not need telling.
+  const page = runChatPage();
+  page.seen['say'].value = 'the first question';
+  page.fire('send', 'click');
+
+  assert.strictEqual(page.seen['say'].disabled, true, 'the box stayed open between the send and the answer');
+  assert.strictEqual(page.seen['send'].disabled, true, 'the Send button stayed open between the send and the answer');
+
+  page.seen['say'].value = 'and immediately a second';
+  page.fire('send', 'click');
+  page.fire('say', 'keydown', { key: 'Enter', shiftKey: false });
+  assert.strictEqual(
+    page.posted.filter((message) => message['command'] === 'send').length,
+    1,
+    'a second turn went down the pipe while the first was still in flight',
+  );
+});
+
+test('the composer comes back with the focus when the turn ends', () => {
+  // send() deliberately does NOT focus: it locks, and focusing a control you have just disabled is
+  // how a caret ends up in a box nobody can type in. The page already returned focus when a lock
+  // lifts, and that is now the single path — one place decides, whichever way the turn went.
   const page = runChatPage();
   page.seen['say'].value = 'ask';
   page.fire('send', 'click');
-  assert.ok(page.seen['say'].focused > 0, 'the Send button kept the focus it stole');
+  const stolen = page.seen['say'].focused;
 
+  page.deliver({ type: 'state', running: false, capped: false });
+
+  assert.ok(page.seen['say'].focused > stolen, 'the box did not get the focus back when the turn ended');
+  assert.strictEqual(page.seen['say'].disabled, false, 'the finished turn left the box locked');
+});
+
+test('a locked composer posts nothing, however it is asked', () => {
+  const page = runChatPage({ running: true });
   page.seen['say'].value = 'while a turn runs';
-  page.seen['say'].disabled = true;
-  const before = page.posted.length;
+
   page.fire('send', 'click');
-  assert.strictEqual(page.posted.length, before, 'a locked composer sent a second turn down the pipe');
+  page.fire('say', 'keydown', { key: 'Enter', shiftKey: false });
+
+  assert.strictEqual(page.posted.filter((message) => message['command'] === 'send').length, 0,
+    'a locked composer sent a turn');
 });

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { ChatModelChoice, ChatPageState, chatCappedHtml, chatMessagesHtml, chatPageHtml, chatPickerHtml, chatStatusHtml } from '../chatPage';
+import { ChatModelChoice, ChatPageState, FOLLOW_SLACK_PX, chatCappedHtml, chatMessagesHtml, chatPageHtml, chatPickerHtml, chatStatusHtml, shouldFollow } from '../chatPage';
 
 /**
  * The page, as a string.
@@ -257,6 +257,8 @@ test('the text size the person chose is inside the body rule, so it applies befo
  */
 interface Fake {
   innerHTML: string;
+  /** Called when the page writes innerHTML — an insertion, which is what makes the region taller. */
+  onWrite?: (value: string) => void;
   textContent: string;
   hidden: boolean;
   value: string;
@@ -280,8 +282,15 @@ function emptyStyle(): Record<string, string> {
 }
 
 function fake(): Fake {
+  let written = '';
+
   return {
-    innerHTML: '', textContent: '', hidden: false, value: '', disabled: false, focused: 0,
+    get innerHTML() { return written; },
+    set innerHTML(value: string) {
+      written = value;
+      this.onWrite?.(value);
+    },
+    textContent: '', hidden: false, value: '', disabled: false, focused: 0,
     scrollTop: 0, clientHeight: 0, scrollHeight: 0, style: emptyStyle(), listeners: {},
     addEventListener(type, fn) { (this.listeners[type] ??= []).push(fn); },
     focus() { this.focused += 1; },
@@ -297,6 +306,23 @@ interface RunningPage {
   fire(id: string, type: string, event?: Record<string, unknown>): void;
   deliver(message: Record<string, unknown>): void;
   frames(): void;
+  /** Put the reader at the bottom of a page tall enough to have one, and make writes grow it. */
+  scrolledToBottom(): Fake;
+  /** Put the reader a screen above the bottom, same page. */
+  scrolledUp(): Fake;
+}
+
+/**
+ * An element whose content growing makes the SCROLLING REGION taller, which is what an arriving
+ * answer does. Without this the before/after ordering the gate flagged as blocking is invisible: a
+ * test whose scrollHeight never moves passes whichever side of the write the snapshot is taken.
+ */
+function growsTheRegion(region: Fake, by: number): (value: string) => void {
+  return (value: string) => {
+    if (value.length > 0) {
+      region.scrollHeight += by;
+    }
+  };
 }
 
 function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
@@ -343,9 +369,42 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
     (fn: () => void) => { pending.push(fn); },
   );
 
+  const region = () => {
+    // The page's own opening scroll has already happened by the time a reader scrolls anywhere, so
+    // run it out first. Leaving it queued would mean a test that positions a reader and then lets a
+    // frame run is watching the page OPEN, not the page follow.
+    for (const fn of pending.splice(0)) {
+      fn();
+    }
+    const scroll = document_.getElementById('scroll');
+    assert.ok(scroll, 'the page has no scrolling region');
+    scroll.clientHeight = 500;
+    scroll.scrollHeight = 2000;
+    for (const id of ['messages', 'thinking', 'capped', 'failure']) {
+      const written = document_.getElementById(id);
+      if (written) {
+        written.onWrite = growsTheRegion(scroll, 400);
+      }
+    }
+
+    return scroll;
+  };
+
   return {
     seen,
     posted,
+    scrolledToBottom() {
+      const scroll = region();
+      scroll.scrollTop = 1500;
+
+      return scroll;
+    },
+    scrolledUp() {
+      const scroll = region();
+      scroll.scrollTop = 200;
+
+      return scroll;
+    },
     fire(id, type, event = {}) {
       assert.ok(seen[id], `the page never asked for #${id}, so nothing is listening on it`);
       for (const fn of seen[id]?.listeners[type] ?? []) {
@@ -490,4 +549,107 @@ test('a locked composer posts nothing, however it is asked', () => {
 
   assert.strictEqual(page.posted.filter((message) => message['command'] === 'send').length, 0,
     'a locked composer sent a turn');
+});
+
+
+/* ------------------------------------------------------------------------------------------------
+ * Story 2: the decided scroll rule. Entry 23 of the operator's bug list, settled on 2026-09-09 and
+ * implemented ONCE here, because three separate fixes each deciding it their own way is how a page
+ * ends up behaving differently depending on which of them you provoked.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('shouldFollow: at the bottom follows, within the slack follows, a screen up does not', () => {
+  // The boundary is a number, not "a line or two" — the gate asked for exactly that. 48px is about
+  // two lines at the base size and three at the largest zoom step, and it is a constant rather than
+  // something derived from the font, because a reader one pixel short of the bottom considers
+  // themselves at the bottom whatever size they read at.
+  assert.strictEqual(FOLLOW_SLACK_PX, 48);
+
+  const at = (top: number) => shouldFollow(top, 500, 1000, FOLLOW_SLACK_PX);
+  assert.strictEqual(at(500), true, 'the reader was exactly at the bottom');
+  assert.strictEqual(at(452), true, 'the reader was inside the slack');
+  assert.strictEqual(at(451), false, 'one pixel past the slack still followed');
+  assert.strictEqual(at(0), false, 'a reader a screen up was yanked to the bottom');
+
+  // Overscroll, and a page with nothing to scroll, are both "at the bottom".
+  assert.strictEqual(shouldFollow(600, 500, 1000, 48), true, 'overscroll did not count as the bottom');
+  assert.strictEqual(shouldFollow(0, 500, 300, 48), true, 'a page shorter than its viewport did not follow');
+
+  // A page that cannot measure itself is a page whose reader has not scrolled: follow.
+  assert.strictEqual(shouldFollow(Number.NaN, 500, 1000, 48), true, 'an unmeasurable page refused to follow');
+});
+
+test('the page runs the shouldFollow the tests ran, and the slack they share', () => {
+  // The rounds log learned this twice: a function referenced only from a template string is a
+  // function the minifier renames out from under the page. Embedding the source is what makes the
+  // tested function and the shipped function the same one.
+  const script = chatPageHtml(state(), 'n0nce').split('<script nonce="n0nce">')[1];
+
+  assert.ok(script.includes(shouldFollow.toString()), 'the page does not run the tested shouldFollow');
+  assert.ok(script.includes(String(FOLLOW_SLACK_PX)), 'the page does not use the tested slack');
+});
+
+test('the at-bottom decision is taken before anything is inserted, on every path', () => {
+  // The blocking finding: scrollHeight read AFTER a write is the height including the write, so a
+  // reader who was at the bottom reads as "not at the bottom" and is never followed — rule 2 turns
+  // silently into "never follow". Each region is pushed on its own, because each is an insertion.
+  for (const push of ['messagesHtml', 'thinkingHtml', 'cappedHtml', 'failureHtml']) {
+    const page = runChatPage();
+    const scroll = page.scrolledToBottom();
+
+    page.deliver({ type: 'state', [push]: '<p>an answer</p>' });
+    page.frames();
+
+    assert.strictEqual(scroll.scrollTop, scroll.scrollHeight,
+      `a reader at the bottom was not followed when ${push} arrived`);
+  }
+});
+
+test('a reader who scrolled up is left where they were, on every path', () => {
+  for (const push of ['messagesHtml', 'thinkingHtml', 'cappedHtml', 'failureHtml']) {
+    const page = runChatPage();
+    const scroll = page.scrolledUp();
+
+    page.deliver({ type: 'state', [push]: '<p>an answer</p>' });
+    page.frames();
+
+    assert.strictEqual(scroll.scrollTop, 200, `a reader was yanked to the bottom when ${push} arrived`);
+  }
+});
+
+test('the follow happens after layout, not in the tick that inserted the content', () => {
+  // Setting scrollTop in the same tick as the write scrolls to a height the browser has not laid
+  // out yet, which lands short. The scroll is handed to the next frame.
+  const page = runChatPage();
+  const scroll = page.scrolledToBottom();
+
+  page.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+  assert.strictEqual(scroll.scrollTop, 1500, 'the page scrolled inside the tick that inserted');
+
+  page.frames();
+  assert.strictEqual(scroll.scrollTop, scroll.scrollHeight, 'the page never scrolled after layout');
+});
+
+test('a state that inserts nothing does not scroll a reader anywhere', () => {
+  const page = runChatPage();
+  const scroll = page.scrolledUp();
+
+  page.deliver({ type: 'state', running: true, capped: false });
+  page.frames();
+
+  assert.strictEqual(scroll.scrollTop, 200, 'a state with no insertion moved the page');
+});
+
+test('on open the page lands on the last message, and again once the fonts have settled', () => {
+  // Rule 1, and the second blocking finding: scrolling at script time lands mid-page, because the
+  // heights are not final until the fonts are. Immediately, then after layout, then after the fonts
+  // — idempotent, so three calls cost nothing and the first paint is already close.
+  const page = runChatPage({ messages: [{ role: 'model', text: 'the last thing said' }] });
+  const scroll = page.seen['scroll'];
+  assert.ok(scroll, 'the page has no scrolling region');
+
+  // The page scrolled once at script time, before any of this test ran.
+  scroll.scrollHeight = 3000;
+  page.frames();
+  assert.strictEqual(scroll.scrollTop, 3000, 'the page did not land on the last message after layout');
 });

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -653,3 +653,75 @@ test('on open the page lands on the last message, and again once the fonts have 
   page.frames();
   assert.strictEqual(scroll.scrollTop, 3000, 'the page did not land on the last message after layout');
 });
+
+
+test('a reader who scrolls away before the frame runs is not yanked back', () => {
+  // The gate's best finding on this story, raised from two vendors: the follow is DEFERRED to the
+  // next frame, and a reader can move in between — by dragging, by a wheel, by Page Up. The scroll
+  // that was correct when it was scheduled is a hijack by the time it runs. Re-measuring in the
+  // callback cannot answer it, because the insertion has already made a bottom reader measure short;
+  // what is needed is knowing whether the READER moved, which only they can tell us.
+  const page = runChatPage();
+  const scroll = page.scrolledToBottom();
+
+  page.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+  scroll.scrollTop = 100;
+  page.fire('scroll', 'scroll');
+  page.frames();
+
+  assert.strictEqual(scroll.scrollTop, 100, 'the pending follow overrode a reader who had scrolled away');
+});
+
+test('the page scrolling itself does not count as the reader scrolling', () => {
+  // Setting scrollTop fires a scroll event. If that cancelled the next follow, the page would
+  // follow one answer and then never again — the rule would work once per tab.
+  const page = runChatPage();
+  const scroll = page.scrolledToBottom();
+
+  page.deliver({ type: 'state', messagesHtml: '<p>first</p>' });
+  page.frames();
+  assert.strictEqual(scroll.scrollTop, scroll.scrollHeight, 'the first answer was not followed');
+
+  scroll.scrollTop = scroll.scrollHeight - 10;
+  page.deliver({ type: 'state', messagesHtml: '<p>second</p>' });
+  page.frames();
+  assert.strictEqual(scroll.scrollTop, scroll.scrollHeight, 'a follow after the page moved itself was cancelled');
+});
+
+test('the slack the page follows by is the one that was tested, at the boundary', () => {
+  // A pure-function test passes while the call site hands the page a different number, or none. This
+  // drives the real script at exactly the boundary, both sides of it, through a real push.
+  for (const [remaining, followed] of [[FOLLOW_SLACK_PX, true], [FOLLOW_SLACK_PX + 1, false]] as const) {
+    const page = runChatPage();
+    const scroll = page.scrolledToBottom();
+    scroll.scrollTop = scroll.scrollHeight - scroll.clientHeight - remaining;
+    const before = scroll.scrollTop;
+
+    page.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+    page.frames();
+
+    assert.strictEqual(scroll.scrollTop === scroll.scrollHeight, followed,
+      `with ${remaining}px remaining the page ${followed ? 'did not follow' : 'followed'}`);
+    if (!followed) {
+      assert.strictEqual(scroll.scrollTop, before, 'a reader past the slack was moved anyway');
+    }
+  }
+});
+
+test('a push that changes nothing scrolls nobody, however many times it arrives', () => {
+  // A retry, or a poll that pushes the same state again, is not an insertion. Counting the
+  // ASSIGNMENT rather than the change would scroll a reader for content they are already looking at.
+  const page = runChatPage();
+  const scroll = page.scrolledToBottom();
+
+  page.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+  page.frames();
+  const after = scroll.scrollTop;
+
+  scroll.scrollTop = after - 300;
+  page.fire('scroll', 'scroll');
+  page.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+  page.frames();
+
+  assert.strictEqual(scroll.scrollTop, after - 300, 'an identical push moved the reader');
+});

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -173,3 +173,254 @@ test('a turn waiting behind other people says so, and one being answered does no
   // Nothing at all when no turn is in flight — the region is emptied, not left saying "Thinking…".
   assert.strictEqual(chatStatusHtml(false, 4), '');
 });
+
+/**
+ * The stylesheet is PARSED, not just concatenated.
+ *
+ * <p>Found while building the pinned composer: the page's styles opened with a bare
+ * `font-size: 13px;` — the zoom — outside any rule, and CSS has no such thing at the top level. A
+ * parser consuming a qualified rule appends every token to the prelude until it meets `{`, and `;`
+ * does not end one, so the prelude became `font-size: 13px; body` — an invalid selector, and the
+ * whole `body` rule with it. Confirmed against a real parser (esbuild reads exactly that as the
+ * selector), which is why this is a structural test rather than a string match: a selector cannot
+ * contain a semicolon, on this page or any rule added to it later.</p>
+ */
+interface Rule {
+  readonly selector: string;
+  readonly body: string;
+}
+
+/**
+ * The stylesheet as rules — comments stripped FIRST, because that is the order a parser works in
+ * and a comment may contain anything, this file's own explanations included. Flat rules only, which
+ * is all these pages have; an at-rule with a nested block would need a real parser and this would
+ * have to be told so rather than quietly mis-reading it.
+ */
+function rules(css: string): Rule[] {
+  assert.ok(!css.includes('@media') && !css.includes('@supports'), 'this reader cannot see inside a nested at-rule');
+
+  return css
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('}')
+    .flatMap((chunk) => {
+      const [selector, body] = chunk.split('{');
+      return body === undefined ? [] : [{ selector: selector.trim(), body: body.trim() }];
+    });
+}
+
+function ruleFor(css: string, selector: string): string {
+  const found = rules(css).find((rule) => rule.selector === selector);
+  assert.ok(found, `there is no rule for ${selector}`);
+
+  return found.body;
+}
+
+test('no rule in the page styles is swallowed by a declaration outside a rule', () => {
+  const html = chatPageHtml(state(), 'n0nce');
+  const css = html.split('<style>')[1].split('</style>')[0];
+
+  for (const rule of rules(css)) {
+    assert.ok(
+      !rule.selector.includes(';'),
+      `a selector cannot contain ";" — this prelude swallowed the rule after it: ${JSON.stringify(rule.selector)}`,
+    );
+  }
+});
+
+test('the text size the person chose is inside the body rule, so it applies before anything is pushed', () => {
+  // scalePx(2) is 13 × 1.1² = 15.73. It must land in the body block itself: the zoom's live push
+  // sets body.style.fontSize, so a size that only arrives with a push is a page that opens at the
+  // wrong size and corrects itself when something unrelated happens.
+  const css = chatPageHtml(state({ uiScale: 2 }), 'n0nce').split('<style>')[1].split('</style>')[0];
+  const bodyRule = ruleFor(css, 'body');
+
+  assert.ok(bodyRule.includes('15.73px'), `the chosen text size is not in the body rule: ${bodyRule}`);
+});
+
+
+/**
+ * The page's script, RUN.
+ *
+ * <p>Every test above reads the page as a string, which is the right shape for markup and escaping
+ * and the wrong one for a lock, a focus or a scroll — those are behaviour, and a string match on
+ * behaviour asserts that a line was written rather than that it works. Nothing in this repository
+ * executed the chat page's script before this: `bundledPage.test.ts` runs the ROUNDS LOG page (it
+ * asserts on `seen['rows']`) and only reads the chat page's bundle text.</p>
+ *
+ * <p>Modelled on `runPage()` in `theLogLosesItsFirstPush.test.ts`. The fakes record what the page
+ * did — listeners by event name, focus calls, the three scroll numbers — and `deliver` pushes a
+ * host message through the same `window` listener the webview would.</p>
+ */
+interface Fake {
+  innerHTML: string;
+  textContent: string;
+  hidden: boolean;
+  value: string;
+  disabled: boolean;
+  focused: number;
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+  style: Record<string, string>;
+  listeners: Record<string, Array<(event: unknown) => void>>;
+  addEventListener(type: string, fn: (event: unknown) => void): void;
+  focus(): void;
+  getAttribute(): null;
+  setAttribute(): void;
+  querySelectorAll(): never[];
+}
+
+function fake(): Fake {
+  return {
+    innerHTML: '', textContent: '', hidden: false, value: '', disabled: false, focused: 0,
+    scrollTop: 0, clientHeight: 0, scrollHeight: 0, style: {}, listeners: {},
+    addEventListener(type, fn) { (this.listeners[type] ??= []).push(fn); },
+    focus() { this.focused += 1; },
+    getAttribute: () => null,
+    setAttribute() { /* the page sets none */ },
+    querySelectorAll: () => [],
+  };
+}
+
+interface RunningPage {
+  seen: Record<string, Fake>;
+  posted: Array<Record<string, unknown>>;
+  fire(id: string, type: string, event?: Record<string, unknown>): void;
+  deliver(message: Record<string, unknown>): void;
+  frames(): void;
+}
+
+function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
+  const html = chatPageHtml(state(over), 'n0nce');
+  const body = html.split('<script nonce="n0nce">')[1].split('</script>')[0];
+  const seen: Record<string, Fake> = {};
+  const posted: Array<Record<string, unknown>> = [];
+  const pending: Array<() => void> = [];
+  const onWindow: Record<string, Array<(event: unknown) => void>> = {};
+  const document_ = {
+    getElementById: (id: string) => (seen[id] ??= fake()),
+    querySelectorAll: () => [],
+    addEventListener() { /* the page listens on window */ },
+    body: { style: {} as Record<string, string> },
+  };
+  const window_ = {
+    addEventListener(type: string, fn: (event: unknown) => void) { (onWindow[type] ??= []).push(fn); },
+  };
+
+  new Function('document', 'window', 'acquireVsCodeApi', 'requestAnimationFrame', body)(
+    document_,
+    window_,
+    () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message) }),
+    (fn: () => void) => { pending.push(fn); },
+  );
+
+  return {
+    seen,
+    posted,
+    fire(id, type, event = {}) {
+      for (const fn of seen[id]?.listeners[type] ?? []) {
+        fn({ preventDefault() { /* the page calls this on Enter */ }, ...event });
+      }
+    },
+    deliver(message) {
+      for (const fn of onWindow['message'] ?? []) {
+        fn({ data: message });
+      }
+    },
+    frames() {
+      for (const fn of pending.splice(0)) {
+        fn();
+      }
+    },
+  };
+}
+
+test('the composer, the Send button, the picker and the hint sit in a pinned footer', () => {
+  const html = chatPageHtml(state(), 'n0nce');
+  const footer = html.slice(html.indexOf('<footer'), html.indexOf('</footer>'));
+  const region = html.slice(html.indexOf('<main'), html.indexOf('</main>'));
+
+  assert.ok(html.indexOf('<footer') > html.indexOf('id="messages"'), 'the footer is not after the conversation');
+  for (const inFooter of ['id="pickerBox"', 'id="say"', 'id="send"', 'class="hint"']) {
+    assert.ok(footer.includes(inFooter), `${inFooter} is not in the pinned footer`);
+  }
+  for (const inRegion of ['id="passage"', 'id="messages"', 'id="thinking"', 'id="capped"']) {
+    assert.ok(region.includes(inRegion), `${inRegion} is not in the scrolling region`);
+  }
+});
+
+test('the page has one scrolling region: the body cannot scroll and the region can', () => {
+  // The `min-height: 0` is the whole of it. Without it a flex child refuses to shrink below its
+  // content, the region never scrolls, the body does instead — and the composer leaves the screen,
+  // which is the symptom this plan exists for. (The gate raised it; it cannot be unit-tested any
+  // other way than by reading the rule, because there is no layout engine here.)
+  const css = chatPageHtml(state(), 'n0nce').split('<style>')[1].split('</style>')[0];
+
+  assert.match(ruleFor(css, 'body'), /overflow: hidden/, 'the body can still scroll');
+  assert.match(ruleFor(css, 'body'), /flex-direction: column/, 'the body is not a flex column');
+  assert.match(ruleFor(css, '#scroll'), /min-height: 0/, 'the scrolling region will refuse to shrink');
+  assert.match(ruleFor(css, '#scroll'), /overflow-y: auto/, 'the scrolling region does not scroll');
+});
+
+test('the passage has no inner scroll and is still visibly the text being discussed', () => {
+  const passage = ruleFor(chatPageHtml(state(), 'n0nce').split('<style>')[1].split('</style>')[0], '.passage');
+
+  assert.ok(!passage.includes('max-height'), 'the passage is still capped, so it has its own scrollbar');
+  assert.ok(!passage.includes('overflow-y'), 'the passage still scrolls inside itself');
+  assert.match(passage, /border-left/, 'the passage stopped looking like the text being discussed');
+});
+
+test('the Send button is locked exactly when the textarea is', () => {
+  for (const [over, locked] of [[{ running: true }, true], [{ capped: true }, true], [{}, false]] as const) {
+    const html = chatPageHtml(state(over), 'n0nce');
+    const button = html.slice(html.indexOf('id="send"'), html.indexOf('>', html.indexOf('id="send"')));
+    const box = html.slice(html.indexOf('id="say"'), html.indexOf('>', html.indexOf('id="say"')));
+
+    assert.strictEqual(button.includes('disabled'), locked, `the Send button's lock disagrees with ${JSON.stringify(over)}`);
+    assert.strictEqual(box.includes('disabled'), locked, `the textarea's lock disagrees with ${JSON.stringify(over)}`);
+  }
+
+  // And it keeps agreeing when the host pushes a state, which is where the two could drift apart.
+  const page = runChatPage();
+  page.deliver({ type: 'state', running: true, capped: false });
+  assert.strictEqual(page.seen['send']?.disabled, true, 'a running turn left the Send button open');
+  page.deliver({ type: 'state', running: false, capped: false });
+  assert.strictEqual(page.seen['send']?.disabled, false, 'the finished turn left the Send button locked');
+});
+
+test('the Send button and Enter share one send, wired inside the nonced script', () => {
+  const html = chatPageHtml(state(), 'n0nce');
+  const script = html.split('<script nonce="n0nce">')[1].split('</script>')[0];
+  const body = html.slice(html.indexOf('<body>'), html.indexOf('<script'));
+
+  assert.strictEqual(script.split('function send()').length - 1, 1, 'there is more than one way to send');
+  assert.match(html, /<button type="button" id="send"/, 'Send is not a plain button');
+  // CSP is `script-src 'nonce-…'`, so an inline handler would be blocked and the button would be
+  // dead. Every listener is attached in the nonced script.
+  assert.doesNotMatch(body, / on[a-z]+="/, 'a control carries an inline handler the CSP will block');
+
+  const page = runChatPage();
+  page.seen['say'].value = 'what does this do';
+  page.fire('send', 'click');
+  page.seen['say'].value = 'and this';
+  page.fire('say', 'keydown', { key: 'Enter', shiftKey: false });
+
+  const sends = page.posted.filter((m) => m['command'] === 'send');
+  assert.strictEqual(sends.length, 2, 'the button and Enter did not both send');
+  assert.deepStrictEqual(sends.map((m) => m['text']), ['what does this do', 'and this']);
+});
+
+test('a send hands focus back to the textarea, and a locked composer posts nothing', () => {
+  // Clicking a button moves focus to the button. Without this, every follow-up costs a mouse click
+  // back into the box — the same reason the lock already returns focus when a turn ends.
+  const page = runChatPage();
+  page.seen['say'].value = 'ask';
+  page.fire('send', 'click');
+  assert.ok(page.seen['say'].focused > 0, 'the Send button kept the focus it stole');
+
+  page.seen['say'].value = 'while a turn runs';
+  page.seen['say'].disabled = true;
+  const before = page.posted.length;
+  page.fire('send', 'click');
+  assert.strictEqual(page.posted.length, before, 'a locked composer sent a second turn down the pipe');
+});

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -355,7 +355,12 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
       }
       if (seen[id] === undefined) {
         seen[id] = fake();
+        // Boolean attributes are read ACROSS from the markup. A fake that starts open where the page
+        // renders it locked, or visible where the page renders it hidden, is a fake the tests cannot
+        // see the initial state on — and both of those were caught by tests that then passed for the
+        // wrong reason until this was here.
         seen[id].disabled = / disabled(?=[ >])/.test(tag);
+        seen[id].hidden = / hidden(?=[ >])/.test(tag);
       }
 
       return seen[id];
@@ -797,4 +802,91 @@ test('a state that omits the capped notice clears it, as it always did', () => {
 
   assert.strictEqual(page.seen['capped'].innerHTML, '', 'an omitted capped notice stayed on screen');
   assert.strictEqual(page.seen['failure'].innerHTML, '', 'an omitted failure stayed on screen');
+});
+
+
+/* ------------------------------------------------------------------------------------------------
+ * Story 3: rule 3 of the decided behaviour — a reader who was NOT followed is told that something
+ * arrived, and given one way back to it.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('the jump control is an overlay, so showing it moves no layout', () => {
+  // If it took room in the footer, showing it would shrink the scrolling region — which changes
+  // clientHeight, which is one of the three numbers the follow decision is made from. A control that
+  // appears BECAUSE a reader was not followed must not alter what "at the bottom" means.
+  const html = chatPageHtml(state(), 'n0nce');
+  const css = html.split('<style>')[1].split('</style>')[0];
+  const footer = html.slice(html.indexOf('<footer'), html.indexOf('</footer>'));
+
+  assert.ok(footer.includes('id="jump"'), 'the jump control is not in the footer');
+  assert.match(html, /<button type="button" id="jump"[^>]*hidden/, 'the jump control is not a hidden plain button');
+  assert.match(ruleFor(css, '.jump'), /position: absolute/, 'the jump control takes room in the layout');
+  assert.match(ruleFor(css, '#composer'), /position: relative/, 'the overlay has nothing to be positioned against');
+});
+
+test('an answer that lands out of view offers the way back to it; one that lands in view does not', () => {
+  const away = runChatPage();
+  away.scrolledUp();
+  away.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+  away.frames();
+  assert.strictEqual(away.seen['jump'].hidden, false, 'a reader who was not followed was never told an answer arrived');
+
+  const there = runChatPage();
+  there.scrolledToBottom();
+  there.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+  there.frames();
+  assert.strictEqual(there.seen['jump'].hidden, true, 'a reader who was followed was offered a jump to where they already are');
+});
+
+test('a push that inserts nothing offers no jump', () => {
+  const page = runChatPage();
+  page.scrolledUp();
+
+  page.deliver({ type: 'state', running: true, capped: false });
+  page.frames();
+
+  assert.strictEqual(page.seen['jump'].hidden, true, 'a state with no insertion offered a jump to nothing new');
+});
+
+test('pressing jump goes to the newest, retires itself, and hands the box back the focus', () => {
+  const page = runChatPage();
+  const scroll = page.scrolledUp();
+  page.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+  page.frames();
+  const focusedBefore = page.seen['say'].focused;
+
+  page.fire('jump', 'click');
+
+  assert.strictEqual(scroll.scrollTop, scroll.scrollHeight, 'the jump did not go to the newest message');
+  assert.strictEqual(page.seen['jump'].hidden, true, 'the jump control stayed up after doing its one job');
+  assert.ok(page.seen['say'].focused > focusedBefore, 'the jump left the focus on itself');
+});
+
+test('a reader who scrolls back down on their own retires the jump control', () => {
+  // Its lifecycle is not only "click me": a person who returns under their own steam has answered
+  // the question it was asking, and a control that stays up after that is one nobody trusts.
+  const page = runChatPage();
+  const scroll = page.scrolledUp();
+  page.deliver({ type: 'state', messagesHtml: '<p>an answer</p>' });
+  page.frames();
+  assert.strictEqual(page.seen['jump'].hidden, false, 'the jump control was never offered');
+
+  scroll.scrollTop = scroll.scrollHeight - scroll.clientHeight;
+  page.fire('scroll', 'scroll');
+
+  assert.strictEqual(page.seen['jump'].hidden, true, 'the jump control outlived the reader arriving');
+});
+
+test('a locked composer does not get the focus from a jump', () => {
+  // While a turn runs the box is disabled; focusing it would put the caret where nobody can type.
+  const page = runChatPage({ running: true });
+  const scroll = page.scrolledUp();
+  page.deliver({ type: 'state', messagesHtml: '<p>an answer</p>', running: true, capped: false });
+  page.frames();
+  const focusedBefore = page.seen['say'].focused;
+
+  page.fire('jump', 'click');
+
+  assert.strictEqual(scroll.scrollTop, scroll.scrollHeight, 'the jump did not scroll while a turn ran');
+  assert.strictEqual(page.seen['say'].focused, focusedBefore, 'the jump focused a box nobody can type in');
 });

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -312,6 +312,8 @@ interface RunningPage {
   scrolledUp(): Fake;
   /** Resolve `document.fonts.ready`. Await it: what it queued runs on the microtask queue. */
   fontsSettle(): Promise<void>;
+  /** The composer's height changed — what a growing or shrinking box does to the footer. */
+  composerResized(): void;
 }
 
 /**
@@ -373,13 +375,21 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
   const window_ = {
     addEventListener(type: string, fn: (event: unknown) => void) { (onWindow[type] ??= []).push(fn); },
   };
+  // Captured so a test can say "the composer changed height", which is the event story 4 reacts to.
+  let observed: (() => void) | undefined;
+  class FakeResizeObserver {
+    constructor(callback: () => void) { observed = callback; }
+    observe() { /* the page observes one element */ }
+    disconnect() { /* nothing to release in a fake */ }
+  }
 
 
-  new Function('document', 'window', 'acquireVsCodeApi', 'requestAnimationFrame', body)(
+  new Function('document', 'window', 'acquireVsCodeApi', 'requestAnimationFrame', 'ResizeObserver', body)(
     document_,
     window_,
     () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message) }),
     (fn: () => void) => { pending.push(fn); },
+    FakeResizeObserver,
   );
 
   const region = () => {
@@ -406,17 +416,26 @@ function runChatPage(over: Partial<ChatPageState> = {}): RunningPage {
   return {
     seen,
     posted,
+    // Both fire the scroll event a real reader's movement fires. A test that placed somebody
+    // silently would be testing a position nobody can reach: you get anywhere in a scrolling region
+    // BY scrolling, and the page is entitled to learn where they are the same way.
     scrolledToBottom() {
       const scroll = region();
       scroll.scrollTop = 1500;
+      this.fire('scroll', 'scroll');
 
       return scroll;
     },
     scrolledUp() {
       const scroll = region();
       scroll.scrollTop = 200;
+      this.fire('scroll', 'scroll');
 
       return scroll;
+    },
+    composerResized() {
+      assert.ok(observed, 'the page is not watching the composer for a height change');
+      observed();
     },
     fontsSettle() {
       settleFonts();
@@ -889,4 +908,87 @@ test('a locked composer does not get the focus from a jump', () => {
 
   assert.strictEqual(scroll.scrollTop, scroll.scrollHeight, 'the jump did not scroll while a turn ran');
   assert.strictEqual(page.seen['say'].focused, focusedBefore, 'the jump focused a box nobody can type in');
+});
+
+
+/* ------------------------------------------------------------------------------------------------
+ * Story 4: the composer grows with the question, up to 30 % of the viewport, and its height changing
+ * never moves a reader who did not scroll.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('the composer has a ceiling of thirty percent of the viewport, a floor, and scrolls inside past it', () => {
+  const css = chatPageHtml(state(), 'n0nce').split('<style>')[1].split('</style>')[0];
+  const box = ruleFor(css, 'textarea');
+
+  assert.match(box, /max-height: 30vh/, 'the composer has no ceiling');
+  assert.match(box, /min-height: 64px/, 'the composer lost its floor');
+  assert.match(box, /overflow-y: auto/, 'past the ceiling the text has nowhere to go');
+  assert.match(box, /field-sizing: content/, 'the composer does not size itself to its content');
+});
+
+test('a host without field-sizing gets the input handler, and the ceiling stays the one in the CSS', () => {
+  // The gate's blocking finding on the plan: `field-sizing` is Chromium-only and this extension
+  // declares support back to VS Code 1.85, whose engine has never heard of it. On such a host the
+  // box would silently never grow — it works on the machine it was written on, which is the whole
+  // shape of the defect. Node has no `CSS` at all, so the harness IS that host.
+  const page = runChatPage();
+  const box = page.seen['say'];
+
+  box.value = 'one\ntwo\nthree\nfour';
+  box.scrollHeight = 220;
+  page.fire('say', 'input');
+
+  assert.deepStrictEqual(box.style['height'], '220px', 'the fallback did not size the box to its content');
+  const script = chatPageHtml(state(), 'n0nce').split('<script nonce="n0nce">')[1];
+  assert.match(script, /CSS\.supports\('field-sizing', 'content'\)/, 'the page does not ask whether it needs the fallback');
+  assert.doesNotMatch(script, /innerHeight \* 0\.3|30 \/ 100/, 'the page computed a second ceiling of its own');
+});
+
+test('the composer shrinks back after a send and after the text is deleted', () => {
+  // A ceiling with no way down is a box that stays tall for the rest of the conversation.
+  const page = runChatPage();
+  const box = page.seen['say'];
+
+  box.value = 'one\ntwo\nthree';
+  box.scrollHeight = 180;
+  page.fire('say', 'input');
+  assert.strictEqual(box.style['height'], '180px');
+
+  box.scrollHeight = 64;
+  page.fire('send', 'click');
+  assert.strictEqual(box.style['height'], '64px', 'the box stayed tall after the question was sent');
+
+  box.value = 'one\ntwo';
+  box.scrollHeight = 120;
+  page.fire('say', 'input');
+  box.value = 'one';
+  box.scrollHeight = 64;
+  page.fire('say', 'input');
+  assert.strictEqual(box.style['height'], '64px', 'the box stayed tall after its text was deleted');
+});
+
+test('a composer that grows keeps a reader at the bottom at the bottom', () => {
+  // The other side of rule 2: a height change nobody asked for must not move the conversation out
+  // from under someone. Here the flag IS right where re-measuring is not, because the reader did not
+  // scroll — the region shrank underneath them.
+  const page = runChatPage();
+  const scroll = page.scrolledToBottom();
+  scroll.scrollTop = scroll.scrollHeight - scroll.clientHeight;
+
+  scroll.clientHeight -= 100;
+  page.composerResized();
+  page.frames();
+
+  assert.strictEqual(scroll.scrollTop, scroll.scrollHeight, 'a growing composer pushed the last answer out of view');
+});
+
+test('a composer that grows leaves a reader who scrolled up where they were', () => {
+  const page = runChatPage();
+  const scroll = page.scrolledUp();
+
+  scroll.clientHeight -= 100;
+  page.composerResized();
+  page.frames();
+
+  assert.strictEqual(scroll.scrollTop, 200, 'a growing composer moved a reader who was reading something else');
 });

--- a/todo/PLAN_an_answer_as_it_arrives.md
+++ b/todo/PLAN_an_answer_as_it_arrives.md
@@ -105,7 +105,7 @@ only when the whole ritual has run — not when the code works.
       plain text with no image, embed or async highlighter, so one deferred scroll per push lands on
       the final height. A streamed answer breaks that — the height keeps growing after the follow has
       run, leaving a reader who WAS at the bottom short of it. Each partial must go through the same
-      `scheduleFollow()` the pushes use (`chatPage.ts`), never a scrollTop of its own, and a test
+      `scheduleFollow()` the pushes use (`src_vs_code/src/chatPage.ts:304`), never a scrollTop of its own, and a test
       must prove a reader at the bottom is still at the bottom when the last token lands.
 - [ ] `npm test` green; the acceptance ritual complete; promoted on merge.
 

--- a/todo/PLAN_an_answer_as_it_arrives.md
+++ b/todo/PLAN_an_answer_as_it_arrives.md
@@ -100,6 +100,13 @@ only when the whole ritual has run — not when the code works.
 - [ ] Where streaming is possible, partial text appears as it arrives and the final answer replaces it rendered.
 - [ ] Where it is not, nothing changed and the help says so.
 - [ ] Stop works mid-stream; partials after a stop are ignored.
+- [ ] **The scroll rule survives progressive rendering.** Inherited from the composer plan's story-2
+      plan round (gemini, Major), where it was rejected as not-yet-reachable: today the page renders
+      plain text with no image, embed or async highlighter, so one deferred scroll per push lands on
+      the final height. A streamed answer breaks that — the height keeps growing after the follow has
+      run, leaving a reader who WAS at the bottom short of it. Each partial must go through the same
+      `scheduleFollow()` the pushes use (`chatPage.ts`), never a scrollTop of its own, and a test
+      must prove a reader at the bottom is still at the bottom when the last token lands.
 - [ ] `npm test` green; the acceptance ritual complete; promoted on merge.
 
 ## Parallelism

--- a/todo/PLAN_the_composer_stays_put.md
+++ b/todo/PLAN_the_composer_stays_put.md
@@ -89,16 +89,18 @@ failed turn renders under the same rule as an answer. One rule, not one per outc
 Four stories, in order, one commit and one `review_code` each. Every one leaves `npm test` green
 and the page usable on its own.
 
-**Two corrections to the split, made after checking:**
+**One correction to the split — and one correction to that correction, which was mine:**
 
-- Its claim that `bundledPage.test.ts` executes `chatScript` against a fake DOM is **wrong** — the
-  "parses and runs" test there is the ROUNDS LOG page (it asserts on `seen['rows']`); the chat
-  page's bundle test only reads the bundle's text. The `typeof` guards it asks for are still
-  right, for two real reasons instead of the stated one: the older-Chromium host is the whole
-  point of finding 1, and the test harness below runs the script in Node, where
-  `requestAnimationFrame`, `CSS` and `ResizeObserver` genuinely do not exist.
 - There is no `thinkingRegion` helper. `chatPanel.ts:208-214` builds every pushed region by
   calling the same exported functions, so no markup is sliced and no opening tag is load-bearing.
+- **The split's constraint about the fake DOM is CORRECT and my first reading of it was not.**
+  `bundledPage.test.ts:310` — *'the chat page script the bundle produces parses and runs'* — has
+  executed the bundled, minified chat script against a stub DOM since before this branch, and that
+  stub supplies exactly `document`, `window` and `acquireVsCodeApi`: no `requestAnimationFrame`, no
+  `CSS`, no `ResizeObserver`. I had grepped the test folder for `chatPageHtml` and that test reaches
+  the page through `bundledChatPage()` instead, so it did not appear and I wrote that nothing ran
+  the chat script. **Every `typeof` guard stories 2 and 4 add is therefore load-bearing twice over**
+  — the older-Chromium host of finding 1, and an existing test that fails on a bare reference.
 
 **Found while reading for story 1, and not in any list: the page's `body` rule never applied.**
 `chatStyle` opened with `${zoomStyle(uiScale)}` — a bare `font-size: 13px;` outside any rule, and

--- a/todo/PLAN_the_composer_stays_put.md
+++ b/todo/PLAN_the_composer_stays_put.md
@@ -78,6 +78,102 @@ failed turn renders under the same rule as an answer. One rule, not one per outc
 - Manual, recorded in the promotion: open a chat with a 60-line passage — the page lands on the
   last message; scroll up, ask; the answer does not yank; the jump control appears.
 
+## Stories — the split, and the gate's thirteen findings placed
+
+> Split on 2026-09-09 by Fable (the gate's own command routes the split decision to it), then
+> checked against the repository. **One swap from the build order above, and it is an improvement:
+> the scroll rule lands BEFORE the composer's growth.** A footer whose height changes needs the
+> at-bottom rule to already exist — findings 5 and 11 are about exactly that — and a pure function
+> that has not been written cannot be called.
+
+Four stories, in order, one commit and one `review_code` each. Every one leaves `npm test` green
+and the page usable on its own.
+
+**Two corrections to the split, made after checking:**
+
+- Its claim that `bundledPage.test.ts` executes `chatScript` against a fake DOM is **wrong** — the
+  "parses and runs" test there is the ROUNDS LOG page (it asserts on `seen['rows']`); the chat
+  page's bundle test only reads the bundle's text. The `typeof` guards it asks for are still
+  right, for two real reasons instead of the stated one: the older-Chromium host is the whole
+  point of finding 1, and the test harness below runs the script in Node, where
+  `requestAnimationFrame`, `CSS` and `ResizeObserver` genuinely do not exist.
+- There is no `thinkingRegion` helper. `chatPanel.ts:208-214` builds every pushed region by
+  calling the same exported functions, so no markup is sliced and no opening tag is load-bearing.
+
+**Found while reading for story 1, and not in any list: the page's `body` rule never applied.**
+`chatStyle` opened with `${zoomStyle(uiScale)}` — a bare `font-size: 13px;` outside any rule, and
+CSS has no such thing at the top level. A parser consuming a qualified rule appends tokens to the
+prelude until `{`, and `;` does not end one, so the selector became `font-size: 13px; body` and the
+whole rule was dropped: no `margin: 0`, no `padding`, no font-family, no background, and the chosen
+text size never applied until something unrelated pushed it. Confirmed against a real parser
+(esbuild reads exactly that as the selector). Fixed first, with two RED tests, because story 1's
+flex layout goes on `body` and would have been dropped with it.
+
+### Story 1 — one scrolling region, a pinned footer, a Send button
+
+`chatBody`: `<main id="scroll">` wraps header, passage, `#failure`, `#messages`, `#thinking`,
+`#capped`; `<footer id="composer">` after it holds `#pickerBox`, a `.compose` row of the textarea
+and `<button type="button" id="send">`, and the hint. `chatStyle`: `html, body { height: 100% }`;
+body becomes a flex column with `overflow: hidden` and no padding; `#scroll { flex: 1 1 auto;
+min-height: 0; overflow-y: auto }` — the `min-height: 0` IS finding 8, without it the child refuses
+to shrink and the page keeps two scroll surfaces; `#composer { flex: 0 0 auto }`. `.passage` loses
+`max-height`/`overflow-y` in this same commit. `chatScript`: `send()` hands focus back; a click
+listener on `#send` calls the one `send()`; the Send button's `disabled` is set from the textarea's
+in the same block — one lock, never two. The header comment at lines 19-24 is rewritten.
+
+**Findings: 8, 12, 13.** **Expensive if wrong: yes** — it is the skeleton four queued plans build
+on, the CSS cannot be unit-tested, and a missing `min-height: 0` reproduces the exact symptom while
+every test stays green.
+
+### Story 2 — the scroll rule
+
+New exports `FOLLOW_SLACK_PX = 48` and `shouldFollow(scrollTop, clientHeight, scrollHeight, slack)`
+— finding 4's concrete boundary: follow iff `scrollHeight - (scrollTop + clientHeight) <= slack`;
+48 follows, 49 does not; overscroll, nothing-to-scroll and a non-finite input all follow (a page
+that cannot measure is a page whose reader has not scrolled). Embedded into the script by
+`toString()` and bound by assignment — the `roundsLog.ts:850` idiom, because the minifier renames
+declarations. In the `state` handler the snapshot is the FIRST statement, before any `innerHTML`
+write, and the scroll is applied in `afterLayout` (`requestAnimationFrame`, `setTimeout` where it
+does not exist): findings 3 and 6, true by construction because every region arrives through that
+one handler. On open, `landOnNewest()` runs immediately, again after layout, and once more after
+`document.fonts.ready` where it exists — finding 10's lifecycle point.
+
+**Findings: 3, 4, 6, 10.** **Expensive if wrong: yes** — a wrong ordering silently turns rule 2
+into "never follow", and only the real webview shows it.
+
+### Story 3 — jump to newest
+
+`<button type="button" id="jump" hidden>` inside the footer, `position: absolute` out of flow so
+showing it changes neither the footer's height nor `#scroll`'s `clientHeight` — finding 2. Shown
+only when `!follow && wrote`; a click scrolls to the newest, hides itself and returns focus; a
+`scroll` listener retires it once `shouldFollow` reads true — finding 7's missing lifecycle.
+
+**Findings: 2, 7.** **Expensive if wrong: no** — a defect here is a missing or lingering button.
+
+### Story 4 — the composer grows, shrinks back, and moves nobody
+
+`textarea` gains `max-height: 30vh; field-sizing: content; overflow-y: auto`, keeping
+`min-height: 64px`; the 30 % lives in that one rule for both paths. Feature detection is finding 1:
+`CSS.supports('field-sizing', 'content')`, and where it is false an `input` handler sets
+`height = 'auto'` then `scrollHeight + 'px'`, with the CSS ceiling and inner scroll unchanged —
+called on input, after `send()` clears the box, and after a pushed draft, so shrink-back is a call
+rather than a hope (finding 9). A `ResizeObserver` on `#composer`, where it exists, re-pins a
+reader who WAS at the bottom when the footer's height changes — findings 11 and 5; the flag is what
+the reader was before the resize, which is the only measurement that survives it. Documentation,
+CHANGELOG and the recorded manual check close the branch here.
+
+**Findings: 1, 5, 9, 11.** **Expensive if wrong: yes** — the detection cannot be observed from a
+test on the host that matters, and the re-pinning interacts with story 2's ordering.
+
+### The test harness
+
+Stories 2-4 need the script RUN, not read. `runChatPage(state)` follows `runPage()` in
+`theLogLosesItsFirstPush.test.ts:179`: slice the script out of `chatPageHtml`, execute it with
+`new Function('document', 'window', 'acquireVsCodeApi', …)`, fake elements recording listeners,
+`focused`, `style`, `value`, `disabled`, `hidden` and the three scroll numbers; return
+`{ seen, posted, fire, deliver, fireFrames }`. It is the first test in this repository to execute
+the chat page's script at all.
+
 ## Acceptance — one PR per plan, and the gate on both sides of it
 
 This plan ships as **its own branch (`fix/the-composer-stays-put`) and its own pull request**, and the PR is accepted


### PR DESCRIPTION
`todo/PLAN_the_composer_stays_put.md`, all four stories. Four symptoms the operator reported on 2026-09-09 (entries 3, 9, 11 and the decision in 23 of `todo/BUGS_2026-09-09.md`) turn out to be one layout, so they are fixed as one — and the scroll rule they all move is implemented **once**, because three fixes each deciding it their own way is how a page ends up behaving differently depending on which one you provoked.

## What a person will notice

- The composer, the picker and the hint are **pinned** to the bottom; the conversation scrolls above them; there is a **Send** button.
- The captured passage **no longer has a scrollbar of its own** — there were two on the page.
- The box **grows with your question** to about a third of the tab, then scrolls inside itself, and shrinks back.
- The tab **opens on the last message**; a new answer scrolls to itself **only if you were already at the bottom**; otherwise a **Jump to newest** control appears and retires itself when you arrive.

## Three defects found while building it, none of them reported

1. **The page's `body` rule had never applied.** The stylesheet opened with the zoom as a bare `font-size: 13px;` outside any rule, and CSS has no such thing at the top level — a parser appends tokens to a prelude until `{`, and `;` does not end one, so the selector became `font-size: 13px; body` and the whole rule was dropped. No margin, no padding, no font, no background, and the chosen text size never applied until something unrelated pushed it. Confirmed against a real parser.
2. **Between posting a turn and the host's answer, nothing locked the composer.** The window is one Enter wide, and a second turn down a pipe that carries one is the constraint the lock exists for. Two vendors found it independently.
3. **A repeat push was treated as an insertion**, so a retry scrolled a reader for content already in front of them.

## The gate

Six rounds — a plan round and a code round per story pair — with every finding resolved. Notable **accepted**: `field-sizing` is Chromium-only while the manifest declares support back to VS Code 1.85, so the page asks rather than assumes (it would have worked on the machine it was written on and silently never grown anywhere else); the at-bottom snapshot must be taken **before** insertion or rule 2 becomes "never follow"; a deferred follow must be cancellable by the reader, and the fonts-settled correction must die with it; and a cancelled follow must hand over the jump control, or an answer arrives and nobody is told.

Notable **rejected, with reasons in the session record**: a `</script>` injection through the passage and through the seeded state (`escapeHtml` and `jsonForScript` handle both, with tests standing on it); an Enter handler said to send before `preventDefault` (it is the other way round); six copies of a claim that the Send listener closes over an undefined `send`; and a visual cue for the silent scroll, which is the opposite of the rule the operator decided.

**Correction recorded in the plan**: I wrote that nothing in this repository executed the chat page's script. `bundledPage.test.ts:310` has, since before this branch — I grepped for `chatPageHtml` and that test reaches the page through `bundledChatPage()`. Every `typeof` guard here is load-bearing twice over.

## Tests

**1121, 1119 passing, 0 failing** on the rebased branch (1013 before this work; the rest is the other two lanes). Every fix went RED first with the real symptom, and the scroll ordering was additionally proved by breaking it: with the snapshot moved after the writes the suite goes red with *a reader at the bottom was not followed when messagesHtml arrived*.

New: `runChatPage()` runs the page's script from source with elements only where the page renders one, and `bundledPage.test.ts` now drives the bundled, minified page through Send **and** a real state push — which is where a mangled embedded function would throw.

Docs: `research/module_extension.md` carries the layout, the rule and the contract; `research/module_tests.md` names the flow; the CHANGELOG says what a person will notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)