### PR TITLE
feat(chat): a provider is a row, and the pair is checked as a pair

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -421,6 +421,47 @@ flowchart LR
 Two functions are read by both halves, and that is the whole architecture of this section: what the
 panel shows and what the conversation uses cannot disagree, because neither has a reader of its own.
 
+### A provider is a ROW, and the pair is checked as a pair (2026-09-09)
+
+`chatProvidersFrom(vendors, catalog)` sits beside `chatModelsFrom` and answers a different question:
+not "which rows can chat" but "which providers exist, and what can each of them be pointed at". A
+provider carries its own model list — discovered for `codex` and `agy`, curated for Claude, a Team
+server's allowlist for a remote row — from `modelsFor`, with a model the server has withdrawn kept
+and marked rather than dropped.
+
+**A provider is a configured vendor ROW, not a runtime, and that was not the first draft.** The plan
+recommended resolving a chosen runtime to "the first enabled row of that runtime". Three vendors'
+reviewers rejected it independently on one round: two `codex` rows with different executables, base
+URLs or prices are two different backends, and picking whichever comes first is a coin toss that
+bills the wrong one with nothing on screen saying which — and the answer would change on a restart if
+the rows were ever reordered. A fourth finding extended it to Team servers, where one server hosts
+several vendor rows (`<server>-codex`, `<server>-claude`), so a server id alone cannot say which
+vendor is to answer. So resolution is a LOOKUP by row id rather than a search, and nothing in it can
+be ambiguous because nothing in it searches.
+
+`resolveChatPick(vendors, list, providerId, modelId)` turns a pair into the row that says HOW to run
+it. **The pair is checked as a pair**: a model-only membership check would accept `sonnet` against
+the `agy` row whenever any other provider offers a model by that name, and `vendor-routing.md`
+forbids a Claude model going through `agy` by name. The chosen model is returned BESIDE the row
+rather than written into it — a row's configured model belongs to the reviewer that row is, and a
+chat picking another model must not edit somebody's reviewer.
+
+`legacyPick` is what a saved `coai.chatModel` from before the pair means now. Naming a row keeps
+working and brings that row's own model with it. Naming a MODEL resolves only when exactly one
+provider offers it: with two, this code would be choosing a vendor — and a bill — on somebody's
+behalf from a value that never meant to say which, so it keeps the model and leaves the provider
+empty for the caller to strand and ask.
+
+`allowedModelsFor` **moved from `panelView.ts` to `models.ts`**, unchanged. It was always pure, but
+it lived in the file that renders the panel, so anything else needing the same answer had to import a
+webview renderer to get it. It now sits beside `modelsFor`, which consumes what it returns, and
+beside `RemoteProvenance`, which was already declared there.
+
+> The two SELECTS are not here yet. `chatPickerHtml` lives in `chatPage.ts` and the panel's control
+> in `panelView.ts`, both owned by other lanes; the `coai.chatProvider` setting ships with the UI
+> that reads it, since a setting drags a manifest entry, a help article and four translations behind
+> it. What exists is the pure half: the providers, the resolution, and the legacy rule.
+
 **One reader, both sides.** The section renders `chatSettingsFrom(...)` and the command calls
 `chatSettingsFrom(...)` — the same function over the same per-side config reader. That is why these
 four are NOT folded into `CoaiSettings`: two readers for one set of keys is a drift this repository

--- a/src_vs_code/src/chatModels.ts
+++ b/src_vs_code/src/chatModels.ts
@@ -296,11 +296,21 @@ export function resolveChatPick(
   const provider = list.providers.find((one) => one.id === providerId);
   if (provider === undefined) {
     const refused = list.refused.find((one) => one.id === providerId);
+    if (refused !== undefined) {
+      return { ok: false, refusal: refused.reason };
+    }
+    // A row that exists and is switched OFF is not the same thing as a row that is gone, and the
+    // person can act on exactly one of them. `chatProvidersFrom` filters disabled rows out of BOTH
+    // lists — correctly, since a disabled row is not configured for anything — so without this the
+    // two states arrive here indistinguishable and both read as "no longer configured".
+    // (gemini, the code round.)
+    const disabled = vendors.find((one) => one.id === providerId && !one.enabled);
 
     return {
       ok: false,
-      refusal: refused?.reason
-        ?? `${providerId} is not a model this conversation can be sent to any more`,
+      refusal: disabled !== undefined
+        ? `${providerId} is switched off in the panel — turn it back on to send a chat to it`
+        : `${providerId} is not a model this conversation can be sent to any more`,
     };
   }
   const row = vendors.find((one) => one.id === providerId);
@@ -314,6 +324,19 @@ export function resolveChatPick(
   }
 
   return { ok: true, row, model: modelId };
+}
+
+/**
+ * What a legacy value resolved to, and — when it did not — which providers were in the way.
+ *
+ * <p>`candidates` is empty on every path but one: a saved MODEL that more than one provider offers.
+ * It exists so the caller can name them ("`gpt-5.2` is offered by `codex-cheap` and `codex-paid`")
+ * instead of asking a person to pick something out of a list they were never shown.</p>
+ */
+export interface LegacyPick {
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly candidates: readonly string[];
 }
 
 /**
@@ -331,17 +354,31 @@ export function legacyPick(
   list: ChatProviderList,
   vendors: readonly Vendor[],
   saved: string,
-): { readonly providerId: string; readonly modelId: string } {
+): LegacyPick {
   if (saved.length === 0) {
-    return { providerId: '', modelId: '' };
+    return { providerId: '', modelId: '', candidates: [] };
   }
+  // A ROW first, and the precedence is not arbitrary: every legacy value IS a row id, because that
+  // is the only thing the old picker ever offered (`chatModelsFrom` mapped each row to one entry
+  // keyed by `vendor.id`). A saved string that also happens to name a model is therefore a row that
+  // somebody named after a model, and reading it as the row is reading it as what it was written as.
+  // The model branch below exists for a value typed by hand into `settings.json`, which is the only
+  // way one can arrive. (gemini, the code round, asked for this precedence to be stated.)
   const asRow = list.providers.find((one) => one.id === saved);
   if (asRow !== undefined) {
-    return { providerId: saved, modelId: vendors.find((one) => one.id === saved)?.model ?? '' };
+    return {
+      providerId: saved,
+      modelId: vendors.find((one) => one.id === saved)?.model ?? '',
+      candidates: [],
+    };
   }
   const offering = list.providers.filter((one) => one.models.some((model) => model.id === saved));
+  if (offering.length === 1) {
+    return { providerId: offering[0]!.id, modelId: saved, candidates: [] };
+  }
 
-  return offering.length === 1
-    ? { providerId: offering[0]!.id, modelId: saved }
-    : { providerId: '', modelId: saved };
+  // Ambiguous, or offered by nobody. The model is KEPT either way so the caller can strand it under
+  // its own name, and the candidates come with it so the question can be "which of these two?"
+  // rather than "pick something". (gemini, the code round.)
+  return { providerId: '', modelId: saved, candidates: offering.map((one) => one.id) };
 }

--- a/src_vs_code/src/chatModels.ts
+++ b/src_vs_code/src/chatModels.ts
@@ -1,6 +1,9 @@
 import { ChatModelChoice } from './chatPage';
 import { CHAT_RUNTIMES } from './cliChatLaunch';
+import { LocalEngine } from './localEngines';
+import { allowedModelsFor, ModelChoice, modelsFor } from './models';
 import { REMOTE_TURNS } from './remoteAsk';
+import { TeamServerState } from './teamServerView';
 import { Vendor } from './vendors';
 
 /**
@@ -190,4 +193,155 @@ function refusalWhenNothingIsOffered(list: ChatModelList): string {
   return why.length > 0
     ? `No model can answer a chat yet: ${why}`
     : 'Enable a reviewer on the antigravity runtime to chat with it.';
+}
+
+/**
+ * One provider a chat can be sent to — which is a configured vendor ROW, not a runtime.
+ *
+ * <p><b>The distinction is the whole design, and it was not the first draft's.</b> The plan
+ * recommended resolving a chosen runtime to "the first enabled row of that runtime". Three vendors'
+ * reviewers rejected that independently on one round, and they were right: two `codex` rows with
+ * different executables, base URLs or prices are two different backends, and picking whichever comes
+ * first is a coin toss that bills the wrong one with nothing on screen saying which — and the answer
+ * would change on a restart if the rows were ever reordered. A fourth finding extended it to Team
+ * servers, where ONE server hosts several vendor rows (`<server>-codex`, `<server>-claude`) so a
+ * server id alone cannot say which vendor is to answer.</p>
+ *
+ * <p>So a provider is a row, local and remote alike, and resolution is a LOOKUP rather than a
+ * search. Nothing here can be ambiguous, because nothing here searches.</p>
+ */
+export interface ChatProvider {
+  /** The vendor ROW id. This is the identity a saved choice stores and resolution looks up. */
+  readonly id: string;
+  readonly label: string;
+  readonly caption: string;
+  /** What this row can be pointed at — discovered, curated or a server's allowlist. */
+  readonly models: readonly ModelChoice[];
+}
+
+export interface ChatProviderList {
+  readonly providers: readonly ChatProvider[];
+  /** Rows that exist and are enabled, but cannot answer. Shown, not hidden. */
+  readonly refused: readonly RefusedModel[];
+}
+
+/**
+ * Everything a provider's model list is derived FROM, passed in rather than reached for.
+ *
+ * <p>`modelsFor` needs discovered Codex and agy lists, a local engine and a server allowlist. A
+ * function that took only the vendor rows would have to read those from somewhere else, and then it
+ * would not be pure — it would be a function whose answer depends on state its caller cannot see.
+ * (codex, the plan round.)</p>
+ */
+export interface ChatCatalog {
+  readonly discoveredCodex: readonly ModelChoice[];
+  readonly discoveredAgy: readonly ModelChoice[];
+  readonly localEngine?: LocalEngine | undefined;
+  readonly teamServers: readonly TeamServerState[];
+}
+
+/** The providers a chat may be sent to, and the reason for every configured row that is not one. */
+export function chatProvidersFrom(
+  vendors: readonly Vendor[],
+  catalog: ChatCatalog,
+): ChatProviderList {
+  const enabled = vendors.filter((vendor) => vendor.enabled);
+  const providers = enabled.filter(canChat).map((vendor): ChatProvider => ({
+    id: vendor.id,
+    label: vendor.model.length > 0 ? `${vendor.id} · ${vendor.model}` : vendor.id,
+    caption: captionOf(vendor),
+    models: modelsFor(
+      vendor.runtime,
+      catalog.discoveredCodex,
+      vendor.model,
+      catalog.localEngine,
+      catalog.discoveredAgy,
+      allowedModelsFor(vendor, catalog.teamServers).models,
+    ),
+  }));
+  const refused = enabled.filter((vendor) => !canChat(vendor)).map((vendor): RefusedModel => ({
+    id: vendor.id,
+    reason: `the chat can only speak to ${CHAT_RUNTIMES.join(', ')} and Team servers so far`
+      + ` — ${vendor.id} runs on ${vendor.runtime}`,
+  }));
+
+  return { providers, refused };
+}
+
+/** Either the row and model that will answer, or the sentence saying why nothing will. Never both. */
+export type ChatPick =
+  | { readonly ok: true; readonly row: Vendor; readonly model: string }
+  | { readonly ok: false; readonly refusal: string };
+
+/**
+ * A chosen (provider, model) pair, resolved to the row that says HOW to run it.
+ *
+ * <p><b>The pair is checked as a PAIR.</b> A model-only membership check would accept `sonnet`
+ * against the `agy` row whenever some other provider offers a model by that name — and
+ * `vendor-routing.md` forbids a Claude model going through `agy` by name. The check is therefore
+ * "this provider offers this model", never "somebody offers this model". (codex, the plan round.)</p>
+ *
+ * <p>The row is what the caller actually needs: it carries the runtime, the executable, the base
+ * URL, the price, and for a Team server the server AND `remoteVendor` — the field this family lost
+ * once for three releases. The chosen MODEL is returned beside it rather than written into the row,
+ * because a row's configured model belongs to the reviewer that row is, and a chat picking another
+ * model must not edit somebody's reviewer.</p>
+ */
+export function resolveChatPick(
+  vendors: readonly Vendor[],
+  list: ChatProviderList,
+  providerId: string,
+  modelId: string,
+): ChatPick {
+  const provider = list.providers.find((one) => one.id === providerId);
+  if (provider === undefined) {
+    const refused = list.refused.find((one) => one.id === providerId);
+
+    return {
+      ok: false,
+      refusal: refused?.reason
+        ?? `${providerId} is not a model this conversation can be sent to any more`,
+    };
+  }
+  const row = vendors.find((one) => one.id === providerId);
+  if (row === undefined) {
+    // The list and the rows disagreeing is a defect rather than a state, but it is reported as a
+    // sentence instead of thrown: the caller is a command handler, and a throw there closes a tab.
+    return { ok: false, refusal: `${providerId} is no longer configured` };
+  }
+  if (!provider.models.some((model) => model.id === modelId)) {
+    return { ok: false, refusal: `${providerId} does not offer ${modelId}` };
+  }
+
+  return { ok: true, row, model: modelId };
+}
+
+/**
+ * What a saved `coai.chatModel` from before the pair existed means now.
+ *
+ * <p>Every installation has one string today: the id of a reviewer row. That keeps working — it
+ * names a provider, and the provider's own configured model comes with it.</p>
+ *
+ * <p>A value naming a MODEL rather than a row resolves only when exactly ONE provider offers it.
+ * With two, this code would be choosing a vendor — and a bill — on somebody's behalf from a value
+ * that never meant to say which. Ambiguity keeps the model and leaves the provider empty, so the
+ * caller strands it and asks rather than guessing. (codex, the plan round.)</p>
+ */
+export function legacyPick(
+  list: ChatProviderList,
+  vendors: readonly Vendor[],
+  saved: string,
+): { readonly providerId: string; readonly modelId: string } {
+  if (saved.length === 0) {
+    return { providerId: '', modelId: '' };
+  }
+  const asRow = list.providers.find((one) => one.id === saved);
+  if (asRow !== undefined) {
+    return { providerId: saved, modelId: vendors.find((one) => one.id === saved)?.model ?? '' };
+  }
+  const offering = list.providers.filter((one) => one.models.some((model) => model.id === saved));
+
+  return offering.length === 1
+    ? { providerId: offering[0]!.id, modelId: saved }
+    : { providerId: '', modelId: saved };
 }

--- a/src_vs_code/src/models.ts
+++ b/src_vs_code/src/models.ts
@@ -349,6 +349,8 @@ export function allowedModelsFor(vendor: Vendor, servers: readonly TeamServerSta
     return { models: [vendor.model], named, catalog: 'waiting' };
   }
 
+  const wanted = named.toLowerCase();
+
   return {
     // Case-insensitively, because `RemoteProbe.Read` on the other side of this seam compares with
     // `OrdinalIgnoreCase`. A server whose catalog says `DeepSeek` answers a row that recorded
@@ -356,8 +358,11 @@ export function allowedModelsFor(vendor: Vendor, servers: readonly TeamServerSta
     // caption saying the server allows it nothing. Neither side may lower-case the name it SENDS —
     // that is the server's own spelling — but both must agree about which names are the same one.
     // Found by the automated reviewer on this change's pull request.
+    // `named` is lower-cased ONCE rather than inside the predicate. It was a fresh string allocation
+    // per catalog entry, per remote row, per rebuild of the picker — invisible at three rows and not
+    // at thirty. (gemini, the code round.)
     models: (server.catalog.vendors ?? [])
-      .find((v) => v.id.toLowerCase() === named.toLowerCase())?.models ?? [],
+      .find((v) => v.id.toLowerCase() === wanted)?.models ?? [],
     named,
     catalog: 'here',
   };

--- a/src_vs_code/src/models.ts
+++ b/src_vs_code/src/models.ts
@@ -1,4 +1,7 @@
 import { engineNote, LocalEngine } from './localEngines';
+import { canonicalTeamServerUrl } from './teamServers';
+import { TeamServerState } from './teamServerView';
+import { Vendor } from './vendors';
 /**
  * Which models a vendor can be pointed at, and where that list comes from.
  *
@@ -283,3 +286,79 @@ export function modelsProvenance(
 // the wrong question: `process.platform` is 'linux' both in a WSL distro and on a native Linux box,
 // and only one of them has a `.wslconfig` to edit. The engine now carries whether the probe ran
 // under WSL, which is the fact the message actually needed.
+
+
+/**
+ * MOVED HERE from `panelView.ts` (2026-09-09), unchanged.
+ *
+ * <p>It was always pure — it reads a row and a list of server states and returns three fields — but
+ * it lived in the file that renders the panel, so anything else that needed the same answer had to
+ * import the view to get it. The chat picker needs exactly this answer, and a pure module importing
+ * a webview renderer to ask what a Team server allows is the coupling that makes a lane boundary
+ * meaningless. It sits beside `modelsFor`, which consumes what it returns, and beside
+ * `RemoteProvenance`, which was already declared here. (gemini, the plan round.)</p>
+ */
+/**
+ * What a Team server allows, and whether the server has actually said so.
+ *
+ * <p>The two cannot be collapsed into a list length. When the catalog has not arrived this returns
+ * the row's OWN model — never an empty list, because an empty one means "your server withdrew this
+ * model" and `modelsFor` would mark it so, on every reload, for as long as a server stayed
+ * unreachable. So a one-item list is ambiguous by construction, and the caption has to be told which
+ * of the two it is looking at rather than counting.</p>
+ *
+ * <p>The shape is `RemoteProvenance`, declared beside the caption that reads it. It was declared
+ * twice for one release — the same three fields, once here and once there — which is the beginning
+ * of the drift this plan spent two stories closing on the other seam.</p>
+ */
+export function allowedModelsFor(vendor: Vendor, servers: readonly TeamServerState[]): RemoteProvenance {
+  if (vendor.runtime !== 'remote') {
+    return { models: [], named: vendor.id, catalog: 'no-server' };
+  }
+
+  // By ID first, because an address is CORRECTABLE and an id is not: fixing a typo in a hostname
+  // would otherwise orphan every row that matched the old string. The address is the fallback, for
+  // rows written before the id was recorded — and it is compared CANONICALLY, never as typed, since
+  // the row stores one spelling and the server entry holds whatever the person entered.
+  const url = canonicalTeamServerUrl(vendor.baseUrl);
+  const server = servers.find((s) => (vendor.teamServerId !== undefined && vendor.teamServerId.length > 0)
+    ? s.server.id === vendor.teamServerId
+    : canonicalTeamServerUrl(s.server.url) === url);
+  // Guarded by `typeof`, not by `!== undefined`: a JSON null passes the second and then has
+  // `.length` read off it, and this is a field a person can hand-write. Length-checked rather than
+  // `??`, because nullish coalescing keeps an EMPTY string — a row carrying `remoteVendor: ''` would
+  // be looked up in the catalog under a blank name. The C# side of this seam asks the same question
+  // the same way (`VendorIdentity.Recorded`), and two halves of one contract disagreeing about what
+  // counts as absent is how this whole plan started. Both raised on this story's rounds.
+  const named = typeof vendor.remoteVendor === 'string' && vendor.remoteVendor.length > 0
+    ? vendor.remoteVendor
+    : vendor.id;
+
+  // Three states, not two. "No server entry matches this row" is not "its catalog has not arrived
+  // yet" — it is what a person is left with after removing a Team server and keeping its reviewers,
+  // and sending them to a section that no longer lists their server is worse than saying nothing.
+  if (server === undefined) {
+    return { models: [vendor.model], named, catalog: 'no-server' };
+  }
+
+  if (server.catalog === undefined) {
+    // NOT an empty allowlist. An empty one means "this server no longer offers your model", and
+    // `modelsFor` would then mark every remote row's saved model as withdrawn — on every reload,
+    // before the first fetch has landed, and for as long as a server stays unreachable. A person
+    // would read that as their configuration having been dropped. Caught on the code round.
+    return { models: [vendor.model], named, catalog: 'waiting' };
+  }
+
+  return {
+    // Case-insensitively, because `RemoteProbe.Read` on the other side of this seam compares with
+    // `OrdinalIgnoreCase`. A server whose catalog says `DeepSeek` answers a row that recorded
+    // `deepseek` perfectly well, and this comparison showed that same row an empty dropdown and a
+    // caption saying the server allows it nothing. Neither side may lower-case the name it SENDS —
+    // that is the server's own spelling — but both must agree about which names are the same one.
+    // Found by the automated reviewer on this change's pull request.
+    models: (server.catalog.vendors ?? [])
+      .find((v) => v.id.toLowerCase() === named.toLowerCase())?.models ?? [],
+    named,
+    catalog: 'here',
+  };
+}

--- a/src_vs_code/src/panelView.ts
+++ b/src_vs_code/src/panelView.ts
@@ -4,7 +4,6 @@ import {
   teamUsageBlock,
   usageScopeControl,
 } from './teamServerView';
-import { canonicalTeamServerUrl } from './teamServers';
 import { escapeHtml } from './escapeHtml';
 import { availabilityOf, ProviderHealth, ProvidersAnswer } from './providers';
 import { ChatSettings, chatSettingsFrom } from './chatSettings';
@@ -12,7 +11,7 @@ import { ChatModelList, chatModelsFrom } from './chatModels';
 import { CoaiSettings, LANGUAGES, enabledCodeRoles, roleIsOn } from './settingsShape';
 import { Escalation } from './escalations';
 import { HELP, HelpKey } from './help';
-import { ModelChoice, modelsFor, modelsProvenance, RemoteProvenance } from './models';
+import { allowedModelsFor, ModelChoice, modelsFor, modelsProvenance, RemoteProvenance } from './models';
 import { CONVENTIONS_ROLE_SINCE, ROLE_SWITCH_SINCE, ROLES, promptsFor, selectedFor } from './prompts';
 import { barWidth, estimated, money, shortDuration, shortNumber, totalsByVendor, UsageEntry, Window, within } from './usage';
 import { costPhrase, elapsed, isRunning, reviewerRows, RoundRecord, SessionFile, stageName } from './rounds';
@@ -604,70 +603,6 @@ const KNOWS_ITS_OWN_ENDPOINT: ReadonlySet<string> = new Set(['codex', 'claude', 
  * — a guessed list would let somebody pick a model that was never going to be accepted. The row's
  * own saved model is added back by `modelsFor`, marked, so a selection never silently vanishes.</p>
  */
-/**
- * What a Team server allows, and whether the server has actually said so.
- *
- * <p>The two cannot be collapsed into a list length. When the catalog has not arrived this returns
- * the row's OWN model — never an empty list, because an empty one means "your server withdrew this
- * model" and `modelsFor` would mark it so, on every reload, for as long as a server stayed
- * unreachable. So a one-item list is ambiguous by construction, and the caption has to be told which
- * of the two it is looking at rather than counting.</p>
- *
- * <p>The shape is `RemoteProvenance`, declared beside the caption that reads it. It was declared
- * twice for one release — the same three fields, once here and once there — which is the beginning
- * of the drift this plan spent two stories closing on the other seam.</p>
- */
-function allowedModelsFor(vendor: Vendor, servers: readonly TeamServerState[]): RemoteProvenance {
-  if (vendor.runtime !== 'remote') {
-    return { models: [], named: vendor.id, catalog: 'no-server' };
-  }
-
-  // By ID first, because an address is CORRECTABLE and an id is not: fixing a typo in a hostname
-  // would otherwise orphan every row that matched the old string. The address is the fallback, for
-  // rows written before the id was recorded — and it is compared CANONICALLY, never as typed, since
-  // the row stores one spelling and the server entry holds whatever the person entered.
-  const url = canonicalTeamServerUrl(vendor.baseUrl);
-  const server = servers.find((s) => (vendor.teamServerId !== undefined && vendor.teamServerId.length > 0)
-    ? s.server.id === vendor.teamServerId
-    : canonicalTeamServerUrl(s.server.url) === url);
-  // Guarded by `typeof`, not by `!== undefined`: a JSON null passes the second and then has
-  // `.length` read off it, and this is a field a person can hand-write. Length-checked rather than
-  // `??`, because nullish coalescing keeps an EMPTY string — a row carrying `remoteVendor: ''` would
-  // be looked up in the catalog under a blank name. The C# side of this seam asks the same question
-  // the same way (`VendorIdentity.Recorded`), and two halves of one contract disagreeing about what
-  // counts as absent is how this whole plan started. Both raised on this story's rounds.
-  const named = typeof vendor.remoteVendor === 'string' && vendor.remoteVendor.length > 0
-    ? vendor.remoteVendor
-    : vendor.id;
-
-  // Three states, not two. "No server entry matches this row" is not "its catalog has not arrived
-  // yet" — it is what a person is left with after removing a Team server and keeping its reviewers,
-  // and sending them to a section that no longer lists their server is worse than saying nothing.
-  if (server === undefined) {
-    return { models: [vendor.model], named, catalog: 'no-server' };
-  }
-
-  if (server.catalog === undefined) {
-    // NOT an empty allowlist. An empty one means "this server no longer offers your model", and
-    // `modelsFor` would then mark every remote row's saved model as withdrawn — on every reload,
-    // before the first fetch has landed, and for as long as a server stays unreachable. A person
-    // would read that as their configuration having been dropped. Caught on the code round.
-    return { models: [vendor.model], named, catalog: 'waiting' };
-  }
-
-  return {
-    // Case-insensitively, because `RemoteProbe.Read` on the other side of this seam compares with
-    // `OrdinalIgnoreCase`. A server whose catalog says `DeepSeek` answers a row that recorded
-    // `deepseek` perfectly well, and this comparison showed that same row an empty dropdown and a
-    // caption saying the server allows it nothing. Neither side may lower-case the name it SENDS —
-    // that is the server's own spelling — but both must agree about which names are the same one.
-    // Found by the automated reviewer on this change's pull request.
-    models: (server.catalog.vendors ?? [])
-      .find((v) => v.id.toLowerCase() === named.toLowerCase())?.models ?? [],
-    named,
-    catalog: 'here',
-  };
-}
 
 /**
  * A reviewer the SERVER says it cannot run, named on its own card.

--- a/src_vs_code/src/test/chatProviders.test.ts
+++ b/src_vs_code/src/test/chatProviders.test.ts
@@ -1,0 +1,310 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { ChatCatalog, chatProvidersFrom, legacyPick, resolveChatPick } from '../chatModels';
+import { Vendor } from '../vendors';
+import { TeamServerState } from '../teamServerView';
+import { requestBody } from '../remoteAsk';
+import { serverVendorOf } from '../teamServers';
+
+/**
+ * Provider first, then model — and the provider is a ROW.
+ *
+ * <p><b>That is the whole design, and it was not the plan's.</b> The plan recommended resolving a
+ * chosen runtime to "the first enabled row of that runtime". Three vendors' reviewers rejected that
+ * independently on one round: two `codex` rows with different executables, prices or base URLs are
+ * two different backends, and picking whichever comes first is a coin toss that bills the wrong one
+ * with nothing on screen saying which. A fourth finding extended it to Team servers, where one
+ * server hosts several vendor rows (`<server>-codex`, `<server>-claude`) and a server id alone
+ * cannot say which vendor is to answer.</p>
+ *
+ * <p>So a provider IS a configured vendor row, local and remote alike, and resolution is a lookup by
+ * row id rather than a search by runtime. Nothing here is ambiguous because nothing here searches.</p>
+ */
+
+function vendor(over: Partial<Vendor> = {}): Vendor {
+  return {
+    id: 'antigravity',
+    runtime: 'antigravity',
+    model: 'gemini-3.7-flash-high',
+    enabled: true,
+    plan: true,
+    code: true,
+    baseUrl: '',
+    executablePath: '',
+    pricePerMillionIn: 0,
+    pricePerMillionOut: 0,
+    ...over,
+  };
+}
+
+/**
+ * A Team server with a catalog, built without a cast.
+ *
+ * <p>`doctrine.md` §3 forbids the `as TeamServerState` that would make this three lines shorter: a
+ * cast is a promise to keep a shape by hand, and it comes due silently the day the type gains a
+ * required field and every fixture in the suite goes on compiling against a shape it no longer has.</p>
+ */
+function serverOffering(models: readonly string[]): TeamServerState {
+  return {
+    server: { id: 'srv1', name: 'Company', url: 'https://coai.example.com' },
+    email: 'somebody@example.com',
+    problem: '',
+    stale: false,
+    catalog: {
+      serverVersion: '0.5.6',
+      isAdmin: false,
+      error: '',
+      vendors: [
+        { id: 'codex', runtime: 'codex', models, slots: { total: 1, ready: 1, coolingDown: 0, needsSignIn: 0 } },
+      ],
+    },
+  };
+}
+
+const CATALOG: ChatCatalog = {
+  discoveredCodex: [{ id: 'gpt-5.2', label: 'gpt-5.2' }, { id: 'gpt-5.2-mini', label: 'gpt-5.2-mini' }],
+  discoveredAgy: [{ id: 'gemini-3.7-flash-high', label: 'gemini-3.7-flash-high' }],
+  teamServers: [],
+};
+
+test('two rows on one runtime are two providers, told apart by their row id', () => {
+  // The finding the whole design turns on. These are two different backends — a different executable
+  // and a different price — and collapsing them into one `codex` provider would let a pick land on
+  // either. (codex, gemini and the local reviewer, the plan round, independently.)
+  const list = chatProvidersFrom(
+    [
+      vendor({ id: 'codex-cheap', runtime: 'codex', model: 'gpt-5.2-mini', pricePerMillionIn: 1 }),
+      vendor({ id: 'codex-paid', runtime: 'codex', model: 'gpt-5.2', pricePerMillionIn: 20 }),
+    ],
+    CATALOG,
+  );
+
+  assert.deepStrictEqual(
+    list.providers.map((provider) => provider.id),
+    ['codex-cheap', 'codex-paid'],
+    'two configured rows must be two providers, never one collapsed runtime',
+  );
+});
+
+test('a provider carries the models its runtime can actually run', () => {
+  const list = chatProvidersFrom([vendor({ id: 'codex', runtime: 'codex', model: 'gpt-5.2' })], CATALOG);
+
+  assert.deepStrictEqual(
+    list.providers[0]?.models.map((model) => model.id),
+    ['gpt-5.2', 'gpt-5.2-mini'],
+    'the model list is what `modelsFor` discovered for that runtime',
+  );
+});
+
+test('a Team server row offers only what that server allows, under its own vendor name', () => {
+  const remote = vendor({
+    id: 'srv1-codex',
+    runtime: 'remote',
+    model: 'gpt-5.2',
+    remoteVendor: 'codex',
+    teamServerId: 'srv1',
+    baseUrl: 'https://coai.example.com',
+  });
+  const list = chatProvidersFrom([remote], {
+    ...CATALOG,
+    teamServers: [serverOffering(['gpt-5.2', 'gpt-5.3'])],
+  });
+
+  assert.deepStrictEqual(
+    list.providers[0]?.models.map((model) => model.id),
+    ['gpt-5.2', 'gpt-5.3'],
+    'a Team server provider offers its allowlist, looked up by the row\u2019s remoteVendor',
+  );
+});
+
+test('a model the server has withdrawn is kept and marked, never silently dropped', () => {
+  const remote = vendor({
+    id: 'srv1-codex',
+    runtime: 'remote',
+    model: 'gpt-4.9',
+    remoteVendor: 'codex',
+    teamServerId: 'srv1',
+  });
+  const list = chatProvidersFrom([remote], {
+    ...CATALOG,
+    teamServers: [serverOffering(['gpt-5.2'])],
+  });
+
+  const withdrawn = list.providers[0]?.models.find((model) => model.id === 'gpt-4.9');
+  assert.notStrictEqual(withdrawn, undefined, 'the saved model must still be there');
+  assert.match(
+    withdrawn?.label ?? '',
+    /does not offer it any more/,
+    'a withdrawn model is MARKED — silently swapping it would send a round nobody chose',
+  );
+});
+
+test('a row on a runtime with no adapter is refused by name, not hidden', () => {
+  const list = chatProvidersFrom([vendor({ id: 'ollama', runtime: 'local' })], CATALOG);
+
+  assert.deepStrictEqual(list.providers, [], 'a runtime with no chat adapter offers nothing');
+  assert.strictEqual(list.refused[0]?.id, 'ollama');
+  assert.match(list.refused[0]?.reason ?? '', /ollama/, 'the refusal must name the row');
+});
+
+test('a disabled row is neither offered nor refused — it is not configured', () => {
+  const list = chatProvidersFrom([vendor({ id: 'off', enabled: false })], CATALOG);
+
+  assert.deepStrictEqual(list.providers, []);
+  assert.deepStrictEqual(list.refused, []);
+});
+
+test('resolving a pair returns the row that says HOW to run it', () => {
+  const paid = vendor({ id: 'codex-paid', runtime: 'codex', model: 'gpt-5.2', executablePath: 'C:/paid/codex.cmd' });
+  const vendors = [vendor({ id: 'codex-cheap', runtime: 'codex', model: 'gpt-5.2-mini' }), paid];
+  const list = chatProvidersFrom(vendors, CATALOG);
+
+  const picked = resolveChatPick(vendors, list, 'codex-paid', 'gpt-5.2-mini');
+
+  assert.strictEqual(picked.ok, true);
+  assert.strictEqual(picked.ok === true ? picked.row.id : '', 'codex-paid', 'the ROW is the one named');
+  assert.strictEqual(
+    picked.ok === true ? picked.row.executablePath : '',
+    'C:/paid/codex.cmd',
+    'the row carries the executable, the price and the base URL — that is what resolution is for',
+  );
+  assert.strictEqual(
+    picked.ok === true ? picked.model : '',
+    'gpt-5.2-mini',
+    'the chosen model, not the row\u2019s configured one',
+  );
+});
+
+test('a resolved Team-server pair carries the vendor name that server knows', () => {
+  // The field this family lost once for three releases. The row id is `<server>-<vendor>`; what goes
+  // on the wire is the vendor's own name, and a resolution that dropped it would reproduce a 400
+  // reading "'srv1-codex' is not a vendor here", in seconds, for no tokens.
+  const remote = vendor({
+    id: 'srv1-codex',
+    runtime: 'remote',
+    model: 'gpt-5.2',
+    remoteVendor: 'codex',
+    teamServerId: 'srv1',
+  });
+  const list = chatProvidersFrom([remote], {
+    ...CATALOG,
+    teamServers: [serverOffering(['gpt-5.2'])],
+  });
+
+  const picked = resolveChatPick([remote], list, 'srv1-codex', 'gpt-5.2');
+
+  assert.strictEqual(picked.ok, true);
+  assert.strictEqual(picked.ok === true ? picked.row.remoteVendor : '', 'codex');
+});
+
+test('a model valid under ANOTHER provider is refused, because the pair is checked as a pair', () => {
+  // The security half. A stale or tampered choice of a Claude model against the `agy` row would
+  // otherwise pass a model-only membership check and route a Claude model through the wrong CLI,
+  // which `vendor-routing.md` forbids by name. (codex, the plan round.)
+  const vendors = [
+    vendor({ id: 'claude', runtime: 'claude', model: 'sonnet' }),
+    vendor({ id: 'agy', runtime: 'antigravity', model: 'gemini-3.7-flash-high' }),
+  ];
+  const list = chatProvidersFrom(vendors, CATALOG);
+
+  const picked = resolveChatPick(vendors, list, 'agy', 'sonnet');
+
+  assert.strictEqual(picked.ok, false, 'a model this provider does not offer must not resolve');
+  assert.match(
+    picked.ok === false ? picked.refusal : '',
+    /sonnet/,
+    'the refusal names the model that was asked for',
+  );
+});
+
+test('a pick naming a provider that is not configured is refused by that name', () => {
+  const vendors = [vendor({ id: 'claude', runtime: 'claude', model: 'sonnet' })];
+  const list = chatProvidersFrom(vendors, CATALOG);
+
+  const picked = resolveChatPick(vendors, list, 'codex-gone', 'gpt-5.2');
+
+  assert.strictEqual(picked.ok, false);
+  assert.match(picked.ok === false ? picked.refusal : '', /codex-gone/);
+});
+
+test('a legacy chatModel naming a ROW resolves to that row and its configured model', () => {
+  // What every existing installation has in `settings.json` today: one string, the id of a reviewer
+  // row. It must go on working without anybody re-picking anything.
+  const vendors = [vendor({ id: 'codex', runtime: 'codex', model: 'gpt-5.2' })];
+  const list = chatProvidersFrom(vendors, CATALOG);
+
+  assert.deepStrictEqual(legacyPick(list, vendors, 'codex'), { providerId: 'codex', modelId: 'gpt-5.2' });
+});
+
+test('a legacy value naming a MODEL resolves only when exactly one provider offers it', () => {
+  // Ambiguity is refused rather than guessed: `sonnet` offered by a local Claude row AND by a Team
+  // server is not a choice this code may make on somebody's behalf. (codex, the plan round.)
+  const only = [vendor({ id: 'codex', runtime: 'codex', model: 'gpt-5.2' })];
+  const onlyList = chatProvidersFrom(only, CATALOG);
+  assert.deepStrictEqual(
+    legacyPick(onlyList, only, 'gpt-5.2-mini'),
+    { providerId: 'codex', modelId: 'gpt-5.2-mini' },
+    'one provider offers it, so there is nothing to guess',
+  );
+
+  const both = [
+    vendor({ id: 'codex-a', runtime: 'codex', model: 'gpt-5.2' }),
+    vendor({ id: 'codex-b', runtime: 'codex', model: 'gpt-5.2' }),
+  ];
+  const bothList = chatProvidersFrom(both, CATALOG);
+  assert.deepStrictEqual(
+    legacyPick(bothList, both, 'gpt-5.2-mini'),
+    { providerId: '', modelId: 'gpt-5.2-mini' },
+    'two providers offer it, so the person must say which — the model is kept, stranded',
+  );
+});
+
+test('an empty legacy value picks nothing, so the first provider can answer as it always did', () => {
+  const vendors = [vendor({ id: 'codex', runtime: 'codex', model: 'gpt-5.2' })];
+  const list = chatProvidersFrom(vendors, CATALOG);
+
+  assert.deepStrictEqual(legacyPick(list, vendors, ''), { providerId: '', modelId: '' });
+});
+
+/**
+ * What actually goes on the wire for a resolved Team-server pick.
+ *
+ * <p>The gate refused a contract case that only asserts the server ACCEPTS the request, and it was
+ * right: a request can be accepted while the field is missing, empty, or carrying the prefixed row
+ * id, and a stricter server would then reject it later for a reason nobody could trace. So the VALUE
+ * is asserted, at the point where the row becomes the payload, for both ways the value can be
+ * arrived at. (codex, gemini and the local reviewer, the plan round.)</p>
+ *
+ * <p>This is the field this family lost once for three releases, with both suites green.</p>
+ */
+
+test('a resolved remote pick puts the server\u2019s own vendor name on the wire, when the row records one', () => {
+  const row = vendor({ id: 'srv1-codex', runtime: 'remote', model: 'gpt-5.2', remoteVendor: 'codex' });
+
+  const body = requestBody(serverVendorOf(row, 'srv1'), 'gpt-5.3', 'explain this', 60);
+
+  assert.strictEqual(body['vendor'], 'codex', 'the wire carries the vendor name, never the row id');
+  assert.strictEqual(body['model'], 'gpt-5.3', 'and the CHOSEN model, not the row\u2019s configured one');
+});
+
+test('a remote row with no recorded vendor falls back to its id with the server prefix stripped', () => {
+  // The rows written before `remoteVendor` existed. They must keep working, and the fallback is the
+  // half a test that only covered the recorded case would never have exercised.
+  const row = vendor({ id: 'srv1-claude', runtime: 'remote', model: 'sonnet' });
+
+  const body = requestBody(serverVendorOf(row, 'srv1'), 'sonnet', 'explain this', 60);
+
+  assert.strictEqual(body['vendor'], 'claude');
+});
+
+test('the wire never carries the prefixed row id, which is the 400 this family has already paid for', () => {
+  const row = vendor({ id: 'srv1-codex', runtime: 'remote', model: 'gpt-5.2', remoteVendor: 'codex' });
+
+  const body = requestBody(serverVendorOf(row, 'srv1'), 'gpt-5.2', 'explain this', 60);
+
+  assert.notStrictEqual(
+    body['vendor'],
+    'srv1-codex',
+    'sending the row id is the measured failure: a 400 saying it is not a vendor here, for no tokens',
+  );
+});

--- a/src_vs_code/src/test/chatProviders.test.ts
+++ b/src_vs_code/src/test/chatProviders.test.ts
@@ -233,7 +233,7 @@ test('a legacy chatModel naming a ROW resolves to that row and its configured mo
   const vendors = [vendor({ id: 'codex', runtime: 'codex', model: 'gpt-5.2' })];
   const list = chatProvidersFrom(vendors, CATALOG);
 
-  assert.deepStrictEqual(legacyPick(list, vendors, 'codex'), { providerId: 'codex', modelId: 'gpt-5.2' });
+  assert.deepStrictEqual(legacyPick(list, vendors, 'codex'), { providerId: 'codex', modelId: 'gpt-5.2', candidates: [] });
 });
 
 test('a legacy value naming a MODEL resolves only when exactly one provider offers it', () => {
@@ -243,7 +243,7 @@ test('a legacy value naming a MODEL resolves only when exactly one provider offe
   const onlyList = chatProvidersFrom(only, CATALOG);
   assert.deepStrictEqual(
     legacyPick(onlyList, only, 'gpt-5.2-mini'),
-    { providerId: 'codex', modelId: 'gpt-5.2-mini' },
+    { providerId: 'codex', modelId: 'gpt-5.2-mini', candidates: [] },
     'one provider offers it, so there is nothing to guess',
   );
 
@@ -254,7 +254,7 @@ test('a legacy value naming a MODEL resolves only when exactly one provider offe
   const bothList = chatProvidersFrom(both, CATALOG);
   assert.deepStrictEqual(
     legacyPick(bothList, both, 'gpt-5.2-mini'),
-    { providerId: '', modelId: 'gpt-5.2-mini' },
+    { providerId: '', modelId: 'gpt-5.2-mini', candidates: ['codex-a', 'codex-b'] },
     'two providers offer it, so the person must say which — the model is kept, stranded',
   );
 });
@@ -263,7 +263,7 @@ test('an empty legacy value picks nothing, so the first provider can answer as i
   const vendors = [vendor({ id: 'codex', runtime: 'codex', model: 'gpt-5.2' })];
   const list = chatProvidersFrom(vendors, CATALOG);
 
-  assert.deepStrictEqual(legacyPick(list, vendors, ''), { providerId: '', modelId: '' });
+  assert.deepStrictEqual(legacyPick(list, vendors, ''), { providerId: '', modelId: '', candidates: [] });
 });
 
 /**
@@ -306,5 +306,52 @@ test('the wire never carries the prefixed row id, which is the 400 this family h
     body['vendor'],
     'srv1-codex',
     'sending the row id is the measured failure: a 400 saying it is not a vendor here, for no tokens',
+  );
+});
+
+test('a provider that is switched off says so, instead of reading as one that is gone', () => {
+  // Two states a person can act on in different ways, and `chatProvidersFrom` filters both out of
+  // its lists — correctly, since a disabled row is configured for nothing. Without this they arrive
+  // at the refusal indistinguishable. (gemini, the code round.)
+  const off = vendor({ id: 'codex', runtime: 'codex', model: 'gpt-5.2', enabled: false });
+  const list = chatProvidersFrom([off], CATALOG);
+
+  const picked = resolveChatPick([off], list, 'codex', 'gpt-5.2');
+
+  assert.strictEqual(picked.ok, false);
+  assert.match(
+    picked.ok === false ? picked.refusal : '',
+    /switched off/,
+    'a row that is merely off must not be reported as one that no longer exists',
+  );
+});
+
+test('a provider that never existed still reads as gone, not as switched off', () => {
+  const list = chatProvidersFrom([vendor({ id: 'codex', runtime: 'codex' })], CATALOG);
+
+  const picked = resolveChatPick([], list, 'never-was', 'gpt-5.2');
+
+  assert.strictEqual(picked.ok, false);
+  assert.doesNotMatch(picked.ok === false ? picked.refusal : '', /switched off/);
+});
+
+test('an ambiguous legacy model names the providers that offer it', () => {
+  // So the caller can ask "which of these two?" rather than "pick something". (gemini.)
+  const both = [
+    vendor({ id: 'codex-a', runtime: 'codex', model: 'gpt-5.2' }),
+    vendor({ id: 'codex-b', runtime: 'codex', model: 'gpt-5.2' }),
+  ];
+  const list = chatProvidersFrom(both, CATALOG);
+
+  assert.deepStrictEqual(legacyPick(list, both, 'gpt-5.2-mini').candidates, ['codex-a', 'codex-b']);
+});
+
+test('a legacy value nobody offers strands with no candidates to suggest', () => {
+  const vendors = [vendor({ id: 'codex', runtime: 'codex', model: 'gpt-5.2' })];
+  const list = chatProvidersFrom(vendors, CATALOG);
+
+  assert.deepStrictEqual(
+    legacyPick(list, vendors, 'a-model-that-went-away'),
+    { providerId: '', modelId: 'a-model-that-went-away', candidates: [] },
   );
 });

--- a/todo/PLAN_provider_then_model.md
+++ b/todo/PLAN_provider_then_model.md
@@ -1,6 +1,18 @@
 # PLAN — pick the provider, then the model
 
-> Status: **plan only, nothing implemented yet.** Kind: **feature**. Scope: the chat model picker —
+> Status: **the PURE half is implemented (2026-09-09, branch `feat/provider-then-model-pure`); the
+> two SELECTS and the `coai.chatProvider` setting are not built.** `chatProvidersFrom`,
+> `resolveChatPick` and `legacyPick` exist and are tested, and `allowedModelsFor` moved out of
+> `panelView.ts` into `models.ts` so a pure module no longer has to import a webview renderer to ask
+> what a Team server allows.
+>
+> **The plan's own recommendation was OVERTURNED by its gate, and this is the record of it.** It said
+> a provider is a runtime, resolved to "the first enabled row of that runtime". Three vendors'
+> reviewers rejected that independently — two rows on one runtime are two backends, and picking the
+> first is a coin toss that bills the wrong one — and a fourth extended it to Team servers, where one
+> server hosts several vendor rows. **A provider is a ROW.** Resolution is a lookup, not a search.
+>
+> Kind: **feature**. Scope: the chat model picker —
 > `src_vs_code/src/chatModels.ts`, `chatPage.ts` (`chatPickerHtml`), the panel's *Which model
 > answers* control (`panelView.ts`), `chatSettings.ts`, and the resolution of a choice to a vendor
 > row in `chatCommand.ts`. Origin: [BUGS_2026-09-09.md](BUGS_2026-09-09.md), entry 21.


### PR DESCRIPTION
The **pure half** of [PLAN_provider_then_model.md](todo/PLAN_provider_then_model.md).

## The problem

The chat picker is not a list of models. It maps each configured reviewer ROW to one entry labelled `${vendor.id} · ${vendor.model}`, so choosing a different model means going to the panel and re-configuring a reviewer.

## The plan's own recommendation was overturned by its gate

The plan said `coai.chatProvider` should be a **runtime**, resolved to *"the first enabled row of that runtime"*. **Three vendors' reviewers rejected that independently on one round**, and a fourth finding extended it:

- two `codex` rows with different executables, base URLs or prices are two different backends, and picking whichever comes first is a coin toss that **bills the wrong one** with nothing on screen saying which;
- the answer would change on a restart if the rows were ever reordered;
- one Team server hosts **several** vendor rows (`<server>-codex`, `<server>-claude`), so a server id alone cannot say which vendor is to answer.

So **a provider IS a configured vendor row**, local and remote alike, and resolution is a lookup by row id rather than a search. Nothing in it can be ambiguous, because nothing in it searches. The plan's status line records the overturn.

## What shipped

- **`chatProvidersFrom(vendors, catalog)`** — the providers a chat can be sent to, each carrying the models it can be pointed at, and every configured row that cannot chat named as refused. It takes a `ChatCatalog` (discovered codex/agy lists, the local engine, the server states) rather than reaching for them, so it stays pure.
- **`resolveChatPick`** — a pair → the row that says HOW to run it. **The pair is checked as a pair**: a model-only check would accept `sonnet` against the `agy` row whenever any other provider offers a model by that name, and `vendor-routing.md` forbids a Claude model going through `agy` by name. The chosen model is returned *beside* the row, never written into it — a row's configured model belongs to the reviewer that row is.
- **`legacyPick`** — what a saved `coai.chatModel` means now. A row keeps working and brings its model. A MODEL resolves only when exactly one provider offers it; with two it strands, carrying the candidates so the caller can ask "which of these two?".
- **`allowedModelsFor` moved from `panelView.ts` to `models.ts`**, unchanged. It was always pure, but living in the file that renders the panel meant a pure module had to import a webview renderer to ask what a Team server allows.

## The wire value is asserted, not just acceptance

The gate refused a contract case that only proves the server *accepts* a request: it can accept one while the field is missing, empty, or carrying the prefixed row id. Three tests assert what `serverVendorOf` actually puts on the wire — the recorded `remoteVendor`, the prefix-stripped fallback for rows written before that field existed, and that the row id **never** goes out. This is the field this family lost once for three releases with both suites green.

## The gate

- Plan round: `good_enough`, all 3 reviewers, 15 gating — 16 accepted, 1 rejected.
- Code round: **`proceed`**, 8 of 12 reviewers (codex hit its usage limit on four roles), 14 gating — 4 accepted, 18 rejected with reasons.

Accepted from the code round: a switched-off row now says so instead of reading as one that is gone; `legacyPick` names the conflicting providers; the row-first precedence is stated rather than assumed; `allowedModelsFor` lower-cases once instead of per catalog entry per row per rebuild.

Three findings were reported as **Blocking security defects and are refuted by the code they name**, which is checkable: `typeof null === 'object'`, so the `remoteVendor` string guard excludes null and never reaches `.length` (the comment on that line already said so); `server.catalog.vendors ?? []` is already there; the empty-model label already falls back to the bare row id. All three name lines this branch moved between files without editing.

## Tests

RED first: `Module '../chatModels' has no exported member 'chatProvidersFrom'`. GREEN after: `npm test` **1103 tests, 1102 pass, 0 fail, 1 skipped** — 20 new. `plan-lifecycle.mjs` and `pin-check.mjs` clean.

## Not in scope

The two SELECTS (`chatPickerHtml` in `chatPage.ts`, the panel control in `panelView.ts`) — other lanes own those files. **And the `coai.chatProvider` setting itself**, which drags a manifest entry, a `SETTING_ALIAS`, an English help article and four translations behind it; it ships with the UI that reads it. Nothing a person can see changed here, so there is deliberately no CHANGELOG entry and no help article.

**A named next step this branch does not take:** `remoteChatFor` passes `vendor.model` — the ROW's configured model — so the wiring lane must widen it to take the CHOSEN model, or a picked model would be resolved and then ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
