### PR TITLE
feat(chat): the picker asks for a provider, then for one of its models

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -29,6 +29,45 @@ local model` the page would otherwise still show the remote one as selected whil
 somewhere else), a pushed state that has not changed is not sent at all, a `pick` naming a model the
 conversation was never offered is refused at the host boundary rather than trusted, and the
 composer takes focus back when a turn ends — without which every follow-up costs a mouse click.
+### The picker asks for a provider, then for a model (2026-09-10)
+
+It used to be one flat list of the configured reviewer ROWS, each labelled with the single model it
+happened to be set to — so `gemini · gemini-3.8-flash` was a row rather than a choice, and picking a
+different model meant leaving the conversation and reconfiguring a reviewer. The operator's words
+were that it read as an arbitrary handful.
+
+**A provider is a vendor ROW, not a runtime**, and that was settled by measurement rather than by
+preference: three vendors' reviewers independently overturned the plan's recommendation on the pure
+half's round. The row carries the runtime, the executable, the base URL, the price and — for a Team
+server — the server and the vendor name on it, so it is the identity a saved choice stores and the
+identity resolution looks up.
+
+**The model list is the chosen provider's and nobody else's.** A list holding another row's models is
+a list somebody can pick a combination from that has no adapter — a Claude model through `agy`, which
+`vendor-routing.md` forbids.
+
+**Either half posts BOTH.** A message carrying only what changed would leave the host pairing it with
+whatever it last heard, and the two can disagree, because the model list belongs to a provider.
+Changing the provider carries no model: which of the new row's models answers is the host's to decide
+— it holds the catalog — and sending the old one would name a model that belongs to somebody else.
+
+**A lone provider is still shown.** The flat list hid itself when it had one entry, which made sense
+while an entry was a whole row: there was nothing to choose. With two steps there always is, and
+hiding it would leave a person unable to see what will answer.
+
+**What is saved was always a row id.** `coai.chatModel` and a restored tab's `modelId` both predate
+the pair, so `savedPick` reads them through `legacyPick` rather than as model names — one function,
+two callers, so they cannot drift.
+
+**The open tail is discovery.** Three of the four model sources are FETCHED rather than read: a local
+engine's list and the codex and agy CLIs' own lists are discovered by asking the machine, and a Team
+server's allowlist is fetched from the server. All three live in the panel, which has already done
+that work; the chat command has none of it, and starting subprocesses or HTTP calls to open a tab
+would trade the operator's complaint for a slower one. So a row whose list must be fetched offers the
+model it is configured to and nothing else — exactly what the flat list offered, which makes this
+strictly not worse — and what gains a real choice today is Claude's curated three. Handing the
+panel's discovered lists across is the next step.
+
 ### Every answer says which model gave it (2026-09-09)
 
 Every answer was captioned `The other AI`, while switching the model mid-conversation is a shipped

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**Choose the provider, then the model.** The list under a chat used to be your configured reviewers,
+each showing the one model it happened to be set to — so picking a different model meant leaving the
+conversation and editing a reviewer. There are two lists now: who answers, and which of their models.
+Claude offers its three; a row whose model list has to be fetched still shows the one it is set to,
+which is what the old list showed anyway.
+
 **Every answer says which model gave it**, in that model's own colour — the same colour it has in the
 rounds list and on its reviewer card. Switching models mid-conversation has always carried the
 thread across, so a tab could hold answers from two of them looking identical; now the one you

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -10,7 +10,18 @@ import { ChatSession } from './chatSession';
 import { AnsweredBy, ChatMessage, ChatModelChoice } from './chatPage';
 import { CliChatSession, REAL_TIMERS } from './cliChatSession';
 import { DEFAULT_BUDGETS } from './chatSession';
-import { ChatMemory, chatChoice, chatModelsFrom, isRemote, memoryOf } from './chatModels';
+import {
+  ChatCatalog,
+  ChatMemory,
+  LegacyPick,
+  ChatProvider,
+  chatModelsFrom,
+  chatProvidersFrom,
+  isRemote,
+  legacyPick,
+  memoryOf,
+  resolveChatPick,
+} from './chatModels';
 import { remoteIsFull } from './remoteAsk';
 import { remoteChatFor } from './chatRemote';
 import { TeamServer, rowBelongsTo, teamServersFrom } from './teamServers';
@@ -60,6 +71,10 @@ interface Thread extends ChatMemory {
   home: ChatHome;
   readonly passage: string;
   readonly models: readonly ChatModelChoice[];
+  /** Every row that can answer, each with its own models. Replaced whenever a pick resolves. */
+  providers: readonly ChatProvider[];
+  /** The row that answers, and which of its models — empty for whatever the row is set to. */
+  providerId: string;
   modelId: string;
   /** Whether a turn is in flight. Only so a switch can say out loud that it is waiting for one. */
   running: boolean;
@@ -197,6 +212,8 @@ function show(entry: ChatEntry, running: boolean, failure: string, queued = 0): 
     capped: thread.forgetful && remoteIsFull(thread.asked),
     failure,
     models: thread.models,
+    providers: thread.providers,
+    providerId: thread.providerId,
     modelId: thread.modelId,
     queued,
     // The turn a stop would name. Zero while nothing runs, which is also what the page renders no
@@ -276,7 +293,7 @@ async function reopened(thread: Thread): Promise<string> {
     return '';
   }
   const config = vscode.workspace.getConfiguration('coai');
-  const ready = readyToChat(config, thread.modelId);
+  const ready = readyToChat(config, thread.providerId, thread.modelId);
   if (!ready.ok) {
     return ready.refusal;
   }
@@ -294,6 +311,8 @@ async function reopened(thread: Thread): Promise<string> {
   thread.home.release();
   thread.session = opened.session;
   thread.home = opened.home;
+  thread.providers = ready.providers;
+  thread.providerId = ready.providerId;
   thread.modelId = ready.modelId;
   // The WHOLE memory object, not one field of it: a switch that set `forgetful` and forgot `asked`
   // is a defect this file has already had once, and the type is what stops it happening twice.
@@ -425,30 +444,92 @@ type Ready =
     readonly ok: true;
     readonly vendor: Vendor;
     readonly models: readonly ChatModelChoice[];
+    /** Every row that can answer, each with its own models — what the picker offers. */
+    readonly providers: readonly ChatProvider[];
+    /** The row that answers. */
+    readonly providerId: string;
+    /** Which of that row's models, or empty for whatever the row is set to. */
     readonly modelId: string;
   }
   | { readonly ok: false; readonly refusal: string };
 
-function readyToChat(config: vscode.WorkspaceConfiguration, asked: string): Ready {
+/**
+ * What each row may be pointed at.
+ *
+ * <p><b>Discovery is not here, and that is the honest limit of this step.</b> Three of the four
+ * sources are FETCHED rather than read: a local engine's models and the codex and agy CLIs' own
+ * lists are discovered by asking the machine, and a Team server's allowlist is fetched from the
+ * server. All three live in the panel, which has already done that work and holds the answers; the
+ * chat command has no such state and starting subprocesses or HTTP calls to open a tab would trade
+ * the operator's complaint for a slower one.</p>
+ *
+ * <p>So a row whose list must be fetched offers the model it is CONFIGURED to and nothing else —
+ * exactly what the flat list offered before, which makes this strictly not worse. What gains a real
+ * choice today is the one source that needs no fetching: Claude's curated three. Handing the panel's
+ * discovered lists to this function is the plan's open tail, and it is written down as one.</p>
+ */
+function chatCatalogFrom(config: vscode.WorkspaceConfiguration): ChatCatalog {
+  return {
+    discoveredCodex: [],
+    discoveredAgy: [],
+    localEngine: undefined,
+    // The servers, with no catalog: what a server ALLOWS is fetched from it, and the fetch lives in
+    // the panel. A row without one keeps the model it is set to rather than being offered nothing.
+    teamServers: teamServersFrom(config.get('teamServers'))
+      .map((server) => ({ server, email: '', problem: '', stale: false })),
+  };
+}
+
+/**
+ * A value saved before the pair existed, read as the pair it always was.
+ *
+ * <p>`coai.chatModel` and a restored tab's `modelId` have always held a ROW id — both predate the
+ * two-step choice — so passing either as a MODEL would look for a model of that name and find
+ * nothing. `legacyPick` is the pure half's function for exactly this, and it is called through one
+ * place so the two callers cannot drift.</p>
+ */
+function savedPick(config: vscode.WorkspaceConfiguration, saved: string): LegacyPick {
   const vendors = vendorsFrom(config.get('vendors'));
-  const models = chatModelsFrom(vendors);
-  // A model the person NAMED and which cannot answer is refused by that name — never quietly
-  // replaced by another vendor's, which is somebody else's model, billed, in a voice nobody chose.
-  const choice = chatChoice(models, asked);
-  if (choice.refusal.length > 0) {
-    return { ok: false, refusal: choice.refusal };
+
+  return legacyPick(chatProvidersFrom(vendors, chatCatalogFrom(config)), vendors, saved);
+}
+
+/**
+ * The row that will answer, and which of its models.
+ *
+ * <p>A PROVIDER is a vendor row, not a runtime, and that was settled by measurement rather than by
+ * preference: three vendors' reviewers independently overturned the plan's recommendation on the
+ * pure half's round. The row carries the runtime, the executable, the base URL, the price and — for
+ * a Team server — the server and the vendor name on it, so it is the identity a saved choice stores
+ * and the identity resolution looks up.</p>
+ *
+ * <p>A row the person NAMED and which cannot answer is refused BY NAME — never quietly replaced by
+ * another vendor's, which is somebody else's model, billed, in a voice nobody chose.</p>
+ */
+function readyToChat(
+  config: vscode.WorkspaceConfiguration,
+  askedProvider: string,
+  askedModel: string,
+): Ready {
+  const vendors = vendorsFrom(config.get('vendors'));
+  const list = chatProvidersFrom(vendors, chatCatalogFrom(config));
+  const pick = resolveChatPick(vendors, list, askedProvider, askedModel);
+  if (!pick.ok) {
+    return { ok: false, refusal: pick.refusal };
   }
 
-  const vendor = vendors.find((row) => row.id === choice.modelId);
-  if (vendor === undefined) {
-    return { ok: false, refusal: `The model ${choice.modelId} is no longer configured.` };
-  }
-
-  const refusal = chatRuntimeRefusal(vendor);
+  const refusal = chatRuntimeRefusal(pick.row);
 
   return refusal.length > 0
     ? { ok: false, refusal }
-    : { ok: true, vendor, models: models.offered, modelId: choice.modelId };
+    : {
+      ok: true,
+      vendor: pick.row,
+      models: chatModelsFrom(vendors).offered,
+      providers: list.providers,
+      providerId: pick.row.id,
+      modelId: pick.model,
+    };
 }
 
 /** The clipboard, as `selectionCapture` wants it. VS Code answers a Thenable, not a Promise. */
@@ -679,6 +760,8 @@ function newConversation(
       passage: state.passage,
       messages: [],
       models: ready.models,
+      providers: ready.providers,
+      providerId: ready.providerId,
       modelId: ready.modelId,
       running: false,
       capped: false,
@@ -699,6 +782,8 @@ function newConversation(
     home: first.home,
     passage: state.passage,
     models: ready.models,
+    providers: ready.providers,
+    providerId: ready.providerId,
     modelId: ready.modelId,
     running: false,
     // Counted from 1 by the first turn, so 0 is "this conversation has not asked anything yet" and
@@ -865,7 +950,8 @@ export function restoreConversation(
   extensionUri: vscode.Uri,
 ): void {
   const config = vscode.workspace.getConfiguration('coai');
-  const ready = readyToChat(config, saved.modelId);
+  const restored = savedPick(config, saved.modelId);
+  const ready = readyToChat(config, restored.providerId, restored.modelId);
   // A dead session, and the page can never reach it: `reopened` replaces it before the first turn is
   // sent. It answers rather than throws, because a `ChatSession` that rejects is a contract this
   // codebase does not have — every failure here is a sentence.
@@ -881,6 +967,9 @@ export function restoreConversation(
       passage: saved.passage,
       messages: saved.messages,
       models: ready.ok ? ready.models : [],
+      providers: ready.ok ? ready.providers : [],
+      // The row this tab was speaking to, read by `savedPick` out of the old `modelId`.
+      providerId: ready.ok ? ready.providerId : restored.providerId,
       modelId: saved.modelId,
       running: false,
       capped: false,
@@ -900,6 +989,8 @@ export function restoreConversation(
     home: { dir: '', release: () => undefined },
     passage: saved.passage,
     models: ready.ok ? ready.models : [],
+    providers: ready.ok ? ready.providers : [],
+    providerId: ready.ok ? ready.providerId : restored.providerId,
     modelId: saved.modelId,
     running: false,
     turn: 0,
@@ -936,7 +1027,8 @@ export async function chatWithOtherAi(
 ): Promise<void> {
   const config = vscode.workspace.getConfiguration('coai');
   const settings = chatSettingsFrom((key) => config.get(key));
-  const ready = readyToChat(config, settings.model);
+  const opening = savedPick(config, settings.model);
+  const ready = readyToChat(config, opening.providerId, opening.modelId);
   if (!ready.ok) {
     void vscode.window.showWarningMessage(ready.refusal);
 

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -2,6 +2,7 @@ import { escapeHtml, jsonForScript } from './webviewHtml';
 import { renderAnswer } from './renderAnswer';
 import { ZOOM_CSS, zoomControlHtml, zoomScript, zoomStyle } from './zoomControl';
 import { vendorPalette } from './vendorColour';
+import { ChatProvider, ChatProviderList } from './chatModels';
 
 /**
  * The conversation tab: the passage that started it, what has been said, and a box to say more.
@@ -85,6 +86,11 @@ export interface ChatPageState {
   readonly passage: string;
   readonly messages: readonly ChatMessage[];
   readonly models: readonly ChatModelChoice[];
+  /** Every provider this conversation may put a question to, each with its own models. */
+  readonly providers: readonly ChatProvider[];
+  /** The vendor ROW that answers — the identity a saved choice stores. */
+  readonly providerId: string;
+  /** Which of that row's models. Empty means "whatever the row is set to". */
   readonly modelId: string;
   /**
    * Which turn is in flight, counted from 1 — and 0 when the page cannot say.
@@ -159,21 +165,49 @@ export function chatMessagesHtml(messages: readonly ChatMessage[]): string {
 }
 
 /** The picker, or nothing at all when there is only one model to pick. */
-export function chatPickerHtml(models: readonly ChatModelChoice[], chosen: string): string {
-  if (models.length < 2) {
+/** One `<option>`, with everything in it escaped — labels come from a Team server's catalog. */
+function option(id: string, label: string, chosen: string): string {
+  return `<option value="${escapeHtml(id)}"${id === chosen ? ' selected' : ''}>${escapeHtml(label)}</option>`;
+}
+
+/**
+ * Two steps: WHICH PROVIDER, and then which of its models.
+ *
+ * <p>It used to be one flat list of the configured reviewer ROWS, each labelled with the single
+ * model it happened to be set to — so `gemini · gemini-3.8-flash` was a row, not a choice, and
+ * picking a different model meant leaving the conversation and reconfiguring a reviewer. The
+ * operator's words for it were that the list read as an arbitrary handful.</p>
+ *
+ * <p><b>A provider is a vendor ROW, not a runtime</b>, and that was settled by measurement rather
+ * than by preference: three vendors' reviewers independently overturned the plan's recommendation on
+ * the pure half's round. The row is the identity a saved choice stores and the identity resolution
+ * looks up, because the row carries the runtime, the executable, the base URL, the price and — for a
+ * Team server — the server and the vendor name on it.</p>
+ *
+ * <p><b>The model list is the CHOSEN provider's and nobody else's.</b> A list holding another row's
+ * models is a list somebody can pick a combination from that has no adapter — a Claude model through
+ * `agy`, which `vendor-routing.md` forbids.</p>
+ *
+ * <p>A provider with ONE model still shows it. Hiding a list of one would leave a person unable to
+ * see what will answer, which is the complaint the two steps exist for.</p>
+ */
+export function chatPickerHtml(list: ChatProviderList, providerId: string, modelId: string): string {
+  if (list.providers.length === 0 && list.refused.length === 0) {
     return '';
   }
-  const options = models
-    .map(
-      (model) =>
-        `<option value="${escapeHtml(model.id)}"${model.id === chosen ? ' selected' : ''}>`
-        + `${escapeHtml(model.label)}</option>`,
-    )
+  const chosen = list.providers.find((provider) => provider.id === providerId) ?? list.providers[0];
+  const providers = list.providers.map((provider) => option(provider.id, provider.label, chosen?.id ?? '')).join('');
+  const models = (chosen?.models ?? []).map((model) => option(model.id, model.label, modelId)).join('');
+  // Refused rows are SHOWN. A person who configured a reviewer and finds the picker silently missing
+  // it has no way to tell a bug from a policy — the rule the flat list already followed.
+  const refused = list.refused
+    .map((row) => `<div class="refused">${escapeHtml(row.reason)}</div>`)
     .join('');
-  const caption = models.find((model) => model.id === chosen)?.caption ?? '';
 
-  return `<div class="picker"><select id="model" aria-label="Which model answers">${options}</select>`
-    + `<span class="caption" id="caption">${escapeHtml(caption)}</span></div>`;
+  return `<div class="picker">`
+    + `<select id="provider" aria-label="Which provider answers">${providers}</select>`
+    + `<select id="model" aria-label="Which model answers">${models}</select>`
+    + `<span class="caption" id="caption">${escapeHtml(chosen?.caption ?? '')}</span></div>${refused}`;
 }
 
 /** What a capped conversation offers instead of a composer nobody can use. */
@@ -290,7 +324,9 @@ function chatStyle(
   .failure { border: 1px solid var(--vscode-inputValidation-errorBorder, var(--vscode-panel-border)); border-radius: 4px; padding: 8px 10px; margin: 0 0 12px; }
   .capped { border: 1px solid var(--vscode-panel-border); border-radius: 4px; padding: 10px 12px; margin: 0 0 10px; }
   .capped p { margin: 0 0 8px; }
-  .picker { display: flex; gap: 8px; align-items: center; margin: 0 0 8px; }
+  .picker { display: flex; gap: 8px; align-items: center; margin: 0 0 8px; flex-wrap: wrap; }
+  .picker select { max-width: 45%; }
+  .refused { font-size: .85em; opacity: .75; margin: 0 0 8px; }
   .caption { font-size: .85em; opacity: .7; }
   /* The 30 % lives HERE and only here, so the CSS path and the JavaScript fallback below cannot
      disagree about where the ceiling is: the fallback sets a height and this caps it. field-sizing
@@ -368,7 +404,7 @@ function chatBody(state: ChatPageState, regions: Regions): string {
 </main>
 <footer id="composer">
 <button type="button" id="jump" class="jump" hidden>Jump to newest ↓</button>
-<div id="pickerBox">${chatPickerHtml(state.models, state.modelId)}</div>
+<div id="pickerBox">${chatPickerHtml({ providers: state.providers, refused: [] }, state.providerId, state.modelId)}</div>
 <div class="compose">
 <textarea id="say" rows="3" placeholder="Ask about the text above…"${locked ? ' disabled' : ''}>${escapeHtml(state.draft)}</textarea>
 <button type="button" id="send"${locked ? ' disabled' : ''}>Send</button>
@@ -587,13 +623,25 @@ function chatScript(state: ChatPageState, regions: Regions): string {
     sendButton.addEventListener('click', function () { send(); });
   }
   function wirePicker() {
+    const provider = document.getElementById('provider');
     const model = document.getElementById('model');
-    if (!model) { return; }
-    model.addEventListener('change', function () {
+    // BOTH halves, whichever one moved. A message carrying only what changed would leave the host
+    // pairing it with whatever it last heard, and the two can disagree — the model list belongs to a
+    // provider, so changing the provider invalidates the model that was showing.
+    function pick(providerId, modelId) {
       const caption = document.getElementById('caption');
-      if (caption) { caption.textContent = captions[model.value] || ''; }
-      vscode.postMessage({ type: 'command', command: 'pick', id: model.value });
-    });
+      if (caption) { caption.textContent = captions[providerId] || ''; }
+      vscode.postMessage({ type: 'command', command: 'pick', provider: providerId, model: modelId });
+    }
+    if (provider) {
+      // A provider changed: the model is not carried across. Which of the new row's models answers is
+      // the host's to decide - it holds the catalog - and sending the old one would name a model that
+      // belongs to somebody else.
+      provider.addEventListener('change', function () { pick(provider.value, ''); });
+    }
+    if (model) {
+      model.addEventListener('change', function () { pick(provider ? provider.value : '', model.value); });
+    }
   }
   function wireCapped() {
     const restart = document.getElementById('restart');

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -12,6 +12,7 @@ import {
   chatPickerHtml,
   chatStatusHtml,
 } from './chatPage';
+import { ChatProvider } from './chatModels';
 import { chatTabIcon } from './chatIcon';
 import { escapeHtml } from './webviewHtml';
 import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
@@ -90,6 +91,9 @@ export interface ChatPushState {
   readonly capped: boolean;
   readonly failure: string;
   readonly models: readonly ChatModelChoice[];
+  /** Every row that can answer, each with its own models — what the picker offers. */
+  readonly providers: readonly ChatProvider[];
+  readonly providerId: string;
   readonly modelId: string;
   /**
    * How many turns are ahead of this one on a Team server, or 0 for none and for a local model.
@@ -303,7 +307,7 @@ export function pushChatState(entry: ChatEntry, state: ChatPushState): boolean {
     thinkingHtml: chatStatusHtml(state.running, state.queued, state.turn),
     cappedHtml: chatCappedHtml(state.capped),
     failureHtml: state.failure.length === 0 ? '' : `<div class="failure">${escapeHtml(state.failure)}</div>`,
-    pickerHtml: chatPickerHtml(state.models, state.modelId),
+    pickerHtml: chatPickerHtml({ providers: state.providers, refused: [] }, state.providerId, state.modelId),
     modelId: state.modelId,
   };
 

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -285,7 +285,11 @@ function bundledChatPage(): { bundle: string; html: string } {
         { id: 'antigravity', label: 'Gemini', caption: 'local' },
         { id: 'remsoftdev-codex', label: 'GPT (team)', caption: 'remote · no memory' },
       ],
-      modelId: 'antigravity',
+      providers: [
+        { id: 'antigravity', label: 'Gemini', caption: 'local', models: [{ id: 'g', label: 'G' }] },
+      ],
+      providerId: 'antigravity',
+      modelId: 'g',
       running: false,
       failure: '',
       draft: '',

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import { ChatProvider } from '../chatModels';
 import { ChatModelChoice, ChatPageState, FOLLOW_SLACK_PX, chatCappedHtml, chatMessagesHtml, chatPageHtml, chatPickerHtml, chatStatusHtml, shouldFollow } from '../chatPage';
 
 /**
@@ -25,6 +26,8 @@ function state(over: Partial<ChatPageState> = {}): ChatPageState {
     passage: 'The reviewers are read-only.',
     messages: [],
     models: MODELS,
+    providers: [],
+    providerId: 'antigravity',
     modelId: 'antigravity',
     running: false,
     capped: false,
@@ -100,20 +103,48 @@ test('a failure is shown in words rather than left to be guessed', () => {
   assert.ok(html.includes('agy exited before answering'));
 });
 
-test('the picker is hidden when there is only one model to pick', () => {
-  assert.strictEqual(chatPickerHtml([MODELS[0]!], 'antigravity'), '');
-  assert.strictEqual(chatPickerHtml([], ''), '');
+test('a lone provider is still SHOWN, and nothing at all is hidden', () => {
+  // The flat list hid itself when it had one entry, and that made sense while an entry was a whole
+  // configured row: there was nothing to choose. With two steps there always is — the row still has
+  // models — and hiding the row would leave a person unable to see what will answer, which is the
+  // complaint the two steps exist for.
+  const one = chatPickerHtml(
+    { providers: [{ id: 'a', label: 'a', caption: 'local', models: [{ id: 'm', label: 'M' }] }], refused: [] },
+    'a',
+    'm',
+  );
+
+  assert.match(one, /<select id="provider"/, 'a single provider was hidden along with its models');
+  assert.strictEqual(chatPickerHtml({ providers: [], refused: [] }, '', ''), '',
+    'a page with nothing configured drew a picker of nothing');
 });
 
-test('the picker offers every model and marks the chosen one', () => {
-  const picker = chatPickerHtml(MODELS, 'remsoftdev-codex');
+test('the picker offers every provider and marks the chosen one', () => {
+  const picker = chatPickerHtml(
+    {
+      providers: [
+        { id: 'antigravity', label: 'Gemini 3.8 Flash', caption: 'local', models: [{ id: 'g', label: 'G' }] },
+        { id: 'remsoftdev-codex', label: 'GPT (team)', caption: 'team server · no memory', models: [{ id: 'p', label: 'P' }] },
+      ],
+      refused: [],
+    },
+    'remsoftdev-codex',
+    'p',
+  );
 
   assert.ok(picker.includes('Gemini 3.8 Flash'));
-  assert.ok(/value="remsoftdev-codex" selected/.test(picker), 'the chosen model is not selected');
+  assert.ok(/value="remsoftdev-codex" selected/.test(picker), 'the chosen provider is not selected');
 });
 
 test('a remote model says what it cannot do, where the choice is made', () => {
-  const picker = chatPickerHtml(MODELS, 'remsoftdev-codex');
+  const picker = chatPickerHtml(
+    {
+      providers: [{ id: 'remsoftdev-codex', label: 'GPT (team)', caption: 'team server · no memory', models: [{ id: 'p', label: 'P' }] }],
+      refused: [],
+    },
+    'remsoftdev-codex',
+    'p',
+  );
 
   // The panel must not know which kind it holds; the person must, because the difference shows up
   // in latency and in cost.
@@ -1462,4 +1493,93 @@ test('a model label that is markup is escaped like everything else', () => {
 
   assert.doesNotMatch(html, /<img/i, 'a model label reached the page as markup');
   assert.match(html, /&lt;img/, 'the label was dropped rather than shown');
+});
+
+
+/* ------------------------------------------------------------------------------------------------
+ * Entry 21: the picker was one flat list of configured ROWS, each labelled with the one model it
+ * happened to be set to — so choosing a different model meant leaving the tab and reconfiguring a
+ * reviewer. Two steps: the provider, then its models.
+ * ---------------------------------------------------------------------------------------------- */
+
+const PROVIDERS: readonly ChatProvider[] = [
+  {
+    id: 'antigravity',
+    label: 'antigravity · gemini-3.8-flash',
+    caption: 'local · antigravity · keeps the conversation',
+    models: [{ id: 'gemini-3.8-flash', label: 'Gemini 3.8 Flash' }, { id: 'gemini-3.8-pro', label: 'Gemini 3.8 Pro' }],
+  },
+  {
+    id: 'remsoftdev-codex',
+    label: 'remsoftdev-codex · gpt-5.6',
+    caption: 'team server · no memory',
+    models: [{ id: 'gpt-5.6', label: 'GPT-5.6' }],
+  },
+];
+
+test('the picker asks for a provider and then for one of its models', () => {
+  const html = chatPickerHtml({ providers: PROVIDERS, refused: [] }, 'antigravity', 'gemini-3.8-pro');
+
+  assert.match(html, /<select id="provider"/, 'there is no provider to choose');
+  assert.match(html, /<select id="model"/, 'there is no model to choose');
+  // The chosen provider's models, and only those: a list holding another row's models is a list
+  // somebody can pick a combination from that has no adapter.
+  assert.match(html, /<option value="gemini-3\.8-pro" selected>/, 'the chosen model is not marked');
+  assert.doesNotMatch(html, /value="gpt-5\.6"/, 'another provider\'s models are on offer');
+});
+
+test('changing the provider offers that provider\'s models, not the last one\'s', () => {
+  const html = chatPickerHtml({ providers: PROVIDERS, refused: [] }, 'remsoftdev-codex', 'gpt-5.6');
+
+  assert.match(html, /value="gpt-5\.6"/);
+  assert.doesNotMatch(html, /value="gemini-3\.8-flash"/, 'the previous provider\'s models stayed');
+});
+
+test('a provider with one model still shows the model it will use', () => {
+  // Hiding a list of one would leave a person unable to see WHAT will answer — which is the whole
+  // complaint the two steps exist for.
+  const html = chatPickerHtml({ providers: PROVIDERS, refused: [] }, 'remsoftdev-codex', 'gpt-5.6');
+
+  assert.match(html, /<select id="model"[^>]*>[\s\S]*?GPT-5\.6/, 'a single model was hidden');
+});
+
+test('a row that cannot answer is named, not quietly dropped', () => {
+  const html = chatPickerHtml(
+    { providers: PROVIDERS, refused: [{ id: 'ollama', reason: 'the chat cannot speak to local yet' }] },
+    'antigravity',
+    'gemini-3.8-flash',
+  );
+
+  assert.match(html, /the chat cannot speak to local yet/, 'a configured row vanished with no reason given');
+});
+
+test('picking either half posts both halves, so the host never has to guess', () => {
+  const page = runChatPage({ providers: [...PROVIDERS], providerId: 'antigravity', modelId: 'gemini-3.8-flash' });
+
+  // Changing the PROVIDER carries no model: which of the new row's models answers is the host's to
+  // decide, because it holds the catalog, and sending the old one would name a model belonging to
+  // somebody else.
+  page.seen['provider'].value = 'remsoftdev-codex';
+  page.fire('provider', 'change');
+  // Then a model — of the provider that is now chosen, which is the only kind the page can offer.
+  page.seen['model'].value = 'gpt-5.6';
+  page.fire('model', 'change');
+
+  assert.deepStrictEqual(page.posted.filter((message) => message['command'] === 'pick'), [
+    { type: 'command', command: 'pick', provider: 'remsoftdev-codex', model: '' },
+    { type: 'command', command: 'pick', provider: 'remsoftdev-codex', model: 'gpt-5.6' },
+  ]);
+});
+
+test('a provider label that is markup is escaped', () => {
+  const html = chatPickerHtml(
+    {
+      providers: [{ id: 'x', label: '<img src=x onerror=alert(1)>', caption: '<b>c</b>', models: [{ id: 'm', label: '<i>m</i>' }] }],
+      refused: [],
+    },
+    'x',
+    'm',
+  );
+
+  assert.doesNotMatch(html, /<img|<b>|<i>/, 'a catalog label reached the page as markup');
 });


### PR DESCRIPTION
The **picker** half of `todo/PLAN_provider_then_model.md`. The pure half — `chatProvidersFrom`, `resolveChatPick`, `legacyPick` and `allowedModelsFor`'s move into `models.ts` — shipped in #162 from another lane; this is the two selects, the wiring and the host resolution behind them.

## The symptom

The list was the configured reviewer **rows**, each labelled with the single model it happened to be set to. `gemini · gemini-3.8-flash` was a row, not a choice, and picking a different model meant leaving the conversation to reconfigure a reviewer. The operator's words: it read as an arbitrary handful.

## What decides the shape

**A provider is a vendor ROW, not a runtime** — settled on the pure half's round, where three vendors' reviewers independently overturned the plan's recommendation. The row carries the runtime, the executable, the base URL, the price and, for a Team server, the server and the vendor name on it.

**Either half posts both.** A message carrying only what changed would leave the host pairing it with whatever it last heard, and the two can disagree — the model list belongs to a provider. Changing the provider carries no model: which of the new row's models answers is the host's to decide, because it holds the catalog, and sending the old one names a model belonging to somebody else.

**A lone provider is still shown.** The flat list hid itself at one entry, which made sense while an entry was a whole row. With two steps there is always something to choose.

**What was saved has always been a row id.** `coai.chatModel` and a restored tab's `modelId` both predate the pair, so `savedPick` reads them through `legacyPick` rather than as model names — one place, so the two callers cannot drift.

## The open tail, stated rather than implied

Three of the four model sources are **fetched**, not read: a local engine's list and the codex and agy CLIs' own lists are discovered by asking the machine, and a Team server's allowlist is fetched from the server. All three live in the panel, which has already done that work; the chat command has none of it, and starting subprocesses or HTTP calls to open a tab would trade the operator's complaint for a slower one.

So a row whose list must be fetched offers the model it is configured to and nothing else — **exactly what the flat list offered, which makes this strictly not worse** — and Claude's curated three are a real choice today. Handing the panel's discovered lists across is the next step, and it is written into the plan.

## Two other branches' guards earned their keep

One reads the first 2500 characters of `restoreConversation` for the carry; my additions pushed it to 2508. The legacy resolution became a named function and my comment lost eight characters — rather than the guard losing its window.

## Tests

**1226, 1224 passing, 0 failing** (1200 before). One old test changed its guarantee rather than its shape: *the picker is hidden when there is only one model* became *a lone provider is still shown*, because with two steps there is always a choice to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)