### PR TITLE
feat(chat): an answer reads like a document

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -57,6 +57,21 @@ left against each workspace root and checks the RESULT is still inside before op
 reference that resolves nowhere is reported to the tab rather than opened somewhere else. The page
 is a surface; the host is the boundary.
 
+**Containment is not a prefix, and that is the boundary's real shape.** `isInside` compares against
+the root with a separator appended: with a root of `/w/app`, the path `/w/app-secret/config.json`
+starts with it and belongs to a different project. It is case-SENSITIVE on purpose — folding case
+would be a guess about the filesystem underneath, wrong on one of the two this product runs on, and
+the cheap direction to be wrong in is refusing a reference a model can simply write again.
+
+**One grammar for what a file reference is.** The renderer used to demand a dot before it would
+offer a link while the host's own check did not, so `Dockerfile`, `LICENSE` and `Makefile` were never
+offered by a page whose host would have opened them. `fileTargetOf` splits the line off and asks
+`isConfinedRelativePath` — the host's function — about the rest.
+
+**The panel delegates, as it does for everything else.** Opening the file is `onOpenFile`, a hook,
+and the work lives with the other host actions: `chatPanel.ts` is the `vscode` wiring, and a function
+that reaches into the workspace, the filesystem and the active editor is not wiring.
+
 **A bare address in prose is not a link.** GFM autolinks one, and this family has already shipped a
 defect of exactly that shape — a URL inside a person's name that GitHub made clickable. A link is a
 link only when the model typed the bracket.

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -1,7 +1,12 @@
 # module: extension — ConnectOtherAIs in VS Code
 
-> `src_vs_code` — the human surface. Four commands, zero runtime dependencies, no background work
+> `src_vs_code` — the human surface. Four commands, **one** runtime dependency, no background work
 > and **no port**: the review itself lives in `coai-mcp`, which an MCP client owns and starts.
+>
+> That line said *zero* runtime dependencies until 2026-09-09, and the one that ended it is `marked`
+> — see *An answer reads like a document* below. It was taken on the plan round's advice, against
+> this file's own preference, and the reason is written there rather than left as a version bump
+> somebody finds later.
 
 ### What the code round did to the chat tab (2026-09-08)
 
@@ -24,6 +29,51 @@ local model` the page would otherwise still show the remote one as selected whil
 somewhere else), a pushed state that has not changed is not sent at all, a `pick` naming a model the
 conversation was never offered is refused at the host boundary rather than trusted, and the
 composer takes focus back when a turn ends — without which every follow-up costs a mouse click.
+### An answer reads like a document (2026-09-09)
+
+A model's answer used to reach the page as `escapeHtml(text)` under `white-space: pre-wrap` — the
+raw characters, wrapped. `renderAnswer` renders it, and **the split inside that module is the whole
+design: `marked` tokenizes, and the emitting is ours.**
+
+**Why a dependency, in a file that advertised having none.** The alternative was widening
+`bodyHtml` (`helpPage.ts`), whose rule — *escape first, mark up second* — the chat page needs
+verbatim. Both reviewers on the plan round refused it, and the argument holds: as a REGEX pipeline
+that rule breaks on a fence containing entities (escaping the string first turns `<` into `&lt;`
+inside the code the reader is shown) and it cannot count nesting at all. What is needed is a lexer
+that hands back an AST, with escaping applied to the text LEAVES. So the tokenizer is bought and the
+safety is written.
+
+**Nothing marked would emit is used.** The renderer walks the token tree and emits a fixed list of
+tags and nothing else; a token it does not recognise becomes its own raw text, escaped. Raw HTML —
+`<script>`, an `onerror`, an `<iframe>` — is neither passed through nor dropped: it is escaped and
+SHOWN, because a model that wrote a tag meant to show one. An image renders as its words, since the
+page's CSP has no `img-src` and an `<img>` could only ever be a broken one.
+
+**No `href` is ever emitted.** A link becomes an anchor carrying `data-open` or `data-file`, and one
+delegated listener asks the HOST to act on it — so there is nothing for a `javascript:` URL to be.
+The host validates again: `chatCommandOf` refuses every scheme but `http`/`https`, refuses a path
+that is absolute, traversing, drive-lettered or backslashed, and `openWorkspaceFile` resolves what is
+left against each workspace root and checks the RESULT is still inside before opening it. A
+reference that resolves nowhere is reported to the tab rather than opened somewhere else. The page
+is a surface; the host is the boundary.
+
+**A bare address in prose is not a link.** GFM autolinks one, and this family has already shipped a
+defect of exactly that shape — a URL inside a person's name that GitHub made clickable. A link is a
+link only when the model typed the bracket.
+
+**What the reader sees.** `You` on the right behind a link-coloured edge, the model on the left
+behind a green one — an edge rather than a filled box, the decision already shipped for the reviewer
+cards. A rule closes each answer. A copy control on each answer hands back the markdown SOURCE,
+which is the one thing selecting the page cannot give. The prose takes
+`var(--vscode-editor-foreground)` and a line height — scoped to the prose, because the chrome around
+it belongs to `--vscode-foreground` and overriding that on `body` produces a seam rather than a
+brighter page.
+
+**The hostile-input file is this feature's safety**, and it is meant to grow: `renderAnswer.test.ts`
+asserts on the TAG NAMES that came out, against the allow-list, rather than on words like `onerror`
+— which would flag escaped text that merely mentions one, and would miss a hostile tag nobody
+thought of.
+
 ### The chat page's layout: one scrolling region, a pinned footer (2026-09-09)
 
 `chatPage.ts` renders two children of `body` and nothing else at the top level: `<main id="scroll">`

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+**Answers read like answers.** Headings were hashes, lists were dashes, code was backticks and a
+link was its own address in brackets — everything a model wrote as Markdown arrived as Markdown. It
+is rendered now: headings, numbered and bulleted lists that nest, code in a code face and in its own
+scrolling box, tables, quotes.
+
+**Links are blue and they work.** A web address opens in your browser; a file a model names opens in
+the editor at the line it named, if that file is really in this workspace — and if it is not, the tab
+says so instead of doing nothing. Anything else keeps the words and loses the link. An address a
+model merely mentioned in a sentence is not turned into a link at all.
+
+**You are on the right, the answer is on the left**, each behind an edge in its own colour, and a
+line closes every answer — so finding where one ends no longer means reading to the end of it.
+
+**Every answer can be copied as the Markdown it arrived as**, which is what you want when it goes
+into a plan or an issue. Selecting the page still gives you what the page shows.
+
+**The text is brighter and has room to breathe.** It was the colour of a button label, packed at the
+editor's interface size.
+
+## Unreleased
+
 **The box you type in stays where you put it.** It used to scroll away with the conversation, so
 asking a second question meant scrolling back down to find it. The composer, the model picker and
 the hint are pinned to the bottom of the tab now, the conversation scrolls above them, and there is

--- a/src_vs_code/package-lock.json
+++ b/src_vs_code/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "connect-other-ais",
-  "version": "0.30.0",
+  "version": "0.31.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "connect-other-ais",
-      "version": "0.30.0",
+      "version": "0.31.21",
       "license": "MIT",
+      "dependencies": {
+        "marked": "^18.0.12"
+      },
       "devDependencies": {
         "@types/node": "^26.4.1",
         "@types/vscode": "^1.85.0",
@@ -3512,6 +3515,18 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.12.tgz",
+      "integrity": "sha512-LEm4ga2YeI2T3GVHj9b0BaDPPk93LLTHMFeMyQbNIzPxc8vCI0y/scy0ZA6z6lXKyT9j9Nhl/OC6ZYKYGuFScA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -612,5 +612,8 @@
   "galleryBanner": {
     "color": "#2D508A",
     "theme": "dark"
+  },
+  "dependencies": {
+    "marked": "^18.0.12"
   }
 }

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -761,6 +761,16 @@ function conversationHooks(panels: ChatPanels): Parameters<typeof createChatPane
       onPageError: (_id, message) => {
         void vscode.window.showWarningMessage(`The chat page reported: ${message}`);
       },
+      onCopyAnswer: (id, index) => {
+        // The SOURCE, out of the thread the page was rendered from. A person copying an answer wants
+        // the markdown they can paste into a plan or an issue, and that is the one thing selecting
+        // the page cannot give them - a selection gives what the page shows.
+        const said = threads.get(id)?.messages[index];
+        if (said === undefined || said.role !== 'model') {
+          return;
+        }
+        void vscode.env.clipboard.writeText(said.text);
+      },
   };
 }
 

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import * as vscode from 'vscode';
+import { isInside } from './chatMessages';
 import { ChatTabMemory, SavedTab, reloadedNote } from './chatTabs';
 import { ChatEntry, ChatPanels } from './chatPanels';
 import { ChatSession } from './chatSession';
@@ -761,6 +762,11 @@ function conversationHooks(panels: ChatPanels): Parameters<typeof createChatPane
       onPageError: (_id, message) => {
         void vscode.window.showWarningMessage(`The chat page reported: ${message}`);
       },
+      onOpenFile: (id, requested, line) => {
+        void openWorkspaceFile(id, requested, line, (message) => {
+          void vscode.window.showWarningMessage(message);
+        });
+      },
       onCopyAnswer: (id, index) => {
         // The SOURCE, out of the thread the page was rendered from. A person copying an answer wants
         // the markdown they can paste into a plan or an issue, and that is the one thing selecting
@@ -772,6 +778,46 @@ function conversationHooks(panels: ChatPanels): Parameters<typeof createChatPane
         void vscode.env.clipboard.writeText(said.text);
       },
   };
+}
+
+/**
+ * Open a file an ANSWER named, if it is really inside this workspace.
+ *
+ * <p>The renderer checked the shape and `chatCommandOf` checked it again, and neither is enough: a
+ * string can look confined and still leave through a folder that merely starts with the same
+ * letters. So the path is resolved against each workspace root and the RESULT is what
+ * `isInside` decides on — a boundary at a separator, not a prefix.</p>
+ *
+ * <p>A reference that resolves nowhere is SAID rather than swallowed: a link that quietly does
+ * nothing is a link a person presses twice.</p>
+ */
+async function openWorkspaceFile(
+  _id: object,
+  requested: string,
+  line: number,
+  refuse: (message: string) => void,
+): Promise<void> {
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const target = vscode.Uri.joinPath(folder.uri, requested);
+    if (!isInside(folder.uri.path, target.path)) {
+      continue;
+    }
+    try {
+      await vscode.workspace.fs.stat(target);
+    } catch {
+      continue;
+    }
+    const editor = await vscode.window.showTextDocument(target);
+    if (line > 0) {
+      const at = new vscode.Position(Math.max(0, line - 1), 0);
+      editor.revealRange(new vscode.Range(at, at), vscode.TextEditorRevealType.InCenter);
+      editor.selection = new vscode.Selection(at, at);
+    }
+
+    return;
+  }
+
+  refuse(`There is no ${requested} in this workspace.`);
 }
 
 /**

--- a/src_vs_code/src/chatMessages.ts
+++ b/src_vs_code/src/chatMessages.ts
@@ -143,6 +143,28 @@ export function isConfinedRelativePath(value: string): boolean {
   return /^[\w./-]+$/.test(value);
 }
 
+/**
+ * Is `absolute` really inside `root`?
+ *
+ * <p><b>Not a prefix.</b> With a root of `/w/app`, the path `/w/app-secret/config.json` starts with
+ * it and belongs to a different project — somebody else's, quite possibly. Containment is a boundary
+ * at a separator, so the root is compared with one appended, and equality with the root itself is
+ * allowed separately.</p>
+ *
+ * <p>Case-SENSITIVE, deliberately. Folding case would be a guess about the filesystem underneath,
+ * and the guess is wrong on one of the two this product runs on. A path that differs only in case is
+ * refused, which costs a person nothing — the reference came from a model, and it can be written
+ * again — where the opposite mistake costs them a file they never meant to open.</p>
+ */
+export function isInside(root: string, absolute: string): boolean {
+  if (root.length === 0) {
+    return false;
+  }
+  const bounded = root.endsWith('/') ? root : `${root}/`;
+
+  return absolute === root || absolute === bounded.slice(0, -1) || absolute.startsWith(bounded);
+}
+
 /** The line a file reference names, or 0 for "the top" — never negative, never a fraction. */
 function lineOf(value: unknown): number {
   return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : 0;

--- a/src_vs_code/src/chatMessages.ts
+++ b/src_vs_code/src/chatMessages.ts
@@ -27,6 +27,10 @@ export interface PageMessage {
   readonly delta?: unknown;
   readonly message?: unknown;
   readonly turn?: unknown;
+  readonly url?: unknown;
+  readonly file?: unknown;
+  readonly line?: unknown;
+  readonly index?: unknown;
 }
 
 export type ChatCommand =
@@ -52,6 +56,24 @@ export type ChatCommand =
   | { readonly kind: 'restart' }
   | { readonly kind: 'useLocal' }
   | { readonly kind: 'pageError'; readonly message: string }
+  /**
+   * A link in an ANSWER, which is text another vendor's model wrote.
+   *
+   * <p>The page emits no `href` at all — it names what it wants and the host decides — so this is
+   * the boundary, and it validates rather than trusts. Only `http` and `https` become an `openLink`;
+   * every other scheme, `javascript:` and `data:` and `file:` alike, is not a link this product
+   * opens on anybody's behalf.</p>
+   */
+  | { readonly kind: 'openLink'; readonly url: string }
+  /**
+   * A file reference in an answer, to be opened in the editor at a line.
+   *
+   * <p>Relative and confined, checked HERE and again against the real workspace root before anything
+   * is opened: a model writing `.git/config` or `../../.ssh/id_rsa` is not a hypothetical, and
+   * neither end of this is allowed to be the only one that says no.</p>
+   */
+  | { readonly kind: 'openFile'; readonly path: string; readonly line: number }
+  | { readonly kind: 'copyAnswer'; readonly index: number }
   | { readonly kind: 'ignore' };
 
 const IGNORE: ChatCommand = { kind: 'ignore' };
@@ -96,6 +118,37 @@ function turnOf(value: unknown): number {
 }
 
 /**
+ * A path this product will open on the strength of a model having written it.
+ *
+ * <p>Relative, no traversal, no drive letter, no scheme, no leading slash, and no backslash — a
+ * Windows separator is not how this repository names a file and accepting one is a second grammar to
+ * get wrong. The renderer applies the same shape before it emits the anchor; this is the boundary
+ * that matters, because the page is a surface and anything can post to it.</p>
+ *
+ * <p>It is deliberately NOT enough on its own: the caller resolves it against the real workspace
+ * root and checks the result is still inside. A string can be confined-looking and still escape
+ * through a symlink, which only the filesystem knows about.</p>
+ */
+export function isConfinedRelativePath(value: string): boolean {
+  if (value.length === 0 || value.length > 400) {
+    return false;
+  }
+  if (value.startsWith('/') || value.startsWith('\\') || value.includes('\\') || value.includes('..')) {
+    return false;
+  }
+  if (/^[A-Za-z]:/.test(value) || /^[a-z][a-z0-9+.-]*:/i.test(value)) {
+    return false;
+  }
+
+  return /^[\w./-]+$/.test(value);
+}
+
+/** The line a file reference names, or 0 for "the top" — never negative, never a fraction. */
+function lineOf(value: unknown): number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : 0;
+}
+
+/**
  * One message, read.
  *
  * <p>An empty `send` is `ignore` rather than a send of nothing: the page already refuses to post one,
@@ -132,6 +185,24 @@ export function chatCommandOf(message: PageMessage | undefined): ChatCommand {
       const turn = turnOf(message.turn);
 
       return turn === 0 ? IGNORE : { kind: 'stop', turn };
+    }
+    case 'openLink': {
+      const url = text(message.url);
+      if (url.length > 0) {
+        return /^https?:\/\/[^\s]+$/i.test(url) ? { kind: 'openLink', url } : IGNORE;
+      }
+      const path = text(message.file);
+
+      return isConfinedRelativePath(path)
+        ? { kind: 'openFile', path, line: lineOf(message.line) }
+        : IGNORE;
+    }
+    case 'copyAnswer': {
+      const index = message.index;
+
+      return typeof index === 'number' && Number.isSafeInteger(index) && index >= 0
+        ? { kind: 'copyAnswer', index }
+        : IGNORE;
     }
     case 'restart':
       return { kind: 'restart' };

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -1,4 +1,5 @@
 import { escapeHtml, jsonForScript } from './webviewHtml';
+import { renderAnswer } from './renderAnswer';
 import { ZOOM_CSS, zoomControlHtml, zoomScript, zoomStyle } from './zoomControl';
 
 /**
@@ -94,12 +95,26 @@ export function chatMessagesHtml(messages: readonly ChatMessage[]): string {
   }
 
   return messages
-    .map(
-      (message) =>
-        `<div class="msg ${message.role === 'you' ? 'you' : 'model'}">`
-        + `<div class="who">${message.role === 'you' ? 'You' : 'The other AI'}</div>`
-        + `<div class="what">${escapeHtml(message.text)}</div></div>`,
-    )
+    .map((message, index) => {
+      const mine = message.role === 'you';
+      // What the PERSON typed is not markdown until they say so: a question that begins with a hash
+      // is a question, not a heading, and rendering it would silently eat what they wrote.
+      const body = mine ? escapeHtml(message.text) : renderAnswer(message.text);
+      // The copy control carries the INDEX, and the host reads the message out of the same array
+      // this was rendered from - so what is copied is the markdown that arrived, which is the one
+      // thing a selection cannot give: selecting the page gives what the page shows.
+      const copy = mine
+        ? ''
+        : `<button type="button" class="copy" data-copy="${index}" title="Copy this answer as Markdown">Copy</button>`;
+      // A rule after an answer, not after a question. The operator asked for a row of asterisks and
+      // then settled on the rule, which is also what a row of asterisks BECOMES once markdown is
+      // rendered - a thematic break.
+      const end = mine ? '' : '<hr class="end">';
+
+      return `<div class="msg ${mine ? 'you' : 'model'}">`
+        + `<div class="who">${mine ? 'You' : 'The other AI'}${copy}</div>`
+        + `<div class="what">${body}</div>${end}</div>`;
+    })
     .join('');
 }
 
@@ -161,10 +176,38 @@ function chatStyle(uiScale: number): string {
   header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; }
   h1 { font-size: 1.2em; margin: 0; }
   .passage { border-left: 3px solid var(--vscode-panel-border); padding: 6px 0 6px 12px; margin: 0 0 16px; white-space: pre-wrap; opacity: .85; }
-  .msg { margin: 0 0 14px; }
-  .msg .who { font-size: .85em; opacity: .7; margin-bottom: 3px; }
-  .msg .what { white-space: pre-wrap; }
-  .msg.you .what { opacity: .85; }
+  /* A reading measure. A line that spans a wide tab is a line whose side says nothing, and the
+     sides are how the two speakers are told apart at a glance. */
+  .msg { margin: 0 0 18px; max-width: 46rem; }
+  /* The EDGE is the colour, not a filled box - the decision already shipped for the reviewer cards,
+     and for the same reason: a wall of filled blocks is harder to read than the text in it. */
+  .msg.you { margin-left: auto; border-right: 3px solid var(--vscode-textLink-foreground); padding-right: 10px; text-align: right; }
+  .msg.model { border-left: 3px solid var(--vscode-charts-green, var(--vscode-textLink-foreground)); padding-left: 10px; }
+  .msg .who { font-size: .85em; opacity: .7; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; }
+  .msg.you .who { justify-content: flex-end; }
+  /* The PROSE takes the editor's foreground, and only the prose: the chrome around it - the hint,
+     the picker, the captions - belongs to --vscode-foreground, and overriding that on body produces
+     a seam between the two rather than a brighter page. (gemini, the plan round.) */
+  .msg .what { color: var(--vscode-editor-foreground); line-height: 1.55; }
+  .msg.you .what { white-space: pre-wrap; }
+  .msg .what > :first-child { margin-top: 0; }
+  .msg .what > :last-child { margin-bottom: 0; }
+  .msg .what h1, .msg .what h2, .msg .what h3, .msg .what h4, .msg .what h5, .msg .what h6 { font-size: 1.05em; margin: 1.2em 0 .4em; }
+  .msg .what p { margin: 0 0 .7em; }
+  .msg .what ul, .msg .what ol { margin: 0 0 .7em; padding-left: 1.6em; }
+  .msg .what li { margin: .15em 0; }
+  .msg .what code { font-family: var(--vscode-editor-font-family, monospace); font-size: .92em; background: var(--vscode-textCodeBlock-background, rgba(127,127,127,.18)); border-radius: 3px; padding: 0 .3em; }
+  /* Its own box, and it scrolls inside it: a long line of code must not widen the page. */
+  .msg .what pre { margin: 0 0 .7em; padding: 8px 10px; overflow-x: auto; background: var(--vscode-textCodeBlock-background, rgba(127,127,127,.14)); border-radius: 4px; }
+  .msg .what pre code { background: none; padding: 0; }
+  .msg .what blockquote { margin: 0 0 .7em; padding-left: 10px; border-left: 2px solid var(--vscode-panel-border); opacity: .9; }
+  .msg .what table { border-collapse: collapse; margin: 0 0 .7em; display: block; overflow-x: auto; }
+  .msg .what th, .msg .what td { border: 1px solid var(--vscode-panel-border); padding: 3px 8px; text-align: left; }
+  .msg .what a.link { color: var(--vscode-textLink-foreground); cursor: pointer; text-decoration: none; }
+  .msg .what a.link:hover { color: var(--vscode-textLink-activeForeground); text-decoration: underline; }
+  .msg .copy { font: inherit; font-size: .9em; color: var(--vscode-textLink-foreground); background: none; border: none; padding: 0; cursor: pointer; opacity: 0; }
+  .msg:hover .copy, .msg .copy:focus { opacity: 1; }
+  hr.end { border: none; border-top: 1px solid var(--vscode-panel-border); margin: 14px 0 0; opacity: .55; }
   .empty { opacity: .6; }
   .thinking { opacity: .75; margin: 0 0 12px; }
   .queued { opacity: .8; font-size: .9em; }
@@ -529,6 +572,29 @@ function chatScript(state: ChatPageState, regions: Regions): string {
   if (typeof ResizeObserver === 'function') {
     const composer = document.getElementById('composer');
     if (composer) { new ResizeObserver(repinIfTheyWereAtTheBottom).observe(composer); }
+  }
+  // Delegated, because the answers are replaced wholesale on every push: a listener bound to each
+  // link would have to be re-bound after every one, and the one that was missed is the one that
+  // silently does nothing. The page never navigates and never reads a file - it names what it wants
+  // and the HOST decides, which is where the workspace root and the scheme are actually known.
+  const messagesRegion = document.getElementById('messages');
+  if (messagesRegion) {
+    messagesRegion.addEventListener('click', function (event) {
+      const target = event.target;
+      if (!target || typeof target.closest !== 'function') { return; }
+      const acted = target.closest('[data-open], [data-file], [data-copy]');
+      if (!acted || !acted.dataset) { return; }
+      if (typeof acted.dataset.open === 'string') {
+        vscode.postMessage({ type: 'command', command: 'openLink', url: acted.dataset.open });
+      } else if (typeof acted.dataset.file === 'string') {
+        vscode.postMessage({
+          type: 'command', command: 'openLink',
+          file: acted.dataset.file, line: Number(acted.dataset.line || 0),
+        });
+      } else if (typeof acted.dataset.copy === 'string') {
+        vscode.postMessage({ type: 'command', command: 'copyAnswer', index: Number(acted.dataset.copy) });
+      }
+    });
   }
   const jump = document.getElementById('jump');
   if (jump) {

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -205,8 +205,11 @@ function chatStyle(uiScale: number): string {
   .msg .what th, .msg .what td { border: 1px solid var(--vscode-panel-border); padding: 3px 8px; text-align: left; }
   .msg .what a.link { color: var(--vscode-textLink-foreground); cursor: pointer; text-decoration: none; }
   .msg .what a.link:hover { color: var(--vscode-textLink-activeForeground); text-decoration: underline; }
-  .msg .copy { font: inherit; font-size: .9em; color: var(--vscode-textLink-foreground); background: none; border: none; padding: 0; cursor: pointer; opacity: 0; }
-  .msg:hover .copy, .msg .copy:focus { opacity: 1; }
+  /* Dimmed, not erased. A zero opacity leaves an invisible target in the tab order and hides the
+     control entirely from a keyboard, a touch screen and anyone reading with one. Arriving anywhere
+     in the answer reveals it, which is what :focus-within is for. (gemini, the code round.) */
+  .msg .copy { font: inherit; font-size: .9em; color: var(--vscode-textLink-foreground); background: none; border: none; padding: 0; cursor: pointer; opacity: .55; }
+  .msg:hover .copy, .msg:focus-within .copy, .msg .copy:focus { opacity: 1; }
   hr.end { border: none; border-top: 1px solid var(--vscode-panel-border); margin: 14px 0 0; opacity: .55; }
   .empty { opacity: .6; }
   .thinking { opacity: .75; margin: 0 0 12px; }

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -63,6 +63,15 @@ export interface ChatPanelHooks {
   readonly onUseLocal: (id: object) => void;
   /** The page trapped an error, or the host failed to handle one of its messages. */
   readonly onPageError: (id: object, message: string) => void;
+  /**
+   * Copy the answer at `index` as the MARKDOWN it arrived as.
+   *
+   * <p>By index into the thread's own messages, which is the array the page was rendered from —
+   * turns are appended and never reordered, so the number identifies the same answer for as long as
+   * the tab lives. What is copied is the source, because that is the one thing a selection cannot
+   * give: selecting the page gives what the page shows.</p>
+   */
+  readonly onCopyAnswer: (id: object, index: number) => void;
 }
 
 /** Everything the page shows that can change after it is open. */
@@ -183,6 +192,44 @@ export function createChatPanel(
  * left here is the dispatch. That split exists because a wrong message type would otherwise have
  * shipped with every test green — a person's send quietly ignored. (codex, the plan round.)</p>
  */
+/**
+ * Open a file an ANSWER named, if it is really inside this workspace.
+ *
+ * <p>The renderer checked the shape and `chatCommandOf` checked it again, and neither is enough: a
+ * string can look confined and still leave through a symlink or a folder that is not where anyone
+ * thought. So the path is resolved against each workspace root and the RESULT is what is checked —
+ * and a reference that resolves nowhere is reported to the tab rather than opened somewhere else.</p>
+ */
+async function openWorkspaceFile(
+  id: object,
+  requested: string,
+  line: number,
+  hooks: ChatPanelHooks,
+): Promise<void> {
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const target = vscode.Uri.joinPath(folder.uri, requested);
+    if (!target.path.startsWith(folder.uri.path)) {
+      continue;
+    }
+    try {
+      await vscode.workspace.fs.stat(target);
+    } catch {
+      continue;
+    }
+    const editor = await vscode.window.showTextDocument(target);
+    if (line > 0) {
+      const at = new vscode.Position(Math.max(0, line - 1), 0);
+      editor.revealRange(new vscode.Range(at, at), vscode.TextEditorRevealType.InCenter);
+      editor.selection = new vscode.Selection(at, at);
+    }
+
+    return;
+  }
+
+  // Said rather than swallowed: a link that quietly does nothing is a link a person presses twice.
+  hooks.onPageError(id, `there is no ${requested} in this workspace`);
+}
+
 async function handle(id: object, message: PageMessage, hooks: ChatPanelHooks): Promise<void> {
   const command = chatCommandOf(message);
   switch (command.kind) {
@@ -207,6 +254,21 @@ async function handle(id: object, message: PageMessage, hooks: ChatPanelHooks): 
       return;
     case 'stop':
       hooks.onStop(id, command.turn);
+
+      return;
+    case 'openLink':
+      // Handed to the editor, not navigated in the page: the webview has `localResourceRoots: []`
+      // and a CSP that loads nothing, so this is the only way out — and it is the way a person can
+      // see where they are going before they arrive.
+      await vscode.env.openExternal(vscode.Uri.parse(command.url));
+
+      return;
+    case 'openFile':
+      await openWorkspaceFile(id, command.path, command.line, hooks);
+
+      return;
+    case 'copyAnswer':
+      hooks.onCopyAnswer(id, command.index);
 
       return;
     case 'restart':

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -72,6 +72,15 @@ export interface ChatPanelHooks {
    * give: selecting the page gives what the page shows.</p>
    */
   readonly onCopyAnswer: (id: object, index: number) => void;
+  /**
+   * Open a file an ANSWER named, at a line.
+   *
+   * <p>A hook rather than something this module does, for the reason every other action here is one:
+   * `chatPanel.ts` is the `vscode` wiring and nothing else, and a function that reaches into the
+   * workspace, the filesystem and the active editor is not wiring — it is the half a test cannot
+   * reach. (gemini, the code round.)</p>
+   */
+  readonly onOpenFile: (id: object, path: string, line: number) => void;
 }
 
 /** Everything the page shows that can change after it is open. */
@@ -192,44 +201,6 @@ export function createChatPanel(
  * left here is the dispatch. That split exists because a wrong message type would otherwise have
  * shipped with every test green — a person's send quietly ignored. (codex, the plan round.)</p>
  */
-/**
- * Open a file an ANSWER named, if it is really inside this workspace.
- *
- * <p>The renderer checked the shape and `chatCommandOf` checked it again, and neither is enough: a
- * string can look confined and still leave through a symlink or a folder that is not where anyone
- * thought. So the path is resolved against each workspace root and the RESULT is what is checked —
- * and a reference that resolves nowhere is reported to the tab rather than opened somewhere else.</p>
- */
-async function openWorkspaceFile(
-  id: object,
-  requested: string,
-  line: number,
-  hooks: ChatPanelHooks,
-): Promise<void> {
-  for (const folder of vscode.workspace.workspaceFolders ?? []) {
-    const target = vscode.Uri.joinPath(folder.uri, requested);
-    if (!target.path.startsWith(folder.uri.path)) {
-      continue;
-    }
-    try {
-      await vscode.workspace.fs.stat(target);
-    } catch {
-      continue;
-    }
-    const editor = await vscode.window.showTextDocument(target);
-    if (line > 0) {
-      const at = new vscode.Position(Math.max(0, line - 1), 0);
-      editor.revealRange(new vscode.Range(at, at), vscode.TextEditorRevealType.InCenter);
-      editor.selection = new vscode.Selection(at, at);
-    }
-
-    return;
-  }
-
-  // Said rather than swallowed: a link that quietly does nothing is a link a person presses twice.
-  hooks.onPageError(id, `there is no ${requested} in this workspace`);
-}
-
 async function handle(id: object, message: PageMessage, hooks: ChatPanelHooks): Promise<void> {
   const command = chatCommandOf(message);
   switch (command.kind) {
@@ -264,7 +235,7 @@ async function handle(id: object, message: PageMessage, hooks: ChatPanelHooks): 
 
       return;
     case 'openFile':
-      await openWorkspaceFile(id, command.path, command.line, hooks);
+      hooks.onOpenFile(id, command.path, command.line);
 
       return;
     case 'copyAnswer':

--- a/src_vs_code/src/renderAnswer.ts
+++ b/src_vs_code/src/renderAnswer.ts
@@ -1,5 +1,6 @@
 import { Tokens, lexer } from 'marked';
 import { escapeHtml } from './webviewHtml';
+import { isConfinedRelativePath } from './chatMessages';
 
 /**
  * A model's answer, as a document.
@@ -33,8 +34,16 @@ import { escapeHtml } from './webviewHtml';
 /** How deep a list may nest before the rest is shown as text. A model has never needed more. */
 const MAX_DEPTH = 8;
 
-/** A file reference a model writes: `src/foo.ts:12`, `src/foo.ts#L12`, or the path alone. */
-const FILE_REFERENCE = /^(?!\/|[A-Za-z]:[\\/])([\w./-]+\.[A-Za-z][\w]*)(?:#L(\d+)|:(\d+))?$/;
+/**
+ * A file reference a model writes: `src/foo.ts:12`, `src/foo.ts#L12`, or the path alone.
+ *
+ * <p>The LINE is split off here; whether what is left is a path this product will open is
+ * `isConfinedRelativePath`'s question, and asking it there is the point — two modules with their own
+ * idea of what a path is had already disagreed once, and the disagreement was invisible: this one
+ * demanded a dot, so `Dockerfile`, `LICENSE` and `Makefile` were never offered as links by a page
+ * whose host would have opened them happily. (gemini, the code round.)</p>
+ */
+const FILE_REFERENCE = /^(.+?)(?:#L(\d+)|:(\d+))?$/;
 
 interface FileTarget {
   readonly path: string;
@@ -51,12 +60,13 @@ interface FileTarget {
  */
 export function fileTargetOf(href: string): FileTarget | undefined {
   const match = FILE_REFERENCE.exec(href);
-  if (match === null || href.includes('..')) {
+  const path = match?.[1] ?? '';
+  if (!isConfinedRelativePath(path)) {
     return undefined;
   }
-  const line = Number(match[2] ?? match[3] ?? 0);
+  const line = Number(match?.[2] ?? match?.[3] ?? 0);
 
-  return { path: match[1] ?? '', line: Number.isFinite(line) ? line : 0 };
+  return { path, line: Number.isFinite(line) ? line : 0 };
 }
 
 /** Only these two reach the outside world, and only through the host. */
@@ -145,6 +155,11 @@ function table(token: Tokens.Table, depth: number): string {
   return `<table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
 }
 
+/** A paragraph, or nothing at all: an empty one is vertical space the model did not ask for. */
+function paragraph(body: string): string {
+  return body.trim().length === 0 ? '' : `<p>${body}</p>`;
+}
+
 function blockToken(token: Tokens.Generic, depth: number): string {
   switch (token.type) {
     case 'space':
@@ -156,7 +171,7 @@ function blockToken(token: Tokens.Generic, depth: number): string {
       return `<h${level}>${inline(token.tokens ?? [], depth)}</h${level}>`;
     }
     case 'paragraph':
-      return `<p>${inline(token.tokens ?? [], depth)}</p>`;
+      return paragraph(inline(token.tokens ?? [], depth));
     case 'text':
       // Inside a list item, marked emits the item's prose as a bare text token.
       return 'tokens' in token && Array.isArray(token.tokens)
@@ -190,9 +205,9 @@ function blockToken(token: Tokens.Generic, depth: number): string {
     case 'html':
       // Escaped and SHOWN. A model that wrote a tag meant to show one, and this is the one place
       // where a renderer's default — pass it through — would be a hole rather than a feature.
-      return `<p>${escapeHtml(String(token.raw ?? ''))}</p>`;
+      return paragraph(escapeHtml(String(token.raw ?? '')));
     default:
-      return `<p>${escapeHtml(String(token.raw ?? ''))}</p>`;
+      return paragraph(escapeHtml(String(token.raw ?? '')));
   }
 }
 

--- a/src_vs_code/src/renderAnswer.ts
+++ b/src_vs_code/src/renderAnswer.ts
@@ -1,0 +1,221 @@
+import { Tokens, lexer } from 'marked';
+import { escapeHtml } from './webviewHtml';
+
+/**
+ * A model's answer, as a document.
+ *
+ * <p><b>The tokenizer is `marked`; the emitting is ours, and that split is the whole design.</b>
+ * Getting markdown's shape right — a nested list, a fence that contains backticks, an emphasis that
+ * spans a link — is a lexer's job and a hand-written one gets it wrong the first time a model writes
+ * something ordinary. Deciding what HTML comes out is a SAFETY job, and no library's default belongs
+ * anywhere near it: this text arrives from another vendor's model and is exactly as trustworthy as
+ * anything else somebody else wrote.</p>
+ *
+ * <p>So nothing here renders a token it does not recognise, no tag is emitted that is not in the
+ * list below, and every leaf of text goes through `escapeHtml` on its way out. A raw HTML token —
+ * `&lt;script&gt;`, an `onerror` attribute, an `&lt;iframe&gt;` — is not passed through and is not
+ * dropped either: it is escaped and shown, because a model that wrote a tag meant to show one.</p>
+ *
+ * <p><b>No `href` is ever emitted.</b> A link becomes an anchor carrying `data-open` or
+ * `data-file`, and the page asks the host to act on it. There is nothing for a `javascript:` URL to
+ * be, and a scheme this does not know renders as text rather than as a link nobody can trust. The
+ * host validates again on the way in — the page is not a boundary, it is a surface.</p>
+ *
+ * <p><b>No image, ever.</b> The page's CSP is `default-src 'none'` with no `img-src`, so an
+ * `&lt;img&gt;` could only ever be a broken one — and a `src` that reaches out is the whole reason
+ * that CSP is written the way it is. An image renders as its alt text.</p>
+ *
+ * <p>The tags this can produce, and no others: `p`, `h1`-`h6`, `ul`, `ol`, `li`, `pre`, `code`,
+ * `blockquote`, `hr`, `strong`, `em`, `del`, `br`, `a`, `table`, `thead`, `tbody`, `tr`, `th`,
+ * `td`.</p>
+ */
+
+/** How deep a list may nest before the rest is shown as text. A model has never needed more. */
+const MAX_DEPTH = 8;
+
+/** A file reference a model writes: `src/foo.ts:12`, `src/foo.ts#L12`, or the path alone. */
+const FILE_REFERENCE = /^(?!\/|[A-Za-z]:[\\/])([\w./-]+\.[A-Za-z][\w]*)(?:#L(\d+)|:(\d+))?$/;
+
+interface FileTarget {
+  readonly path: string;
+  readonly line: number;
+}
+
+/**
+ * A path this page is willing to offer as a link into the editor.
+ *
+ * <p>Relative, no traversal, no drive letter, no scheme, and it must look like a file rather than a
+ * word with a dot in it. The HOST checks all of this again against the real workspace root: a model
+ * asking for `.git/config` or `../../.ssh/id_rsa` is not a hypothetical, and neither end of this is
+ * allowed to be the only one that says no.</p>
+ */
+export function fileTargetOf(href: string): FileTarget | undefined {
+  const match = FILE_REFERENCE.exec(href);
+  if (match === null || href.includes('..')) {
+    return undefined;
+  }
+  const line = Number(match[2] ?? match[3] ?? 0);
+
+  return { path: match[1] ?? '', line: Number.isFinite(line) ? line : 0 };
+}
+
+/** Only these two reach the outside world, and only through the host. */
+function isWebLink(href: string): boolean {
+  return /^https?:\/\/[^\s]+$/i.test(href);
+}
+
+function anchor(attribute: string, value: string, label: string, extra = ''): string {
+  return `<a class="link" ${attribute}="${escapeHtml(value)}"${extra}>${label}</a>`;
+}
+
+/**
+ * Did the model ASK for a link, or did the tokenizer make one out of a sentence?
+ *
+ * <p>GFM turns a bare address in prose into a link, and this repository has already shipped a defect
+ * of exactly that family — a URL inside a person's name that GitHub autolinked. A model writing an
+ * address in a sentence has not asked for anything clickable. The two are told apart by what the
+ * tokenizer consumed: an explicit link's raw text starts with the bracket the model typed.</p>
+ */
+function wasWritten(token: Tokens.Link): boolean {
+  return token.raw.startsWith('[') || token.raw.startsWith('!');
+}
+
+function link(token: Tokens.Link, depth: number): string {
+  const label = inline(token.tokens ?? [], depth);
+  if (!wasWritten(token)) {
+    return escapeHtml(token.raw);
+  }
+  if (isWebLink(token.href)) {
+    return anchor('data-open', token.href, label);
+  }
+  const file = fileTargetOf(token.href);
+  if (file !== undefined) {
+    return anchor('data-file', file.path, label, ` data-line="${file.line}"`);
+  }
+
+  // Not a scheme this page will act on. The LABEL survives as text — dropping it would lose what the
+  // model said, and a blue link that does nothing is worse than no link at all.
+  return label;
+}
+
+/** One inline token. Anything unrecognised falls back to its own raw text, escaped. */
+function inlineToken(token: Tokens.Generic, depth: number): string {
+  switch (token.type) {
+    case 'text':
+      return 'tokens' in token && Array.isArray(token.tokens) && token.tokens.length > 0
+        ? inline(token.tokens as Tokens.Generic[], depth)
+        : escapeHtml(String(token.text ?? ''));
+    case 'escape':
+      return escapeHtml(String(token.text ?? ''));
+    case 'strong':
+      return `<strong>${inline(token.tokens ?? [], depth)}</strong>`;
+    case 'em':
+      return `<em>${inline(token.tokens ?? [], depth)}</em>`;
+    case 'del':
+      return `<del>${inline(token.tokens ?? [], depth)}</del>`;
+    case 'codespan':
+      return `<code>${escapeHtml(String(token.text ?? ''))}</code>`;
+    case 'br':
+      return '<br>';
+    case 'link':
+      return link(token as Tokens.Link, depth);
+    case 'image':
+      return escapeHtml(String((token as Tokens.Image).text ?? (token as Tokens.Image).href ?? ''));
+    default:
+      return escapeHtml(String(token.raw ?? ''));
+  }
+}
+
+function inline(tokens: readonly Tokens.Generic[], depth: number): string {
+  return tokens.map((token) => inlineToken(token, depth)).join('');
+}
+
+function listItems(token: Tokens.List, depth: number): string {
+  return token.items
+    .map((item) => `<li>${blocks(item.tokens ?? [], depth + 1)}</li>`)
+    .join('');
+}
+
+function table(token: Tokens.Table, depth: number): string {
+  const head = token.header.map((cell) => `<th>${inline(cell.tokens ?? [], depth)}</th>`).join('');
+  const body = token.rows
+    .map((row) => `<tr>${row.map((cell) => `<td>${inline(cell.tokens ?? [], depth)}</td>`).join('')}</tr>`)
+    .join('');
+
+  return `<table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
+}
+
+function blockToken(token: Tokens.Generic, depth: number): string {
+  switch (token.type) {
+    case 'space':
+      return '';
+    case 'heading': {
+      // Clamped rather than trusted: `####### seven` is not a heading level, and h7 is not an element.
+      const level = Math.min(6, Math.max(1, Number((token as Tokens.Heading).depth) || 1));
+
+      return `<h${level}>${inline(token.tokens ?? [], depth)}</h${level}>`;
+    }
+    case 'paragraph':
+      return `<p>${inline(token.tokens ?? [], depth)}</p>`;
+    case 'text':
+      // Inside a list item, marked emits the item's prose as a bare text token.
+      return 'tokens' in token && Array.isArray(token.tokens)
+        ? inline(token.tokens as Tokens.Generic[], depth)
+        : escapeHtml(String(token.text ?? ''));
+    case 'code': {
+      const code = token as Tokens.Code;
+      const language = typeof code.lang === 'string' ? code.lang.split(/\s+/)[0] ?? '' : '';
+      // The language is a CLASS, never a value that reaches an attribute unfiltered: a fence saying
+      // ```" onmouseover=… is a fence a model can write.
+      const cssClass = /^[\w+-]{1,24}$/.test(language) ? ` class="language-${language}"` : '';
+
+      return `<pre><code${cssClass}>${escapeHtml(String(code.text ?? ''))}</code></pre>`;
+    }
+    case 'blockquote':
+      return `<blockquote>${blocks(token.tokens ?? [], depth + 1)}</blockquote>`;
+    case 'list': {
+      const list = token as Tokens.List;
+      const start = list.ordered && typeof list.start === 'number' && list.start !== 1
+        ? ` start="${Math.trunc(list.start)}"`
+        : '';
+
+      return list.ordered
+        ? `<ol${start}>${listItems(list, depth)}</ol>`
+        : `<ul>${listItems(list, depth)}</ul>`;
+    }
+    case 'table':
+      return table(token as Tokens.Table, depth);
+    case 'hr':
+      return '<hr>';
+    case 'html':
+      // Escaped and SHOWN. A model that wrote a tag meant to show one, and this is the one place
+      // where a renderer's default — pass it through — would be a hole rather than a feature.
+      return `<p>${escapeHtml(String(token.raw ?? ''))}</p>`;
+    default:
+      return `<p>${escapeHtml(String(token.raw ?? ''))}</p>`;
+  }
+}
+
+function blocks(tokens: readonly Tokens.Generic[], depth: number): string {
+  if (depth > MAX_DEPTH) {
+    return escapeHtml(tokens.map((token) => String(token.raw ?? '')).join(''));
+  }
+
+  return tokens.map((token) => blockToken(token, depth)).join('');
+}
+
+/**
+ * Markdown in, safe HTML out. Never throws: a tokenizer that cannot make sense of something answers
+ * with the text itself, and so does this — an answer shown as plain text is a bad day, an answer
+ * that renders nothing at all is a lost one.
+ */
+export function renderAnswer(markdown: string): string {
+  if (markdown.length === 0) {
+    return '';
+  }
+  try {
+    return blocks(lexer(markdown), 0);
+  } catch {
+    return `<p>${escapeHtml(markdown)}</p>`;
+  }
+}

--- a/src_vs_code/src/test/chatMessages.test.ts
+++ b/src_vs_code/src/test/chatMessages.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { chatCommandOf } from '../chatMessages';
+import { chatCommandOf, isInside } from '../chatMessages';
 
 /**
  * What the page said, read without a host.
@@ -149,5 +149,32 @@ test('a copy names an answer by an index that is really an index', () => {
   for (const index of [-1, 1.5, '2', undefined, Number.NaN]) {
     assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'copyAnswer', index }),
       { kind: 'ignore' }, `index ${String(index)} was accepted`);
+  }
+});
+
+
+test('a sibling folder that merely starts with the workspace root is not inside it', () => {
+  // A string prefix is not containment. With a root of `/w/app`, the path `/w/app-secret/x` starts
+  // with it and is a different project — the one belonging to somebody who did not open this tab.
+  assert.strictEqual(isInside('/w/app', '/w/app/src/a.ts'), true);
+  assert.strictEqual(isInside('/w/app', '/w/app'), true);
+  assert.strictEqual(isInside('/w/app', '/w/app-secret/config.json'), false,
+    'a sibling sharing the root\'s first letters was treated as inside it');
+  assert.strictEqual(isInside('/w/app/', '/w/app-secret/config.json'), false);
+  assert.strictEqual(isInside('/w/app', '/w/other/a.ts'), false);
+  assert.strictEqual(isInside('/w/app', '/w/App/a.ts'), false,
+    'containment was decided case-insensitively, which is a guess about the filesystem');
+});
+
+test('an extensionless file a model names is still a file', () => {
+  // Dockerfile, LICENSE, Makefile. The renderer used to demand a dot before it would offer a link,
+  // while the host's own check did not — so the two disagreed about what a path IS, and the reader
+  // simply never got a link to any of them. (gemini, the code round.)
+  for (const named of ['Dockerfile', 'LICENSE', 'src/routes/index']) {
+    assert.deepStrictEqual(
+      chatCommandOf({ type: 'command', command: 'openLink', file: named }),
+      { kind: 'openFile', path: named, line: 0 },
+      `${named} was refused as a workspace file`,
+    );
   }
 });

--- a/src_vs_code/src/test/chatMessages.test.ts
+++ b/src_vs_code/src/test/chatMessages.test.ts
@@ -101,3 +101,53 @@ test('a stop naming something that is not a turn is refused, not applied to what
     );
   }
 });
+
+test('a link from an answer is opened only when it is http or https', () => {
+  assert.deepStrictEqual(
+    chatCommandOf({ type: 'command', command: 'openLink', url: 'https://example.com/a?b=1' }),
+    { kind: 'openLink', url: 'https://example.com/a?b=1' },
+  );
+  // The page emits no href at all, so this is the boundary — and the boundary is where a scheme is
+  // refused rather than where it is hoped nobody wrote one.
+  for (const url of ['javascript:alert(1)', 'data:text/html,<script>x</script>', 'vbscript:x',
+    'file:///etc/passwd', 'ftp://example.com', 'HTTPS:/broken', 'https://', '']) {
+    assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'openLink', url }),
+      { kind: 'ignore' }, `${url} was accepted as a link to open`);
+  }
+});
+
+test('a file reference from an answer is confined before anything opens it', () => {
+  assert.deepStrictEqual(
+    chatCommandOf({ type: 'command', command: 'openLink', file: 'src/a.ts', line: 12 }),
+    { kind: 'openFile', path: 'src/a.ts', line: 12 },
+  );
+  assert.deepStrictEqual(
+    chatCommandOf({ type: 'command', command: 'openLink', file: 'a.ts' }),
+    { kind: 'openFile', path: 'a.ts', line: 0 },
+  );
+
+  // A model writing `.git/config` or `../../.ssh/id_rsa` is not a hypothetical. The renderer refuses
+  // these too; a page is a surface, not a boundary, and anything can post to it.
+  for (const file of ['../a.ts', 'a/../b.ts', '/etc/passwd', 'C:/x/a.ts', 'C:\\x\\a.ts',
+    'src\\a.ts', 'file:///a.ts', 'https://e.com/a.ts', '']) {
+    assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'openLink', file }),
+      { kind: 'ignore' }, `${file} was accepted as a workspace file`);
+  }
+
+  // A line that is not a line is the top of the file, never a negative or a fraction.
+  for (const line of [-3, 1.5, Number.NaN, '12', undefined]) {
+    const command = chatCommandOf({ type: 'command', command: 'openLink', file: 'a.ts', line });
+    assert.deepStrictEqual(command, { kind: 'openFile', path: 'a.ts', line: 0 }, `line ${String(line)}`);
+  }
+});
+
+test('a copy names an answer by an index that is really an index', () => {
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'copyAnswer', index: 3 }),
+    { kind: 'copyAnswer', index: 3 });
+  assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'copyAnswer', index: 0 }),
+    { kind: 'copyAnswer', index: 0 });
+  for (const index of [-1, 1.5, '2', undefined, Number.NaN]) {
+    assert.deepStrictEqual(chatCommandOf({ type: 'command', command: 'copyAnswer', index }),
+      { kind: 'ignore' }, `index ${String(index)} was accepted`);
+  }
+});

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { ChatModelChoice, ChatPageState, FOLLOW_SLACK_PX, chatCappedHtml, chatMessagesHtml, chatPageHtml, chatPickerHtml, chatStatusHtml, shouldFollow } from '../chatPage';
@@ -1124,4 +1126,26 @@ test('a copy control asks the host for the message it names', () => {
     page.posted.filter((message) => message['command'] === 'copyAnswer'),
     [{ type: 'command', command: 'copyAnswer', index: 3 }],
   );
+});
+
+
+test('the copy control can be found without a mouse', () => {
+  // Hidden until hover is hidden entirely for a keyboard, a touch screen and a screen reader — and
+  // `opacity: 0` leaves it in the tab order as an invisible target. It is dimmed, not erased, and
+  // the whole message revealing it means arriving anywhere in the answer is enough.
+  const css = chatPageHtml(state(), 'n0nce').split('<style>')[1].split('</style>')[0];
+  const resting = ruleFor(css, '.msg .copy');
+
+  assert.doesNotMatch(resting, /opacity: 0[;\s}]/, 'the copy control is invisible until a pointer finds it');
+  assert.match(css, /\.msg:focus-within \.copy/, 'reaching the answer by keyboard does not reveal it');
+});
+
+test('the page module carries no backtick inside its own template literals', () => {
+  // Three times in one plan a comment written inside chatStyle or chatScript quoted a CSS property
+  // with backticks, and a backtick ENDS the template literal it sits in — the build broke each time,
+  // in a place the comment made look innocent. A test is cheaper than a fourth time. (The gate
+  // raised it as a convention; it is really a hazard of this file's shape.)
+  const source = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'chatPage.ts'), 'utf8');
+
+  assert.doesNotMatch(source, /\\`/, 'an escaped backtick — inside a template literal, write it as words instead');
 });

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -1037,3 +1037,91 @@ test('a composer that grows re-pins the reader even where nothing observes it', 
   assert.strictEqual(scroll.scrollTop, scroll.scrollHeight,
     'the growing box pushed the last answer out of view on a host with no ResizeObserver');
 });
+
+
+/* ------------------------------------------------------------------------------------------------
+ * An answer reads like a document: entries 4, 5, 6, 7, 8 and 18 of the operator's list, which are
+ * one rendering pass.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('a model answer is rendered as a document; what the person typed is not', () => {
+  const html = chatMessagesHtml([
+    { role: 'you', text: '### not a heading, I typed this' },
+    { role: 'model', text: '### a heading\n\n- and a list' },
+  ]);
+
+  const mine = html.slice(html.indexOf('msg you'), html.indexOf('msg model'));
+  const theirs = html.slice(html.indexOf('msg model'));
+
+  assert.match(theirs, /<h3>a heading<\/h3>/, 'the answer was not rendered');
+  assert.match(theirs, /<ul><li>and a list<\/li><\/ul>/, 'the list was not rendered');
+  assert.match(mine, /### not a heading/, 'what the person typed was rendered as markdown');
+  assert.doesNotMatch(mine, /<h3>/, 'the person typed a hash and got a heading');
+});
+
+test('the person is on the right and the model on the left, each in its own colour', () => {
+  const css = chatPageHtml(state(), 'n0nce').split('<style>')[1].split('</style>')[0];
+
+  assert.match(ruleFor(css, '.msg.you'), /margin-left: auto/, 'the person is not on their own side');
+  assert.match(ruleFor(css, '.msg.you'), /border-right/, 'the person has no colour of their own');
+  assert.match(ruleFor(css, '.msg.model'), /border-left/, 'the model has no colour of its own');
+  assert.match(ruleFor(css, '.msg'), /max-width/, 'a line spans the whole tab, so the sides say nothing');
+  // The edge is the colour, not a filled box — the decision already shipped for the reviewer cards.
+  assert.doesNotMatch(ruleFor(css, '.msg.you'), /background/, 'the sides became filled boxes');
+});
+
+test('an answer ends with a rule, and the person\'s own message does not', () => {
+  const html = chatMessagesHtml([{ role: 'you', text: 'ask' }, { role: 'model', text: 'answer' }]);
+
+  assert.strictEqual((html.match(/<hr class="end">/g) ?? []).length, 1,
+    'the end rule is not exactly once, after the answer');
+  assert.ok(html.indexOf('<hr class="end">') > html.indexOf('answer'), 'the rule is not after the answer');
+});
+
+test('every answer carries a way to copy the markdown it arrived as', () => {
+  const html = chatMessagesHtml([{ role: 'you', text: 'ask' }, { role: 'model', text: '**answer**' }]);
+
+  assert.match(html, /<button type="button" class="copy" data-copy="1"/, 'an answer cannot be copied');
+  assert.strictEqual((html.match(/class="copy"/g) ?? []).length, 1, 'the person\'s own message got a copy control');
+});
+
+test('the prose is the editor\'s foreground and has room to breathe', () => {
+  const css = chatPageHtml(state(), 'n0nce').split('<style>')[1].split('</style>')[0];
+
+  // Scoped to the prose rather than reset on body: the chrome around it — inputs, the hint, the
+  // picker — belongs to `--vscode-foreground`, and a seam between the two is what a blanket
+  // override produces. (gemini, the plan round.)
+  assert.match(ruleFor(css, '.msg .what'), /var\(--vscode-editor-foreground\)/, 'the prose is the chrome colour');
+  assert.match(ruleFor(css, '.msg .what'), /line-height/, 'the lines have no room between them');
+  assert.doesNotMatch(ruleFor(css, '.msg.you .what'), /opacity/, 'the person\'s own words are dimmed');
+});
+
+test('a link posts to the host and never navigates the page itself', () => {
+  const page = runChatPage();
+  page.deliver({
+    type: 'state',
+    messagesHtml: '<div class="msg model"><div class="what">'
+      + '<a class="link" data-open="https://example.com">docs</a>'
+      + '<a class="link" data-file="src/a.ts" data-line="12">a.ts</a></div></div>',
+  });
+
+  page.fire('messages', 'click', { target: { closest: () => ({ dataset: { open: 'https://example.com' } }) } });
+  page.fire('messages', 'click', { target: { closest: () => ({ dataset: { file: 'src/a.ts', line: '12' } }) } });
+
+  const opened = page.posted.filter((message) => message['command'] === 'openLink');
+  assert.strictEqual(opened.length, 2, 'the page did not ask the host to open either link');
+  assert.deepStrictEqual(opened[0], { type: 'command', command: 'openLink', url: 'https://example.com' });
+  assert.deepStrictEqual(opened[1], { type: 'command', command: 'openLink', file: 'src/a.ts', line: 12 });
+});
+
+test('a copy control asks the host for the message it names', () => {
+  const page = runChatPage();
+  page.deliver({ type: 'state', messagesHtml: '<button type="button" class="copy" data-copy="3"></button>' });
+
+  page.fire('messages', 'click', { target: { closest: () => ({ dataset: { copy: '3' } }) } });
+
+  assert.deepStrictEqual(
+    page.posted.filter((message) => message['command'] === 'copyAnswer'),
+    [{ type: 'command', command: 'copyAnswer', index: 3 }],
+  );
+});

--- a/src_vs_code/src/test/renderAnswer.test.ts
+++ b/src_vs_code/src/test/renderAnswer.test.ts
@@ -1,0 +1,226 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { fileTargetOf, renderAnswer } from '../renderAnswer';
+
+/**
+ * The renderer, and the file that is its safety.
+ *
+ * <p>Every other test here asks whether a document reads well. The HOSTILE section asks the only
+ * question that matters more: this text arrives from another vendor's model, through a CLI, and is
+ * exactly as trustworthy as anything else somebody else wrote. This repository has already shipped
+ * one defect of that family — a URL inside a user's name that GitHub autolinked — so the rule is not
+ * a theory here.</p>
+ *
+ * <p>The section is meant to GROW. A construct that turns out to be renderable into markup belongs
+ * in it before it belongs in the renderer.</p>
+ */
+
+/**
+ * Every tag name the output contains.
+ *
+ * <p>The first version of the hostile tests matched on words — `onerror`, `javascript:` — and that
+ * is the wrong question twice over: escaped text that merely MENTIONS `onerror` is exactly what
+ * should be shown, and a hostile tag this list has not thought of would pass. The question is which
+ * ELEMENTS came out, and the answer must always be a subset of what the renderer is allowed to
+ * emit.</p>
+ */
+const ALLOWED = new Set([
+  'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'pre', 'code', 'blockquote', 'hr',
+  'strong', 'em', 'del', 'br', 'a', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
+]);
+
+function tagsIn(html: string): string[] {
+  return [...html.matchAll(/<\/?([a-zA-Z][a-zA-Z0-9]*)/g)].map((match) => (match[1] ?? '').toLowerCase());
+}
+
+function assertOnlyAllowedTags(html: string, what: string): void {
+  for (const tag of tagsIn(html)) {
+    assert.ok(ALLOWED.has(tag), `<${tag}> reached the page from: ${what}`);
+  }
+  // Only inside REAL tags. Scanning the whole string flags escaped text that merely mentions
+  // `onerror` — which is precisely the text that should be shown, and the first version of this
+  // helper failed on exactly that. Escaped markup has no `<`, so this cannot reach it.
+  for (const tag of html.match(/<[a-zA-Z][^>]*>/g) ?? []) {
+    assert.doesNotMatch(tag, / on[a-z]+=/i, `an event attribute reached the page from: ${what}`);
+    assert.doesNotMatch(tag, /\ssrc=|\shref=/i, `a loading or navigating attribute reached the page from: ${what}`);
+  }
+}
+
+test('a heading, a paragraph and emphasis come out as themselves', () => {
+  const html = renderAnswer('### Итог\n\nThe reviewers are **read-only** and *stay* so.\n');
+
+  assert.match(html, /<h3>Итог<\/h3>/);
+  assert.match(html, /<strong>read-only<\/strong>/);
+  assert.match(html, /<em>stay<\/em>/);
+});
+
+test('a heading deeper than six is clamped, because h7 is not an element', () => {
+  assert.match(renderAnswer('####### seven\n'), /<h6>|<p>/);
+  assert.doesNotMatch(renderAnswer('####### seven\n'), /<h7/);
+});
+
+test('lists nest, and an ordered list keeps its own numbering', () => {
+  // The one construct a hand-written renderer was going to be wrong about, which is why the
+  // tokenizing is not hand-written.
+  const html = renderAnswer('- one\n  - inner\n    - deeper\n- two\n');
+
+  assert.match(html, /<ul><li>one<ul><li>inner<ul><li>deeper<\/li><\/ul><\/li><\/ul><\/li>/);
+
+  const ordered = renderAnswer('3. three\n4. four\n');
+  assert.match(ordered, /<ol start="3"><li>three<\/li><li>four<\/li><\/ol>/);
+});
+
+test('a fenced block keeps its text verbatim, entities and all', () => {
+  // The case that decided the whole design: escaping the string BEFORE parsing turns `<` into
+  // `&lt;` inside the fence, and the reader is shown an entity the model never wrote.
+  const html = renderAnswer('```js\nif (a < b && c > d) { return "x"; }\n```\n');
+
+  assert.match(html, /<pre><code class="language-js">/);
+  assert.match(html, /if \(a &lt; b &amp;&amp; c &gt; d\)/);
+  assert.doesNotMatch(html, /&amp;lt;/, 'the fence was escaped twice');
+});
+
+test('a language that is not a word never reaches the class attribute', () => {
+  const html = renderAnswer('```" onmouseover="alert(1)\nx\n```\n');
+
+  assert.match(html, /<pre><code>/, 'a hostile language string was used as a class');
+  assert.doesNotMatch(html, /onmouseover/, 'the language string reached the markup');
+});
+
+test('a code span keeps its backticked text as text', () => {
+  assert.match(renderAnswer('run `git merge-base --is-ancestor`\n'), /<code>git merge-base --is-ancestor<\/code>/);
+});
+
+test('a table, a rule and a quote each become themselves', () => {
+  assert.match(renderAnswer('| a | b |\n|---|---|\n| 1 | 2 |\n'), /<table><thead><tr><th>a<\/th>/);
+  assert.match(renderAnswer('---\n'), /<hr>/);
+  assert.match(renderAnswer('> quoted\n'), /<blockquote><p>quoted<\/p><\/blockquote>/);
+});
+
+test('an http link becomes an anchor the HOST is asked to open, and carries no href', () => {
+  const html = renderAnswer('see [the docs](https://example.com/a?b=1)\n');
+
+  assert.match(html, /<a class="link" data-open="https:\/\/example\.com\/a\?b=1">the docs<\/a>/);
+  assert.doesNotMatch(html, /href=/, 'the page carries a live href');
+  assert.doesNotMatch(html, /src=/, 'the page carries something that loads');
+});
+
+test('a file reference becomes an anchor naming the file and the line', () => {
+  assert.match(
+    renderAnswer('[chatPage.ts:181](src_vs_code/src/chatPage.ts:181)\n'),
+    /data-file="src_vs_code\/src\/chatPage\.ts" data-line="181"/,
+  );
+  assert.match(
+    renderAnswer('[it](src/chatPage.ts#L42)\n'),
+    /data-file="src\/chatPage\.ts" data-line="42"/,
+  );
+});
+
+test('a link this page will not act on keeps its words and loses its link', () => {
+  for (const href of ['javascript:alert(1)', 'data:text/html,<script>x</script>', 'vbscript:x',
+    'file:///etc/passwd', '../../.ssh/id_rsa', '/etc/passwd', 'C:\\Windows\\win.ini',
+    'mailto:someone@example.com']) {
+    const html = renderAnswer(`[press here](${href})\n`);
+
+    assert.match(html, /press here/, `${href} lost the words the model wrote`);
+    assert.doesNotMatch(html, /<a /, `${href} was rendered as a link`);
+  }
+});
+
+test('fileTargetOf refuses everything that is not a plain relative file', () => {
+  assert.deepStrictEqual(fileTargetOf('src/a.ts#L3'), { path: 'src/a.ts', line: 3 });
+  assert.deepStrictEqual(fileTargetOf('a.ts'), { path: 'a.ts', line: 0 });
+  for (const bad of ['../a.ts', 'a/../../b.ts', '/abs/a.ts', 'C:/x/a.ts', 'C:\\x\\a.ts',
+    'https://e.com/a.ts', 'no-extension', '.git/config']) {
+    assert.strictEqual(fileTargetOf(bad), undefined, `${bad} was accepted as a workspace file`);
+  }
+});
+
+/* ------------------------------------------------------------------------------------------------
+ * HOSTILE. Everything below is text a model can write, and none of it may become markup.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('raw HTML in an answer is shown, not run', () => {
+  for (const attack of [
+    '<script>alert(1)</script>',
+    '<img src=x onerror=alert(1)>',
+    '<iframe src="https://example.com"></iframe>',
+    '<svg onload=alert(1)>',
+    '<a href="javascript:alert(1)">x</a>',
+    '<style>body{display:none}</style>',
+    '<div onclick="alert(1)">click</div>',
+  ]) {
+    const html = renderAnswer(`${attack}\n`);
+
+    assertOnlyAllowedTags(html, attack);
+    assert.match(html, /&lt;/, `this was silently dropped instead of shown: ${attack}`);
+  }
+});
+
+test('raw HTML inside a paragraph, a list and a quote is escaped too', () => {
+  for (const markdown of [
+    'text <img src=x onerror=alert(1)> more',
+    '- <script>alert(1)</script>',
+    '> <iframe src=x></iframe>',
+    '| a |\n|---|\n| <script>alert(1)</script> |',
+  ]) {
+    assertOnlyAllowedTags(renderAnswer(markdown + '\n'), markdown);
+  }
+});
+
+test('a closing script tag inside a fence cannot end the page script', () => {
+  const html = renderAnswer('```\n</script><script>alert(1)</script>\n```\n');
+
+  assert.doesNotMatch(html, /<\/script>/i, 'a fence closed the page script');
+  assert.match(html, /&lt;\/script&gt;/);
+});
+
+test('an unclosed fence, an unclosed emphasis and a lone bracket render as text rather than nothing', () => {
+  for (const markdown of ['```js\nnever closed', '**never closed', '[label](', 'a ] b', '`open']) {
+    const html = renderAnswer(markdown);
+
+    assert.notStrictEqual(html.length, 0, `nothing at all came out of: ${markdown}`);
+    assert.doesNotMatch(html, /<script|onerror/i);
+  }
+});
+
+test('a bare URL in prose is not turned into a link', () => {
+  // The defect this family already shipped once, from the other direction: GitHub autolinked a URL
+  // inside a user's name. A model writing an address in a sentence has not asked for a link.
+  const html = renderAnswer('go to https://evil.example.com and sign in\n');
+
+  assert.doesNotMatch(html, /<a /, 'a bare URL was autolinked');
+  assert.match(html, /https:\/\/evil\.example\.com/);
+});
+
+test('an image renders as its words and never as an element', () => {
+  const html = renderAnswer('![a screenshot](https://example.com/a.png)\n');
+
+  assert.doesNotMatch(html, /<img/i, 'an image element reached a page whose CSP forbids loading one');
+  assert.match(html, /a screenshot/);
+});
+
+test('a link whose LABEL is hostile is escaped like any other text', () => {
+  const html = renderAnswer('[<script>alert(1)</script>](https://example.com)\n');
+
+  assert.doesNotMatch(html, /<script/i);
+  assert.match(html, /data-open="https:\/\/example\.com"/);
+});
+
+test('a link href with a quote cannot break out of the attribute', () => {
+  const html = renderAnswer('[x](https://example.com/"onmouseover="alert(1))\n');
+
+  assert.doesNotMatch(html, /onmouseover="alert/, 'the href escaped its attribute');
+});
+
+test('a list nested past any sane depth degrades to text instead of recursing', () => {
+  const deep = Array.from({ length: 30 }, (_, i) => `${' '.repeat(i * 2)}- level ${i}`).join('\n');
+  const html = renderAnswer(deep + '\n');
+
+  assert.ok(html.length > 0, 'a deeply nested list rendered nothing');
+  assert.doesNotMatch(html, /<script/i);
+});
+
+test('an empty answer renders nothing rather than an empty paragraph', () => {
+  assert.strictEqual(renderAnswer(''), '');
+});

--- a/src_vs_code/src/test/renderAnswer.test.ts
+++ b/src_vs_code/src/test/renderAnswer.test.ts
@@ -130,8 +130,18 @@ test('a link this page will not act on keeps its words and loses its link', () =
 test('fileTargetOf refuses everything that is not a plain relative file', () => {
   assert.deepStrictEqual(fileTargetOf('src/a.ts#L3'), { path: 'src/a.ts', line: 3 });
   assert.deepStrictEqual(fileTargetOf('a.ts'), { path: 'a.ts', line: 0 });
+  // A file without a dot is still a file, and the two ends of this must agree about that: the
+  // renderer used to demand an extension where the host's check did not, so `Dockerfile` was never
+  // offered as a link by a page whose host would happily have opened it.
+  assert.deepStrictEqual(fileTargetOf('Dockerfile'), { path: 'Dockerfile', line: 0 });
+  assert.deepStrictEqual(fileTargetOf('LICENSE#L2'), { path: 'LICENSE', line: 2 });
+  // `no-extension` was in this list until the code round pointed out that the renderer and the host
+  // disagreed about what a path is — Dockerfile and LICENSE are files, and the host would have
+  // opened them. What is refused is what ESCAPES, not what lacks a dot. `.git/config` is a path this
+  // will offer; it is inside the workspace, and refusing it here would be a policy invented in the
+  // wrong place — the host decides what exists.
   for (const bad of ['../a.ts', 'a/../../b.ts', '/abs/a.ts', 'C:/x/a.ts', 'C:\\x\\a.ts',
-    'https://e.com/a.ts', 'no-extension', '.git/config']) {
+    'https://e.com/a.ts']) {
     assert.strictEqual(fileTargetOf(bad), undefined, `${bad} was accepted as a workspace file`);
   }
 });
@@ -223,4 +233,12 @@ test('a list nested past any sane depth degrades to text instead of recursing', 
 
 test('an empty answer renders nothing rather than an empty paragraph', () => {
   assert.strictEqual(renderAnswer(''), '');
+});
+
+
+test('nothing empty is wrapped in a paragraph of its own', () => {
+  // An empty <p> is vertical space the model did not ask for, between things it did.
+  for (const markdown of ['<span></span>\n', 'text\n\n\n\nmore\n']) {
+    assert.doesNotMatch(renderAnswer(markdown), /<p>\s*<\/p>/, `an empty paragraph came out of: ${markdown}`);
+  }
 });


### PR DESCRIPTION
`todo/PLAN_an_answer_reads_like_a_document.md`. Six of the operator's reports (entries 4, 5, 6, 7, 8, 18 of `todo/BUGS_2026-09-09.md`) that are one rendering pass. A model's answer used to reach the page as `escapeHtml(text)` under `white-space: pre-wrap` — the raw characters, wrapped.

## What a person will notice

- **Answers read like answers**: headings, nested and numbered lists, code in a code face and in its own scrolling box, tables, quotes.
- **Links are blue and they work.** A web address opens in the browser; a file a model names opens in the editor at that line if it is really in this workspace — and if it is not, the tab says so instead of doing nothing. An address a model merely mentioned in a sentence is not turned into a link at all.
- **You are on the right, the answer on the left**, each behind an edge in its own colour, and a line closes every answer.
- **Every answer can be copied as the Markdown it arrived as.**
- **The prose is brighter and has room to breathe** — it was the colour of a button label, at the interface's own size.

## The decision this PR takes, and why it is not mine

This extension advertised **zero runtime dependencies** in the first line of `research/module_extension.md`, and my inclination was to widen `bodyHtml` in `helpPage.ts` — whose rule, *escape first, mark up second*, is exactly what a chat page needs.

**Both plan-round reviewers refused it**, and the argument holds: as a REGEX pipeline that rule breaks on a fence containing entities — escaping the string first turns `<` into `&lt;` inside the code the reader is shown — and it cannot count nesting at all. What is needed is a lexer handing back an AST, with escaping applied to the text LEAVES.

So `marked` is the first runtime dependency this extension has had, **and the line that advertised none now says one, with the reason beside it** rather than left as a version bump somebody finds later. Nothing marked would emit is used: the walker emits a fixed list of tags and nothing else.

## Safety

- **No `href` is emitted at all.** A link becomes an anchor carrying `data-open` or `data-file`, and the host is asked to act on it — so there is nothing for a `javascript:` URL to be.
- **The host is the boundary, the page a surface.** Every scheme but `http`/`https` is refused; every path that is absolute, traversing, drive-lettered or backslashed is refused; and what survives is resolved against each workspace root and checked for containment.
- **Containment is not a prefix** — the code round caught that `startsWith('/w/app')` admits `/w/app-secret/config.json`.
- **Raw HTML is escaped and shown**, not passed through and not dropped: a model that wrote a tag meant to show one.
- **`renderAnswer.test.ts` is the safety**, and it found two real things on its first run: GFM autolinking a bare address (the defect this family shipped once already, from the other direction), and a weakness in its own assertions — it matched the *word* `onerror`, which flags escaped text that merely mentions one and would miss a hostile tag nobody thought of. It asserts on the tag names that came out, against the allow-list.

## Tests

**1181, 1179 passing, 0 failing.** Every fix went RED first. One new guard: three times in this plan a comment inside a template literal quoted something with backticks and ended the literal — the build broke each time in a place the comment made look innocent, so the fourth time is a red test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI chat answers now support Markdown formatting, including headings, lists, code, tables, quotes, and horizontal rules.
  - Web links open in the browser, while workspace file references open at the specified line.
  - Added a Copy action for copying answers as Markdown.
  - Updated chat layout and styling for clearer distinction between user and assistant messages.

- **Security**
  - Unsafe links and embedded HTML are safely escaped or blocked.
  - Workspace file access is restricted to valid paths within the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->