### PR TITLE
feat(chat): the page can stop the turn it is showing

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -41,6 +41,15 @@ was drawn for: nothing in the script remembers one across a push, which is the p
 no button** — a control that posted a message the seam refuses would look to a person exactly like a
 stop that did not work.
 
+**A push must not hand the control back.** The thinking line is replaced wholesale whenever it
+changes — a Team server pushes its queue position while a turn waits — and the replacement carried a
+fresh, pressable control for a turn the person had already stopped: they would press it again and
+watch it come back. The page remembers the ONE turn a stop was asked for, and a redrawn control
+naming that turn comes back disabled. One number rather than a set, because there is one turn in
+flight, and the next turn's control is live — inheriting a stop nobody asked for is the opposite
+defect. The keyboard's place is carried across the same replacement, since somebody who tabbed to
+Stop while waiting is precisely somebody who wants it.
+
 The listener is delegated on `#thinking` for the same reason the answers' links are delegated on
 `#messages`: the region is replaced wholesale on every push, and a listener bound to the old button
 dies with it. Pressing it disables it at once — a second press names the same turn, and by the time

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -29,6 +29,23 @@ local model` the page would otherwise still show the remote one as selected whil
 somewhere else), a pushed state that has not changed is not sent at all, a `pick` naming a model the
 conversation was never offered is refused at the host boundary rather than trusted, and the
 composer takes focus back when a turn ends — without which every follow-up costs a mouse click.
+### A turn can be stopped from the page it is running on (2026-09-09)
+
+The seam shipped first and waited: `ChatSession.stop()` and an `onStop(id, turn)` hook that takes a
+TURN NUMBER, because a wildcard stop ends whatever is running — which, by the time a late message
+lands, can be the turn AFTER the one somebody pressed for. So the page had to be able to name it.
+
+`turn` travels in the page state and in every push, and the control is rendered INTO the thinking
+line with that number in its markup. A control on screen can therefore only ever name the turn it
+was drawn for: nothing in the script remembers one across a push, which is the point. **No number,
+no button** — a control that posted a message the seam refuses would look to a person exactly like a
+stop that did not work.
+
+The listener is delegated on `#thinking` for the same reason the answers' links are delegated on
+`#messages`: the region is replaced wholesale on every push, and a listener bound to the old button
+dies with it. Pressing it disables it at once — a second press names the same turn, and by the time
+it landed the host could have moved on.
+
 ### An answer reads like a document (2026-09-09)
 
 A model's answer used to reach the page as `escapeHtml(text)` under `white-space: pre-wrap` — the

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**A turn can be stopped.** While an answer is coming there is a *Stop* beside *Thinking…* — for the
+question you saw was wrong the moment you sent it, and for the one that is taking far longer than it
+should. It stops the turn it is showing and no other, so a press that lands late cannot end the
+question you asked afterwards.
+## Unreleased
+
 **Answers read like answers.** Headings were hashes, lists were dashes, code was backticks and a
 link was its own address in brackets — everything a model wrote as Markdown arrived as Markdown. It
 is rendered now: headings, numbered and bulleted lists that nest, code in a code face and in its own

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -6,8 +6,6 @@
 question you saw was wrong the moment you sent it, and for the one that is taking far longer than it
 should. It stops the turn it is showing and no other, so a press that lands late cannot end the
 question you asked afterwards.
-## Unreleased
-
 **Answers read like answers.** Headings were hashes, lists were dashes, code was backticks and a
 link was its own address in brackets — everything a model wrote as Markdown arrived as Markdown. It
 is rendered now: headings, numbered and bulleted lists that nest, code in a code face and in its own
@@ -26,9 +24,6 @@ into a plan or an issue. Selecting the page still gives you what the page shows.
 
 **The text is brighter and has room to breathe.** It was the colour of a button label, packed at the
 editor's interface size.
-
-## Unreleased
-
 **The box you type in stays where you put it.** It used to scroll away with the conversation, so
 asking a second question meant scrolling back down to find it. The composer, the model picker and
 the hint are pinned to the bottom of the tab now, the conversation scrolls above them, and there is

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -201,7 +201,7 @@ function show(entry: ChatEntry, running: boolean, failure: string, queued = 0): 
     queued,
     // The turn a stop would name. Zero while nothing runs, which is also what the page renders no
     // control for — a stop that names no turn is refused by the seam rather than obeyed loosely.
-    turn: running ? (threads.get(entry.id)?.turn ?? 0) : 0,
+    turn: running ? (thread?.turn ?? 0) : 0,
   });
   // The one place the transcript reaches a page is the one place it is written down — but only when
   // there is something new to write. `show` runs on every state push: a turn starting, a queue

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -199,6 +199,9 @@ function show(entry: ChatEntry, running: boolean, failure: string, queued = 0): 
     models: thread.models,
     modelId: thread.modelId,
     queued,
+    // The turn a stop would name. Zero while nothing runs, which is also what the page renders no
+    // control for — a stop that names no turn is refused by the seam rather than obeyed loosely.
+    turn: running ? (threads.get(entry.id)?.turn ?? 0) : 0,
   });
   // The one place the transcript reaches a page is the one place it is written down — but only when
   // there is something new to write. `show` runs on every state push: a turn starting, a queue
@@ -670,6 +673,8 @@ function newConversation(
       modelId: ready.modelId,
       running: false,
       capped: false,
+      // Nothing is in flight on a page that has just opened, so there is no turn to stop.
+      turn: 0,
       failure: '',
       draft: state.draft,
       uiScale: chatUiScale(),
@@ -854,6 +859,8 @@ export function restoreConversation(
       modelId: saved.modelId,
       running: false,
       capped: false,
+      // Nothing is in flight on a page that has just opened, so there is no turn to stop.
+      turn: 0,
       failure: ready.ok ? reloadedNote(saved.modelId) : ready.refusal,
       draft: '',
       uiScale: chatUiScale(),

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -62,6 +62,16 @@ export interface ChatPageState {
   readonly messages: readonly ChatMessage[];
   readonly models: readonly ChatModelChoice[];
   readonly modelId: string;
+  /**
+   * Which turn is in flight, counted from 1 — and 0 when the page cannot say.
+   *
+   * <p>It is in the STATE rather than kept in the script because the thinking line is replaced
+   * wholesale on every push: the control that stops a turn is rendered with that turn's number in
+   * it, so a control on screen can only ever name the turn it was drawn for. The seam refuses a stop
+   * that names no turn at all, deliberately — a wildcard stop ends whatever is running, which by the
+   * time a late message lands can be the turn AFTER the one somebody pressed for.</p>
+   */
+  readonly turn: number;
   /** A turn is in flight: the composer is locked and the thinking line is shown. */
   readonly running: boolean;
   /**
@@ -213,6 +223,8 @@ function chatStyle(uiScale: number): string {
   hr.end { border: none; border-top: 1px solid var(--vscode-panel-border); margin: 14px 0 0; opacity: .55; }
   .empty { opacity: .6; }
   .thinking { opacity: .75; margin: 0 0 12px; }
+  #stop { font: inherit; font-size: .9em; color: var(--vscode-textLink-foreground); background: none; border: none; padding: 0 0 0 4px; cursor: pointer; text-decoration: underline; }
+  #stop[disabled] { opacity: .5; cursor: default; text-decoration: none; }
   .queued { opacity: .8; font-size: .9em; }
   .failure { border: 1px solid var(--vscode-inputValidation-errorBorder, var(--vscode-panel-border)); border-radius: 4px; padding: 8px 10px; margin: 0 0 12px; }
   .capped { border: 1px solid var(--vscode-panel-border); border-radius: 4px; padding: 10px 12px; margin: 0 0 10px; }
@@ -245,15 +257,20 @@ ${ZOOM_CSS}`;
  * <p>`position` is 0 when the server did not say, or when the turn has left the queue and is being
  * answered. Both are "no number to show", and neither is position zero.</p>
  */
-export function chatStatusHtml(running: boolean, position: number): string {
+export function chatStatusHtml(running: boolean, position: number, turn: number): string {
   if (!running) {
     return '';
   }
   const where = Number.isInteger(position) && position > 0
     ? ` <span class="queued">· waiting in the queue, ${position} ahead</span>`
     : '';
+  // No number, no button. The alternative is a control that posts a message the host will drop,
+  // which looks to a person exactly like a stop that did not work.
+  const stop = Number.isSafeInteger(turn) && turn > 0
+    ? ` <button type="button" id="stop" data-turn="${turn}">Stop</button>`
+    : '';
 
-  return `<p class="thinking">Thinking…${where}</p>`;
+  return `<p class="thinking">Thinking…${where}${stop}</p>`;
 }
 
 /**
@@ -269,7 +286,7 @@ type Regions = Record<'messages' | 'thinking' | 'capped' | 'failure', string>;
 function regionsOf(state: ChatPageState): Regions {
   return {
     messages: chatMessagesHtml(state.messages),
-    thinking: chatStatusHtml(state.running, 0),
+    thinking: chatStatusHtml(state.running, 0, state.turn),
     capped: chatCappedHtml(state.capped),
     failure: state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`,
   };
@@ -580,6 +597,23 @@ function chatScript(state: ChatPageState, regions: Regions): string {
   // link would have to be re-bound after every one, and the one that was missed is the one that
   // silently does nothing. The page never navigates and never reads a file - it names what it wants
   // and the HOST decides, which is where the workspace root and the scheme are actually known.
+  // Delegated on the region that HOLDS the line rather than bound to the button, because the line is
+  // replaced wholesale on every push and a listener bound to the old button dies with it.
+  const thinkingRegion = document.getElementById('thinking');
+  if (thinkingRegion) {
+    thinkingRegion.addEventListener('click', function (event) {
+      const target = event.target;
+      if (!target || typeof target.closest !== 'function') { return; }
+      const control = target.closest('#stop');
+      if (!control || !control.dataset || control.disabled) { return; }
+      const turn = Number(control.dataset.turn);
+      if (!Number.isSafeInteger(turn) || turn <= 0) { return; }
+      // Disabled the instant it is pressed. A second press a moment later would name the same turn,
+      // and by the time it landed the host could have moved on to the next one.
+      control.disabled = true;
+      vscode.postMessage({ type: 'command', command: 'stop', turn: turn });
+    });
+  }
   const messagesRegion = document.getElementById('messages');
   if (messagesRegion) {
     messagesRegion.addEventListener('click', function (event) {

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -618,6 +618,9 @@ function chatScript(state: ChatPageState, regions: Regions): string {
       // Disabled the instant it is pressed. A second press a moment later would name the same turn,
       // and by the time it landed the host could have moved on to the next one.
       control.disabled = true;
+      // Said, not merely greyed. Killing a vendor process and resolving the turn takes a moment, and
+      // a dimmed control still reading Stop cannot be told from one that did nothing at all.
+      control.textContent = 'Stopping…';
       stopAsked = turn;
       vscode.postMessage({ type: 'command', command: 'stop', turn: turn });
     });
@@ -688,8 +691,13 @@ function chatScript(state: ChatPageState, regions: Regions): string {
       wrote = true;
       const redrawn = document.getElementById('stop');
       if (redrawn) {
-        if (Number(redrawn.dataset && redrawn.dataset.turn) === stopAsked) { redrawn.disabled = true; }
-        if (hadFocus && typeof redrawn.focus === 'function') { redrawn.focus(); }
+        if (Number(redrawn.dataset && redrawn.dataset.turn) === stopAsked) {
+          redrawn.disabled = true;
+          redrawn.textContent = 'Stopping…';
+        }
+        // Only onto a control that still has something to do. Putting a keyboard on a disabled
+        // button leaves it somewhere with no action left, which is worse than leaving it be.
+        if (hadFocus && !redrawn.disabled && typeof redrawn.focus === 'function') { redrawn.focus(); }
       }
     }
     // These two clear when they are NOT mentioned - the protocol has always meant that, and a
@@ -733,6 +741,14 @@ function chatScript(state: ChatPageState, regions: Regions): string {
     // Only a real boolean moves the lock. A state that says nothing about running - a partial push,
     // or a null across the bridge - must leave the composer as it is rather than quietly unlocking
     // it while a turn is still in flight. (local, the second code round.)
+    // A stop is about the turn in flight. When nothing is in flight it is about nothing — and
+    // holding on to the number would disable the same-numbered turn of the NEXT conversation, since
+    // restarting keeps this page and begins counting again. (gemini and local, the code round, from
+    // two directions.) The phrase the restart button uses is deliberately not written here: comments
+    // in this template ship to the browser, and a test that looks for that text found this one.
+    if (data.running === false) {
+      stopAsked = 0;
+    }
     if (box && typeof data.running === 'boolean' && typeof data.capped === 'boolean') {
       const wasLocked = box.disabled;
       lock(data.running || data.capped);

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -374,6 +374,13 @@ function chatScript(state: ChatPageState, regions: Regions): string {
   var shouldFollow = ${shouldFollow.toString()};
   var SLACK = ${FOLLOW_SLACK_PX};
   var pendingFollow = 0;
+  // The ONE turn a stop has been asked for and not yet answered. The thinking line is replaced
+  // wholesale on every push - a Team server pushes its queue position while a turn waits - and the
+  // replacement carried a fresh, pressable control for a turn the person had already stopped. They
+  // would press it again and watch it come back. It is one number, not a set, because there is one
+  // turn in flight; the next turn's control is live, and inheriting a stop nobody asked for would be
+  // the opposite defect. (gemini, the plan round.)
+  var stopAsked = 0;
   // Whether the reader was at the bottom BEFORE the last thing that moved the layout under them.
   // Recomputed on every scroll, which is the only event that means the READER moved; a resize or a
   // growing composer must ask what this remembers, because after one the numbers no longer describe
@@ -611,6 +618,7 @@ function chatScript(state: ChatPageState, regions: Regions): string {
       // Disabled the instant it is pressed. A second press a moment later would name the same turn,
       // and by the time it landed the host could have moved on to the next one.
       control.disabled = true;
+      stopAsked = turn;
       vscode.postMessage({ type: 'command', command: 'stop', turn: turn });
     });
   }
@@ -671,9 +679,18 @@ function chatScript(state: ChatPageState, regions: Regions): string {
       wrote = true;
     }
     if (thinking && typeof data.thinkingHtml === 'string' && lastWritten.thinking !== data.thinkingHtml) {
+      // Whether the keyboard was on the control this is about to destroy. Replacing the line while a
+      // remote turn's queue position moves would otherwise take the focus away repeatedly, silently,
+      // from somebody waiting - which is exactly when they are most likely to want it.
+      const hadFocus = document.activeElement === document.getElementById('stop');
       thinking.innerHTML = data.thinkingHtml;
       lastWritten.thinking = data.thinkingHtml;
       wrote = true;
+      const redrawn = document.getElementById('stop');
+      if (redrawn) {
+        if (Number(redrawn.dataset && redrawn.dataset.turn) === stopAsked) { redrawn.disabled = true; }
+        if (hadFocus && typeof redrawn.focus === 'function') { redrawn.focus(); }
+      }
     }
     // These two clear when they are NOT mentioned - the protocol has always meant that, and a
     // capped notice or a failure left on screen after it stopped being true is one a person acts on.

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -99,6 +99,14 @@ export interface ChatPushState {
    * stale position would be pushed exactly once and then stick.</p>
    */
   readonly queued: number;
+  /**
+   * Which turn is in flight, counted from 1 — 0 when none is, or when it cannot be named.
+   *
+   * <p>The control that stops a turn is rendered INTO the thinking line with this number in it, so a
+   * control on screen names the turn it was drawn for and no other. That is the whole reason it
+   * travels with the state rather than being remembered by the page.</p>
+   */
+  readonly turn: number;
 }
 
 /**
@@ -292,7 +300,7 @@ export function pushChatState(entry: ChatEntry, state: ChatPushState): boolean {
     messagesHtml: chatMessagesHtml(state.messages),
     running: state.running,
     capped: state.capped,
-    thinkingHtml: chatStatusHtml(state.running, state.queued),
+    thinkingHtml: chatStatusHtml(state.running, state.queued, state.turn),
     cappedHtml: chatCappedHtml(state.capped),
     failureHtml: state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`,
     pickerHtml: chatPickerHtml(state.models, state.modelId),

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -28,6 +28,7 @@ function state(over: Partial<ChatPageState> = {}): ChatPageState {
     modelId: 'antigravity',
     running: false,
     capped: false,
+    turn: 0,
     failure: '',
     draft: '',
     uiScale: 0,
@@ -164,17 +165,17 @@ test('a turn waiting behind other people says so, and one being answered does no
   // A shared Team server queues twenty deep per person by design, so "still waiting" is minutes —
   // and an unchanging spinner is the one shape a busy server and a broken tab look identical in.
   // The position was already parsed out of every poll and thrown away. (gemini, the code round.)
-  assert.match(chatStatusHtml(true, 4), /Thinking/);
-  assert.match(chatStatusHtml(true, 4), /4 ahead/);
+  assert.match(chatStatusHtml(true, 4, 0), /Thinking/);
+  assert.match(chatStatusHtml(true, 4, 0), /4 ahead/);
 
   // Zero is "no number to show", not position zero: the server says 0 both when it did not count
   // and when the turn has left the queue and is being answered. Neither is a place in a line.
-  assert.strictEqual(chatStatusHtml(true, 0), '<p class="thinking">Thinking…</p>');
-  assert.strictEqual(chatStatusHtml(true, -1), '<p class="thinking">Thinking…</p>');
-  assert.strictEqual(chatStatusHtml(true, 1.5), '<p class="thinking">Thinking…</p>');
+  assert.strictEqual(chatStatusHtml(true, 0, 0), '<p class="thinking">Thinking…</p>');
+  assert.strictEqual(chatStatusHtml(true, -1, 0), '<p class="thinking">Thinking…</p>');
+  assert.strictEqual(chatStatusHtml(true, 1.5, 0), '<p class="thinking">Thinking…</p>');
 
   // Nothing at all when no turn is in flight — the region is emptied, not left saying "Thinking…".
-  assert.strictEqual(chatStatusHtml(false, 4), '');
+  assert.strictEqual(chatStatusHtml(false, 4, 0), '');
 });
 
 /**
@@ -1148,4 +1149,79 @@ test('the page module carries no backtick inside its own template literals', () 
   const source = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'chatPage.ts'), 'utf8');
 
   assert.doesNotMatch(source, /\\`/, 'an escaped backtick — inside a template literal, write it as words instead');
+});
+
+
+/* ------------------------------------------------------------------------------------------------
+ * The page half of "a turn nobody can stop". The seam landed first and has been waiting: it takes a
+ * TURN NUMBER and refuses a stop that names none, so the page has to know which turn it is showing.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('a running turn offers a way to stop it, and names the turn it would stop', () => {
+  assert.match(chatStatusHtml(true, 0, 4), /<button type="button" id="stop" data-turn="4"/,
+    'a turn in flight offers no way out of it');
+  assert.match(chatStatusHtml(true, 0, 4), /Thinking/, 'the thinking line lost its words');
+});
+
+test('nothing offers a stop when nothing is running', () => {
+  assert.strictEqual(chatStatusHtml(false, 0, 4), '', 'an idle page offered to stop something');
+});
+
+test('a turn the page cannot name offers no stop at all', () => {
+  // The seam refuses a stop with no turn — deliberately, because a wildcard stop ends whatever is
+  // running, which by then can be the turn AFTER the one somebody pressed for. A page that cannot
+  // name the turn must not offer the button rather than post a message the host will drop.
+  for (const turn of [0, -1, 1.5, Number.NaN]) {
+    const html = chatStatusHtml(true, 0, turn);
+
+    assert.doesNotMatch(html, /id="stop"/, `a stop was offered for turn ${String(turn)}`);
+    assert.match(html, /Thinking/, `the thinking line vanished for turn ${String(turn)}`);
+  }
+});
+
+/** A stop control as the page sees one: a click on the region, with the control as its target. */
+function pressStop(page: RunningPage, control: { dataset: { turn: string }; disabled: boolean }): void {
+  page.fire('thinking', 'click', { target: { closest: () => control } });
+}
+
+test('pressing stop names its turn, and cannot name it twice', () => {
+  // Delegated on the region, because the thinking line is replaced wholesale on every push and a
+  // listener bound to the old button dies with it — the same reason the answers' links are.
+  const page = runChatPage({ running: true, turn: 7 });
+  const control = { dataset: { turn: '7' }, disabled: false };
+
+  pressStop(page, control);
+  pressStop(page, control);
+
+  assert.deepStrictEqual(
+    page.posted.filter((message) => message['command'] === 'stop'),
+    [{ type: 'command', command: 'stop', turn: 7 }],
+    'the second press sent a second stop, which by then could be the next turn',
+  );
+  assert.strictEqual(control.disabled, true, 'the control stayed pressable after being pressed');
+});
+
+test('the stop control names the turn it was rendered with, not one the page remembers', () => {
+  // Nothing in the script remembers a turn across a push: the number is in the markup, so a control
+  // on screen can only ever name the turn it was drawn for.
+  const page = runChatPage({ running: true, turn: 7 });
+
+  pressStop(page, { dataset: { turn: '8' }, disabled: false });
+
+  assert.deepStrictEqual(
+    page.posted.filter((message) => message['command'] === 'stop'),
+    [{ type: 'command', command: 'stop', turn: 8 }],
+    'the page stopped a turn other than the one its control named',
+  );
+});
+
+test('a stop control that names no turn posts nothing', () => {
+  const page = runChatPage({ running: true, turn: 7 });
+
+  for (const turn of ['0', '-1', '1.5', 'seven', '']) {
+    pressStop(page, { dataset: { turn }, disabled: false });
+  }
+
+  assert.deepStrictEqual(page.posted.filter((message) => message['command'] === 'stop'), [],
+    'a control with no usable turn posted a stop the host would only drop');
 });

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -1299,6 +1299,56 @@ test('the next turn gets its own control, live', () => {
   assert.strictEqual(page.seen['stop'].disabled, false, 'the next turn inherited the last one\'s stop');
 });
 
+test('a turn that ends forgets the stop it was asked for', () => {
+  // `stopAsked` was never cleared, and *Start a new conversation* keeps the same page: the turns
+  // begin again at 1, and a stale 7 would have disabled the seventh question of the next
+  // conversation before anybody pressed anything. It is about the turn in flight, so when nothing is
+  // in flight it is about nothing.
+  const page = runChatPage({ running: true, turn: 7 });
+  page.fire('thinking', 'click', { target: { closest: () => ({ dataset: { turn: '7' }, disabled: false }) } });
+
+  page.deliver({ type: 'state', thinkingHtml: '', running: false, capped: false });
+  page.deliver({
+    type: 'state',
+    thinkingHtml: '<p class="thinking">Thinking…<button type="button" id="stop" data-turn="7">Stop</button></p>',
+    running: true,
+    capped: false,
+  });
+
+  assert.strictEqual(page.seen['stop'].disabled, false,
+    'a later turn with the same number inherited a stop nobody had asked for');
+});
+
+test('pressing stop says that it is stopping', () => {
+  // Stopping is not instant — a vendor process has to be killed and a turn resolved — and a greyed
+  // out control still reading "Stop" cannot be told from one that did nothing.
+  const page = runChatPage({ running: true, turn: 7 });
+  const control = { dataset: { turn: '7' }, disabled: false, textContent: 'Stop' };
+  page.fire('thinking', 'click', { target: { closest: () => control } });
+
+  assert.strictEqual(control.textContent, 'Stopping…', 'the control said nothing about what it had done');
+});
+
+test('a redrawn control that is already stopping says so, and does not take the keyboard', () => {
+  // Focusing a disabled control leaves a keyboard on something with no action left. The place to be
+  // is wherever the person was, not on an inert button.
+  const page = runChatPage({ running: true, turn: 7 });
+  page.focusOn('stop');
+  const before = page.seen['stop'].focused;
+  page.fire('thinking', 'click', { target: { closest: () => ({ dataset: { turn: '7' }, disabled: false }) } });
+
+  page.deliver({
+    type: 'state',
+    thinkingHtml: '<p class="thinking">Thinking…<button type="button" id="stop" data-turn="7">Stop</button></p>',
+    running: true,
+    capped: false,
+  });
+
+  assert.strictEqual(page.seen['stop'].disabled, true);
+  assert.strictEqual(page.seen['stop'].textContent, 'Stopping…', 'the redrawn control forgot what was asked of it');
+  assert.strictEqual(page.seen['stop'].focused, before, 'the keyboard was put on a control with nothing left to do');
+});
+
 test('a stop control keeps the focus a push would have taken from it', () => {
   // Replacing the line destroys the element the keyboard was on. For a remote turn the line is
   // replaced every time the queue position moves, so somebody who tabbed to Stop would lose it

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -261,6 +261,8 @@ test('the text size the person chose is inside the body rule, so it applies befo
  */
 interface Fake {
   innerHTML: string;
+  /** A region learning the elements a push just wrote into it. */
+  reparse?: ((markup: string) => void) | undefined;
   /** Called when the page writes innerHTML — an insertion, which is what makes the region taller. */
   onWrite?: (value: string) => void;
   textContent: string;
@@ -268,6 +270,8 @@ interface Fake {
   value: string;
   disabled: boolean;
   focused: number;
+  /** The element's `data-*` attributes, as the page wrote them. */
+  dataset: Record<string, string>;
   scrollTop: number;
   clientHeight: number;
   scrollHeight: number;
@@ -292,11 +296,15 @@ function fake(): Fake {
     get innerHTML() { return written; },
     set innerHTML(value: string) {
       written = value;
+      // What a push writes into a region IS new elements — the page looks them up by id and reads
+      // their attributes, so the registry has to learn them or every such read comes back stale.
+      this.reparse?.(value);
       this.onWrite?.(value);
     },
-    textContent: '', hidden: false, value: '', disabled: false, focused: 0,
+    textContent: '', hidden: false, value: '', disabled: false, focused: 0, dataset: {},
     scrollTop: 0, clientHeight: 0, scrollHeight: 0, style: emptyStyle(), listeners: {},
     addEventListener(type, fn) { (this.listeners[type] ??= []).push(fn); },
+    reparse: undefined,
     focus() { this.focused += 1; },
     getAttribute: () => null,
     setAttribute() { /* the page sets none */ },
@@ -318,6 +326,8 @@ interface RunningPage {
   fontsSettle(): Promise<void>;
   /** The composer's height changed — what a growing or shrinking box does to the footer. */
   composerResized(): void;
+  /** Put the keyboard on an element, as a person tabbing to it would. */
+  focusOn(id: string): void;
 }
 
 /**
@@ -352,14 +362,33 @@ function runChatPage(over: RunOptions = {}): RunningPage {
   // fake, and the shipped webview is inert. (The gate raised this looking ahead to story 3's jump
   // control.) The `disabled` attribute is read across for the same reason: a page rendered locked
   // whose fakes start unlocked is a page the tests cannot see the lock on.
-  const rendered = new Map(
-    [...html.matchAll(/<[a-z]+[^>]*\bid="([^"]+)"[^>]*>/g)].map((match) => [match[1], match[0]]),
+  const taggedIn = (markup: string): Map<string, string> => new Map(
+    [...markup.matchAll(/<[a-z]+[^>]*\bid="([^"]+)"[^>]*>/g)].map((match) => [match[1] ?? '', match[0] ?? '']),
   );
+  const seed = (element: Fake, tag: string): void => {
+    element.disabled = / disabled(?=[ >])/.test(tag);
+    element.hidden = / hidden(?=[ >])/.test(tag);
+    element.dataset = {};
+    for (const attribute of tag.matchAll(/ data-([a-z-]+)="([^"]*)"/g)) {
+      element.dataset[attribute[1] ?? ''] = attribute[2] ?? '';
+    }
+  };
+  const rendered = taggedIn(html);
+  const reparse = (markup: string): void => {
+    for (const [id, tag] of taggedIn(markup)) {
+      rendered.set(id, tag);
+      if (seen[id] !== undefined) {
+        seed(seen[id], tag);
+      }
+    }
+  };
   // The page corrects its opening scroll once the fonts have settled. A test that cannot say WHEN
   // that happens cannot show what a reader who moved in the meantime experiences.
   let settleFonts = () => { /* replaced by the promise below */ };
   const fontsReady = new Promise<void>((resolve) => { settleFonts = () => { resolve(); }; });
+  let focused: Fake | undefined;
   const document_ = {
+    get activeElement() { return focused; },
     getElementById: (id: string) => {
       const tag = rendered.get(id);
       if (tag === undefined) {
@@ -371,8 +400,8 @@ function runChatPage(over: RunOptions = {}): RunningPage {
         // renders it locked, or visible where the page renders it hidden, is a fake the tests cannot
         // see the initial state on — and both of those were caught by tests that then passed for the
         // wrong reason until this was here.
-        seen[id].disabled = / disabled(?=[ >])/.test(tag);
-        seen[id].hidden = / hidden(?=[ >])/.test(tag);
+        seen[id].reparse = reparse;
+        seed(seen[id], tag);
       }
 
       return seen[id];
@@ -444,6 +473,11 @@ function runChatPage(over: RunOptions = {}): RunningPage {
       this.fire('scroll', 'scroll');
 
       return scroll;
+    },
+    focusOn(id) {
+      const element = document_.getElementById(id);
+      assert.ok(element, `the page renders no #${id} to focus`);
+      focused = element;
     },
     composerResized() {
       assert.ok(observed, 'the page is not watching the composer for a height change');
@@ -1224,4 +1258,64 @@ test('a stop control that names no turn posts nothing', () => {
 
   assert.deepStrictEqual(page.posted.filter((message) => message['command'] === 'stop'), [],
     'a control with no usable turn posted a stop the host would only drop');
+});
+
+
+test('a push while a stop is in flight does not hand the control back', () => {
+  // The gate's finding, and it is real: the thinking line is replaced wholesale on every push — a
+  // Team server pushes its queue position while a turn waits — and the replacement carried a fresh,
+  // pressable control for a turn the person had already asked to stop. They would press it again,
+  // and see it come back a second time.
+  const page = runChatPage({ running: true, turn: 7 });
+  page.fire('thinking', 'click', { target: { closest: () => ({ dataset: { turn: '7' }, disabled: false }) } });
+
+  page.deliver({
+    type: 'state',
+    thinkingHtml: '<p class="thinking">Thinking…<button type="button" id="stop" data-turn="7">Stop</button></p>',
+    running: true,
+    capped: false,
+  });
+
+  assert.strictEqual(page.seen['stop'].disabled, true,
+    'a push handed back a control for a turn the person had already stopped');
+  page.fire('thinking', 'click', { target: { closest: () => page.seen['stop'] } });
+  assert.strictEqual(page.posted.filter((message) => message['command'] === 'stop').length, 1,
+    'the re-rendered control sent a second stop for the same turn');
+});
+
+test('the next turn gets its own control, live', () => {
+  // The memory is about ONE turn. A conversation that carries on must not inherit a stop nobody
+  // asked for.
+  const page = runChatPage({ running: true, turn: 7 });
+  page.fire('thinking', 'click', { target: { closest: () => ({ dataset: { turn: '7' }, disabled: false }) } });
+
+  page.deliver({
+    type: 'state',
+    thinkingHtml: '<p class="thinking">Thinking…<button type="button" id="stop" data-turn="8">Stop</button></p>',
+    running: true,
+    capped: false,
+  });
+
+  assert.strictEqual(page.seen['stop'].disabled, false, 'the next turn inherited the last one\'s stop');
+});
+
+test('a stop control keeps the focus a push would have taken from it', () => {
+  // Replacing the line destroys the element the keyboard was on. For a remote turn the line is
+  // replaced every time the queue position moves, so somebody who tabbed to Stop would lose it
+  // repeatedly, silently, while waiting — which is exactly when they are most likely to want it.
+  const page = runChatPage({ running: true, turn: 7 });
+  // Focus first: nothing has asked the page for #stop yet, and the registry answers only for
+  // elements somebody looked up — which is the same property that catches a control the page never
+  // rendered.
+  page.focusOn('stop');
+  const before = page.seen['stop'].focused;
+
+  page.deliver({
+    type: 'state',
+    thinkingHtml: '<p class="thinking">Thinking…<button type="button" id="stop" data-turn="7">Stop</button></p>',
+    running: true,
+    capped: false,
+  });
+
+  assert.ok(page.seen['stop'].focused > before, 'the keyboard lost the control when the line was redrawn');
 });


### PR DESCRIPTION
The page half of `todo/PLAN_a_turn_nobody_can_stop.md`. The seam shipped earlier — `ChatSession.stop()`, the three adapters, the carry that keeps a conversation alive across a killed process, and an `onStop(id, turn)` hook. This is the half a person can press.

## What a person will notice

While an answer is coming there is a **Stop** beside *Thinking…* — for the question you saw was wrong the moment you sent it, and for the one taking far longer than it should. Pressing it says *Stopping…*, because killing a vendor process takes a moment and a greyed-out control still reading *Stop* cannot be told from one that did nothing.

## Why the turn number is in the markup

`chatCommandOf` refuses a stop that names no turn, and `chatCommand.ts:740` refuses one naming a turn that is not running. Both were decided on the seam's own round: a wildcard stop ends whatever is in flight, which by the time a late message lands can be the turn **after** the one somebody pressed for.

So the page names it — by rendering the number **into** the control, which means a control on screen can only ever name the turn it was drawn for. **No number, no button**: a control posting a message the seam refuses looks exactly like a stop that did not work.

## What the gate changed

- **A push must not hand the control back.** The thinking line is replaced whenever it changes — a Team server pushes its queue position while a turn waits — and the replacement carried a fresh, pressable Stop for a turn already stopped. The page remembers the one turn a stop was asked for; the next turn's control stays live, because inheriting a stop nobody asked for is the opposite defect.
- **And forgets it when the turn ends.** Restarting keeps the same page and counts turns again, so a stale 7 would have disabled the seventh question of the next conversation.
- Focus is carried across the redraw, but only onto a control that still has something to do.
- `show()` already had the thread in scope; one lookup, not two.
- Three `## Unreleased` headings in the CHANGELOG (mine and two from other branches) merged into one.

## Found by a test that has been there all along

A comment I wrote inside the page's script template quoted the restart button's words — and comments in that template ship to the browser, so the test looking for that text found my comment. It now says so where it is.

## Tests

**1193, 1191 passing, 0 failing.** The harness learned two more things, both the same lesson it has taught before — a fake must model what the page RENDERED: it reads `data-*` across from the markup, and a push writing into a region re-seeds the elements that region holds. Without the second, the test for the re-enabling defect passed for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)