### PR TITLE
feat(chat): every answer says which model gave it

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -47,6 +47,15 @@ carries a class per model and `chatStyle` emits one rule per model the page know
 answered once and is no longer offered gets no rule and falls back to the ordinary caption colour,
 which is honest — the page cannot say what colour a vendor it has never been told about would have.
 
+**The rules are built from every model the page will SHOW, not only the ones it can still offer.**
+Switching models carries the whole thread across — which is the feature this caption exists for — so
+a conversation routinely displays a model the picker has moved on from, and building the rules from
+the picker alone left those answers with a class and no rule. The ids are in the messages already.
+
+**The caption is its own element.** It began as a `who` span inside the `who` row, which meant every
+rule written for the row — its flex, its gap, its margin, its opacity — landed on the label too, and
+the next person to change the row's layout would have moved the text with it without knowing why.
+
 The label comes from the picker, so the caption reads as the name a person chose from; a model the
 catalog has withdrawn is still named by its id, because what answered is a fact about the past.
 

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -29,6 +29,27 @@ local model` the page would otherwise still show the remote one as selected whil
 somewhere else), a pushed state that has not changed is not sent at all, a `pick` naming a model the
 conversation was never offered is refused at the host boundary rather than trusted, and the
 composer takes focus back when a turn ends — without which every follow-up costs a mouse click.
+### Every answer says which model gave it (2026-09-09)
+
+Every answer was captioned `The other AI`, while switching the model mid-conversation is a shipped
+feature and the thread is carried across — so one tab routinely held answers from two models with
+nothing on screen telling them apart.
+
+`ChatMessage.model` is recorded when the answer ARRIVES, from the model that gave it. Reading the
+setting at render time would relabel every earlier answer the day somebody switched, which is the
+defect stated backwards. It is optional for two honest reasons: what the PERSON said has no model,
+and an answer from before the field existed has none either — both fall back to the old caption
+rather than rendering an empty line where a name should be.
+
+**The colour is the vendor's own**, through the same `vendorPalette` the rounds list and the reviewer
+cards call, so a vendor a person has learned is that colour wherever they meet it. The caption
+carries a class per model and `chatStyle` emits one rule per model the page knows; a model that
+answered once and is no longer offered gets no rule and falls back to the ordinary caption colour,
+which is honest — the page cannot say what colour a vendor it has never been told about would have.
+
+The label comes from the picker, so the caption reads as the name a person chose from; a model the
+catalog has withdrawn is still named by its id, because what answered is a fact about the past.
+
 ### A turn can be stopped from the page it is running on (2026-09-09)
 
 The seam shipped first and waited: `ChatSession.stop()` and an `onStop(id, turn)` hook that takes a

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**Every answer says which model gave it**, in that model's own colour — the same colour it has in the
+rounds list and on its reviewer card. Switching models mid-conversation has always carried the
+thread across, so a tab could hold answers from two of them looking identical; now the one you
+switched away from and the one you switched to are told apart at a glance.
+
 **A turn can be stopped.** While an answer is coming there is a *Stop* beside *Thinking…* — for the
 question you saw was wrong the moment you sent it, and for the one that is taking far longer than it
 should. It stops the turn it is showing and no other, so a press that lands late cannot end the

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -309,6 +309,9 @@ async function reopened(thread: Thread): Promise<string> {
  * <p>The question is appended BEFORE the turn is sent, so the page shows it while the model is
  * thinking — nine measured seconds of silence otherwise look like a tab that ignored a keypress.</p>
  */
+/** What a stopped turn leaves in the transcript, so it never ends on a dangling question. */
+const STOPPED_ANSWER = '(you stopped this answer)';
+
 async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
   const thread = threads.get(entry.id);
   if (thread === undefined) {
@@ -831,9 +834,6 @@ async function openWorkspaceFile(
   refuse(`There is no ${requested} in this workspace.`);
 }
 
-/** What a stopped turn leaves in the transcript, so it never ends on a dangling question. */
-const STOPPED_ANSWER = '(you stopped this answer)';
-
 /**
  * Which model a turn was answered by, as the page will caption it.
  *
@@ -843,8 +843,11 @@ const STOPPED_ANSWER = '(you stopped this answer)';
  */
 function answeredBy(thread: Thread): AnsweredBy {
   const chosen = thread.models.find((model) => model.id === thread.modelId);
+  // An empty label is not a label. `??` keeps one, and the caption would then fall through to
+  // "The other AI" for a model whose id was known all along. (gemini, the code round.)
+  const named = chosen?.label.trim() ?? '';
 
-  return { id: thread.modelId, label: chosen?.label ?? thread.modelId };
+  return { id: thread.modelId, label: named.length > 0 ? named : thread.modelId };
 }
 
 /**

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -7,7 +7,7 @@ import { isInside } from './chatMessages';
 import { ChatTabMemory, SavedTab, reloadedNote } from './chatTabs';
 import { ChatEntry, ChatPanels } from './chatPanels';
 import { ChatSession } from './chatSession';
-import { ChatMessage, ChatModelChoice } from './chatPage';
+import { AnsweredBy, ChatMessage, ChatModelChoice } from './chatPage';
 import { CliChatSession, REAL_TIMERS } from './cliChatSession';
 import { DEFAULT_BUDGETS } from './chatSession';
 import { ChatMemory, chatChoice, chatModelsFrom, isRemote, memoryOf } from './chatModels';
@@ -368,7 +368,10 @@ async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
     // appends a second `you` directly on top of the first. One line saying what happened makes the
     // transcript true, and it is only then worth carrying. (gemini, the plan round, Blocking.)
     if (result.stopped === true) {
-      thread.messages = [...thread.messages, { role: 'model', text: '(you stopped this answer)' }];
+      // One line, deliberately: a structural guard in `chatWiring.test.ts` reads the ORDERING here
+      // as a regex, and breaking the append across lines breaks its pattern without changing what it
+      // guards. The ordering is load-bearing and the guard is right to watch it.
+      thread.messages = [...thread.messages, { role: 'model', text: STOPPED_ANSWER, model: answeredBy(thread) }];
     }
     // And only a vendor that LOST the conversation needs it re-sent. `contextLost` on the failure arm
     // is the session saying which of the two it is: a killed process that held the thread says yes, a
@@ -397,7 +400,10 @@ async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
   const answer = result.contextLost === true
     ? `(the conversation restarted — this answer does not remember the earlier ones)\n\n${result.answer}`
     : result.answer;
-  thread.messages = [...thread.messages, { role: 'model', text: answer }];
+  // Recorded from the model that ANSWERED, at the moment it did. Reading the setting later would
+  // relabel every earlier answer the day somebody switches models, and switching mid-conversation
+  // is a shipped feature — the thread is carried across, so one tab routinely holds two.
+  thread.messages = [...thread.messages, { role: 'model', text: answer, model: answeredBy(thread) }];
   thread.asked += 1;
   show(entry, false, '');
 }
@@ -823,6 +829,22 @@ async function openWorkspaceFile(
   }
 
   refuse(`There is no ${requested} in this workspace.`);
+}
+
+/** What a stopped turn leaves in the transcript, so it never ends on a dangling question. */
+const STOPPED_ANSWER = '(you stopped this answer)';
+
+/**
+ * Which model a turn was answered by, as the page will caption it.
+ *
+ * <p>The label is the one the picker offered, so the caption reads as the name a person chose from
+ * rather than an id. A model that is not in the list any more — a Team server that withdrew it — is
+ * still named by its id: what answered is a fact about the past, and the page's job is to say it.</p>
+ */
+function answeredBy(thread: Thread): AnsweredBy {
+  const chosen = thread.models.find((model) => model.id === thread.modelId);
+
+  return { id: thread.modelId, label: chosen?.label ?? thread.modelId };
 }
 
 /**

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -137,9 +137,12 @@ export function chatMessagesHtml(messages: readonly ChatMessage[]): string {
       // The copy control carries the INDEX, and the host reads the message out of the same array
       // this was rendered from - so what is copied is the markdown that arrived, which is the one
       // thing a selection cannot give: selecting the page gives what the page shows.
+      // Its OWN class. It used to be a `who` span inside the `who` row, so every rule written for
+      // the row — flex, gap, margin, opacity — landed on the label too, and the next person to change
+      // the row's layout would have moved the text with it. (gemini, the code round.)
       const said = !mine && message.model !== undefined && message.model.label.length > 0
-        ? `<span class="who ${modelClass(message.model.id)}">${escapeHtml(message.model.label)}</span>`
-        : `<span class="who">${mine ? 'You' : 'The other AI'}</span>`;
+        ? `<span class="author ${modelClass(message.model.id)}">${escapeHtml(message.model.label)}</span>`
+        : `<span class="author">${mine ? 'You' : 'The other AI'}</span>`;
       const copy = mine
         ? ''
         : `<button type="button" class="copy" data-copy="${index}" title="Copy this answer as Markdown">Copy</button>`;
@@ -194,15 +197,30 @@ export function chatCappedHtml(capped: boolean): string {
  * and is no longer offered gets no rule and falls back to the ordinary caption colour — which is
  * honest: the page cannot say what colour a vendor it has never been told about would have.</p>
  */
-function modelColours(models: readonly ChatModelChoice[]): string {
-  const colour = vendorPalette(models.map((model) => model.id));
+function modelColours(
+  models: readonly ChatModelChoice[],
+  messages: readonly ChatMessage[] = [],
+): string {
+  // Every model this page will SHOW, not only the ones it can still offer. Switching models carries
+  // the whole thread across — which is the feature this caption exists for — so a conversation
+  // routinely displays a model the picker has moved on from, and building the rules from the picker
+  // alone left those answers with a class and no rule. The ids are in the messages already.
+  const shown = [...new Set([
+    ...models.map((model) => model.id),
+    ...messages.flatMap((message) => (message.model === undefined ? [] : [message.model.id])),
+  ])].filter((id) => id.length > 0);
+  const colour = vendorPalette(shown);
 
-  return models
-    .map((model) => `  .msg .who.${modelClass(model.id)} { color: ${colour(model.id)}; opacity: 1; }`)
+  return shown
+    .map((id) => `  .msg .author.${modelClass(id)} { color: ${colour(id)}; opacity: 1; }`)
     .join('\n');
 }
 
-function chatStyle(uiScale: number, models: readonly ChatModelChoice[] = []): string {
+function chatStyle(
+  uiScale: number,
+  models: readonly ChatModelChoice[] = [],
+  messages: readonly ChatMessage[] = [],
+): string {
   // The zoom goes INSIDE the body rule, and that is not a tidiness preference. It used to sit above
   // it, where CSS has no such thing as a declaration: a parser consuming a qualified rule appends
   // every token to the prelude until it meets `{`, and `;` does not end one — so the selector became
@@ -285,7 +303,7 @@ function chatStyle(uiScale: number, models: readonly ChatModelChoice[] = []): st
   #send:hover:not([disabled]) { background: var(--vscode-button-hoverBackground); }
   #send[disabled] { opacity: .6; cursor: default; }
   .hint { font-size: .85em; opacity: .6; margin-top: 4px; }
-${modelColours(models)}
+${modelColours(models, messages)}
 ${ZOOM_CSS}`;
 }
 
@@ -825,7 +843,7 @@ export function chatPageHtml(state: ChatPageState, nonce: string): string {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${escapeHtml(state.title)}</title>
 <style>
-${chatStyle(state.uiScale, state.models)}
+${chatStyle(state.uiScale, state.models, state.messages)}
 </style>
 </head>
 <body>

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -1,6 +1,7 @@
 import { escapeHtml, jsonForScript } from './webviewHtml';
 import { renderAnswer } from './renderAnswer';
 import { ZOOM_CSS, zoomControlHtml, zoomScript, zoomStyle } from './zoomControl';
+import { vendorPalette } from './vendorColour';
 
 /**
  * The conversation tab: the passage that started it, what has been said, and a box to say more.
@@ -34,9 +35,32 @@ import { ZOOM_CSS, zoomControlHtml, zoomScript, zoomStyle } from './zoomControl'
  */
 
 /** One thing said, by one of the two parties. */
+/** Which model gave an answer — recorded when it ARRIVED, never looked up afterwards. */
+export interface AnsweredBy {
+  readonly id: string;
+  readonly label: string;
+}
+
 export interface ChatMessage {
   readonly role: 'you' | 'model';
   readonly text: string;
+  /**
+   * The model that gave this answer, for a `model` message.
+   *
+   * <p>Optional because two kinds of message legitimately have none: what the PERSON said, and an
+   * answer from before this field existed — a conversation restored from a tab that predates it.
+   * Both fall back to the old caption rather than rendering an empty line where a name should be.</p>
+   *
+   * <p>It is what ANSWERED, not what is configured. Switching the model mid-conversation is a
+   * shipped feature and the thread is carried across, so a tab routinely holds answers from two
+   * models; reading the current setting would relabel every one of them.</p>
+   */
+  readonly model?: AnsweredBy | undefined;
+}
+
+/** A model id as a class name. Ids come from a Team server's catalog, so they are not trusted. */
+export function modelClass(id: string): string {
+  return `model-${id.toLowerCase().replace(/[^a-z0-9-]/g, '-').slice(0, 48)}`;
 }
 
 /** A model the picker may offer. `remote` models say what they cannot do. */
@@ -113,6 +137,9 @@ export function chatMessagesHtml(messages: readonly ChatMessage[]): string {
       // The copy control carries the INDEX, and the host reads the message out of the same array
       // this was rendered from - so what is copied is the markdown that arrived, which is the one
       // thing a selection cannot give: selecting the page gives what the page shows.
+      const said = !mine && message.model !== undefined && message.model.label.length > 0
+        ? `<span class="who ${modelClass(message.model.id)}">${escapeHtml(message.model.label)}</span>`
+        : `<span class="who">${mine ? 'You' : 'The other AI'}</span>`;
       const copy = mine
         ? ''
         : `<button type="button" class="copy" data-copy="${index}" title="Copy this answer as Markdown">Copy</button>`;
@@ -122,7 +149,7 @@ export function chatMessagesHtml(messages: readonly ChatMessage[]): string {
       const end = mine ? '' : '<hr class="end">';
 
       return `<div class="msg ${mine ? 'you' : 'model'}">`
-        + `<div class="who">${mine ? 'You' : 'The other AI'}${copy}</div>`
+        + `<div class="who">${said}${copy}</div>`
         + `<div class="what">${body}</div>${end}</div>`;
     })
     .join('');
@@ -159,7 +186,23 @@ export function chatCappedHtml(capped: boolean): string {
 }
 
 /** The page's own styles. Its own function so the document below stays readable. */
-function chatStyle(uiScale: number): string {
+/**
+ * A colour rule per model the page knows about, from the palette every other surface uses.
+ *
+ * <p>One call to `vendorPalette` answers here, in the rounds list and on the reviewer cards, so a
+ * vendor a person has learned is the same colour wherever they meet it. A model that answered once
+ * and is no longer offered gets no rule and falls back to the ordinary caption colour — which is
+ * honest: the page cannot say what colour a vendor it has never been told about would have.</p>
+ */
+function modelColours(models: readonly ChatModelChoice[]): string {
+  const colour = vendorPalette(models.map((model) => model.id));
+
+  return models
+    .map((model) => `  .msg .who.${modelClass(model.id)} { color: ${colour(model.id)}; opacity: 1; }`)
+    .join('\n');
+}
+
+function chatStyle(uiScale: number, models: readonly ChatModelChoice[] = []): string {
   // The zoom goes INSIDE the body rule, and that is not a tidiness preference. It used to sit above
   // it, where CSS has no such thing as a declaration: a parser consuming a qualified rule appends
   // every token to the prelude until it meets `{`, and `;` does not end one — so the selector became
@@ -242,6 +285,7 @@ function chatStyle(uiScale: number): string {
   #send:hover:not([disabled]) { background: var(--vscode-button-hoverBackground); }
   #send[disabled] { opacity: .6; cursor: default; }
   .hint { font-size: .85em; opacity: .6; margin-top: 4px; }
+${modelColours(models)}
 ${ZOOM_CSS}`;
 }
 
@@ -781,7 +825,7 @@ export function chatPageHtml(state: ChatPageState, nonce: string): string {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${escapeHtml(state.title)}</title>
 <style>
-${chatStyle(state.uiScale)}
+${chatStyle(state.uiScale, state.models)}
 </style>
 </head>
 <body>

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -1419,10 +1419,39 @@ test('the caption wears its vendor colour, and two vendors do not share one', ()
     { role: 'model', text: 'a', model: { id: 'antigravity', label: 'Gemini' } },
     { role: 'model', text: 'b', model: { id: 'remsoftdev-codex', label: 'GPT' } },
   ]);
-  const colours = [...html.matchAll(/class="who model-([a-z0-9-]+)"/g)].map((match) => match[1]);
+  const colours = [...html.matchAll(/class="author model-([a-z0-9-]+)"/g)].map((match) => match[1]);
 
   assert.strictEqual(colours.length, 2, 'the captions carry no vendor of their own');
   assert.notStrictEqual(colours[0], colours[1], 'two vendors were given the same class');
+});
+
+test('the caption is its own element, not a second one wearing the container\'s class', () => {
+  // A `.who` span inside a `.who` div: every rule written for the row — its flex, its gap, its
+  // margin, its opacity — landed on the label as well, and the next person to change the row's
+  // layout would have moved the text with it without knowing why. (gemini, the code round, twice.)
+  const html = chatMessagesHtml([
+    { role: 'you', text: 'ask' },
+    { role: 'model', text: 'answered', model: { id: 'antigravity', label: 'Gemini' } },
+  ]);
+
+  assert.doesNotMatch(html, /class="who"[^>]*>\s*<span class="who/, 'a .who is nested inside a .who');
+  assert.match(html, /<span class="author model-antigravity">Gemini<\/span>/, 'the label has no class of its own');
+  assert.match(html, /<span class="author">You<\/span>/, 'the person\'s caption has no class of its own');
+});
+
+test('an answer from a model the picker no longer offers keeps its colour', () => {
+  // The colours were built from the picker's CURRENT list, so switching models — which carries the
+  // whole thread across, and is the feature this caption exists for — left every earlier answer
+  // with a class and no rule. The ids are in the messages; the page can simply read them.
+  const html = chatPageHtml(state({
+    models: [{ id: 'claude', label: 'Claude', caption: 'local' }],
+    modelId: 'claude',
+    messages: [{ role: 'model', text: 'from before', model: { id: 'antigravity', label: 'Gemini' } }],
+  }), 'n0nce');
+  const css = html.split('<style>')[1].split('</style>')[0];
+
+  assert.match(css, /\.author\.model-antigravity \{/, 'an answer from a withdrawn model lost its colour');
+  assert.match(css, /\.author\.model-claude \{/, 'the offered model lost its colour');
 });
 
 test('a model label that is markup is escaped like everything else', () => {

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -1369,3 +1369,53 @@ test('a stop control keeps the focus a push would have taken from it', () => {
 
   assert.ok(page.seen['stop'].focused > before, 'the keyboard lost the control when the line was redrawn');
 });
+
+
+/* ------------------------------------------------------------------------------------------------
+ * Who said it. Entry 17 of the operator's list: every answer was captioned `The other AI`, while
+ * switching the model mid-conversation is a shipped feature — so one tab routinely holds answers
+ * from two models with nothing on screen telling them apart.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('an answer is captioned with the model that gave it', () => {
+  const html = chatMessagesHtml([
+    { role: 'you', text: 'ask' },
+    { role: 'model', text: 'first', model: { id: 'antigravity', label: 'Gemini 3.8 Flash' } },
+    { role: 'model', text: 'second', model: { id: 'remsoftdev-codex', label: 'GPT-5.6 (team)' } },
+  ]);
+
+  assert.match(html, /Gemini 3\.8 Flash/, 'the first answer does not say who gave it');
+  assert.match(html, /GPT-5\.6 \(team\)/, 'the second answer does not say who gave it');
+  assert.doesNotMatch(html, /The other AI/, 'an answer that knows its model still says "The other AI"');
+});
+
+test('an answer from before this existed still says something', () => {
+  // A conversation restored from a tab that predates the field, or a turn a failure produced. The
+  // caption falls back rather than rendering an empty line where a name should be.
+  const html = chatMessagesHtml([{ role: 'model', text: 'answered' }]);
+
+  assert.match(html, /The other AI/, 'an answer with no model recorded lost its caption entirely');
+});
+
+test('the caption wears its vendor colour, and two vendors do not share one', () => {
+  // The same colour the rounds list and the reviewer cards give that vendor — one call to
+  // `vendorPalette`, so a vendor a person has learned is the same colour everywhere.
+  const html = chatMessagesHtml([
+    { role: 'model', text: 'a', model: { id: 'antigravity', label: 'Gemini' } },
+    { role: 'model', text: 'b', model: { id: 'remsoftdev-codex', label: 'GPT' } },
+  ]);
+  const colours = [...html.matchAll(/class="who model-([a-z0-9-]+)"/g)].map((match) => match[1]);
+
+  assert.strictEqual(colours.length, 2, 'the captions carry no vendor of their own');
+  assert.notStrictEqual(colours[0], colours[1], 'two vendors were given the same class');
+});
+
+test('a model label that is markup is escaped like everything else', () => {
+  // It comes from a Team server's catalog, which is somebody else's text.
+  const html = chatMessagesHtml([
+    { role: 'model', text: 'x', model: { id: 'a', label: '<img src=x onerror=alert(1)>' } },
+  ]);
+
+  assert.doesNotMatch(html, /<img/i, 'a model label reached the page as markup');
+  assert.match(html, /&lt;img/, 'the label was dropped rather than shown');
+});

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -1389,6 +1389,21 @@ test('an answer is captioned with the model that gave it', () => {
   assert.doesNotMatch(html, /The other AI/, 'an answer that knows its model still says "The other AI"');
 });
 
+test('what the person said is captioned as theirs, whatever else is going on', () => {
+  // A reviewer read the plan's sentence about the fallback as covering BOTH kinds of message and
+  // asked whether a person's own words could end up captioned `The other AI`. The code has never
+  // done that — the caption is chosen by role before anything looks at a model — but the question is
+  // fair enough to be worth a test rather than a paragraph.
+  const html = chatMessagesHtml([
+    { role: 'you', text: 'ask' },
+    { role: 'model', text: 'answered', model: { id: 'antigravity', label: 'Gemini' } },
+  ]);
+  const mine = html.slice(0, html.indexOf('msg model'));
+
+  assert.match(mine, />You</, "the person's own message lost its caption");
+  assert.doesNotMatch(mine, /The other AI|Gemini/, 'the person was captioned as a model');
+});
+
 test('an answer from before this existed still says something', () => {
   // A conversation restored from a tab that predates the field, or a turn a failure produced. The
   // caption falls back rather than rendering an empty line where a name should be.

--- a/todo/PLAN_who_said_it_and_what_it_cost.md
+++ b/todo/PLAN_who_said_it_and_what_it_cost.md
@@ -43,7 +43,9 @@ vendor actually charged. The tab and the log both keep the tilde.
   money, estimated }` on `model` messages — recorded from what ACTUALLY answered (the resolved
   row and model from [PLAN_provider_then_model.md](PLAN_provider_then_model.md)), never from what
   is configured now.
-- The caption `The other AI` becomes the model's label in its vendor colour (the edge
+- The caption `The other AI` becomes the model's label in its vendor colour — for an ANSWER. What
+  the person said is captioned `You`, chosen by role before anything looks at a model; a reviewer
+  read an earlier wording as covering both and was right to ask (the edge
   [PLAN_an_answer_reads_like_a_document.md](../research/PLAN_an_answer_reads_like_a_document.md) draws).
 - A running total in the picker row: *this conversation: ~$0.13 · 9.2k tokens*, updated per turn.
 - The ledger: every chat turn writes a usage entry with `kind: chat`, the model, tokens, money and


### PR DESCRIPTION
The **caption** half of `todo/PLAN_who_said_it_and_what_it_cost.md`. The ledger and the rounds log are another branch's; the running total in the tab waits on that ledger and is deliberately not here.

## The symptom

Every answer was captioned `The other AI` — while switching the model mid-conversation is a shipped feature that carries the whole thread across. One tab routinely held answers from two different models with nothing on screen telling them apart. Entry 17 of the operator's list, and the same defect as `PLAN_the_log_names_the_model.md` on the review side.

## What it does

Each answer is captioned with the model that gave it, in that model's own colour — the same `vendorPalette` the rounds list and the reviewer cards call, so a vendor a person has learned is that colour wherever they meet it.

The model is recorded when the answer **arrives**. Looking it up at render time from the current setting would relabel every earlier answer the day somebody switches, which is the defect stated backwards.

## What the gate changed

- **The caption was a `.who` span inside a `.who` div.** Every rule written for the row — flex, gap, margin, opacity — landed on the label as well. Nothing looked wrong today; the next person to change the row's layout would have moved the text with it and had no way to see why.
- **The colours were built from the picker's current list**, so every answer from a model the picker had moved on from carried a class with no rule behind it — in exactly the conversations this caption exists for. The ids are in the messages already.
- **An empty label is not a label**: `??` kept one, and the caption then fell through to `The other AI` for a model whose id was known all along.

Both of the first two were proved by removing the fix and watching the suite name the symptom: *a .who is nested inside a .who*, and *an answer from a withdrawn model lost its colour*.

## One thing another branch's test caught

A structural guard in `chatWiring.test.ts` reads the **ordering** of the stopped-turn append as a regex. Breaking that append across lines broke its pattern without changing what it guards — it is back on one line with the reason beside it. The guard belongs to the seam's branch, it watches something load-bearing, and it should not be weakened to accommodate a reformat.

## Tests

**1200, 1198 passing, 0 failing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)