### PR TITLE
feat(chat): a conversation survives a window reload

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -958,6 +958,14 @@ would have made the whole feature a no-op. A closed tab is simply never restored
 only deserializes panels that were open. The store is bounded instead: a record per conversation,
 newest first, cut at a week and at twenty, swept once on activation.
 
+**A push that changed nothing writes nothing.** `show` runs on every state push — a turn starting, a
+queue position moving, a failure clearing — and the first version rewrote up to twenty whole
+transcripts into one key each time, which is a great deal of JSON on the extension host for a page
+that said the same words. The comparison is by REFERENCE, exact because `thread.messages` is replaced
+rather than mutated. And a question a restored conversation refuses comes BACK to the composer: the
+page clears its box when it sends, so a refusal that said only what was wrong would also have thrown
+away what the person typed, leaving them to write it again to try the fix they were just told to make.
+
 `chatTabs.ts` holds all of that with no `vscode` import — what is written, what a damaged record does
 (dropped, never repaired: a transcript with a hole reads as a model that said nothing), what a
 different `version` does (discarded, never guessed at), and the write queue. The queue matters

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -920,6 +920,55 @@ because it could override the value out of sight. A second test in the file driv
 guard that cannot be described in a fixture is a guard nobody can trust. The discovery walks `.ts`,
 `.tsx`, `.mts` and `.cts`, so a panel arriving as a `.tsx` is not a panel nobody scans.
 
+## A conversation survives a window reload (2026-09-09)
+
+There was no `registerWebviewPanelSerializer` anywhere in this extension, so a window reload — or an
+extension update restarting the host — emptied every chat tab. `retainContextWhenHidden` keeps a
+panel alive while it is HIDDEN, which is a different thing entirely.
+
+**Identity is the whole design, and the plan round is why.** The first draft keyed the store by the
+tab's TITLE, because nothing was calling `setState` and a title is the only thing VS Code preserves
+by itself. Six reviewers took it apart independently and they were right on every count: two namesake
+tabs would overwrite each other on the way IN, so the collision could never even be detected on the
+way out; a `deserializeWebviewPanel` call cannot know whether another panel of the same name is still
+coming; and `workspaceState` is shared by two windows on one folder. So the conversation carries its
+own id — minted in `newConversation`, rendered into the page, handed straight back through
+`setState`, and returned to the serializer after a reload. That is the one line in `chatPage.ts`.
+
+**Nothing is started when a tab comes back.** The process that was answering died with the window,
+and most restored tabs are never spoken to again; opening a CLI for each of them at every reload
+would be a window full of vendor processes nobody asked for. The transcript is rendered, the composer
+works, and `reopened` starts the session inside the FIRST turn — re-running the same three checks the
+command makes before opening a tab at all, because a reload can be a week and a machine rebuild away
+from the conversation it restores. The transcript is already in `carry`, so the model that answers is
+handed the whole thread through `carriedTurn`: the handover a model switch already ships, which is
+why nothing here resumes a vendor thread and no adapter learns anything new.
+
+**A restored panel is built by `createChatPanel`, with the panel VS Code handed back.** That is what
+keeps the icon, the message wiring, the zoom hook and the disposal in one place; the icon plan's own
+test holds it from the other side. Two halves of the options are not the same: `webview.options` can
+be set again on a restored panel and is, but `retainContextWhenHidden` and `enableFindWidget` are
+fixed at creation with no API to change them, so whether a restored tab keeps its find bar is the
+workbench's decision and not ours.
+
+**Nothing is deleted when a tab closes**, and that is deliberate: a disposal cannot tell a person
+closing a tab from a reload tearing one down, and VS Code disposes every panel on reload. Deleting
+there would erase the transcript at exactly the moment it is needed — the code round named it, and it
+would have made the whole feature a no-op. A closed tab is simply never restored, because VS Code
+only deserializes panels that were open. The store is bounded instead: a record per conversation,
+newest first, cut at a week and at twenty, swept once on activation.
+
+`chatTabs.ts` holds all of that with no `vscode` import — what is written, what a damaged record does
+(dropped, never repaired: a transcript with a hole reads as a model that said nothing), what a
+different `version` does (discarded, never guessed at), and the write queue. The queue matters
+because every write is read-modify-write of one key: two tabs saving in the same moment would both
+read the same old value and the later write would drop the earlier one's conversation. It recovers
+from a rejection rather than staying poisoned, since a storage failure that silently stopped every
+later write would be indistinguishable from the bug this fixes.
+
+**The open tail.** A panel restored into a window where the conversation's record was pruned is
+disposed rather than left as an empty tab pretending to be one.
+
 ## The chat tab wears its own glyph (2026-09-09)
 
 Every chat tab wore the generic `≡`, because `createWebviewPanel` never set `iconPath` — there was

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -974,8 +974,17 @@ read the same old value and the later write would drop the earlier one's convers
 from a rejection rather than staying poisoned, since a storage failure that silently stopped every
 later write would be indistinguishable from the bug this fixes.
 
-**The open tail.** A panel restored into a window where the conversation's record was pruned is
-disposed rather than left as an empty tab pretending to be one.
+**Two open tails.** A panel restored into a window where the conversation's record was pruned is
+disposed rather than left as an empty tab pretending to be one — silently, which is the right trade at
+window start and the wrong one if anybody reports the tab vanishing.
+
+And `chatCommand.ts` is 920 lines, over the 800 the coding-style rule allows; it was 720 before this
+change. The extraction that fixes it is real and named: `readyToChat`, `cliFor`, `remoteFor` and
+`started` are a coherent "what can answer, and how is it started" cluster with no tie to the thread
+registry, used by three callers — opening a tab, switching a model, and reopening a restored
+conversation. It is NOT done here on purpose: this diff has been through its code round, a file move
+afterwards would ship unreviewed movement, and two other plans are editing the same file. It is worth
+one small change of its own.
 
 ## The chat tab wears its own glyph (2026-09-09)
 

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -32,6 +32,11 @@ margins, its font, its background and the text size you had chosen, all of it, o
 size only appeared when something unrelated happened to push it. Fixed, with a test that fails the
 build if any rule on that page is ever swallowed again.
 
+**Reloading the window no longer throws away your conversations.** Every open chat tab comes back
+with its questions and its answers, and a line saying it was closed by the reload. The model behind it
+is genuinely gone, so nothing is running until you ask again — and that first question carries the
+whole conversation across to a new session, which is said out loud because it is what it costs.
+
 ## Extension 0.31.21 — 2026-09-09
 
 **A chat tab looks like a chat tab.** It wore the same generic icon as everything else in the editor,

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -102,6 +102,9 @@ interface Thread extends ChatMemory {
   readonly saveId: string;
   /** The tab's heading, kept here because what is written down has to name the conversation. */
   readonly title: string;
+  /** What was last written to the store, so a push that changed nothing writes nothing. */
+  savedMessages?: readonly ChatMessage[];
+  savedModelId?: string;
   /**
    * A conversation restored from a reload, whose vendor process does not exist yet.
    *
@@ -196,9 +199,17 @@ function show(entry: ChatEntry, running: boolean, failure: string, queued = 0): 
     modelId: thread.modelId,
     queued,
   });
-  // The one place the transcript reaches a page is the one place it is written down. A record per
-  // push is a record that cannot be a turn behind, and the store is small: a title, a passage, a
-  // model id and the messages.
+  // The one place the transcript reaches a page is the one place it is written down — but only when
+  // there is something new to write. `show` runs on every state push: a turn starting, a queue
+  // position moving, a failure clearing. Each of those used to rewrite up to twenty whole
+  // transcripts into one key, which is a lot of JSON on the extension host for a page that said the
+  // same words. The comparison is by REFERENCE, because `thread.messages` is replaced rather than
+  // mutated, so it is exact and costs nothing. (gemini, the code round.)
+  if (thread.savedMessages === thread.messages && thread.savedModelId === thread.modelId) {
+    return;
+  }
+  thread.savedMessages = thread.messages;
+  thread.savedModelId = thread.modelId;
   memory?.remember({
     id: thread.saveId,
     title: thread.title,
@@ -306,6 +317,10 @@ async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
   const refused = await reopened(thread);
   if (refused.length > 0) {
     show(entry, false, refused);
+    // And the question comes BACK. The page cleared its composer when it sent, so a refusal that
+    // said only what was wrong would also have thrown away what the person typed — and they would
+    // have to write it again to try the fix they were just told to make. (gemini, the code round.)
+    pushChatDraft(entry, text);
 
     return;
   }

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -1,7 +1,9 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import * as vscode from 'vscode';
+import { ChatTabMemory, SavedTab, reloadedNote } from './chatTabs';
 import { ChatEntry, ChatPanels } from './chatPanels';
 import { ChatSession } from './chatSession';
 import { ChatMessage, ChatModelChoice } from './chatPage';
@@ -91,9 +93,41 @@ interface Thread extends ChatMemory {
    * chain is here, mirroring the one inside `cliChatSession`. (gemini, the code round.)</p>
    */
   turns: Promise<unknown>;
+  /**
+   * This conversation's id in the store, so what it is holding can be written down as it changes.
+   *
+   * <p>Not the entry's identity object — that one dies with the window. This is the string the page
+   * hands back to the serializer after a reload.</p>
+   */
+  readonly saveId: string;
+  /** The tab's heading, kept here because what is written down has to name the conversation. */
+  readonly title: string;
+  /**
+   * A conversation restored from a reload, whose vendor process does not exist yet.
+   *
+   * <p>Nothing is started when a tab comes back: the process behind it died with the window, a
+   * restored tab may never be spoken to again, and starting one per tab at every reload would spawn
+   * a CLI for each of them for nothing. The first question opens the session and hands it the whole
+   * transcript through `carry`, which is the handover a model switch already ships.</p>
+   */
+  reopen: boolean;
 }
 
 const threads = new WeakMap<object, Thread>();
+
+/**
+ * Where conversations are kept so a window reload does not empty them. Set once, in `activate`.
+ *
+ * <p>A module-level handle rather than a parameter on six signatures: the command has no context and
+ * neither do the callbacks a panel is wired with, and threading a store through both to reach two
+ * call sites would be a wide change for a narrow need. It is absent only in tests of this file's
+ * pure neighbours, and every use is guarded.</p>
+ */
+let memory: ChatTabMemory | undefined;
+
+export function rememberChatsIn(store: ChatTabMemory): void {
+  memory = store;
+}
 
 /** The tabs, narrowed to what `sessionKey` judges on. */
 function snapshots(): { active: TabSnapshot | undefined; all: TabSnapshot[] } {
@@ -162,6 +196,16 @@ function show(entry: ChatEntry, running: boolean, failure: string, queued = 0): 
     modelId: thread.modelId,
     queued,
   });
+  // The one place the transcript reaches a page is the one place it is written down. A record per
+  // push is a record that cannot be a turn behind, and the store is small: a title, a passage, a
+  // model id and the messages.
+  memory?.remember({
+    id: thread.saveId,
+    title: thread.title,
+    passage: thread.passage,
+    modelId: thread.modelId,
+    messages: thread.messages,
+  });
 }
 
 /**
@@ -204,6 +248,47 @@ function asText(reason: unknown): string {
 }
 
 /**
+ * Give a restored conversation the process it has not got, or say why it cannot have one.
+ *
+ * <p>Returns an empty string when there is nothing to do, which is every ordinary turn. A refusal is
+ * the sentence the page shows: the model this conversation was having may no longer be configured,
+ * its CLI may be gone, a Team server may have signed out. All three are the same three checks the
+ * command makes before opening a tab at all — asked again here, because a reload can be a week and
+ * a machine rebuild away from the conversation it is restoring.</p>
+ */
+async function reopened(thread: Thread): Promise<string> {
+  if (!thread.reopen) {
+    return '';
+  }
+  const config = vscode.workspace.getConfiguration('coai');
+  const ready = readyToChat(config, thread.modelId);
+  if (!ready.ok) {
+    return ready.refusal;
+  }
+  const cli = await cliFor(ready.vendor);
+  if (cli.refusal.length > 0) {
+    return cli.refusal;
+  }
+  const remote = isRemote(ready.vendor) ? await remoteFor(ready.vendor) : { session: undefined, refusal: '' };
+  if (remote.refusal.length > 0) {
+    return remote.refusal;
+  }
+
+  const opened = started(ready.vendor, cli.resolved, remote.session);
+  thread.session.dispose();
+  thread.home.release();
+  thread.session = opened.session;
+  thread.home = opened.home;
+  thread.modelId = ready.modelId;
+  // The WHOLE memory object, not one field of it: a switch that set `forgetful` and forgot `asked`
+  // is a defect this file has already had once, and the type is what stops it happening twice.
+  Object.assign(thread, memoryOf(ready.vendor));
+  thread.reopen = false;
+
+  return '';
+}
+
+/**
  * One turn, start to finish.
  *
  * <p>The question is appended BEFORE the turn is sent, so the page shows it while the model is
@@ -212,6 +297,16 @@ function asText(reason: unknown): string {
 async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
   const thread = threads.get(entry.id);
   if (thread === undefined) {
+    return;
+  }
+  // A conversation that came back from a reload has no process yet. It is opened HERE, on the first
+  // question and not before, so a window with five restored tabs starts nothing until one of them is
+  // spoken to — and the transcript is already in `carry`, so the model that answers is handed the
+  // whole thread exactly as it is after a model switch.
+  const refused = await reopened(thread);
+  if (refused.length > 0) {
+    show(entry, false, refused);
+
     return;
   }
   thread.messages = [...thread.messages, { role: 'you', text }];
@@ -545,8 +640,13 @@ function newConversation(
 ): ChatEntry {
   const first = started(ready.vendor, resolved, remote);
   const session = first.session;
+  // Minted here, once, and never seen by anybody: it goes into the page, comes back from the page
+  // after a reload, and names this conversation in the store. A title could not — two Claude Code
+  // sessions can share one, which is the defect `chatPanels.ts` was keyed by identity to avoid.
+  const saveId = randomUUID();
   const entry = createChatPanel(
     {
+      id: saveId,
       title: state.title,
       passage: state.passage,
       messages: [],
@@ -559,7 +659,42 @@ function newConversation(
       uiScale: chatUiScale(),
     },
     session,
-    {
+    conversationHooks(panels),
+    extensionUri,
+  );
+  // Recorded against the entry's OWN id, which `createChatPanel` made — not against the tab key,
+  // which can move under a live conversation. That distinction cost a whole code round.
+  threads.set(entry.id, {
+    session,
+    home: first.home,
+    passage: state.passage,
+    models: ready.models,
+    modelId: ready.modelId,
+    running: false,
+    // Counted from 1 by the first turn, so 0 is "this conversation has not asked anything yet" and
+    // can never be mistaken for a turn a stop could name.
+    turn: 0,
+    ...memoryOf(ready.vendor),
+    carry: [],
+    messages: [],
+    turns: Promise.resolve(),
+    saveId,
+    title: state.title,
+    reopen: false,
+  });
+
+  return entry;
+}
+
+/**
+ * Everything a chat page can ask of the host, for a conversation that is opened OR restored.
+ *
+ * <p>One object built in one place. Both paths create a panel, and a second copy of these six
+ * callbacks would be six chances for a restored tab to stop stopping turns, or to leak a session on
+ * close, the day one of them changes.</p>
+ */
+function conversationHooks(panels: ChatPanels): Parameters<typeof createChatPanel>[2] {
+  return {
       onSend: (id, text) => {
         const found = panels.entryOf(id);
         if (found !== undefined) {
@@ -611,28 +746,78 @@ function newConversation(
       onPageError: (_id, message) => {
         void vscode.window.showWarningMessage(`The chat page reported: ${message}`);
       },
-    },
-    extensionUri,
-  );
-  // Recorded against the entry's OWN id, which `createChatPanel` made — not against the tab key,
-  // which can move under a live conversation. That distinction cost a whole code round.
-  threads.set(entry.id, {
-    session,
-    home: first.home,
-    passage: state.passage,
-    models: ready.models,
-    modelId: ready.modelId,
-    running: false,
-    // Counted from 1 by the first turn, so 0 is "this conversation has not asked anything yet" and
-    // can never be mistaken for a turn a stop could name.
-    turn: 0,
-    ...memoryOf(ready.vendor),
-    carry: [],
-    messages: [],
-    turns: Promise.resolve(),
-  });
+  };
+}
 
-  return entry;
+/**
+ * Bring one conversation back into a panel VS Code has just restored.
+ *
+ * <p>No process is started. The transcript is rendered, the composer works, and the session is opened
+ * by the first question — see `reopened`. The panel is built by `createChatPanel` like every other
+ * one, so the icon, the message wiring, the zoom hook and the disposal are the same code and cannot
+ * drift apart.</p>
+ */
+export function restoreConversation(
+  panels: ChatPanels,
+  panel: vscode.WebviewPanel,
+  saved: SavedTab,
+  extensionUri: vscode.Uri,
+): void {
+  const config = vscode.workspace.getConfiguration('coai');
+  const ready = readyToChat(config, saved.modelId);
+  // A dead session, and the page can never reach it: `reopened` replaces it before the first turn is
+  // sent. It answers rather than throws, because a `ChatSession` that rejects is a contract this
+  // codebase does not have — every failure here is a sentence.
+  const closed: ChatSession = {
+    send: () => Promise.resolve({ ok: false, failure: reloadedNote(saved.modelId) }),
+    stop: () => undefined,
+    dispose: () => undefined,
+  };
+  const entry = createChatPanel(
+    {
+      id: saved.id,
+      title: saved.title,
+      passage: saved.passage,
+      messages: saved.messages,
+      models: ready.ok ? ready.models : [],
+      modelId: saved.modelId,
+      running: false,
+      capped: false,
+      failure: ready.ok ? reloadedNote(saved.modelId) : ready.refusal,
+      draft: '',
+      uiScale: chatUiScale(),
+    },
+    closed,
+    conversationHooks(panels),
+    extensionUri,
+    panel,
+  );
+  threads.set(entry.id, {
+    session: closed,
+    home: { dir: '', release: () => undefined },
+    passage: saved.passage,
+    models: ready.ok ? ready.models : [],
+    modelId: saved.modelId,
+    running: false,
+    turn: 0,
+    // Replaced by `reopened` with the rules of whatever model actually answers — this conversation
+    // asks nothing until then, so neither field is consulted before it is right. Written out rather
+    // than taken from `memoryOf`, which needs a vendor, and a restored tab has none yet.
+    forgetful: false,
+    asked: 0,
+    // The whole transcript, ready to travel with the first question — the same handover a model
+    // switch performs, and the reason nothing has to resume a vendor thread.
+    carry: [...saved.messages],
+    messages: [...saved.messages],
+    turns: Promise.resolve(),
+    saveId: saved.id,
+    title: saved.title,
+    reopen: true,
+  });
+  // Its own key: the tab this conversation was opened FROM may be gone, may be a different object,
+  // or may already hold a live conversation of its own. A restored tab is its own thing until
+  // somebody closes it.
+  panels.open({}, saved.title, () => entry);
 }
 
 /**

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -46,6 +46,15 @@ export interface ChatModelChoice {
 }
 
 export interface ChatPageState {
+  /**
+   * This conversation's own id, minted where the tab is made and never shown to anybody.
+   *
+   * <p>The page hands it straight back through `setState`, which is the only thing VS Code preserves
+   * about a webview across a window reload — so it is the whole of how a restored tab knows WHICH
+   * conversation it is. A title cannot do that job: two Claude Code sessions can both be called
+   * `main`, which is why `chatPanels.ts` is keyed by object identity rather than by name.</p>
+   */
+  readonly id: string;
   /** The Claude Code session this tab belongs to — its label, shown as the heading. */
   readonly title: string;
   readonly passage: string;
@@ -281,6 +290,10 @@ export function shouldFollow(
 function chatScript(state: ChatPageState, regions: Regions): string {
   return `(function () {
   const vscode = acquireVsCodeApi();
+  // The one thing VS Code keeps about this page across a window reload, and it hands it back to
+  // deserializeWebviewPanel. It is how a restored tab says which conversation it is — a title could
+  // not, because two Claude Code sessions can share one.
+  vscode.setState(${jsonForScript({ id: state.id })});
   let captions = ${jsonForScript(Object.fromEntries(state.models.map((model) => [model.id, model.caption])))};
   // The webview swallows a thrown error silently, and a page that stops responding to Enter with no
   // sign of why is the defect this trap exists to name. Same shape as the rounds log's.

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -91,12 +91,18 @@ export interface ChatPushState {
  *
  * @param known whether a model id the page asks for is one this conversation was actually offered
  * @param extensionUri where this extension was installed — the only way to name a file it ships
+ * @param restored the panel VS Code handed back after a window reload, for the serializer to fill.
+ *   Absent for a tab somebody opened, which is the ordinary case. It exists so that a RESTORED tab
+ *   is built here and nowhere else: the icon, the message wiring, the disposal and the zoom hook are
+ *   all set up in this one function, and a second place that made a chat panel would have to
+ *   remember every one of them, forever, on every change to any of them.
  */
 export function createChatPanel(
   state: ChatPageState,
   session: DisposableSession,
   hooks: ChatPanelHooks,
   extensionUri: vscode.Uri,
+  restored?: vscode.WebviewPanel,
 ): ChatEntry {
   // The conversation's own identity, created once and never replaced. See the module comment.
   const id = { conversation: state.title };
@@ -106,7 +112,7 @@ export function createChatPanel(
   // model is, one of them frozen. (gemini, the second code round.)
   offered.set(id, new Set(state.models.map((model) => model.id)));
 
-  const panel = vscode.window.createWebviewPanel(
+  const panel = restored ?? vscode.window.createWebviewPanel(
     'coaiChat',
     state.title,
     vscode.ViewColumn.Active,
@@ -119,6 +125,15 @@ export function createChatPanel(
       localResourceRoots: [],
     },
   );
+  if (restored !== undefined) {
+    // A panel VS Code rebuilt runs the page again, so the script has to be allowed again — the
+    // webview half of the options is settable and this is where it is set. The PANEL half is not:
+    // `retainContextWhenHidden` and `enableFindWidget` are fixed at creation and there is no API to
+    // change them afterwards, so whether a restored tab keeps its find bar is the workbench's call
+    // and not ours. Named here rather than pretended about.
+    restored.webview.options = { enableScripts: true, localResourceRoots: [] };
+    restored.title = state.title;
+  }
   // A pair, because a tab icon is workbench chrome and no theme reaches it — `var(--vscode-…)` is
   // unavailable there, and the colour has to be baked into the file. The paths are resolved by
   // `chatTabIcon` rather than spelled out here: a path written twice is a path that goes stale on the

--- a/src_vs_code/src/chatTabs.ts
+++ b/src_vs_code/src/chatTabs.ts
@@ -1,0 +1,185 @@
+import { ChatMessage } from './chatPage';
+
+/**
+ * What is kept of a chat tab so a window reload does not take the conversation with it.
+ *
+ * <p>There is no `WebviewPanelSerializer` in this extension before this module, so a reload emptied
+ * every chat tab: `retainContextWhenHidden` keeps a panel alive while it is HIDDEN, which is a
+ * different thing entirely.</p>
+ *
+ * <p>No `vscode` import, on purpose. Every rule here — what is written, what a corrupt record does,
+ * what is pruned and when — is a decision, and a decision inside the host is a decision no test can
+ * reach. The host half is thirty lines that call this.</p>
+ */
+
+/** One conversation, as much of it as is worth carrying across a reload. */
+export interface SavedTab {
+  /**
+   * The conversation's own id, minted when its tab is created and echoed back by the page.
+   *
+   * <p>Not the title. Two Claude Code sessions can both be called `main`, and `chatPanels.ts` exists
+   * because of it — *"a registry keyed by name hands the second tab the first tab's conversation, an
+   * answer that arrives and is simply about somebody else's question."* A title-keyed store would
+   * have reproduced that defect at reload, and worse: the two records would have overwritten each
+   * other on the way in, so the collision could not even be detected on the way out.</p>
+   */
+  readonly id: string;
+  /** When this record was last written, for the pruning below. */
+  readonly savedAt: number;
+  readonly title: string;
+  readonly passage: string;
+  readonly modelId: string;
+  readonly messages: readonly ChatMessage[];
+}
+
+/** The `globalState`/`workspaceState` key, in the dotted form `coai.usageForgottenBefore` set. */
+export const TAB_STORE_KEY = 'coai.chatTabs';
+
+/**
+ * The shape this module writes. Bumping it discards every older record rather than guessing at it.
+ *
+ * <p>A stored object is read back by a build that may be newer or older than the one that wrote it,
+ * and a half-understood transcript is worse than none: it would be rendered as a conversation the
+ * person recognises, with pieces missing.</p>
+ */
+export const TAB_VERSION = 1;
+
+/** Records older than this are dropped: a week-old conversation is not one anybody is resuming. */
+export const KEEP_FOR_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * And no more than this many, newest first.
+ *
+ * <p>Age alone does not bound the store: somebody who opens thirty tabs in an afternoon has thirty
+ * records within the week, and `workspaceState` is a bounded thing whose overflow is silent.</p>
+ */
+export const KEEP_TABS = 20;
+
+const isMessage = (value: unknown): value is ChatMessage => {
+  const row = value as { role?: unknown; text?: unknown } | null;
+
+  return row !== null && typeof row === 'object'
+    && (row.role === 'you' || row.role === 'model') && typeof row.text === 'string';
+};
+
+const isTab = (value: unknown): value is SavedTab => {
+  const tab = value as Partial<Record<keyof SavedTab, unknown>> | null;
+
+  return tab !== null && typeof tab === 'object'
+    && typeof tab.id === 'string' && tab.id.length > 0
+    && typeof tab.savedAt === 'number' && Number.isFinite(tab.savedAt)
+    && typeof tab.title === 'string' && typeof tab.passage === 'string'
+    && typeof tab.modelId === 'string'
+    && Array.isArray(tab.messages) && tab.messages.every(isMessage);
+};
+
+/**
+ * The records in a stored value, and nothing else.
+ *
+ * <p>Every field is checked because every field is rendered, and what is stored can be edited by
+ * hand, written by another version, or half-written by a host that was killed. A record that does
+ * not survive this is DROPPED rather than repaired: the alternative is a transcript with a hole in
+ * it that reads as if the model said nothing.</p>
+ */
+export function tabsFrom(raw: unknown): readonly SavedTab[] {
+  const stored = raw as { version?: unknown; tabs?: unknown } | null;
+  if (stored === null || typeof stored !== 'object' || stored.version !== TAB_VERSION) {
+    return [];
+  }
+
+  return Array.isArray(stored.tabs) ? stored.tabs.filter(isTab) : [];
+}
+
+/** What `tabsFrom` reads back. */
+export function stored(tabs: readonly SavedTab[]): { readonly version: number; readonly tabs: readonly SavedTab[] } {
+  return { version: TAB_VERSION, tabs };
+}
+
+/** Newest first, then cut by age and by count. */
+export function pruned(tabs: readonly SavedTab[], now: number): readonly SavedTab[] {
+  return [...tabs]
+    .sort((left, right) => right.savedAt - left.savedAt)
+    .filter((tab) => now - tab.savedAt < KEEP_FOR_MS)
+    .slice(0, KEEP_TABS);
+}
+
+/** This conversation, replacing whatever was held for it, with the store pruned on the way. */
+export function remembered(tabs: readonly SavedTab[], tab: SavedTab, now: number): readonly SavedTab[] {
+  return pruned([tab, ...tabs.filter((held) => held.id !== tab.id)], now);
+}
+
+/** This conversation forgotten — for a tab the person closed, not one a reload took away. */
+export function forgotten(tabs: readonly SavedTab[], id: string): readonly SavedTab[] {
+  return tabs.filter((tab) => tab.id !== id);
+}
+
+export const savedTab = (tabs: readonly SavedTab[], id: string): SavedTab | undefined =>
+  tabs.find((tab) => tab.id === id);
+
+/**
+ * The sentence a restored tab opens with. Shown in the page, where the person is looking.
+ *
+ * <p>It has to be honest about two different things at once: the process that was answering is gone
+ * and is not coming back, and the conversation itself is not — the next question opens a new session
+ * and hands it everything above. A tab that simply reappeared full of text would be a tab that looks
+ * alive, and the first question would then quietly cost a whole transcript with nothing having said
+ * so.</p>
+ */
+export function reloadedNote(modelId: string): string {
+  return 'This conversation was closed by a window reload. Ask again to continue it — the next '
+    + `question opens a new ${modelId} session and carries everything above across to it.`;
+}
+
+/** The two methods of a VS Code memento this module needs, and no more of it than that. */
+export interface TabStore {
+  get(key: string): unknown;
+  update(key: string, value: unknown): Thenable<void>;
+}
+
+/**
+ * The store, written in order.
+ *
+ * <p>Every write is read-modify-write of one key, so two tabs saving at the same moment would both
+ * read the same old value and the later write would drop the earlier one's conversation. They queue,
+ * and the queue recovers from a rejection instead of staying poisoned — a storage failure that
+ * silently stopped every later write would be indistinguishable from this bug.</p>
+ */
+export class ChatTabMemory {
+  private queued: Promise<void> = Promise.resolve();
+
+  constructor(private readonly store: TabStore, private readonly clock: () => number = Date.now) {}
+
+  /** What is held right now, validated. */
+  held(): readonly SavedTab[] {
+    return tabsFrom(this.store.get(TAB_STORE_KEY));
+  }
+
+  saved(id: string): SavedTab | undefined {
+    return savedTab(this.held(), id);
+  }
+
+  remember(tab: Omit<SavedTab, 'savedAt'>): void {
+    this.write((tabs) => remembered(tabs, { ...tab, savedAt: this.clock() }, this.clock()));
+  }
+
+  forget(id: string): void {
+    this.write((tabs) => forgotten(tabs, id));
+  }
+
+  /** On activation: a week of closed conversations is not something to carry forever. */
+  prune(): void {
+    this.write((tabs) => pruned(tabs, this.clock()));
+  }
+
+  /** Resolves when everything asked for so far has been written — the tests' way in, and only that. */
+  settled(): Promise<void> {
+    return this.queued;
+  }
+
+  private write(change: (tabs: readonly SavedTab[]) => readonly SavedTab[]): void {
+    const step = async (): Promise<void> => {
+      await this.store.update(TAB_STORE_KEY, stored(change(this.held())));
+    };
+    this.queued = this.queued.then(step, step).catch(() => undefined);
+  }
+}

--- a/src_vs_code/src/chatTabs.ts
+++ b/src_vs_code/src/chatTabs.ts
@@ -180,6 +180,12 @@ export class ChatTabMemory {
     const step = async (): Promise<void> => {
       await this.store.update(TAB_STORE_KEY, stored(change(this.held())));
     };
-    this.queued = this.queued.then(step, step).catch(() => undefined);
+    this.queued = this.queued.then(step, step).catch((reason: unknown) => {
+      // Swallowed so the queue survives — a chain left rejected would stop every later write, which
+      // is the same silence as the bug this module exists to end. Said out loud in the host's own
+      // log rather than in a notification: nobody can act on a memento that would not take a write,
+      // and one per turn would be a wall of them.
+      console.error('ConnectOtherAIs: a chat tab could not be saved for a reload', reason);
+    });
   }
 }

--- a/src_vs_code/src/extension.ts
+++ b/src_vs_code/src/extension.ts
@@ -3,7 +3,8 @@ import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { ChatPanels } from './chatPanels';
-import { chatWithOtherAi } from './chatCommand';
+import { chatWithOtherAi, rememberChatsIn, restoreConversation } from './chatCommand';
+import { ChatTabMemory } from './chatTabs';
 import { openLedger, reconcile } from './chatOrphans';
 import { coaiDataDir } from './dataDir';
 import { installFailureHint, SingleFlight } from './coaiInstall';
@@ -116,6 +117,17 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // One registry per window: a conversation belongs to a Claude Code tab, and tabs are per window.
   const chatPanels = new ChatPanels();
+  // Where conversations are kept so a window reload does not empty every chat tab. `workspaceState`
+  // rather than `globalState`, which everything else here uses: a setting belongs to the person and
+  // is shared by every window of the profile, but a chat tab belongs to THIS workspace, and offering
+  // one window's conversations to another is the namesake defect wearing a different hat.
+  const chatTabMemory = new ChatTabMemory(context.workspaceState);
+  rememberChatsIn(chatTabMemory);
+  // A record is kept when a tab CLOSES as well as when it is reloaded, because a disposal cannot tell
+  // the two apart — VS Code disposes every panel on reload too, and deleting on disposal would erase
+  // the transcript at exactly the moment it is needed. A closed tab is simply never restored: VS Code
+  // only deserializes panels that were open. So the store is bounded by this sweep instead.
+  chatTabMemory.prune();
   // Bound once, and never asked for again: an extension host has one storage directory for its
   // whole life, and threading it through six functions paired a per-call path with a module-level
   // list of children — two things that must agree, with nothing making them.
@@ -166,6 +178,25 @@ export function activate(context: vscode.ExtensionContext): void {
     // Deactivation is not a tab closing: nobody has told VS Code about these panels, so both the
     // panel and the vendor process behind it have to be ended here or they outlive the extension.
     { dispose: () => chatPanels.closeAll() },
+    // How a chat tab comes back after a window reload. VS Code hands back the panel and whatever the
+    // page saved with `setState` — here, the conversation's own id — and the transcript is looked up
+    // by that. A panel whose conversation is not in the store is disposed rather than left as an
+    // empty tab pretending to be one: the record can have been pruned, or written by a build that
+    // stored a different shape.
+    vscode.window.registerWebviewPanelSerializer('coaiChat', {
+      deserializeWebviewPanel: (panel: vscode.WebviewPanel, state: unknown) => {
+        const id = (state as { id?: unknown } | null)?.id;
+        const saved = typeof id === 'string' ? chatTabMemory.saved(id) : undefined;
+        if (saved === undefined) {
+          panel.dispose();
+
+          return Promise.resolve();
+        }
+        restoreConversation(chatPanels, panel, saved, context.extensionUri);
+
+        return Promise.resolve();
+      },
+    }),
     // Both doors repaint. The panel's own button used to be the only path that did — it awaits
     // the command and then renders — so an update started from THIS menu left the Server section
     // showing the version it had replaced, which is the very symptom the button was fixed for.

--- a/src_vs_code/src/helpContent.ts
+++ b/src_vs_code/src/helpContent.ts
@@ -241,7 +241,7 @@ export const HELP_ARTICLES: readonly HelpArticle[] = [
       usage:
         'The keybinding copies the selection for you and asks straight away. The right-click item cannot — closing that menu takes the selection out of the panel — so it takes whatever you last copied and puts it in the box for you to send, which is also why the passage is shown at the top of the tab: you can see what is about to be asked. One tab per assistant session, so two conversations never mix.',
       whatCanGoWrong:
-        'Copying the selection needs Windows; elsewhere the keybinding says so and points you at the menu, which works everywhere. If the model’s process dies the answer after it says the conversation restarted, because it genuinely does not remember the earlier turns. A reviewer on another runtime is refused by name rather than quietly missing — the chat speaks one protocol so far.',
+        'Copying the selection needs Windows; elsewhere the keybinding says so and points you at the menu, which works everywhere. If the model’s process dies the answer after it says the conversation restarted, because it genuinely does not remember the earlier turns. A reviewer on another runtime is refused by name rather than quietly missing — the chat speaks one protocol so far. Reloading the window keeps what was SAID: every open chat tab comes back with its questions and answers, and a line saying the conversation was closed by the reload. The model behind it is gone — nothing is running until you ask again, and that first question carries the whole transcript across to a new session, which is what it costs.',
     },
   },
   {

--- a/src_vs_code/src/test/aConversationSurvivesAReload.test.ts
+++ b/src_vs_code/src/test/aConversationSurvivesAReload.test.ts
@@ -259,3 +259,22 @@ test('the first question after a restore carries the whole transcript', () => {
   assert.match(restore.slice(0, 2_500), /carry: \[\.\.\.saved\.messages\]/,
     'a restored conversation hands the next model nothing, so it answers a follow-up it never heard');
 });
+
+test('a push that changed nothing writes nothing', () => {
+  // `show` runs on every state push — a turn starting, a queue position moving, a failure clearing —
+  // and each of those used to rewrite up to twenty whole transcripts into one key. The comparison is
+  // by reference, which is exact because `thread.messages` is replaced rather than mutated.
+  const command = source('chatCommand.ts');
+
+  assert.match(command, /if \(thread\.savedMessages === thread\.messages && thread\.savedModelId === thread\.modelId\) \{\s*\n\s*return;/,
+    'every state push writes the whole store again, transcripts and all');
+  assert.match(command, /thread\.savedMessages = thread\.messages;/, 'nothing records what was written');
+});
+
+test('a question refused by a dead conversation comes back to the composer', () => {
+  const command = source('chatCommand.ts');
+  const guard = command.slice(command.indexOf('const refused = await reopened(thread);'));
+
+  assert.match(guard.slice(0, 600), /pushChatDraft\(entry, text\)/,
+    'the refusal threw away what the person typed, so they must write it again to try the fix');
+});

--- a/src_vs_code/src/test/aConversationSurvivesAReload.test.ts
+++ b/src_vs_code/src/test/aConversationSurvivesAReload.test.ts
@@ -1,0 +1,261 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  ChatTabMemory,
+  KEEP_FOR_MS,
+  KEEP_TABS,
+  SavedTab,
+  TAB_STORE_KEY,
+  TAB_VERSION,
+  forgotten,
+  pruned,
+  reloadedNote,
+  remembered,
+  savedTab,
+  stored,
+  tabsFrom,
+} from '../chatTabs';
+
+/**
+ * A window reload no longer empties every chat tab.
+ *
+ * <p>2026-09-09: there was no `registerWebviewPanelSerializer` anywhere in this extension, so a
+ * reload — or an extension update restarting the host — took every open conversation with it.
+ * `retainContextWhenHidden` keeps a panel alive while it is HIDDEN, which is a different thing.</p>
+ *
+ * <p><b>Identity is the whole design, and the plan round is why.</b> The first draft keyed the store
+ * by the tab's TITLE, because without touching `chatPage.ts` nothing calls `setState` and a title is
+ * the only thing VS Code preserves. Six reviewers took that apart independently: two namesake tabs
+ * would overwrite each other on the way IN, so the collision could never be detected on the way out;
+ * a `deserializeWebviewPanel` call cannot know whether another panel of the same name is still
+ * coming; and `workspaceState` is shared by two windows on one folder. The conversation now carries
+ * its own id, minted where the tab is made and echoed back by the page.</p>
+ */
+
+const message = (role: 'you' | 'model', text: string) => ({ role, text });
+const tab = (over: Partial<SavedTab> = {}): SavedTab => ({
+  id: 'a1',
+  savedAt: 1_000,
+  title: 'main',
+  passage: 'the selected text',
+  modelId: 'gemini',
+  messages: [message('you', 'поясни'), message('model', 'вот что это значит')],
+  ...over,
+});
+
+// ---------------------------------------------------------------------------------------------
+// What is stored, and what a store that has been damaged does.
+// ---------------------------------------------------------------------------------------------
+
+test('a conversation round-trips through the store unchanged', () => {
+  const read = tabsFrom(stored([tab()]));
+
+  assert.deepEqual(read, [tab()]);
+  assert.deepEqual(savedTab(read, 'a1'), tab());
+  assert.equal(savedTab(read, 'nobody'), undefined);
+});
+
+test('a store written by another version is not guessed at', () => {
+  assert.deepEqual(tabsFrom({ version: TAB_VERSION + 1, tabs: [tab()] }), [],
+    'a record from a shape this build does not know was rendered anyway');
+  assert.deepEqual(tabsFrom({ tabs: [tab()] }), [], 'a record with no version was rendered anyway');
+});
+
+test('a record that cannot be read is dropped, and its neighbours survive', () => {
+  // Every field is checked because every field is rendered, and this value can be edited by hand,
+  // written by another build, or half-written by a host that was killed mid-update.
+  const damaged: unknown[] = [
+    null,
+    'a conversation',
+    { ...tab(), id: '' },
+    { ...tab(), savedAt: 'yesterday' },
+    { ...tab(), messages: 'поясни' },
+    { ...tab(), messages: [{ role: 'somebody else', text: 'hi' }] },
+    { ...tab(), messages: [{ role: 'you' }] },
+  ];
+
+  for (const bad of damaged) {
+    assert.deepEqual(
+      tabsFrom(stored([bad as SavedTab, tab({ id: 'b2' })])), [tab({ id: 'b2' })],
+      `a damaged record was read back as a conversation: ${JSON.stringify(bad)}`,
+    );
+  }
+});
+
+test('the newest record for a conversation replaces the one before it', () => {
+  const first = tab({ messages: [message('you', 'first')] });
+  const second = tab({ savedAt: 2_000, messages: [message('you', 'second')] });
+
+  const held = remembered([first, tab({ id: 'other', savedAt: 500 })], second, 2_000);
+
+  assert.deepEqual(held.map((held) => held.id), ['a1', 'other'], 'newest first, and no duplicate id');
+  assert.deepEqual(savedTab(held, 'a1'), second);
+});
+
+test('a week-old conversation is not carried forever, and neither are thirty of them', () => {
+  const now = 10 * KEEP_FOR_MS;
+  const old = tab({ id: 'old', savedAt: now - KEEP_FOR_MS - 1 });
+  const fresh = tab({ id: 'fresh', savedAt: now - 1 });
+
+  assert.deepEqual(pruned([old, fresh], now).map((held) => held.id), ['fresh']);
+
+  const many = Array.from({ length: KEEP_TABS + 5 }, (_, at) => tab({ id: `t${at}`, savedAt: now - at }));
+
+  assert.equal(pruned(many, now).length, KEEP_TABS, 'the store grows without bound');
+  assert.equal(pruned(many, now)[0].id, 't0', 'the oldest were kept and the newest dropped');
+});
+
+test('a conversation the person closed is forgotten; one they only reloaded is not', () => {
+  assert.deepEqual(forgotten([tab(), tab({ id: 'b2' })], 'a1').map((held) => held.id), ['b2']);
+  assert.deepEqual(forgotten([tab()], 'nobody').map((held) => held.id), ['a1'],
+    'forgetting an id nobody holds threw the store away');
+});
+
+// ---------------------------------------------------------------------------------------------
+// The store as the host uses it: one key, many writers.
+// ---------------------------------------------------------------------------------------------
+
+function fakeStore(): { store: { get(k: string): unknown; update(k: string, v: unknown): Promise<void> }; writes(): number } {
+  let held: unknown;
+  let writes = 0;
+
+  return {
+    store: {
+      get: (key: string) => (key === TAB_STORE_KEY ? held : undefined),
+      update: async (key: string, value: unknown) => {
+        writes += 1;
+        // A tick, so a queue that did not exist would let two writers read the same old value.
+        await Promise.resolve();
+        if (key === TAB_STORE_KEY) {
+          held = value;
+        }
+      },
+    },
+    writes: () => writes,
+  };
+}
+
+test('two tabs saving at the same moment do not drop each other', async () => {
+  const fake = fakeStore();
+  const memory = new ChatTabMemory(fake.store, () => 5_000);
+
+  memory.remember({ id: 'a1', title: 'main', passage: 'p', modelId: 'gemini', messages: [] });
+  memory.remember({ id: 'b2', title: 'other', passage: 'p', modelId: 'codex', messages: [] });
+  await memory.settled();
+
+  assert.deepEqual(memory.held().map((held) => held.id).sort(), ['a1', 'b2'],
+    'a write read a value another write had not finished replacing');
+});
+
+test('a storage failure does not stop every write after it', async () => {
+  const fake = fakeStore();
+  let failNext = true;
+  const flaky = {
+    get: (key: string) => fake.store.get(key),
+    update: async (key: string, value: unknown) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('settings.json is not writable');
+      }
+      await fake.store.update(key, value);
+    },
+  };
+  const memory = new ChatTabMemory(flaky, () => 5_000);
+
+  memory.remember({ id: 'a1', title: 'main', passage: 'p', modelId: 'gemini', messages: [] });
+  memory.remember({ id: 'b2', title: 'other', passage: 'p', modelId: 'codex', messages: [] });
+  await memory.settled();
+
+  assert.deepEqual(memory.held().map((held) => held.id), ['b2'],
+    'one rejected write poisoned the queue and nothing was ever saved again');
+});
+
+test('the store is pruned on demand, and a tab is forgotten by id', async () => {
+  const fake = fakeStore();
+  let now = 5_000;
+  const memory = new ChatTabMemory(fake.store, () => now);
+
+  memory.remember({ id: 'a1', title: 'main', passage: 'p', modelId: 'gemini', messages: [] });
+  await memory.settled();
+  assert.notEqual(memory.saved('a1'), undefined);
+
+  memory.forget('a1');
+  await memory.settled();
+  assert.equal(memory.saved('a1'), undefined, 'a closed tab was kept');
+
+  memory.remember({ id: 'b2', title: 'other', passage: 'p', modelId: 'codex', messages: [] });
+  await memory.settled();
+  now += KEEP_FOR_MS + 1;
+  memory.prune();
+  await memory.settled();
+
+  assert.deepEqual(memory.held(), [], 'a week-old conversation survived the sweep');
+});
+
+// ---------------------------------------------------------------------------------------------
+// The wiring, which imports `vscode` and so can only be read.
+// ---------------------------------------------------------------------------------------------
+
+const source = (file: string): string =>
+  fs.readFileSync(path.join(__dirname, '..', '..', 'src', file), 'utf8');
+
+test('the extension tells VS Code how to bring a chat tab back', () => {
+  // The symptom, as a test: there was no serializer anywhere, so a reload had nothing to restore
+  // through and every tab came back empty or not at all.
+  const wiring = source('extension.ts');
+
+  assert.match(wiring, /registerWebviewPanelSerializer\(\s*'coaiChat'/,
+    'nothing registers a serializer for the chat tab, so a reload still empties every one of them');
+  assert.match(wiring, /chatTabMemory|ChatTabMemory/, 'the serializer has no store to restore from');
+});
+
+test('a restored tab is built the way an opened one is', () => {
+  // The requirement `theTabWearsAnIcon.test.ts` holds from the other side: a panel restored past
+  // `createChatPanel` would come back without its icon, without its message wiring and without its
+  // disposal. This asserts the same rule from this plan's side, so removing either test still leaves
+  // one of them saying it.
+  assert.match(source('chatCommand.ts'), /createChatPanel\(/,
+    'the restore path builds a panel some other way');
+});
+
+test('a restored tab says what it is, and names the model the next question goes to', () => {
+  const note = reloadedNote('gemini');
+
+  assert.match(note, /closed by a window reload/,
+    'a tab full of text with nothing saying the process is gone reads as a live conversation');
+  assert.match(note, /carries everything above across/,
+    'nothing warns that the next question re-sends the whole transcript, which is what it costs');
+  assert.ok(note.includes('gemini'), 'the sentence does not name the model that will answer');
+});
+
+test('a panel whose conversation is not in the store is not left as an empty tab', () => {
+  const wiring = source('extension.ts');
+  const handler = wiring.slice(wiring.indexOf('deserializeWebviewPanel'));
+
+  assert.match(handler.slice(0, 700), /panel\.dispose\(\)/,
+    'a reload with no record left a chat tab that looks like a conversation and holds none');
+});
+
+test('no process is started until the first question after a restore', () => {
+  // The stop condition of the plan, as a test. A window with five restored tabs must spawn nothing:
+  // the process behind each of them died with the window, and most restored tabs are never spoken to
+  // again. `reopened` is what opens one, and it runs inside a turn.
+  const command = source('chatCommand.ts');
+  const restore = command.slice(command.indexOf('export function restoreConversation'));
+
+  assert.doesNotMatch(restore.slice(0, 2_000), /started\(/,
+    'restoring a tab starts a vendor process for a conversation nobody has asked anything');
+  assert.match(command, /const refused = await reopened\(thread\);/,
+    'a turn no longer opens the session a restored conversation has not got');
+  assert.match(command, /thread\.reopen = false;/, 'a reopened conversation would reopen on every turn');
+});
+
+test('the first question after a restore carries the whole transcript', () => {
+  const command = source('chatCommand.ts');
+  const restore = command.slice(command.indexOf('export function restoreConversation'));
+
+  assert.match(restore.slice(0, 2_500), /carry: \[\.\.\.saved\.messages\]/,
+    'a restored conversation hands the next model nothing, so it answers a follow-up it never heard');
+});

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -277,6 +277,7 @@ function bundledChatPage(): { bundle: string; html: string } {
   };
   const html = module_.chatPageHtml(
     {
+      id: 'conversation-1',
       title: 'привет',
       passage: 'The reviewers are read-only.',
       messages: [{ role: 'model', text: 'because the worktree is pinned' }],
@@ -416,11 +417,17 @@ test('the chat page script the bundle produces parses and runs', () => {
   };
   const window_: Record<string, unknown> = { addEventListener() {} };
 
+  // `setState` as well as `postMessage`: the page hands VS Code its conversation id the moment it
+  // loads, so a fake without that method is a fake the real page cannot run against — which is what
+  // this test caught the day the id was added.
+  let kept: unknown;
   assert.doesNotThrow(
     () => new Function('document', 'window', 'acquireVsCodeApi', body)(
-      document_, window_, () => ({ postMessage() {} })),
+      document_, window_, () => ({ postMessage() {}, setState(value: unknown) { kept = value; } })),
     'the chat page script threw on its first render',
   );
+  assert.deepEqual(kept, { id: 'conversation-1' },
+    'the page did not tell VS Code which conversation it is, so a reload could not restore it');
   // The trap must be installed, not merely written: a webview swallows a thrown error, and a page
   // that stops answering Enter with no sign of why is the defect it exists to name.
   assert.strictEqual(typeof window_['onerror'], 'function', 'the page installed no error trap');

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -164,7 +164,7 @@ test('the page script the bundle produces parses and runs', () => {
   };
   assert.doesNotThrow(
     () => new Function('document', 'window', 'acquireVsCodeApi', body)(
-      document_, { addEventListener() {} }, () => ({ postMessage() {} })),
+      document_, { addEventListener() {} }, () => ({ postMessage() {}, setState() {} })),
     'the page script threw on its first render',
   );
   assert.equal(seen['failed']?.textContent ?? '', '', 'the page reported an error to itself on first render');
@@ -337,7 +337,9 @@ test('the chat page the bundle produces runs, and its Send button sends exactly 
           (onWindow[type] ??= []).push(fn);
         },
       },
-      () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message) }),
+      // `setState` too: the page hands VS Code its conversation id on load, so a fake without it
+      // is a fake the shipped page cannot run against.
+      () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message), setState: () => undefined }),
       (fn: () => void) => { frames.push(fn); },
     ),
     'the minified chat page script threw on its first render',

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -18,6 +18,7 @@ const MODELS: readonly ChatModelChoice[] = [
 
 function state(over: Partial<ChatPageState> = {}): ChatPageState {
   return {
+    id: 'conversation-1',
     title: 'привет',
     passage: 'The reviewers are read-only.',
     messages: [],

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -394,7 +394,9 @@ function runChatPage(over: RunOptions = {}): RunningPage {
   new Function('document', 'window', 'acquireVsCodeApi', 'requestAnimationFrame', 'ResizeObserver', body)(
     document_,
     window_,
-    () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message) }),
+    // `setState` as well as `postMessage`: the page tells VS Code which conversation it is the
+    // moment it loads, so a fake without it is a fake the real page cannot run against.
+    () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message), setState: () => undefined }),
     (fn: () => void) => { pending.push(fn); },
     withoutResizeObserver === true ? undefined : FakeResizeObserver,
   );

--- a/src_vs_code/src/test/theTabWearsAnIcon.test.ts
+++ b/src_vs_code/src/test/theTabWearsAnIcon.test.ts
@@ -84,10 +84,10 @@ test('the chat tab asks the workbench for that pair', () => {
 });
 
 test('a panel restored after a reload must be built the same way', () => {
-  // The code round's open tail, held rather than written down. There is no `WebviewPanelSerializer`
-  // in this extension today, so no tab loses its icon — but the plan that adds one restores a panel
-  // WITHOUT passing through `chatWithOtherAi`, and would hand back tabs wearing the generic glyph
-  // again. The day a serializer appears, the file that registers it has to reach `createChatPanel`.
+  // Written as an open tail when there was no serializer at all, and it earned its keep the week
+  // after: the reload plan's first version restored a panel WITHOUT passing through
+  // `createChatPanel`, and this went red. A restored tab that skipped the builder would come back
+  // with no icon, no message wiring and no disposal.
   const root = path.join(EXTENSION_ROOT, 'src');
   const walk = (dir: string): string[] => fs.readdirSync(dir, { withFileTypes: true })
     .flatMap((entry) => {
@@ -108,7 +108,12 @@ test('a panel restored after a reload must be built the same way', () => {
     .filter((file) => /createChatPanel\(/.test(fs.readFileSync(file, 'utf8')))
     .map((file) => path.basename(file, '.ts'));
 
-  assert.ok(builders.length > 0, 'nothing builds a chat panel any more, so this scan guards nothing');
+  // The known instances, so a scan that has stopped matching anything cannot pass by matching
+  // nothing — the same pairing every structural test in this suite carries.
+  assert.ok(builders.includes('chatPanel'),
+    `the module that defines the builder is not among them; found ${builders.join(', ')}`);
+  assert.ok(builders.includes('chatCommand'),
+    `the module that opens and restores conversations is not among them; found ${builders.join(', ')}`);
 
   for (const file of files) {
     const source = fs.readFileSync(file, 'utf8');

--- a/src_vs_code/src/test/theTabWearsAnIcon.test.ts
+++ b/src_vs_code/src/test/theTabWearsAnIcon.test.ts
@@ -99,14 +99,31 @@ test('a panel restored after a reload must be built the same way', () => {
       return entry.name.endsWith('.ts') ? [full] : [];
     });
 
-  for (const file of walk(root)) {
+  const files = walk(root);
+  // Whoever builds a chat panel — `createChatPanel` itself, and anything that calls it. A serializer
+  // may reach the builder through one of those rather than call it directly, which is what
+  // `extension.ts` does; what it may not do is make a panel of its own, because the builder is the
+  // only place that sets the icon, the message wiring and the disposal.
+  const builders = files
+    .filter((file) => /createChatPanel\(/.test(fs.readFileSync(file, 'utf8')))
+    .map((file) => path.basename(file, '.ts'));
+
+  assert.ok(builders.length > 0, 'nothing builds a chat panel any more, so this scan guards nothing');
+
+  for (const file of files) {
     const source = fs.readFileSync(file, 'utf8');
     if (!source.includes('registerWebviewPanelSerializer')) {
       continue;
     }
 
-    assert.match(source, /createChatPanel/,
-      `${path.basename(file)} restores a chat panel without building it the way an opened one is built`);
+    assert.ok(
+      builders.some((builder) => source.includes(`'./${builder}'`)),
+      `${path.basename(file)} restores a chat panel without going through the one place that builds one`,
+    );
+    assert.doesNotMatch(
+      source, /createWebviewPanel\(/,
+      `${path.basename(file)} makes a chat panel of its own, so a restored tab would wear no icon`,
+    );
   }
 });
 


### PR DESCRIPTION
There was no `registerWebviewPanelSerializer` anywhere in this extension, so a window reload — or an
extension update restarting the host — emptied every chat tab. `retainContextWhenHidden` keeps a panel
alive while it is HIDDEN, which is a different thing.

## Identity is the whole design, and the plan round is why

The draft keyed the store by the tab's TITLE, because nothing called `setState` and a title is the
only thing VS Code preserves by itself. Six reviewers took it apart independently and were right on
every count: two namesake tabs would overwrite each other **on the way in**, so the collision could
never be detected on the way out; a `deserializeWebviewPanel` call cannot know whether another panel
of the same name is still coming; and `workspaceState` is shared by two windows on one folder.

The operator was asked and chose the one-line touch. The conversation carries its **own id** now —
minted where the tab is made, rendered into the page, handed straight back through `vscode.setState`,
and returned to the serializer after a reload. That line in `chatPage.ts` is the entire cross-lane
change, and it removes every one of those four defects rather than working around them.

## Nothing is started when a tab comes back

The process died with the window and most restored tabs are never spoken to again, so a window full
of them would be a window full of vendor processes nobody asked for. `reopened` opens the session
inside the **first turn**, re-running the three checks the command makes before opening a tab at all —
a reload can be a week and a machine rebuild away from the conversation it restores. The transcript is
already in `carry`, so the model that answers is handed the whole thread through `carriedTurn`: the
handover a model switch already ships. **No adapter learns anything new and no vendor thread is
resumed**, which is this plan's stop condition, respected rather than argued around.

## Nothing is deleted when a tab closes

A disposal cannot tell a person closing a tab from a reload tearing one down, and VS Code disposes
every panel on reload — deleting there would erase the transcript at exactly the moment it is needed,
which the plan round named and which would have made the whole feature a no-op. A closed tab is simply
never restored, because only open panels are deserialized. The store is bounded instead: newest first,
cut at a week and at twenty, swept on activation.

## `chatTabs.ts`, with no `vscode` import

A damaged record is **dropped, never repaired** — a transcript with a hole reads as a model that said
nothing. A record from another `version` is discarded rather than guessed at. Writes **queue**, because
read-modify-write of one key would let two tabs saving in the same moment drop each other's
conversation, and the queue recovers from a rejection rather than staying poisoned — a storage failure
that silently stopped every later write would be indistinguishable from the bug this fixes.

## What the code round changed

- **A push that changed nothing writes nothing.** `show` runs on every state push — a turn starting, a
  queue position moving, a failure clearing — and each rewrote up to twenty whole transcripts into one
  key. The comparison is by reference, exact because `thread.messages` is replaced rather than mutated.
- **A refused question comes back to the composer.** The page clears its box when it sends, so a
  refusal that said only what was wrong also threw away what the person typed.
- A failed write is logged rather than merely swallowed.
- The builder scan gained its known instances — this repository's rule is that a structural scan gets
  the prohibition *and* a test proving it still finds a sanctioned instance.

## Evidence

- RED first: `nothing registers a serializer for the chat tab, so a reload still empties every one of
  them`.
- **The icon plan's guard caught the first version of this change** going around `createChatPanel` —
  written a day earlier as an open tail, red the moment it mattered. It now checks the chain rather
  than one file's text.
- Whole suite: **1099 pass, 1 skipped, 0 fail**. `plan-lifecycle.mjs` clean; `pin-check.mjs` OK.

## The gate

Plan round `good_enough` — 3 reviewers, 15 findings, all 15 accepted, and they are what produced the
question to the operator. Code round `proceed` — but **7 of 12 reviewers answered**: codex hit its
account usage limit on all four roles and one gemini role timed out, so this round is thinner than it
reads. 21 findings, 4 accepted and built, 17 rejected with reasons — chief among them a Blocking claim
that the imports are missing, whose own text works out that they are present, and three that a
corrupted `savedAt` reaches the pruning, which `isTab` refuses before it can.

## Open tails, named rather than built

A tab whose record was pruned is disposed silently rather than announcing itself at window start. A
`LazyRestoredChatSession` would be a tidier shape than the placeholder-plus-flag, but would put
`getConfiguration`, `cliFor` and `remoteFor` inside a session object, and `chatSession.ts` deliberately
has no host in it.

Manual verification of a real reload with two tabs open is **not** done here — it needs a running
workbench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)