### PR TITLE
feat(chat): phase 0 — can a vendor CLI be handed a picture, and how

### DIFF
--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -578,7 +578,8 @@
     "package": "npm run test && npm run bundle && vsce package --no-dependencies",
     "icon": "node scripts/generate-icon.mjs",
     "test:live": "npm run compile && node scripts/live-chat.mjs",
-    "measure:stream": "npm run compile && node scripts/measure-stream.mjs"
+    "measure:stream": "npm run compile && node scripts/measure-stream.mjs",
+    "measure:image": "npm run compile && node scripts/measure-image.mjs"
   },
   "devDependencies": {
     "@types/node": "^26.4.1",

--- a/src_vs_code/scripts/cliHarness.mjs
+++ b/src_vs_code/scripts/cliHarness.mjs
@@ -21,7 +21,7 @@
  *       and released in one write is indistinguishable from a trickling one once you count lines.</li>
  * </ul>
  */
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 /**
  * How a run ended. Only `closed` with code 0 is a run whose CONTENT may be believed.
@@ -41,7 +41,11 @@ export function killTree(child) {
   }
   if (process.platform === 'win32') {
     try {
-      spawn('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], { windowsHide: true, stdio: 'ignore' });
+      // spawnSync, not spawn, and the difference bites on cleanup. Asynchronously, `taskkill` returns
+      // before the tree is dead, the caller resolves, and the caller's `rmSync` of the temp directory
+      // meets a process that still holds it as its working directory — EBUSY, mid-run, after the
+      // turns have already been spent. Waiting costs milliseconds. (gemini, the code round.)
+      spawnSync('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], { windowsHide: true, stdio: 'ignore' });
 
       return;
     } catch {

--- a/src_vs_code/scripts/cliHarness.mjs
+++ b/src_vs_code/scripts/cliHarness.mjs
@@ -1,0 +1,161 @@
+/**
+ * Driving a real vendor CLI once, and being honest about how it ended.
+ *
+ * <p>Extracted from `measure-stream.mjs` when a second probe needed the same machinery, so that the
+ * rules that probe's review round established are kept in ONE place rather than re-derived by
+ * whoever writes the third one. The rules are not obvious and each was paid for:</p>
+ *
+ * <ul>
+ *   <li><b>A failure is never evidence.</b> Hung, non-zero, unspawnable and over-long are each their
+ *       own {@link Ending}, and a caller that treats "did not answer" as "cannot do it" is reading a
+ *       broken environment as a property of the vendor.</li>
+ *   <li><b>The child is killed as a TREE.</b> With `shell: true` the direct child is `cmd.exe`, and
+ *       killing it orphans the vendor CLI — still signed in, still spending a turn.</li>
+ *   <li><b>`spawn` can throw synchronously.</b> Node has refused to spawn a `.cmd` without a shell
+ *       since the fix for CVE-2024-27980, and `codex` installs as `codex.cmd`. That is a RESULT, not
+ *       a crash.</li>
+ *   <li><b>stdin can break under you.</b> A CLI that exits at once — a refused sign-in, a rate limit
+ *       — turns the write into an unhandled `EPIPE` that takes the harness down instead of recording
+ *       the run.</li>
+ *   <li><b>Arrival is stamped per CHUNK</b>, before any line splitting, because a stream held back
+ *       and released in one write is indistinguishable from a trickling one once you count lines.</li>
+ * </ul>
+ */
+import { spawn } from 'node:child_process';
+
+/**
+ * How a run ended. Only `closed` with code 0 is a run whose CONTENT may be believed.
+ *
+ * @typedef {'closed' | 'timeout' | 'error' | 'stdin' | 'overflow' | 'unspawnable'} Ending
+ */
+
+/**
+ * Kill a whole process TREE.
+ *
+ * <p>Windows has no process groups to signal, so `taskkill /T /F` is the way. Without it, killing a
+ * shell arm reaps `cmd.exe` and leaves the vendor CLI running against somebody's account.</p>
+ */
+export function killTree(child) {
+  if (child.pid === undefined) {
+    return;
+  }
+  if (process.platform === 'win32') {
+    try {
+      spawn('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], { windowsHide: true, stdio: 'ignore' });
+
+      return;
+    } catch {
+      // Fall through to the ordinary kill; a tree is better than nothing but nothing is not an option.
+    }
+  }
+  child.kill();
+}
+
+/**
+ * Run one CLI once, write `stdin` to it, and return everything about how it went.
+ *
+ * @param {{ executable: string, args: string[], cwd: string }} spec from `launchSpecFor`, never retyped
+ * @param {{ useShell: boolean, stdin: string, timeoutMs: number, maxBytes: number,
+ *           onChunk?: (count: number) => void }} how
+ * @returns {Promise<{ chunks: { atMs: number, text: string }[], stderr: string, code: number,
+ *                     ending: Ending, failure: string, ms: number }>}
+ */
+export function runCli(spec, how) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const chunks = [];
+    let stderr = '';
+    let bytes = 0;
+    let settled = false;
+    const finish = (result) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve({ chunks, stderr, ms: Date.now() - started, ...result });
+    };
+
+    let child;
+    try {
+      child = spawn(spec.executable, spec.args, {
+        cwd: spec.cwd,
+        shell: how.useShell,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+    } catch (reason) {
+      finish({ code: -1, ending: 'unspawnable', failure: String(reason) });
+
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      killTree(child);
+      finish({ code: -1, ending: 'timeout', failure: `no terminal event within ${how.timeoutMs} ms` });
+    }, how.timeoutMs);
+
+    child.stdout.on('data', (data) => {
+      const text = data.toString('utf8');
+      bytes += text.length;
+      if (bytes > how.maxBytes) {
+        killTree(child);
+        clearTimeout(timer);
+        finish({ code: -1, ending: 'overflow', failure: `more than ${how.maxBytes} bytes of stdout` });
+
+        return;
+      }
+      chunks.push({ atMs: Date.now() - started, text });
+      how.onChunk?.(chunks.length);
+    });
+    child.stderr.on('data', (data) => {
+      stderr += data.toString('utf8');
+    });
+    child.stdin.on('error', () => undefined);
+    child.on('error', (reason) => {
+      clearTimeout(timer);
+      finish({ code: -1, ending: 'error', failure: String(reason) });
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      finish({ code: code ?? -1, ending: 'closed', failure: '' });
+    });
+
+    try {
+      child.stdin.write(how.stdin);
+      child.stdin.end();
+    } catch (reason) {
+      clearTimeout(timer);
+      finish({ code: -1, ending: 'stdin', failure: String(reason) });
+    }
+  });
+}
+
+/** Every complete NDJSON line in arrival order, each carrying the chunk time it completed in. */
+export function linesOf(chunks) {
+  const lines = [];
+  let held = '';
+  for (const chunk of chunks) {
+    held += chunk.text;
+    const parts = held.split(/\r?\n/);
+    held = parts[parts.length - 1] ?? '';
+    for (const part of parts.slice(0, -1)) {
+      if (part.trim().length > 0) {
+        lines.push({ atMs: chunk.atMs, text: part });
+      }
+    }
+  }
+  if (held.trim().length > 0) {
+    lines.push({ atMs: chunks[chunks.length - 1]?.atMs ?? 0, text: held });
+  }
+
+  return lines;
+}
+
+/** The environment a measurement was taken in. Recorded, because a table without it ages badly. */
+export function environment() {
+  return {
+    node: process.version,
+    platform: `${process.platform} ${process.arch}`,
+    takenUtc: new Date().toISOString(),
+  };
+}

--- a/src_vs_code/scripts/measure-image.mjs
+++ b/src_vs_code/scripts/measure-image.mjs
@@ -1,0 +1,321 @@
+/**
+ * Phase 0 of `todo/PLAN_a_picture_in_the_question.md`: can a vendor CLI be handed a picture at all,
+ * in the mode this extension runs it, and how?
+ *
+ * <p>`ChatSession.send` takes `text: string` and nothing else. Whether each CLI accepts an image in a
+ * non-interactive turn is not documented anywhere this repository can reach, so it is measured. Run
+ * it as `npm run measure:image`, optionally `-- <vendor>`.</p>
+ *
+ * <h2>Why a run that exits 0 is NOT a yes</h2>
+ *
+ * <p>The sharpest finding on this probe's plan round, and the one the whole script is shaped by: a
+ * CLI answering cheerfully does not prove the model RECEIVED the image. An unknown field in a JSON
+ * turn can be ignored silently; an unsupported payload can be dropped on the floor; either way the
+ * process exits 0 and a naive probe records a "yes" that commits the project to building a paste
+ * feature, a CSP change and a temp-file discipline for a vendor that throws pictures away.</p>
+ *
+ * <p>So the image SAYS something. `tokenPng` draws a four-digit number, the prompt asks for that
+ * number back and nothing else, and only the token appearing in the answer counts as receipt.
+ * Everything else is a different outcome with a different name — see {@link OUTCOMES}.</p>
+ *
+ * <h2>Why a "no" here is not allowed to be vague</h2>
+ *
+ * <p>A probe that searches for a mechanism can fail to find one, and that is not the same fact as a
+ * vendor refusing. If those two arrive in the table as one word, a feature gets killed by a bad
+ * afternoon. Every attempt therefore records which of them happened, and the plan's decision line is
+ * only allowed to say "cannot" where a vendor actually REFUSED or accepted-and-ignored.</p>
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { environment, linesOf, runCli } from './cliHarness.mjs';
+import { tokenPng } from './tokenPng.mjs';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const OUT = new URL('../out/', import.meta.url).href;
+const MEASUREMENTS = join(HERE, '..', 'measurements');
+
+const { launchSpecFor } = await import(`${OUT}cliChatLaunch.js`);
+const { resolvedExecutable } = await import(`${OUT}versionProbe.js`);
+const { agyAdapter } = await import(`${OUT}agyAdapter.js`);
+const { claudeAdapter } = await import(`${OUT}claudeAdapter.js`);
+const { codexAdapter } = await import(`${OUT}codexAdapter.js`);
+
+/**
+ * What one attempt PROVED. The vocabulary matters more than the code that produces it.
+ *
+ * <p>`received` is the only "yes". `answered-without-token` is the dangerous one — the CLI took the
+ * turn and said something, and the picture went nowhere; a probe without a readable token would have
+ * called it a success. `refused` is a real no, in the vendor's own words. The last three are facts
+ * about this machine and are NOT evidence about the vendor.</p>
+ */
+export const OUTCOMES = {
+  received: 'the answer contained the number drawn in the image',
+  'answered-without-token': 'the CLI answered, and the image was not read',
+  refused: 'the CLI refused the turn on its merits, and said why',
+  unavailable: 'the CLI could not run the turn for a reason about THIS ACCOUNT — not about images',
+  'no-answer': 'the CLI produced no answer at all',
+  unspawnable: 'node refused to spawn this file in this mode',
+  failed: 'the run did not finish — hung, killed, or exited non-zero',
+};
+
+/** The token the image carries, pinned and printed. Digits only — `tokenPng` draws digits. */
+const TOKEN = tokenFrom(process.argv) ?? '7431';
+
+function tokenFrom(argv) {
+  const at = argv.indexOf('--token');
+
+  return at >= 0 && /^[0-9]{2,6}$/.test(argv[at + 1] ?? '') ? argv[at + 1] : undefined;
+}
+
+const ASK = `The image contains a number. Reply with ONLY that number and nothing else.`;
+
+const TIMEOUT_MS = 180_000;
+const MAX_BYTES = 32 * 1024 * 1024;
+
+const VENDORS = {
+  claude: { runtime: 'claude', adapter: claudeAdapter, executable: 'claude' },
+  codex: { runtime: 'codex', adapter: codexAdapter, executable: 'codex' },
+  agy: { runtime: 'antigravity', adapter: agyAdapter, executable: 'agy' },
+};
+
+const row = (runtime) => ({
+  id: runtime, runtime, model: '', enabled: true, plan: true, code: true,
+  baseUrl: '', executablePath: '', pricePerMillionIn: 0, pricePerMillionOut: 0,
+});
+
+/**
+ * The two ways a picture could possibly travel, per vendor, built from each adapter's REAL turn.
+ *
+ * <p>A reviewer asked for both to be tried before Phase 1 designs an attachment around `{ path, mime }`
+ * — testing only file paths against a CLI that takes inline base64, or the reverse, produces a false
+ * negative and then the wrong interface. Which vectors are even structurally possible differs, and
+ * that is a finding in itself:</p>
+ *
+ * <ul>
+ *   <li><b>claude</b> — `message.content` is an ARRAY of blocks and this extension sends exactly one
+ *       text block into it, so an `image` block beside it is the obvious candidate. Both vectors.</li>
+ *   <li><b>agy</b> — `message.content` is a STRING. There is nowhere to put a block, so inline is not
+ *       merely unsupported, it is unrepresentable in the turn this extension sends. Path only.</li>
+ *   <li><b>codex</b> — the turn is the prompt text itself. Path only.</li>
+ * </ul>
+ */
+function attempts(name, png, pngPath) {
+  const base64 = png.toString('base64');
+  const askAboutPath = `${ASK}\nThe image is the file at ${pngPath}`;
+
+  if (name === 'claude') {
+    return [
+      {
+        vector: 'inline base64 block',
+        stdin: JSON.stringify({
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: base64 } },
+              { type: 'text', text: ASK },
+            ],
+          },
+        }),
+      },
+      { vector: 'a path in the prompt', stdin: claudeAdapter.encode(askAboutPath) },
+    ];
+  }
+  if (name === 'agy') {
+    return [
+      {
+        vector: 'inline base64 block',
+        stdin: '',
+        impossible: 'the turn’s `message.content` is a STRING — there is no block to put an image in',
+      },
+      { vector: 'a path in the prompt', stdin: agyAdapter.encode(askAboutPath) },
+    ];
+  }
+
+  return [
+    {
+      vector: 'inline base64 block',
+      stdin: '',
+      impossible: 'the turn IS the prompt text — there is no structure to carry a block',
+    },
+    { vector: 'a path in the prompt', stdin: codexAdapter.encode(askAboutPath) },
+  ];
+}
+
+/**
+ * Whether a refusal is about THIS ACCOUNT rather than about pictures.
+ *
+ * <p>A usage limit, an expired sign-in or a rate limit is a fact about the afternoon, and recording
+ * it as "this vendor cannot take an image" is exactly the silent feature-kill the plan round asked
+ * to be held to. It happened on the first real run: `codex` answered
+ * "You've hit your usage limit", which says nothing whatever about images.</p>
+ */
+/** The vendor's OWN sentence, dug out of the raw stream when the adapter has flattened it away. */
+function reasonIn(raw) {
+  for (const line of raw.split(/\r?\n/)) {
+    try {
+      const event = JSON.parse(line);
+      const message = event?.message ?? event?.error?.message ?? '';
+      if (typeof message === 'string' && isAboutTheAccount(message)) {
+        return message;
+      }
+    } catch {
+      // Not JSON, or not this line. The next one may be.
+    }
+  }
+
+  return '';
+}
+
+function isAboutTheAccount(message) {
+  return /usage limit|rate.?limit|quota|too many requests|sign in|signed in|unauthor|forbidden|credit/i
+    .test(message);
+}
+
+/** What the CLI said, and what that proves. */
+function outcomeOf(run, adapter) {
+  if (run.ending === 'unspawnable') {
+    return { outcome: 'unspawnable', answer: '', note: run.failure };
+  }
+
+  // Parsed BEFORE the exit code is judged. A CLI that exits non-zero and explains itself in its own
+  // NDJSON has told us more than its status did, and the first version of this function threw that
+  // away — it reported `codex` as a bare "failed, code 1" when the stream said, in words, that the
+  // account was out of credit.
+  let answer = '';
+  let refusal = '';
+  for (const line of linesOf(run.chunks)) {
+    const seen = adapter.classify(line.text);
+    if (seen.kind === 'answer') {
+      answer = seen.text;
+    }
+    if (seen.kind === 'failure') {
+      refusal = seen.failure;
+    }
+  }
+  if (refusal.length > 0) {
+    // The RAW output is searched as well as the adapter's sentence, because an adapter is allowed to
+    // flatten a vendor's failure into one phrase for the person reading a chat — `codexAdapter` turns
+    // every `turn.failed` into "the model did not finish the turn" — and that phrase is exactly the
+    // information this probe needs and cannot get from it. The raw stream still carries the reason.
+    const raw = run.chunks.map((one) => one.text).join('');
+    const said = isAboutTheAccount(refusal) || isAboutTheAccount(raw);
+
+    return {
+      outcome: said ? 'unavailable' : 'refused',
+      answer: '',
+      note: (said ? reasonIn(raw) || refusal : refusal).replace(/\s+/g, ' ').slice(0, 300),
+    };
+  }
+  if (run.ending !== 'closed' || run.code !== 0) {
+    return { outcome: 'failed', answer: '', note: `${run.ending}, code ${run.code}. ${run.stderr.trim().slice(-300)}` };
+  }
+  if (answer.length === 0) {
+    return { outcome: 'no-answer', answer: '', note: run.stderr.trim().slice(-300) };
+  }
+
+  return {
+    outcome: answer.includes(TOKEN) ? 'received' : 'answered-without-token',
+    answer: answer.trim().slice(0, 200),
+    note: '',
+  };
+}
+
+async function probe(name, png, raw) {
+  const vendor = VENDORS[name];
+  const resolved = await resolvedExecutable(vendor.executable);
+  if (!resolved) {
+    console.log(`${name.padEnd(8)} NOT INSTALLED`);
+
+    return [];
+  }
+  const home = mkdtempSync(join(tmpdir(), 'coai-image-'));
+  const pngPath = join(home, `token-${TOKEN}.png`);
+  writeFileSync(pngPath, png);
+  const spec = launchSpecFor(row(vendor.runtime), home, '', resolved);
+  if (spec.refusal.length > 0) {
+    console.log(`${name.padEnd(8)} REFUSED: ${spec.refusal}`);
+    rmSync(home, { recursive: true, force: true });
+
+    return [];
+  }
+
+  const results = [];
+  try {
+    for (const attempt of attempts(name, png, pngPath)) {
+      if (attempt.impossible !== undefined) {
+        console.log(`${name.padEnd(8)} ${attempt.vector.padEnd(22)} not representable — ${attempt.impossible}`);
+        results.push({ vendor: name, ...attempt, outcome: 'not-representable', answer: '', note: attempt.impossible });
+        continue;
+      }
+      process.stdout.write(`${name.padEnd(8)} ${attempt.vector.padEnd(22)} asking… `);
+      const run = await runCli(spec, {
+        useShell: spec.shell,
+        stdin: attempt.stdin,
+        timeoutMs: TIMEOUT_MS,
+        maxBytes: MAX_BYTES,
+      });
+      const seen = outcomeOf(run, vendor.adapter);
+      console.log(`${seen.outcome}${seen.answer.length > 0 ? ` — answered "${seen.answer}"` : ''}`);
+      results.push({
+        vendor: name,
+        vector: attempt.vector,
+        stdinBytes: attempt.stdin.length,
+        ms: run.ms,
+        ...seen,
+      });
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+  raw.push(...results);
+
+  return results;
+}
+
+const asked = process.argv.slice(2).find((arg) => !arg.startsWith('-'));
+const names = asked === undefined || asked === 'all' ? Object.keys(VENDORS) : [asked];
+if (names.some((name) => VENDORS[name] === undefined)) {
+  console.error(`unknown vendor: ${asked}. Known: ${Object.keys(VENDORS).join(', ')}, all`);
+  process.exit(2);
+}
+
+const png = tokenPng(TOKEN);
+console.log(`token: ${TOKEN} · image ${png.length} bytes, base64 ${Buffer.from(png).toString('base64').length} chars`);
+console.log(`prompt: ${ASK}`);
+console.log(`environment: ${JSON.stringify(environment())}\n`);
+
+const raw = [];
+const all = [];
+for (const name of names) {
+  all.push(...(await probe(name, png, raw)));
+}
+
+writeFileSync(
+  join(MEASUREMENTS, `image-${new Date().toISOString().replace(/[:.]/g, '-')}.json`),
+  JSON.stringify({ token: TOKEN, ask: ASK, pngBytes: png.length, environment: environment(), attempts: raw }, null, 2),
+);
+
+console.log('\n=== the table ===\n');
+console.log('| vendor | vector | outcome | what it said | bytes on stdin |');
+console.log('|---|---|---|---|---|');
+for (const one of all) {
+  const said = one.outcome === 'received' || one.outcome === 'answered-without-token'
+    ? `answered \`${one.answer}\``
+    : (one.note ?? '').replace(/\s+/g, ' ').slice(0, 120);
+  console.log(`| \`${one.vendor}\` | ${one.vector} | **${one.outcome}** | ${said} | ${one.stdinBytes ?? '—'} |`);
+}
+
+const anyReceived = all.some((one) => one.outcome === 'received');
+const anyInconclusive = all.some((one) =>
+  ['failed', 'unspawnable', 'unavailable', 'no-answer'].includes(one.outcome));
+console.log(`\n${Object.entries(OUTCOMES).map(([key, meaning]) => `  ${key.padEnd(24)} ${meaning}`).join('\n')}`);
+console.log(
+  anyInconclusive
+    ? '\nSOME ATTEMPTS WERE INCONCLUSIVE — those rows are facts about this machine, not about the vendor.'
+    : '\nEvery attempt reached a verdict about the vendor rather than about the environment.',
+);
+process.exitCode = anyReceived || !anyInconclusive ? 0 : 1;

--- a/src_vs_code/scripts/measure-image.mjs
+++ b/src_vs_code/scripts/measure-image.mjs
@@ -25,7 +25,7 @@
  * afternoon. Every attempt therefore records which of them happened, and the plan's decision line is
  * only allowed to say "cannot" where a vendor actually REFUSED or accepted-and-ignored.</p>
  */
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -61,25 +61,70 @@ export const OUTCOMES = {
   failed: 'the run did not finish — hung, killed, or exited non-zero',
 };
 
-/** The token the image carries, pinned and printed. Digits only — `tokenPng` draws digits. */
-const TOKEN = tokenFrom(process.argv) ?? '7431';
-
-function tokenFrom(argv) {
-  const at = argv.indexOf('--token');
-
-  return at >= 0 && /^[0-9]{2,6}$/.test(argv[at + 1] ?? '') ? argv[at + 1] : undefined;
-}
-
-const ASK = `The image contains a number. Reply with ONLY that number and nothing else.`;
-
-const TIMEOUT_MS = 180_000;
-const MAX_BYTES = 32 * 1024 * 1024;
-
 const VENDORS = {
   claude: { runtime: 'claude', adapter: claudeAdapter, executable: 'claude' },
   codex: { runtime: 'codex', adapter: codexAdapter, executable: 'codex' },
   agy: { runtime: 'antigravity', adapter: agyAdapter, executable: 'agy' },
 };
+
+const USAGE = `usage: npm run measure:image -- [vendor|all] [--token NNNN]
+
+  vendor    one of ${Object.keys(VENDORS).join(', ')}, or "all" (the default)
+  --token   the digits drawn into the image and demanded back, 2 to 6 of them (default 7431)
+
+Only the token appearing in the answer counts as the model having SEEN the picture.`;
+
+/**
+ * The vendor and the token, parsed so that neither can be mistaken for the other.
+ *
+ * <p>The naive version — "the first argument that does not start with a dash is the vendor" — reads
+ * `--token 1234` as a request to measure a vendor called `1234`, and refuses the command. The flag's
+ * VALUE has to be excluded by position, and only when the flag is actually present. This is the same
+ * defect the streaming probe shipped and had caught for it on its pull request; it is written down
+ * here because it is now twice. (gemini, the code round.)</p>
+ */
+function optionsFrom(args) {
+  if (args.includes('--help') || args.includes('-h')) {
+    return { kind: 'help' };
+  }
+  const at = args.indexOf('--token');
+  let token = '7431';
+  if (at >= 0) {
+    const given = args[at + 1] ?? '';
+    if (!/^[0-9]{2,6}$/.test(given)) {
+      return { kind: 'error', message: `--token needs 2 to 6 digits, not "${given}"` };
+    }
+    token = given;
+  }
+  const valueAt = at >= 0 ? at + 1 : -1;
+  const positional = args.filter((arg, index) => !arg.startsWith('-') && index !== valueAt);
+  const vendor = positional[0] ?? 'all';
+  if (vendor !== 'all' && VENDORS[vendor] === undefined) {
+    return { kind: 'error', message: `unknown vendor: ${vendor}` };
+  }
+
+  return { kind: 'run', vendor, token };
+}
+
+const options = optionsFrom(process.argv.slice(2));
+if (options.kind === 'help') {
+  console.log(USAGE);
+  // `exitCode`, never `exit()`: this module uses top-level await, and `process.exit` inside that can
+  // end the process before stdout has drained.
+  process.exitCode = 0;
+}
+if (options.kind === 'error') {
+  console.error(`${options.message}\n\n${USAGE}`);
+  process.exitCode = 2;
+}
+
+/** The token the image carries, pinned and printed. Digits only — `tokenPng` draws digits. */
+const TOKEN = options.token ?? '7431';
+
+const ASK = `The image contains a number. Reply with ONLY that number and nothing else.`;
+
+const TIMEOUT_MS = 180_000;
+const MAX_BYTES = 32 * 1024 * 1024;
 
 const row = (runtime) => ({
   id: runtime, runtime, model: '', enabled: true, plan: true, code: true,
@@ -154,7 +199,7 @@ function attempts(name, png, pngPath) {
  * "You've hit your usage limit", which says nothing whatever about images.</p>
  */
 /** The vendor's OWN sentence, dug out of the raw stream when the adapter has flattened it away. */
-function reasonIn(raw) {
+function accountReasonInRawStream(raw) {
   for (const line of raw.split(/\r?\n/)) {
     try {
       const event = JSON.parse(line);
@@ -201,13 +246,13 @@ function outcomeOf(run, adapter) {
     // flatten a vendor's failure into one phrase for the person reading a chat — `codexAdapter` turns
     // every `turn.failed` into "the model did not finish the turn" — and that phrase is exactly the
     // information this probe needs and cannot get from it. The raw stream still carries the reason.
-    const raw = run.chunks.map((one) => one.text).join('');
-    const said = isAboutTheAccount(refusal) || isAboutTheAccount(raw);
+    const rawStream = run.chunks.map((one) => one.text).join('');
+    const said = isAboutTheAccount(refusal) || isAboutTheAccount(rawStream);
 
     return {
       outcome: said ? 'unavailable' : 'refused',
       answer: '',
-      note: (said ? reasonIn(raw) || refusal : refusal).replace(/\s+/g, ' ').slice(0, 300),
+      note: (said ? accountReasonInRawStream(rawStream) || refusal : refusal).replace(/\s+/g, ' ').slice(0, 300),
     };
   }
   if (run.ending !== 'closed' || run.code !== 0) {
@@ -235,6 +280,15 @@ async function probe(name, png, raw) {
   const home = mkdtempSync(join(tmpdir(), 'coai-image-'));
   const pngPath = join(home, `token-${TOKEN}.png`);
   writeFileSync(pngPath, png);
+  // Checked, because the failure would be INVISIBLE otherwise. A file that did not land leaves the
+  // CLI reading a path to nothing, and a model that politely says it cannot see a picture is then
+  // recorded as `answered-without-token` — which reads as 'this vendor ignores images' and is the
+  // exact false negative this probe exists to prevent. (the local reviewer, the code round.)
+  if (!existsSync(pngPath) || statSync(pngPath).size !== png.length) {
+    rmSync(home, { recursive: true, force: true });
+
+    throw new Error(`the probe image did not land at ${pngPath} — nothing was measured for ${name}`);
+  }
   const spec = launchSpecFor(row(vendor.runtime), home, '', resolved);
   if (spec.refusal.length > 0) {
     console.log(`${name.padEnd(8)} REFUSED: ${spec.refusal}`);
@@ -257,6 +311,9 @@ async function probe(name, png, raw) {
         stdin: attempt.stdin,
         timeoutMs: TIMEOUT_MS,
         maxBytes: MAX_BYTES,
+        // A turn can sit for three minutes; a frozen line says nothing about whether bytes are
+        // arriving or the CLI is wedged. Only to a terminal, so a captured log stays clean.
+        onChunk: () => { if (process.stdout.isTTY === true) { process.stdout.write('.'); } },
       });
       const seen = outcomeOf(run, vendor.adapter);
       console.log(`${seen.outcome}${seen.answer.length > 0 ? ` — answered "${seen.answer}"` : ''}`);
@@ -276,46 +333,47 @@ async function probe(name, png, raw) {
   return results;
 }
 
-const asked = process.argv.slice(2).find((arg) => !arg.startsWith('-'));
-const names = asked === undefined || asked === 'all' ? Object.keys(VENDORS) : [asked];
-if (names.some((name) => VENDORS[name] === undefined)) {
-  console.error(`unknown vendor: ${asked}. Known: ${Object.keys(VENDORS).join(', ')}, all`);
-  process.exit(2);
+// The measurement runs ONLY on a good command line. Setting an exit code without stopping is how a
+// mistyped flag still spends real turns on three signed-in accounts: the first version of this
+// block printed the refusal and then measured anyway. (gemini, the code round, on the exit path.)
+if (options.kind === 'run') {
+  const names = options.vendor === 'all' ? Object.keys(VENDORS) : [options.vendor];
+
+  const png = tokenPng(TOKEN);
+  console.log(`token: ${TOKEN} · image ${png.length} bytes, base64 ${Buffer.from(png).toString('base64').length} chars`);
+  console.log(`prompt: ${ASK}`);
+  console.log(`environment: ${JSON.stringify(environment())}\n`);
+
+  const raw = [];
+  const all = [];
+  for (const name of names) {
+    all.push(...(await probe(name, png, raw)));
+  }
+
+  mkdirSync(MEASUREMENTS, { recursive: true });
+  writeFileSync(
+    join(MEASUREMENTS, `image-${new Date().toISOString().replace(/[:.]/g, '-')}.json`),
+    JSON.stringify({ token: TOKEN, ask: ASK, pngBytes: png.length, environment: environment(), attempts: raw }, null, 2),
+  );
+
+  console.log('\n=== the table ===\n');
+  console.log('| vendor | vector | outcome | what it said | bytes on stdin |');
+  console.log('|---|---|---|---|---|');
+  for (const one of all) {
+    const said = one.outcome === 'received' || one.outcome === 'answered-without-token'
+      ? `answered \`${one.answer}\``
+      : (one.note ?? '').replace(/\s+/g, ' ').slice(0, 120);
+    console.log(`| \`${one.vendor}\` | ${one.vector} | **${one.outcome}** | ${said} | ${one.stdinBytes ?? '—'} |`);
+  }
+
+  const anyReceived = all.some((one) => one.outcome === 'received');
+  const anyInconclusive = all.some((one) =>
+    ['failed', 'unspawnable', 'unavailable', 'no-answer'].includes(one.outcome));
+  console.log(`\n${Object.entries(OUTCOMES).map(([key, meaning]) => `  ${key.padEnd(24)} ${meaning}`).join('\n')}`);
+  console.log(
+    anyInconclusive
+      ? '\nSOME ATTEMPTS WERE INCONCLUSIVE — those rows are facts about this machine, not about the vendor.'
+      : '\nEvery attempt reached a verdict about the vendor rather than about the environment.',
+  );
+  process.exitCode = anyReceived || !anyInconclusive ? 0 : 1;
 }
-
-const png = tokenPng(TOKEN);
-console.log(`token: ${TOKEN} · image ${png.length} bytes, base64 ${Buffer.from(png).toString('base64').length} chars`);
-console.log(`prompt: ${ASK}`);
-console.log(`environment: ${JSON.stringify(environment())}\n`);
-
-const raw = [];
-const all = [];
-for (const name of names) {
-  all.push(...(await probe(name, png, raw)));
-}
-
-writeFileSync(
-  join(MEASUREMENTS, `image-${new Date().toISOString().replace(/[:.]/g, '-')}.json`),
-  JSON.stringify({ token: TOKEN, ask: ASK, pngBytes: png.length, environment: environment(), attempts: raw }, null, 2),
-);
-
-console.log('\n=== the table ===\n');
-console.log('| vendor | vector | outcome | what it said | bytes on stdin |');
-console.log('|---|---|---|---|---|');
-for (const one of all) {
-  const said = one.outcome === 'received' || one.outcome === 'answered-without-token'
-    ? `answered \`${one.answer}\``
-    : (one.note ?? '').replace(/\s+/g, ' ').slice(0, 120);
-  console.log(`| \`${one.vendor}\` | ${one.vector} | **${one.outcome}** | ${said} | ${one.stdinBytes ?? '—'} |`);
-}
-
-const anyReceived = all.some((one) => one.outcome === 'received');
-const anyInconclusive = all.some((one) =>
-  ['failed', 'unspawnable', 'unavailable', 'no-answer'].includes(one.outcome));
-console.log(`\n${Object.entries(OUTCOMES).map(([key, meaning]) => `  ${key.padEnd(24)} ${meaning}`).join('\n')}`);
-console.log(
-  anyInconclusive
-    ? '\nSOME ATTEMPTS WERE INCONCLUSIVE — those rows are facts about this machine, not about the vendor.'
-    : '\nEvery attempt reached a verdict about the vendor rather than about the environment.',
-);
-process.exitCode = anyReceived || !anyInconclusive ? 0 : 1;

--- a/src_vs_code/scripts/tokenPng.mjs
+++ b/src_vs_code/scripts/tokenPng.mjs
@@ -1,0 +1,119 @@
+/**
+ * A PNG that SAYS a number, drawn from scratch.
+ *
+ * <p>It exists because of the sharpest finding on this probe's plan round: <b>a CLI exiting 0 does
+ * not prove the model received the image.</b> An unknown field in a JSON turn can be ignored
+ * silently, an unsupported payload can be dropped, and either way the process answers cheerfully and
+ * the probe records a "yes" that commits the project to building a paste feature for a vendor that
+ * throws pictures away. So the image carries an unambiguous token, the prompt demands it back
+ * verbatim, and only the token appearing in the answer counts as receipt.</p>
+ *
+ * <p>Drawn rather than checked in: a binary fixture in the repository is a thing nobody can read in a
+ * diff, and this is sixty lines of digits. No dependency — a PNG is a header, one deflated block of
+ * scanlines and a footer, and `node:zlib` already does the only hard part.</p>
+ */
+import { deflateSync } from 'node:zlib';
+
+/** Five-by-seven digits, one string per row, `#` for ink. Legible at any sane scale. */
+const GLYPHS = {
+  0: ['.###.', '#...#', '#..##', '#.#.#', '##..#', '#...#', '.###.'],
+  1: ['..#..', '.##..', '..#..', '..#..', '..#..', '..#..', '.###.'],
+  2: ['.###.', '#...#', '....#', '...#.', '..#..', '.#...', '#####'],
+  3: ['#####', '...#.', '..#..', '...#.', '....#', '#...#', '.###.'],
+  4: ['...#.', '..##.', '.#.#.', '#..#.', '#####', '...#.', '...#.'],
+  5: ['#####', '#....', '####.', '....#', '....#', '#...#', '.###.'],
+  6: ['..##.', '.#...', '#....', '####.', '#...#', '#...#', '.###.'],
+  7: ['#####', '....#', '...#.', '..#..', '.#...', '.#...', '.#...'],
+  8: ['.###.', '#...#', '#...#', '.###.', '#...#', '#...#', '.###.'],
+  9: ['.###.', '#...#', '#...#', '.####', '....#', '...#.', '.##..'],
+};
+
+const GLYPH_WIDTH = 5;
+const GLYPH_HEIGHT = 7;
+
+/** The CRC every PNG chunk carries. Twelve lines, so that this file needs nothing installed. */
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function chunk(type, data) {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const body = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(body), 0);
+
+  return Buffer.concat([length, body, crc]);
+}
+
+/**
+ * A black-on-white PNG of `token`, scaled up so no model has to squint.
+ *
+ * @param {string} token digits only — the thing the answer must repeat back
+ * @param {number} scale how many pixels per glyph pixel
+ * @param {number} margin white border, in scaled pixels
+ * @returns {Buffer} a complete PNG
+ */
+export function tokenPng(token, scale = 16, margin = 24) {
+  const digits = [...token];
+  if (digits.some((digit) => GLYPHS[digit] === undefined)) {
+    throw new Error(`tokenPng draws digits only, and was given "${token}"`);
+  }
+
+  const gap = 1;
+  const inkWidth = digits.length * GLYPH_WIDTH + (digits.length - 1) * gap;
+  const width = inkWidth * scale + margin * 2;
+  const height = GLYPH_HEIGHT * scale + margin * 2;
+
+  // One byte per pixel, greyscale, with a filter byte at the start of every row.
+  const raw = Buffer.alloc((width + 1) * height, 0xff);
+  for (let y = 0; y < height; y += 1) {
+    raw[y * (width + 1)] = 0;
+  }
+  const plot = (x, y) => {
+    if (x >= 0 && x < width && y >= 0 && y < height) {
+      raw[y * (width + 1) + 1 + x] = 0x00;
+    }
+  };
+
+  digits.forEach((digit, index) => {
+    const rows = GLYPHS[digit];
+    const originX = margin + index * (GLYPH_WIDTH + gap) * scale;
+    rows.forEach((row, rowIndex) => {
+      [...row].forEach((cell, columnIndex) => {
+        if (cell !== '#') {
+          return;
+        }
+        for (let dy = 0; dy < scale; dy += 1) {
+          for (let dx = 0; dx < scale; dx += 1) {
+            plot(originX + columnIndex * scale + dx, margin + rowIndex * scale + dy);
+          }
+        }
+      });
+    });
+  });
+
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8; // bit depth
+  header[9] = 0; // colour type: greyscale
+  header[10] = 0; // deflate
+  header[11] = 0; // adaptive filtering
+  header[12] = 0; // no interlace
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', header),
+    chunk('IDAT', deflateSync(raw, { level: 9 })),
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+}

--- a/todo/PLAN_a_picture_in_the_question.md
+++ b/todo/PLAN_a_picture_in_the_question.md
@@ -36,9 +36,17 @@ Results as a table in this file. If no local adapter takes one, promote this pla
 
 ### Phase 0 RESULTS — measured 2026-09-09
 
-Harness: [`src_vs_code/scripts/measure-image.mjs`](../src_vs_code/scripts/measure-image.mjs), run on
-Windows 11, node v24.18.0, against the real signed-in CLIs, with the launch spec **imported** from
-`launchSpecFor` so it cannot measure a mode the product does not run.
+| | |
+|---|---|
+| **Subject** | `6356ead` — the commit the adapters and `launchSpecFor` were read from |
+| **Harness** | [`src_vs_code/scripts/measure-image.mjs`](../src_vs_code/scripts/measure-image.mjs), with [`tokenPng.mjs`](../src_vs_code/scripts/tokenPng.mjs) and [`cliHarness.mjs`](../src_vs_code/scripts/cliHarness.mjs) |
+| **Date** | 2026-09-09 |
+| **Machine** | Windows 11, node v24.18.0, win32 x64 |
+| **Pinned** | token `7431`; PNG 415 bytes (556 chars of base64); prompt *"The image contains a number. Reply with ONLY that number and nothing else."* |
+| **Vendor builds** | `codex-cli 0.153.4`, `agy` and `claude` as installed on this machine |
+
+The launch spec is **imported** from `launchSpecFor` rather than retyped, so this cannot measure a
+mode the product does not run.
 
 **The image says something, and that is the whole design of the probe.** A CLI exiting 0 does not
 prove the model received a picture — an unknown field in a JSON turn can be ignored silently and an

--- a/todo/PLAN_a_picture_in_the_question.md
+++ b/todo/PLAN_a_picture_in_the_question.md
@@ -1,6 +1,12 @@
 # PLAN — a picture in the question
 
-> Status: **plan only, nothing implemented yet — CONDITIONAL on a measurement.** Kind: **feature**.
+> Status: **PHASE 0 IS DONE (measured 2026-09-09) — Phase 1 is not built, and the measurement says
+> it is worth building.** `claude` and `agy` both read a number out of a real PNG and said it back;
+> `codex` is untested rather than refused (its account hit a usage limit mid-probe) and must be
+> re-run before it is refused by name anywhere. **The mechanism is a file PATH named in the prompt**
+> — the one vector that works for both vendors that answered — which means the vendor process opens
+> the file itself, and the temp file's location and lifetime are part of the contract rather than an
+> implementation detail. Kind: **feature**.
 > Scope: the page's paste handling and CSP (`chatPage.ts:287`), a host handler in `chatCommand.ts`,
 > a temp-file discipline beside `chatOrphans.ts`, and the session seam plus adapters. Origin:
 > [BUGS_2026-09-09.md](BUGS_2026-09-09.md), entry 13.
@@ -27,6 +33,69 @@ image in a non-interactive turn, and how, is not known.** Establish for `claude`
    scope here; recorded as the server's next item.
 
 Results as a table in this file. If no local adapter takes one, promote this plan as a record.
+
+### Phase 0 RESULTS — measured 2026-09-09
+
+Harness: [`src_vs_code/scripts/measure-image.mjs`](../src_vs_code/scripts/measure-image.mjs), run on
+Windows 11, node v24.18.0, against the real signed-in CLIs, with the launch spec **imported** from
+`launchSpecFor` so it cannot measure a mode the product does not run.
+
+**The image says something, and that is the whole design of the probe.** A CLI exiting 0 does not
+prove the model received a picture — an unknown field in a JSON turn can be ignored silently and an
+unsupported payload dropped, and either way the process answers cheerfully. So
+[`tokenPng.mjs`](../src_vs_code/scripts/tokenPng.mjs) draws a four-digit number into a real PNG
+(hand-rolled: a CRC, `node:zlib`, and 5×7 digit glyphs — no dependency, and readable in a diff), the
+prompt asks for that number back and nothing else, and **only the number appearing in the answer
+counts as receipt**.
+
+| vendor | vector | outcome | what it said |
+|---|---|---|---|
+| `claude` | inline base64 block | **received** | answered `7431` |
+| `claude` | a path in the prompt | **received** | answered `7431` |
+| `agy` | inline base64 block | not representable | the turn's `message.content` is a STRING — there is no block to put an image in |
+| `agy` | a path in the prompt | **received** | answered `7431` |
+| `codex` | inline base64 block | not representable | the turn IS the prompt text — there is no structure to carry a block |
+| `codex` | a path in the prompt | **inconclusive — the account, not the vendor** | *"You've hit your usage limit… try again at Sep 10th, 2026 12:41 AM"* |
+
+#### The answers, question by question
+
+**1. Does it take an image at all?** **`claude` and `agy`: yes, proven** — both read the number out
+of the picture and said it back. `codex` is **not yet known**: its account ran out of credit during
+the probe, and that is a fact about this afternoon rather than about the vendor. It must be re-run
+before anything is decided for it.
+
+**2. By what mechanism?** **A path to a file on disk, named in the prompt** — and that is the
+finding that matters, because it is the ONE vector that works for both vendors that answered.
+`claude` also accepts an inline base64 `image` block in its `stream-json` turn, which its
+`message.content` array has room for; `agy` and `codex` have nowhere to put one — their turns carry
+a string and a bare prompt respectively, so inline is not merely unsupported there, it is
+unrepresentable in the shape this extension sends.
+
+That also says something Phase 1 needs: with the path vector the CLI **opens the file itself**, so
+what is being built is not an attachment travelling with the turn but a file the vendor process must
+be able to read. The temp file's location and lifetime are therefore part of the contract, not an
+implementation detail.
+
+**3. Does it survive `cmd.exe`?** The question mostly dissolves: a path is a couple of hundred
+characters and goes on stdin with the rest of the prompt, exactly as prose does today. The base64
+route is the one that would have strained a command line — 556 characters for a 415-byte PNG, and a
+real screenshot is measured in megabytes — and it is only available on `claude`, which takes it on
+stdin too.
+
+### The decision
+
+**Phase 1 is worth building, and the mechanism is a file path.** Two of the three local vendors are
+proven to read a picture that way, the third is untested rather than refused, and the plan's own
+`{ path, mime }` attachment shape turns out to be right — now measured rather than assumed.
+
+Two amendments Phase 1 should carry from this:
+
+* **The base64-over-the-bridge step is only needed to get the clipboard image to the HOST.** From
+  there it is a file on disk and a path in the prompt; no adapter needs to carry base64, and only
+  `claude` could take it if one did.
+* **`codex` must be re-probed** (`npm run measure:image -- codex`) before it is given a refusal by
+  name in the page. Refusing a vendor on the strength of a spent credit balance is exactly the
+  silent feature-kill this probe was shaped to avoid.
 
 ## Phase 1 — only where Phase 0 said yes
 
@@ -90,7 +159,22 @@ only when the whole ritual has run — not when the code works.
 
 **Specific to this plan:** the Phase 0 table is in the PR whatever it says; help sentence under the chat article naming which models take a picture; `module_extension.md` gains the attachment on the seam, the CSP change and the temp-file discipline; CHANGELOG in the person's words; no manifest change; the security note (CSP widened to `data:` images only) called out in the PR body for the gate.
 
-## Definition of Done
+## Definition of Done — PHASE 0 (this pull request)
+
+- [x] The probe drives the REAL CLIs, importing the launch spec rather than retyping it.
+- [x] **A run that exits 0 is not a yes.** The image carries a readable token, the prompt demands it
+      back, and only the token in the answer counts as receipt.
+- [x] **A "no" is distinguishable from "I could not find the way".** Seven named outcomes, of which
+      `unavailable`, `failed`, `unspawnable` and `no-answer` are facts about this machine and are
+      excluded from any conclusion about a vendor. `codex` landed in exactly that bucket, with its own
+      sentence recorded, and is written down as untested rather than as refused.
+- [x] **Both transmission vectors tried** — inline base64 and a path on disk — before Phase 1 designs
+      an attachment shape, with "not representable" recorded where a vendor's turn has nowhere to put
+      a block.
+- [x] The table is in this file, with the environment and the payload sizes.
+- [x] A decision line saying whether Phase 1 is worth building, and by what mechanism.
+
+## Definition of Done — PHASE 1 (not this pull request)
 
 - [ ] Phase 0's table is here with the mechanism per adapter.
 - [ ] Where supported: paste → thumbnail → sent → answered; the temp file is owned and removed.


### PR DESCRIPTION
Phase 0 of [PLAN_a_picture_in_the_question.md](todo/PLAN_a_picture_in_the_question.md) — the measurement the plan calls *"the part that decides whether any of this is worth building"*. Nothing in `src/` is touched.

## The answer

| vendor | inline base64 block | a path in the prompt |
|---|---|---|
| **`claude`** | **received** — answered `7431` | **received** — answered `7431` |
| **`agy`** | not representable | **received** — answered `7431` |
| `codex` | not representable | **inconclusive** — *"You've hit your usage limit… try again at Sep 10th 12:41 AM"* |

**The mechanism is a file PATH named in the prompt** — the one vector that works for both vendors that answered. `codex` is **untested, not refused**: its account ran out of credit mid-probe, which is a fact about the afternoon and not about the vendor.

## A run that exits 0 is not a yes

The sharpest finding on the plan round, and the whole probe is shaped by it: a CLI answering cheerfully does not prove the model *received* a picture. An unknown field in a JSON turn can be ignored silently and an unsupported payload dropped — and a naive probe would then commit the project to a paste feature, a CSP change and a temp-file discipline for a vendor that throws pictures away.

So the image **says something**. [`tokenPng.mjs`](src_vs_code/scripts/tokenPng.mjs) draws a four-digit number into a real PNG — a CRC32, `node:zlib` for the IDAT, and 5×7 digit glyphs; no dependency, and legible in a diff — the prompt asks for that number back and nothing else, and **only the number appearing in the answer counts as receipt.**

## A "no" is not allowed to be vague

Seven named outcomes, of which `unavailable`, `failed`, `unspawnable` and `no-answer` are facts about *this machine* and are excluded from any conclusion about a vendor.

That mattered immediately. The first version judged the exit code *before* parsing the output and reported `codex` as a bare "failed, code 1" — when its stream said, in words, that the account was out of credit. `codexAdapter` flattens every `turn.failed` into "the model did not finish the turn", which is right for a person reading a chat and useless here, so the probe searches the raw stream as well as the adapter's sentence.

## What this changes about Phase 1

With the path vector **the CLI opens the file itself**, so Phase 1 is not building an attachment that travels with the turn — it is building a file the vendor process must be able to read, which makes the temp file's location and lifetime part of the contract. And the base64 step is only needed to get the clipboard image from the webview to the host; no adapter needs to carry it.

## What the code round then found

- **`measure:image -- --token 1234` measured a vendor called "1234"** — a flag's value read as a positional. CodeRabbit caught the identical shape in the streaming probe this morning; it is now written down in the code because it is twice.
- **Worse: the refusal did not stop anything.** The error path set an exit code and let the script carry on, so a mistyped flag printed a complaint and then spent real turns on three signed-in accounts.
- **`killTree` spawned `taskkill` asynchronously** and returned, so on Windows the tree was still holding the temp directory when the caller removed it — EBUSY, mid-run, after the turns were spent.
- The probe now verifies the image **landed** before asking about it; a path to a missing file would have been recorded as `answered-without-token`, the exact false negative the design exists to prevent.

## The gate

- Plan round: `proceed`, both reviewers, 6 gating — 7 accepted, 2 rejected.
- Code round: **`proceed`**, all 8 reviewers, 12 gating — 13 accepted, 10 rejected with reasons.

`cliHarness.mjs` is extracted from the streaming probe that shipped this morning, so the rules that round established — tree kill, unspawnable as a result rather than a crash, stdin `EPIPE` handled, arrival stamped per chunk — live in one place. A reviewer asked for exactly that.

## Tests

`npm test` **1145 tests, 1144 pass, 0 fail, 1 skipped** — unchanged, nothing in `src/` touched. `plan-lifecycle.mjs` and `pin-check.mjs` clean. The probe was run against all three real CLIs, and re-run end to end after the refactor.

## Not in scope

Everything in Phase 1: the paste listener, the `img-src data:` CSP change, the bridge, the temp-file owner, the attachment on the seam, the refusal by name. `chatPage.ts` is untouched — a parallel session owns it. **`codex` must be re-probed** before it is refused by name anywhere; refusing a vendor on the strength of a spent credit balance is the silent feature-kill this probe was shaped to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
