### PR TITLE
fix(gate): a code round is a diff against the merge base, not a base that moved

### DIFF
--- a/research/module_runners.md
+++ b/research/module_runners.md
@@ -19,7 +19,13 @@ sequenceDiagram
   participant E as ReviewerExecutor
   participant V as vendor CLI
   S->>W: ResolveShaAsync(branch) → AddAsync(sha) [one lease per ROUND]
-  S->>C: CollectAsync(base, sha) — numstat, per-file diffs, exclusions
+  S->>C: CollectAsync(base, sha)
+  C->>C: merge-base(base, sha) → the COMMIT this round is a diff of
+  alt no common ancestor found
+    C->>C: is-shallow-repository? — a truncated clone, or genuinely unrelated
+    C->>C: rev-parse the base to a commit — pinned, so three git calls read ONE snapshot
+  end
+  C-->>S: CollectedDiff(files, comparedAgainst, kind) — numstat, per-file diffs, exclusions
   S->>B: RunAllAsync(work[], executor)
   B->>E: per job, under global(3) + per-provider(2) semaphores
   E->>V: launch (read-only, ephemeral); timeout kills the TREE

--- a/research/module_runners.md
+++ b/research/module_runners.md
@@ -38,7 +38,7 @@ sequenceDiagram
 | `WorktreeManager`, `WorktreeLease` | `Worktrees/WorktreeManager.cs` | one detached tree per round, `coai-wt-` prefix under OUR storage; prune-on-open; disposal = finally; never touches a human's worktree |
 | `SubmodulePopulator` | `Worktrees/SubmodulePopulator.cs` | fills the round tree's submodules from the PARENT checkout, not the remote — git populates none in a linked worktree, and in this family the project's rules ARE one; offline, pinned, never fatal, and refused when the source is reached through a reparse point |
 | `GitModules`, `SubmoduleMount` | `Git/GitModules.cs` | `.gitmodules` as (name, path); a file inside the repository under review, so absolute/traversing paths and names that could spell another config key drop the mount |
-| `DiffExclusions`, `ContextAssembler` | `Context/ContextAssembler.cs` | numstat → per-file diffs with `:(exclude,glob)` pathspecs; binary sizes via `cat-file -s` |
+| `DiffExclusions`, `ContextAssembler`, `CollectedDiff`, `DiffBase` | `Context/ContextAssembler.cs` | numstat → per-file diffs with `:(exclude,glob)` pathspecs; binary sizes via `cat-file -s`; every one of the three taken against the MERGE BASE, which the result names |
 | `IReviewerRuntime`: `CodexRuntime`, `DeepseekRuntime`, `GeminiRuntime`, `ClaudeRuntime`, `AntigravityRuntime`, `CustomCodexRuntime` | `Reviewers/ReviewerRuntime.cs`, `ClaudeRuntime.cs`, `CustomRuntime.cs` | THE vendor adapter: `Build` (argv, pure) + `ReadAnswer` + `ReadUsage`, the last two with working defaults. Flags verified against codex 0.147.0 / gemini 0.55.1 / claude 2.1.197 / agy 1.1.22; keys ride env, never argv; DeepSeek = Codex config-shifted |
 | `ReviewerRuntimeSelector` | same | unknown provider refuses naming the catalog |
 | `ReviewerOutcome` (closed), `ReviewerExecutor`, `RateLimit`, `ReviewerLaunch` | `Reviewers/ReviewerExecutor.cs` | one launch + one repair **inside ONE deadline** (2026-09-08: the repair used to carry a whole second budget, so a reviewer could take twice its setting — measured at 668.8 s against ten minutes, reporting `ok`); SIX named outcomes incl. NotStarted; `Ok` carries the run's `Usage`, both launches counted when repaired. **`LaunchAsync` is the public half**: launch → classify → the vendor's RAW answer + usage, with the parse left to the caller |
@@ -139,6 +139,42 @@ sequenceDiagram
 - **The fake CLI** (`src_mcp/tests_fakecli`) is the whole vendor surface in tests: emit / emit-to /
   stderr-exit / sleep / busy (start/end ticks for overlap measurement) / flip (first-launch
   failure), with launch counting. CI never touches a vendor.
+
+## What a code round is a diff OF (2026-09-10)
+
+The merge base of the branch and the base ref — not the tip of the base ref. `ContextAssembler`
+resolves it once with `git merge-base` and uses it for all three git calls, and `CollectedDiff` carries
+it out so the round can say which commit it compared against.
+
+**Why, measured.** On 2026-09-08 a code round produced three Blocking findings from two different
+vendors saying the branch had deleted `chatPrompt.ts`, `processLauncher.ts` and `sessionKey.ts` and
+reverted the extension a version. None of it was true: the branch had been cut from `origin/main`, and
+while the work was in progress another session merged its own pull request. `A..B` diffs two
+ENDPOINTS, so the commits the base has and the branch does not arrive INVERTED — as deletions the
+branch performed. On that branch at that moment, `origin/main..HEAD` was 17 files and 1616 deletions
+where `origin/main...HEAD` was 9 files and 12. It happened three times before it was fixed, and it
+gets likelier the busier the repository is: several agents work here at once, so a base that moves
+during a review is the normal case rather than the exception. A reviewer cannot tell a phantom
+deletion from a real one — the diff says the line was removed — and whether the change matches its
+SCOPE is the one question this gate exists to ask.
+
+**Why an explicit merge base rather than `A...B`.** The three-dot form is the same diff, but it leaves
+the resolved commit inside git where nothing can name it, and there is no three-dot form of
+`cat-file -s`, which is how a BINARY's old side is sized — that third call site would have gone on
+reading a blob from somebody else's commit. One resolution answers all three and gives the round its
+audit line.
+
+**What happens when there is no merge base.** The two-dot form, as before, and a sentence saying so:
+a review taken against the wrong base is worth more than no review, provided nobody has to guess which
+one they are reading. Two cases, deliberately told apart — histories that genuinely share no ancestor,
+and a checkout that is SHALLOW, where an ancestor exists but has not been fetched. The second is a
+clone somebody can deepen; the first is a fact about the commits. `git merge-base` cannot distinguish
+them, so `rev-parse --is-shallow-repository` is asked on the failing path only.
+
+**The resolved commit is named to the reviewer too**, in the diff's own header. Two reviewers of the
+plan asked for it independently and the reason is theirs: a reviewer that checks the branch against
+the tip of `main` sees a diff that does not match, and that discrepancy is indistinguishable from the
+phantom deletions this change exists to stop.
 
 ## Two delivery rules the first real run wrote
 

--- a/src_mcp/runners/Context/ContextAssembler.cs
+++ b/src_mcp/runners/Context/ContextAssembler.cs
@@ -77,7 +77,7 @@ public sealed class ContextAssembler(IProcessLauncher launcher)
         // and two vendors independently filed it as Blocking. Resolved once, and used for all three
         // git calls below — `cat-file` takes a rev rather than a range, so a three-dot form could not
         // have reached it.
-        var (against, kind) = await BaseFor(repoPath, baseRef, sha, ct);
+        var (against, kind) = await ComparisonBase(repoPath, baseRef, sha, ct);
 
         // --numstat: "added deleted path", binaries as "- - path". One call decides binary-ness
         // and file order; each text file then rides its own diff so elision stays whole-file.
@@ -107,13 +107,29 @@ public sealed class ContextAssembler(IProcessLauncher launcher)
         return new CollectedDiff(files, against, kind);
     }
 
-    /// <summary>The commit to compare against, and what kind of answer it is.</summary>
+    /// <summary>An object id and nothing else — never a ref, never anything git could read as a flag.</summary>
     /// <remarks>
-    /// A failure here is never fatal: a review that cannot be taken against the right base is worth
-    /// more than no review, so the two-dot form remains as the fallback — named, so the round says
-    /// which one it used rather than leaving somebody to wonder at the deletions.
+    /// Every value that reaches a `{x}..{sha}` range or a `{x}:{path}` argument passes through here.
+    /// A revision beginning with `-` is a command-line OPTION to git, not a revision, and
+    /// `--output=…` is one that writes a file. The values are hex ids by construction — `merge-base`
+    /// and `rev-parse` both answer with one — so this asserts what is already true rather than
+    /// repairing anything, which is the only kind of check worth having on a path like this.
     /// </remarks>
-    private async Task<(string Against, DiffBase Kind)> BaseFor(
+    private static bool IsCommit(string? value) =>
+        value is { Length: >= 7 and <= 64 } && value.All(Uri.IsHexDigit);
+
+    /// <summary>The COMMIT to compare against, and what kind of answer it is.</summary>
+    /// <remarks>
+    /// <para>A failure here is never fatal: a review taken against the wrong base is worth more than
+    /// no review, so the two-dot form remains as the fallback — named, so the round says which one it
+    /// used rather than leaving somebody to wonder at the deletions.</para>
+    /// <para>But the fallback resolves the ref to a commit before using it, and that is not tidiness.
+    /// `origin/main` is read three times — the numstat, each file's diff, and a binary's old side —
+    /// and another session advancing it between two of them produces a review of two different
+    /// snapshots, which nobody could reproduce afterwards from a log naming only the ref. Pinning it
+    /// is the same lesson as the one this whole change is about. (codex, the code round, three times.)</para>
+    /// </remarks>
+    private async Task<(string Against, DiffBase Kind)> ComparisonBase(
         string repoPath, string baseRef, string sha, CancellationToken ct)
     {
         var found = await launcher.RunAsync(
@@ -126,9 +142,9 @@ public sealed class ContextAssembler(IProcessLauncher launcher)
                 .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .FirstOrDefault()
             : null;
-        if (!string.IsNullOrEmpty(first))
+        if (IsCommit(first))
         {
-            return (first, DiffBase.MergeBase);
+            return (first!, DiffBase.MergeBase);
         }
 
         // A truncated checkout looks exactly like unrelated history from here, and the two want
@@ -138,8 +154,18 @@ public sealed class ContextAssembler(IProcessLauncher launcher)
             new ProcessRequest("git", ["rev-parse", "--is-shallow-repository"], repoPath), ct);
         var truncated = shallow.ExitCode == 0
             && shallow.StdOut.Trim().Equals("true", StringComparison.OrdinalIgnoreCase);
+        var kind = truncated ? DiffBase.ShallowHistory : DiffBase.NoCommonAncestor;
 
-        return (baseRef, truncated ? DiffBase.ShallowHistory : DiffBase.NoCommonAncestor);
+        var pinned = await launcher.RunAsync(
+            new ProcessRequest("git", ["rev-parse", $"{baseRef}^{{commit}}"], repoPath), ct);
+        var commit = pinned.ExitCode == 0 ? pinned.StdOut.Trim() : string.Empty;
+
+        return IsCommit(commit)
+            ? (commit, kind)
+            // Nothing names a commit here, so there is nothing to diff and nothing to pin. Refused
+            // rather than handed to git: a "ref" that begins with a dash is an option, and this is
+            // the one place a caller's own string would have reached a command line.
+            : throw new ContextException("rev-parse", $"{baseRef} names no commit in this repository");
     }
 
     private async Task<long> BlobSize(string repoPath, string sha, string baseRef, string path, CancellationToken ct)

--- a/src_mcp/runners/Context/ContextAssembler.cs
+++ b/src_mcp/runners/Context/ContextAssembler.cs
@@ -33,13 +33,37 @@ public static class DiffExclusions
 public sealed class ContextException(string operation, string detail)
     : Exception($"git {operation}: {detail}");
 
+/// <summary>Which commit a round's diff was actually taken against, and why that one.</summary>
+public enum DiffBase
+{
+    /// <summary>The common ancestor of the base and the branch — what the branch itself changed.</summary>
+    MergeBase,
+
+    /// <summary>No ancestor exists. The diff is between the two tips, so it can show the base's own
+    /// commits as deletions; nothing better is available for two unrelated histories.</summary>
+    NoCommonAncestor,
+
+    /// <summary>The history is TRUNCATED, so an ancestor cannot be found although one exists. It looks
+    /// identical to unrelated histories at the point of asking and deserves a different sentence,
+    /// because this one is a checkout that can be deepened rather than a fact about the commits.</summary>
+    ShallowHistory,
+}
+
+/// <summary>What a code round is a diff OF: the files, and the commit they were compared against.</summary>
+/// <remarks>
+/// The commit is carried out rather than left implicit inside git, because a round that names what it
+/// compared against is a round whose findings can be re-checked afterwards — and a reviewer told the
+/// branch deleted three files it never touched has no way to tell that from a real deletion.
+/// </remarks>
+public sealed record CollectedDiff(IReadOnlyList<FileDiff> Files, string ComparedAgainst, DiffBase Kind);
+
 /// <summary>
 /// Produces the per-file diffs the pure <see cref="DiffShaper"/> then budgets. All git, no rules:
 /// which files gate, what gets elided, what a reviewer reads — none of that is decided here.
 /// </summary>
 public sealed class ContextAssembler(IProcessLauncher launcher)
 {
-    public async Task<IReadOnlyList<FileDiff>> CollectAsync(
+    public async Task<CollectedDiff> CollectAsync(
         string repoPath,
         string baseRef,
         string sha,
@@ -47,10 +71,17 @@ public sealed class ContextAssembler(IProcessLauncher launcher)
         CancellationToken ct = default)
     {
         var excludes = (exclusions ?? DiffExclusions.Default).Select(e => $":(exclude,glob){e}").ToArray();
+        // The whole of this fix. `{base}..{sha}` diffs two ENDPOINTS, so every commit the base has
+        // and the branch does not arrives INVERTED — as a deletion the branch performed. Measured on
+        // 2026-09-08: 17 files and 1616 deletions sent where the branch's own change was 9 and 12,
+        // and two vendors independently filed it as Blocking. Resolved once, and used for all three
+        // git calls below — `cat-file` takes a rev rather than a range, so a three-dot form could not
+        // have reached it.
+        var (against, kind) = await BaseFor(repoPath, baseRef, sha, ct);
 
         // --numstat: "added deleted path", binaries as "- - path". One call decides binary-ness
         // and file order; each text file then rides its own diff so elision stays whole-file.
-        var numstat = await Git(repoPath, ct, ["diff", "--numstat", $"{baseRef}..{sha}", "--", ".", .. excludes]);
+        var numstat = await Git(repoPath, ct, ["diff", "--numstat", $"{against}..{sha}", "--", ".", .. excludes]);
 
         var files = new List<FileDiff>();
         foreach (var line in numstat.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
@@ -64,16 +95,51 @@ public sealed class ContextAssembler(IProcessLauncher launcher)
             var path = parts[2];
             if (parts[0] == "-")
             {
-                files.Add(new FileDiff(path, string.Empty, IsBinary: true, BinaryBytes: await BlobSize(repoPath, sha, baseRef, path, ct)));
+                files.Add(new FileDiff(path, string.Empty, IsBinary: true, BinaryBytes: await BlobSize(repoPath, sha, against, path, ct)));
             }
             else
             {
-                var text = await Git(repoPath, ct, ["diff", $"{baseRef}..{sha}", "--", path]);
+                var text = await Git(repoPath, ct, ["diff", $"{against}..{sha}", "--", path]);
                 files.Add(new FileDiff(path, text));
             }
         }
 
-        return files;
+        return new CollectedDiff(files, against, kind);
+    }
+
+    /// <summary>The commit to compare against, and what kind of answer it is.</summary>
+    /// <remarks>
+    /// A failure here is never fatal: a review that cannot be taken against the right base is worth
+    /// more than no review, so the two-dot form remains as the fallback — named, so the round says
+    /// which one it used rather than leaving somebody to wonder at the deletions.
+    /// </remarks>
+    private async Task<(string Against, DiffBase Kind)> BaseFor(
+        string repoPath, string baseRef, string sha, CancellationToken ct)
+    {
+        var found = await launcher.RunAsync(
+            new ProcessRequest("git", ["merge-base", baseRef, sha], repoPath), ct);
+        // One commit per LINE where a criss-cross history has several, and the first is the one git
+        // itself would pick. Interpolating two of them makes a range out of two commits and a
+        // newline, which is not a range at all. (gemini, the plan round.)
+        var first = found.ExitCode == 0
+            ? found.StdOut
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault()
+            : null;
+        if (!string.IsNullOrEmpty(first))
+        {
+            return (first, DiffBase.MergeBase);
+        }
+
+        // A truncated checkout looks exactly like unrelated history from here, and the two want
+        // different sentences: one is a fact about the commits, the other is a clone somebody can
+        // deepen. Asked only on the path that already failed, so an ordinary round pays nothing.
+        var shallow = await launcher.RunAsync(
+            new ProcessRequest("git", ["rev-parse", "--is-shallow-repository"], repoPath), ct);
+        var truncated = shallow.ExitCode == 0
+            && shallow.StdOut.Trim().Equals("true", StringComparison.OrdinalIgnoreCase);
+
+        return (baseRef, truncated ? DiffBase.ShallowHistory : DiffBase.NoCommonAncestor);
     }
 
     private async Task<long> BlobSize(string repoPath, string sha, string baseRef, string path, CancellationToken ct)

--- a/src_mcp/src/Server/PanelService.cs
+++ b/src_mcp/src/Server/PanelService.cs
@@ -433,7 +433,17 @@ public sealed partial class PanelService
                     // and the discrepancy is indistinguishable from the phantom deletions this whole
                     // change exists to stop.
                     $"## The change ({bundle.Branch} over {bundle.BaseRef}, at {bundle.Sha}; "
-                    + $"compared against {collected.ComparedAgainst})\n\n{bundle.Diff.Text}";
+                    + $"compared against {collected.ComparedAgainst})\n\n"
+                    // And when there is no common ancestor, the reviewer is TOLD, not left to
+                    // discover it: this is the one state in which a deletion in the diff below may
+                    // be somebody else's commit rather than anything this branch did, and a reviewer
+                    // reading it cannot tell the two apart on its own.
+                    + (collected.Kind == DiffBase.MergeBase
+                        ? string.Empty
+                        : "> The base and this branch share no common ancestor that could be found, so what follows "
+                          + "compares the two tips. Deletions in it may be commits the base has and this branch "
+                          + "never removed — weigh them accordingly.\n\n")
+                    + bundle.Diff.Text;
                 _log.Information(
                     "rules for review: {Count} file(s), {Bytes} bytes, {Omitted} omitted, {Missing} mount(s) not in the tree",
                     rules.Files.Count, rules.Bytes, rules.Omitted.Count, rules.MissingMounts.Count);

--- a/src_mcp/src/Server/PanelService.cs
+++ b/src_mcp/src/Server/PanelService.cs
@@ -396,9 +396,27 @@ public sealed partial class PanelService
         return RunStageAsync(repoPath, branch, scope, new StageRun(RoundMachine.BeginCodeRound, NeedsWorktree: true, IsPlanStage: false,
             async (session, workingDir, sha) =>
             {
-                var files = await _context.CollectAsync(repoPath, baseRef, sha, ct: ct);
-                var shaped = DiffShaper.Shape(files);
+                var collected = await _context.CollectAsync(repoPath, baseRef, sha, ct: ct);
+                var shaped = DiffShaper.Shape(collected.Files);
                 var bundle = new ReviewBundle(scope, branch, baseRef, sha, shaped);
+
+                // WHICH commit this round is a diff of, said out loud. Findings re-read a week later
+                // cannot be re-checked without it — and each fallback is worth its own sentence,
+                // because those are the states in which the base's own commits can still arrive as
+                // deletions the branch never made.
+                _log.Information(
+                    collected.Kind switch
+                    {
+                        DiffBase.MergeBase =>
+                            "diffed against the merge base {Against} of {BaseRef} and {Sha}",
+                        DiffBase.ShallowHistory =>
+                            "diffed against {Against} directly: {BaseRef} and {Sha} share no ancestor IN THIS CHECKOUT, "
+                            + "which is shallow — deepen it, or this diff can show the base's commits as deletions",
+                        _ =>
+                            "diffed against {Against} directly: {BaseRef} and {Sha} have no common ancestor, "
+                            + "so this diff can show the base's own commits as deletions",
+                    },
+                    collected.ComparedAgainst, baseRef, sha);
 
                 // The project's OWN written conventions, read from the worktree so they are the
                 // rules as of the commit under review rather than as of this afternoon. Without
@@ -409,7 +427,13 @@ public sealed partial class PanelService
                 var context =
                     $"## The plan this change implements\n\n{bundle.PlanText}\n\n" +
                     RulesSection(rules) +
-                    $"## The change ({bundle.Branch} over {bundle.BaseRef}, at {bundle.Sha})\n\n{bundle.Diff.Text}";
+                    // The resolved base is named to the REVIEWER as well as to the log. Two reviewers
+                    // asked for it on the plan round, and the reason is theirs: a reviewer that
+                    // checks the branch against the tip of `main` sees a diff that does not match,
+                    // and the discrepancy is indistinguishable from the phantom deletions this whole
+                    // change exists to stop.
+                    $"## The change ({bundle.Branch} over {bundle.BaseRef}, at {bundle.Sha}; "
+                    + $"compared against {collected.ComparedAgainst})\n\n{bundle.Diff.Text}";
                 _log.Information(
                     "rules for review: {Count} file(s), {Bytes} bytes, {Omitted} omitted, {Missing} mount(s) not in the tree",
                     rules.Files.Count, rules.Bytes, rules.Omitted.Count, rules.MissingMounts.Count);

--- a/src_mcp/tests/ContextAssemblerTests.cs
+++ b/src_mcp/tests/ContextAssemblerTests.cs
@@ -171,10 +171,28 @@ public sealed class ContextAssemblerTests : IAsyncLifetime
         var collected = await _assembler.CollectAsync(_repo, "stranger", "feature", ct: TestContext.Current.CancellationToken);
 
         collected.Kind.Should().Be(DiffBase.NoCommonAncestor, "the one case three dots cannot answer");
-        collected.ComparedAgainst.Should().Be("stranger", "the fallback compares against what it was given");
+        // A COMMIT even here. `stranger` is read three times — the numstat, each file's diff, a
+        // binary's old side — and a ref another session can advance between two of them is a review
+        // of two snapshots that nobody could reproduce from a log naming only the ref.
+        collected.ComparedAgainst.Should().MatchRegex("^[0-9a-f]{7,64}$",
+            "the fallback pins the ref to a commit rather than carrying a moving one");
         // And it is the two-dot diff, not an empty list dressed up as one: the stranger's own file is
         // absent from `feature` and shows as a deletion, which is exactly what two dots means here.
         var paths = collected.Files.Select(f => f.Path).ToList();
         paths.Should().Contain("app.cs").And.Contain("stranger.cs");
+    }
+
+    [Fact]
+    public async Task ABaseThatNamesNoCommit_IsRefusedRatherThanHandedToGit()
+    {
+        // The one place a caller's own string would have reached a command line. A "ref" beginning
+        // with a dash is an OPTION to git, and `--output=` is one that writes a file; every value
+        // that reaches a range or a `rev:path` argument is an object id by the time it gets there.
+        // (gemini, the code round.)
+        var refused = async () => await _assembler.CollectAsync(
+            _repo, "--output=owned.txt", "feature", ct: TestContext.Current.CancellationToken);
+
+        await refused.Should().ThrowAsync<ContextException>().WithMessage("*names no commit*");
+        File.Exists(Path.Combine(_repo, "owned.txt")).Should().BeFalse("git was never asked to write it");
     }
 }

--- a/src_mcp/tests/ContextAssemblerTests.cs
+++ b/src_mcp/tests/ContextAssemblerTests.cs
@@ -57,8 +57,19 @@ public sealed class ContextAssemblerTests : IAsyncLifetime
         result.ExitCode.Should().Be(0, $"git {string.Join(' ', args)}: {result.StdErr}");
     }
 
-    private Task<IReadOnlyList<FileDiff>> Collect() =>
-        _assembler.CollectAsync(_repo, "main", "feature", ct: TestContext.Current.CancellationToken);
+    private async Task<IReadOnlyList<FileDiff>> Collect() =>
+        (await _assembler.CollectAsync(_repo, "main", "feature", ct: TestContext.Current.CancellationToken)).Files;
+
+    /// <summary>Move `main` on, the way another session merging its own pull request does.</summary>
+    private async Task MoveTheBase()
+    {
+        await Git("checkout", "main");
+        await File.WriteAllTextAsync(Path.Combine(_repo, "somebody-elses.cs"), "merged while you worked\n");
+        await File.WriteAllBytesAsync(Path.Combine(_repo, "theirs.png"), [9, 9, 9, 0, 255, 0, 1, 2, 3]);
+        await Git("add", ".");
+        await Git("commit", "-m", "another session merged its own PR");
+        await Git("checkout", "feature");
+    }
 
     [Fact]
     public async Task LockFilesAndBuildOutput_NeverReachTheDiff()
@@ -98,5 +109,72 @@ public sealed class ContextAssemblerTests : IAsyncLifetime
 
         shaped.Text.Should().Contain("real change");
         shaped.WasElided.Should().BeFalse();
+    }
+
+    /// <remarks>
+    /// 2026-09-08, measured: a round reported three Blocking findings from two vendors saying the
+    /// branch had deleted three files and reverted a version. It had not — `main` had moved under
+    /// it, and `A..B` shows the commits the base has and the branch does not as DELETIONS the branch
+    /// performed. 17 files and 1616 deletions were sent where the branch's own change was 9 files
+    /// and 12. It has happened three times.
+    /// </remarks>
+    [Fact]
+    public async Task AChangeIsDiffedAgainstTheMergeBase_NotTheTipOfMain()
+    {
+        await MoveTheBase();
+
+        var collected = await _assembler.CollectAsync(_repo, "main", "feature", ct: TestContext.Current.CancellationToken);
+
+        collected.Files.Select(f => f.Path).Should().NotContain("somebody-elses.cs",
+            "a file another session merged into the base is not something this branch did");
+        collected.Files.Select(f => f.Path).Should().Contain("app.cs", "the branch's own change is still there");
+        collected.Kind.Should().Be(DiffBase.MergeBase);
+        collected.ComparedAgainst.Should().NotBe("main", "the round can only be re-checked if it names the commit");
+    }
+
+    [Fact]
+    public async Task ABinaryIsSizedAgainstTheMergeBase_NotTheMovedTip()
+    {
+        // `cat-file` takes a rev, not a range, so this call site cannot be fixed by three dots — it
+        // needs the resolved commit, and without it the OLD side of a binary is read from a commit
+        // somebody else made.
+        await MoveTheBase();
+
+        var collected = await _assembler.CollectAsync(_repo, "main", "feature", ct: TestContext.Current.CancellationToken);
+
+        collected.Files.Select(f => f.Path).Should().NotContain("theirs.png");
+        var mine = collected.Files.Should().ContainSingle(f => f.Path == "logo.png").Subject;
+        mine.BinaryBytes.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task AReviewOfOneCommit_IsStillItsOwnDiff()
+    {
+        // The documented usage: pass the commit as the branch and its parent as the base. The parent
+        // IS the merge base, so nothing about this changes — which is the point of asserting it.
+        var collected = await _assembler.CollectAsync(_repo, "feature~1", "feature", ct: TestContext.Current.CancellationToken);
+
+        collected.Files.Select(f => f.Path).Should().Contain("app.cs");
+        collected.Kind.Should().Be(DiffBase.MergeBase);
+    }
+
+    [Fact]
+    public async Task UnrelatedHistoriesFallBackAndSaySo()
+    {
+        await Git("checkout", "--orphan", "stranger");
+        await Git("rm", "-rf", ".");
+        await File.WriteAllTextAsync(Path.Combine(_repo, "stranger.cs"), "no ancestor at all\n");
+        await Git("add", ".");
+        await Git("commit", "-m", "a history of its own");
+        await Git("checkout", "feature");
+
+        var collected = await _assembler.CollectAsync(_repo, "stranger", "feature", ct: TestContext.Current.CancellationToken);
+
+        collected.Kind.Should().Be(DiffBase.NoCommonAncestor, "the one case three dots cannot answer");
+        collected.ComparedAgainst.Should().Be("stranger", "the fallback compares against what it was given");
+        // And it is the two-dot diff, not an empty list dressed up as one: the stranger's own file is
+        // absent from `feature` and shows as a deletion, which is exactly what two dots means here.
+        var paths = collected.Files.Select(f => f.Path).ToList();
+        paths.Should().Contain("app.cs").And.Contain("stranger.cs");
     }
 }

--- a/src_mcp/tests/EndToEndTests.cs
+++ b/src_mcp/tests/EndToEndTests.cs
@@ -183,6 +183,13 @@ public sealed class EndToEndTests : IAsyncLifetime
         // from a token total in the ledger.
         lines().Should().ContainMatch("context for review: diff * bytes over * file(s), * elided; plan * bytes; rules * bytes");
 
+        // And WHICH commit it is a diff of. Asserted here rather than only on `ContextAssembler`,
+        // because the value crossing that seam is exactly what could go on being logged as the ref
+        // the caller named while the diff was taken against something else — which is the state
+        // three rounds were reviewed in before anybody noticed. (codex, the plan round.)
+        lines().Should().ContainMatch("diffed against the merge base * of main and *",
+            "a round that does not name what it compared against is a round nobody can re-check");
+
         // What each reviewer RECEIVED. The two are the same number only while nothing between them
         // is broken, and that is precisely what could not be established.
         lines().Should().ContainMatch("*opening: 6 reviewer(s)*bytes]*");


### PR DESCRIPTION
On 2026-09-08 a code round produced **three Blocking findings, from two different vendors**, saying
the branch had deleted `chatPrompt.ts`, `processLauncher.ts` and `sessionKey.ts` and reverted the
extension a version. codex wrote: *"Installing the extension produced from this release therefore
removes unrelated user-facing features."* gemini asked for the pull request to be split.

None of it was true. The branch had been cut from `origin/main`, and while the work was in progress
another session merged its own pull request.

`A..B` diffs two **endpoints**, so every commit the base has and the branch does not arrives
**inverted** — as a deletion the branch performed. Measured on that branch at that moment:

| | files | insertions | deletions |
|---|---|---|---|
| `origin/main..HEAD` — what the gate sent | 17 | 239 | **1616** |
| `origin/main...HEAD` — the branch's own change | 9 | 988 | 12 |

It has happened three times. Several agents work in this repository at once, so a base that moves
during a review is the normal case rather than the exception — and a reviewer cannot tell a phantom
deletion from a real one, because the diff says the line was removed.

## The merge base is resolved once, and used for all three git calls

Not the three-dot form the plan proposed. That is the same diff, but it leaves the resolved commit
inside git where nothing can name it — and there is **no three-dot form of `cat-file -s`**, which is
how a binary's old side is sized. The draft plan counted two call sites; there are three, and that
one would have gone on reading a blob from somebody else's commit.

`CollectedDiff` carries the commit out, so the round says what it compared against in its log and in
the reviewer's own header. When there is no merge base the two-dot form remains, with a sentence
saying so — and the two reasons are told apart, because `git merge-base` cannot: histories that
genuinely share no ancestor, and a **shallow** checkout where one exists and has not been fetched.
The second is a clone somebody can deepen. That case came from the plan round and would have
reintroduced the whole defect silently on a repository whose histories do meet.

## What the code round then found — the same defect one layer down

On the fallback path the base stayed a **ref**. `origin/main` is read three times, and another
session advancing it between two of them produces a review of two different snapshots that nobody
could reproduce from a log naming only the ref. Three reviewers said it independently. The fallback
resolves the ref to a commit now, so every path pins one.

That also closes the **argument injection** two reviewers named: every value reaching a `{x}..{sha}`
range or a `{x}:{path}` argument is an object id by construction, asserted by `IsCommit`. A "ref"
beginning with a dash is an OPTION to git, and `--output=` is one that writes a file — there is a
test that watches `--output=owned.txt` fail to produce one.

A reviewer is now **told** when the diff is tip-to-tip, in the diff's own header rather than only in
our log: that is the one state in which a deletion below may be somebody else's commit.

## Evidence

- **RED watched by restoring the two-dot form**: the branch's diff carried `somebody-elses.cs` and
  `theirs.png`, both committed to the base after the branch was cut. Green with the fix.
- Nine tests: the moved base, a binary sized against it, a single-commit review, unrelated histories
  (asserting the files it DID return), the injection refusal — plus the audit line, asserted end to
  end in `EndToEndTests`, because the value crossing that seam is exactly what could go on being
  logged as the ref the caller named.
- Whole C# suite: **1134 pass, 1 skipped, 0 fail**. `plan-lifecycle.mjs` clean; `pin-check.mjs` OK.
- The sequence diagram in `module_runners.md` is re-rendered and checked: balanced `alt`/`end`, no
  braces inside a message, every participant declared.

## The gate

Plan round `proceed` — 3 reviewers, 9 findings, 8 accepted (the shallow case, the criss-cross first
line, the end-to-end audit assertion and the header among them), 1 rejected. Code round
`good_enough` — 12 reviewers, 23 findings, 9 accepted, 14 rejected with reasons.

Worth naming among the rejections: a claimed trailing newline in the sha (the split already carries
`TrimEntries`), a null path the finding's own text works out is handled, and a demand to batch the
per-file `git diff`. That last one is real and pre-existing but **load-bearing** — each text file
rides its own diff so elision stays whole-file — and is recorded as an open tail rather than
smuggled into a change about a base ref.

## Not verified here

No TypeScript file is in this diff, so the extension suite is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)