### PR TITLE
fix(gate): a role the round did not ask for is named where the AI can read it

### DIFF
--- a/research/module_server.md
+++ b/research/module_server.md
@@ -445,7 +445,25 @@ not asked*, never *could not run*.
 The list is DERIVED from the difference between the scheduled roles and the ones that survived the
 filter, so the sentence a caller reads and the roles a round actually ran cannot disagree; and the
 reason is one `const` that both the log line and the clause are built from, so one decision cannot
-come to be described in two ways. `StageRun.MakeWork` returns `RoundWork(Reviewers, NotAsked)` rather
+come to be described in two ways.
+
+**Each omitted role carries the reason ITS OWN rule gave it**, and that is the code round's finding.
+Mapping the difference onto a single reason works while there is one rule and tells the caller the
+wrong thing with complete confidence the day there are two: a role dropped for some future cause
+would be reported as having no rules to judge against. `RolesNotAsked` sits beside
+`RolesWithRulesInMind` for that reason — a second rule adds a reason there, next to the filter that
+produces it, rather than inheriting one from a mapping somewhere else.
+
+**And a round whose whole roster was filtered out says so in its refusal.** That path returns before
+any summary exists, so it would otherwise be refused with a sentence about vendors — sending somebody
+to check a configuration that is perfectly correct. Raised twice on the code round.
+
+**The role travels as a string, and that is the ring, not laziness.** Three reviewers asked for
+`ReviewRole` instead, quoting the rule against primitive obsession. `ReviewRole` lives in
+`CoaiMcp.Runners`; `ReviewerSummary` lives in `CoaiMcp.Core`, which references NOTHING — that purity
+is itself held by a test. `Failures` carries `provider/Role: reason` as a string for the same reason,
+and moving the enum across the ring to type one field would be a larger change than this one, in the
+opposite direction to the architecture. `StageRun.MakeWork` returns `RoundWork(Reviewers, NotAsked)` rather
 than a bare list, because the decision is made where the roles are chosen and the sentence is written
 where the round ends, and nothing carried the fact across that gap before.
 

--- a/research/module_server.md
+++ b/research/module_server.md
@@ -418,6 +418,41 @@ first is an EXECUTION rule only: `providers` and the panel's badge report every 
 whatever stage is running, so a credential defect on a code-only vendor is visible during a plan
 round, on its card.
 
+### A role nobody asked for is a third thing again (2026-09-10)
+
+There are now three ways a round can be smaller than the roster suggests, and each says so in its own
+words because each has a different cure.
+
+| | decided | reads as | cure |
+|---|---|---|---|
+| `Failures` | after the launch | a problem with the run | look at the vendor |
+| `Excluded` | before the roster, from `CanRun` | a problem with the configuration | fix the credential or the runtime |
+| `NotAsked` | before the roster, from the REPOSITORY | **not a problem at all** | write some rules, or nothing |
+
+A code round in a repository with no written rules drops its **Conventions** reviewers — correctly,
+because a conventions pass with nothing to judge against would invent a standard. Until 2026-09-10
+the only place that was said was the server's own log, so the AI that called the gate was handed a
+thinner round and no sentence explaining it. Three roles instead of four reads as a failure, or is
+not noticed at all.
+
+`ReviewerSummary.NotAsked` carries `SkippedRole(Role, Reason)` — STRUCTURED, not a finished clause,
+so a caller parsing the summary gets a role it can name and the punctuation is decided once, beside
+the clauses it sits next to. `Sentence` appends it LAST of the three additions, and the order carries
+meaning: a deadline explains the failures, the failures explain the count, and what was never asked
+for is last because it is the only one of the three that is not a problem. Its verb is its own — *was
+not asked*, never *could not run*.
+
+The list is DERIVED from the difference between the scheduled roles and the ones that survived the
+filter, so the sentence a caller reads and the roles a round actually ran cannot disagree; and the
+reason is one `const` that both the log line and the clause are built from, so one decision cannot
+come to be described in two ways. `StageRun.MakeWork` returns `RoundWork(Reviewers, NotAsked)` rather
+than a bare list, because the decision is made where the roles are chosen and the sentence is written
+where the round ends, and nothing carried the fact across that gap before.
+
+The end-to-end fixture is exactly this case — a repository with no rule files — so the journey is
+asserted where it actually happens, including on a round that ALSO failed: a failure must not swallow
+the skip, which is the one path an implementation written for the happy case would have lost.
+
 `RunStageAsync` gained an explicit `isPlanStage` rather than deriving it from `needsWorktree`. That
 derivation happens to be right today, and this file already records what deriving the stage cost
 twice — `planPrompts is { Count: > 0 }` is empty on an ordinary plan round, and reading the roles

--- a/src_mcp/core/Rounds/SessionState.cs
+++ b/src_mcp/core/Rounds/SessionState.cs
@@ -165,17 +165,6 @@ public enum Stage
     Done,
 }
 
-/// <summary>
-/// How many reviewers were asked, how many answered — and who was never asked at all.
-/// </summary>
-/// <param name="Excluded">
-/// Reviewers the operator ENABLED for this stage that the round could not run, each as
-/// <c>name: reason</c>. Empty on almost every round, and the reason it exists is the one where it is
-/// not: a reviewer that is asked and fails has always been reported honestly, and one that never
-/// entered the roster was reported by nothing at all. On 2026-09-07 that made a Team-server reviewer
-/// invisible for a day — the log said "4 enabled" and "3 reviewer(s)" eleven seconds apart, and the
-/// verdict said "all 3 reviewers answered", which was true about what it asked.
-/// </param>
 /// <summary>A role the round decided not to ask for, and why.</summary>
 /// <remarks>
 /// <para>Structured rather than a finished sentence, which the plan round asked for: a caller parsing
@@ -189,6 +178,17 @@ public enum Stage
 /// </remarks>
 public sealed record SkippedRole(string Role, string Reason);
 
+/// <summary>
+/// How many reviewers were asked, how many answered — and who was never asked at all.
+/// </summary>
+/// <param name="Excluded">
+/// Reviewers the operator ENABLED for this stage that the round could not run, each as
+/// <c>name: reason</c>. Empty on almost every round, and the reason it exists is the one where it is
+/// not: a reviewer that is asked and fails has always been reported honestly, and one that never
+/// entered the roster was reported by nothing at all. On 2026-09-07 that made a Team-server reviewer
+/// invisible for a day — the log said "4 enabled" and "3 reviewer(s)" eleven seconds apart, and the
+/// verdict said "all 3 reviewers answered", which was true about what it asked.
+/// </param>
 public sealed record ReviewerSummary(
     int Asked,
     int Answered,

--- a/src_mcp/core/Rounds/SessionState.cs
+++ b/src_mcp/core/Rounds/SessionState.cs
@@ -176,11 +176,25 @@ public enum Stage
 /// invisible for a day — the log said "4 enabled" and "3 reviewer(s)" eleven seconds apart, and the
 /// verdict said "all 3 reviewers answered", which was true about what it asked.
 /// </param>
+/// <summary>A role the round decided not to ask for, and why.</summary>
+/// <remarks>
+/// <para>Structured rather than a finished sentence, which the plan round asked for: a caller parsing
+/// a summary gets a role it can name, the punctuation of the clause is decided in one place beside
+/// the clauses it sits next to, and a second reason one day is a second VALUE rather than a second
+/// way of writing a sentence.</para>
+/// <para>NOT a failure, and the wording must never let it read as one. A reviewer that could not run
+/// is a problem — something was enabled and the round could not deliver it. A role that was not asked
+/// is a DECISION this gate made, with a reason; reporting the two in the same words would teach a
+/// caller to treat a correct round as a degraded one.</para>
+/// </remarks>
+public sealed record SkippedRole(string Role, string Reason);
+
 public sealed record ReviewerSummary(
     int Asked,
     int Answered,
     ImmutableArray<string> Failures,
-    ImmutableArray<string> Excluded = default)
+    ImmutableArray<string> Excluded = default,
+    ImmutableArray<SkippedRole> NotAsked = default)
 {
     public static ReviewerSummary AllAnswered(int asked) => new(asked, asked, []);
 
@@ -215,16 +229,25 @@ public sealed record ReviewerSummary(
                 ? $"{answered}; the round reached its {limit.TotalMinutes:0} minute limit "
                   + "and the reviewers still running were cancelled"
                 : answered;
+            // No early return here any more: a round can skip a role while excluding nobody, and the
+            // clause below has to be reachable in that case — which is the ordinary one.
             var left = Excluded.IsDefaultOrEmpty ? [] : Excluded;
-            if (left.Length == 0)
-            {
-                return withDeadline;
-            }
-
             var plural = left.Length == 1 ? string.Empty : "s";
+            var withExcluded = left.Length == 0
+                ? withDeadline
+                : $"{withDeadline}; {left.Length} enabled reviewer{plural} "
+                  + $"could not run: {string.Join("; ", left)}";
 
-            return $"{withDeadline}; {left.Length} enabled reviewer{plural} "
-                + $"could not run: {string.Join("; ", left)}";
+            // LAST of the three additions, and the order carries meaning: a deadline explains the
+            // failures, the failures explain the count, and what was never asked for is last because
+            // it is the only one of the three that is not a problem. Its own verb, too — "not asked"
+            // and never "could not run", so a correct round cannot read as a degraded one.
+            var skipped = NotAsked.IsDefaultOrEmpty ? [] : NotAsked;
+
+            return skipped.Length == 0
+                ? withExcluded
+                : $"{withExcluded}; "
+                  + string.Join("; ", skipped.Select(s => $"{s.Role} was not asked: {s.Reason}"));
         }
     }
 }

--- a/src_mcp/runners/Reviewers/BoundedScheduler.cs
+++ b/src_mcp/runners/Reviewers/BoundedScheduler.cs
@@ -456,16 +456,23 @@ public static class ReviewerSummaryFactory
     /// empty is the ordinary case — but a round that leaves one out and says nothing is how a
     /// Team-server reviewer stayed invisible for a day.
     /// </param>
+    /// <param name="notAsked">
+    /// Roles the round decided not to ask for at all, each with its reason. Empty on almost every
+    /// round; the one where it is not is a repository with no written rules, whose Conventions
+    /// reviewers are dropped correctly and used to be mentioned only in the server's own log.
+    /// </param>
     public static ReviewerSummary From(
         IReadOnlyList<(ReviewerInvocation Invocation, ReviewerOutcome Outcome)> results,
-        IReadOnlyList<string>? excluded = null) =>
+        IReadOnlyList<string>? excluded = null,
+        IReadOnlyList<SkippedRole>? notAsked = null) =>
         new(
             results.Count,
             results.Count(r => r.Outcome is ReviewerOutcome.Ok),
             [.. results
                 .Where(r => r.Outcome is not ReviewerOutcome.Ok)
                 .Select(r => $"{r.Invocation.Provider}/{r.Invocation.Role}: {Describe(r.Outcome)}")],
-            [.. excluded ?? []]);
+            [.. excluded ?? []],
+            [.. notAsked ?? []]);
 
     public static string Describe(ReviewerOutcome outcome) => outcome switch
     {

--- a/src_mcp/runners/Reviewers/BoundedScheduler.cs
+++ b/src_mcp/runners/Reviewers/BoundedScheduler.cs
@@ -461,10 +461,22 @@ public static class ReviewerSummaryFactory
     /// round; the one where it is not is a repository with no written rules, whose Conventions
     /// reviewers are dropped correctly and used to be mentioned only in the server's own log.
     /// </param>
+    /// <summary>A round that skipped no role, which is every plan round and most code rounds.</summary>
+    /// <remarks>
+    /// An overload rather than a defaulted parameter, because C# cannot default one to `[]` and this
+    /// repository's rule is that an absent value is an EMPTY value and never a null. `excluded`
+    /// keeps its own null default: it predates the rule and widening it belongs to a change about
+    /// exclusions, not to one about skipped roles.
+    /// </remarks>
     public static ReviewerSummary From(
         IReadOnlyList<(ReviewerInvocation Invocation, ReviewerOutcome Outcome)> results,
-        IReadOnlyList<string>? excluded = null,
-        IReadOnlyList<SkippedRole>? notAsked = null) =>
+        IReadOnlyList<string>? excluded = null) =>
+        From(results, excluded, []);
+
+    public static ReviewerSummary From(
+        IReadOnlyList<(ReviewerInvocation Invocation, ReviewerOutcome Outcome)> results,
+        IReadOnlyList<string>? excluded,
+        IReadOnlyList<SkippedRole> notAsked) =>
         new(
             results.Count,
             results.Count(r => r.Outcome is ReviewerOutcome.Ok),
@@ -472,7 +484,7 @@ public static class ReviewerSummaryFactory
                 .Where(r => r.Outcome is not ReviewerOutcome.Ok)
                 .Select(r => $"{r.Invocation.Provider}/{r.Invocation.Role}: {Describe(r.Outcome)}")],
             [.. excluded ?? []],
-            [.. notAsked ?? []]);
+            [.. notAsked]);
 
     public static string Describe(ReviewerOutcome outcome) => outcome switch
     {

--- a/src_mcp/src/Server/PanelService.cs
+++ b/src_mcp/src/Server/PanelService.cs
@@ -345,13 +345,14 @@ public sealed partial class PanelService
 
                 // A plan round skips no role: it has one, and there is nothing for a rule file to
                 // decide about it.
-                return Task.FromResult(RoundWork.Of(
+                return Task.FromResult(new RoundWork(
                     BuildWork([ReviewRole.PlanCritique], workingDir, $"## The plan under review\n\n{planText}",
                         session.State.RoundsRunThisStage + 1,
                         isPlanStage: true,
                         seed: StableSeed(session.State.SessionId, session.State.RoundsRunThisStage + 1),
                         planPrompts: _settings.DealPlanLenses ? UnspentPlanLenses(session) : null,
-                        deal: _settings.DealPlanLenses)));
+                        deal: _settings.DealPlanLenses),
+                    []));
             }),
             ct);
 
@@ -476,14 +477,9 @@ public sealed partial class PanelService
                     .ToList();
 
                 var roles = RolesWithRulesInMind(scheduled, rules.HasRules);
-                // DERIVED from the two lists rather than written down beside the filter: the skipped
-                // roles are the difference by construction, so the sentence a caller reads and the
-                // roles a round actually ran cannot disagree — which is what the plan round asked
-                // for, twice. `Where` rather than `Except`, to keep the scheduled order.
-                var notAsked = scheduled
-                    .Where(r => !roles.Contains(r))
-                    .Select(r => new SkippedRole(r.ToString(), NoWrittenRules))
-                    .ToList();
+                // Each with the reason its own rule gives it — see `RolesNotAsked`, which is where a
+                // second rule would put a second reason rather than inheriting this one.
+                var notAsked = RolesNotAsked(scheduled, rules.HasRules);
                 if (notAsked.Count > 0)
                 {
                     _log.Warning(
@@ -631,8 +627,8 @@ public sealed partial class PanelService
                 : null;
             using var scratch = stage.NeedsWorktree ? null : new ScratchDirectory();
             var workingDir = lease?.Path ?? scratch!.Path;
-            var built = await stage.MakeWork(session, workingDir, sha);
-            var work = built.Reviewers;
+            var roundWork = await stage.MakeWork(session, workingDir, sha);
+            var work = roundWork.Reviewers;
 
             // A stage nobody serves is a REFUSAL, not an empty round. With no reviewer the round
             // runs nothing, merges nothing, and passes the gate — reporting `proceed` having
@@ -640,11 +636,23 @@ public sealed partial class PanelService
             // reachable on purpose: a vendor can be set to review plans and not code.
             if (work.Count == 0)
             {
+                // And if a role was dropped on the way here, the refusal says which and why. This
+                // path returns before any summary is built, so a round whose whole roster was
+                // filtered out would otherwise be refused with a sentence about vendors — sending
+                // somebody to check a configuration that is perfectly correct. (codex, the code
+                // round, twice.)
+                var whyThinner = roundWork.NotAsked.Count == 0
+                    ? string.Empty
+                    : " Before that, "
+                      + string.Join("; ", roundWork.NotAsked.Select(r => $"{r.Role} was not asked: {r.Reason}"))
+                      + ".";
+
                 return Error(
                     $"no reviewer serves the {session.State.Stage} stage — every configured vendor is "
                     + "either disabled, set not to review this stage, or missing its CLI or key. A round "
                     + "with no reviewer would pass the gate having reviewed nothing, so it is refused. "
-                    + "Tick a vendor's stage box in the panel, or enable one that can run.");
+                    + "Tick a vendor's stage box in the panel, or enable one that can run."
+                    + whyThinner);
             }
 
             // The round exists on disk BEFORE the first CLI starts: the panel shows "running" for
@@ -684,7 +692,7 @@ public sealed partial class PanelService
             // the caller's own token did not. Inferring it from cancelled reviewers would have called
             // it a deadline the moment a PERSON cancelled a round, which is a different sentence and
             // a wrong one.
-            var summary = ReviewerSummaryFactory.From(results, excluded, built.NotAsked) with
+            var summary = ReviewerSummaryFactory.From(results, excluded, roundWork.NotAsked) with
             {
                 // Read from the TIMER, and only when the caller did not also cancel. A person who
                 // cancels at the moment the deadline strikes is reported as a person: the round was
@@ -1191,12 +1199,33 @@ public sealed partial class PanelService
     /// after noticing they were about to be written twice.
     /// </remarks>
     internal const string NoWrittenRules =
-        "this repository has no written rules for them to judge against";
+        "this repository has no written rules to judge against";
 
     internal static IReadOnlyList<ReviewRole> RolesWithRulesInMind(
         IReadOnlyList<ReviewRole> scheduled,
         bool hasRules) =>
         hasRules ? scheduled : [.. scheduled.Where(r => r != ReviewRole.Conventions)];
+
+    /// <summary>The roles this round will not ask for, each carrying ITS OWN reason.</summary>
+    /// <remarks>
+    /// <para>Paired with the filter above rather than mapped over its output, and the code round is
+    /// why: taking the difference and giving every omitted role <see cref="NoWrittenRules"/> means
+    /// that the day a second filter drops a role for some other cause, the caller is told the wrong
+    /// thing with complete confidence. A second reason belongs HERE, beside the rule that produces
+    /// it.</para>
+    /// <para>Still DERIVED from the difference, so the sentence a caller reads and the roles a round
+    /// actually ran cannot disagree — a list written out by hand could.</para>
+    /// </remarks>
+    internal static IReadOnlyList<SkippedRole> RolesNotAsked(
+        IReadOnlyList<ReviewRole> scheduled,
+        bool hasRules)
+    {
+        var kept = RolesWithRulesInMind(scheduled, hasRules);
+
+        return [.. scheduled
+            .Where(r => !kept.Contains(r))
+            .Select(r => new SkippedRole(r.ToString(), NoWrittenRules))];
+    }
 
     /// <summary>
     /// How long this round may take: what was configured, or what its shape earns.
@@ -1664,10 +1693,7 @@ public sealed partial class PanelService
 internal sealed record RoundWork(
     IReadOnlyList<ReviewerWork> Reviewers,
     IReadOnlyList<SkippedRole> NotAsked)
-{
-    /// <summary>A round that skipped nothing, which is every plan round and most code rounds.</summary>
-    public static RoundWork Of(IReadOnlyList<ReviewerWork> reviewers) => new(reviewers, []);
-}
+;
 
 internal sealed record StageRun(
     Func<SessionState, Transition> Begin,

--- a/src_mcp/src/Server/PanelService.cs
+++ b/src_mcp/src/Server/PanelService.cs
@@ -343,13 +343,15 @@ public sealed partial class PanelService
                     "context for review: plan {PlanBytes} bytes; no diff and no rules at this stage",
                     System.Text.Encoding.UTF8.GetByteCount(planText));
 
-                return Task.FromResult<IReadOnlyList<ReviewerWork>>(
+                // A plan round skips no role: it has one, and there is nothing for a rule file to
+                // decide about it.
+                return Task.FromResult(RoundWork.Of(
                     BuildWork([ReviewRole.PlanCritique], workingDir, $"## The plan under review\n\n{planText}",
                         session.State.RoundsRunThisStage + 1,
                         isPlanStage: true,
                         seed: StableSeed(session.State.SessionId, session.State.RoundsRunThisStage + 1),
                         planPrompts: _settings.DealPlanLenses ? UnspentPlanLenses(session) : null,
-                        deal: _settings.DealPlanLenses));
+                        deal: _settings.DealPlanLenses)));
             }),
             ct);
 
@@ -474,17 +476,26 @@ public sealed partial class PanelService
                     .ToList();
 
                 var roles = RolesWithRulesInMind(scheduled, rules.HasRules);
-                if (roles.Count != scheduled.Count)
+                // DERIVED from the two lists rather than written down beside the filter: the skipped
+                // roles are the difference by construction, so the sentence a caller reads and the
+                // roles a round actually ran cannot disagree — which is what the plan round asked
+                // for, twice. `Where` rather than `Except`, to keep the scheduled order.
+                var notAsked = scheduled
+                    .Where(r => !roles.Contains(r))
+                    .Select(r => new SkippedRole(r.ToString(), NoWrittenRules))
+                    .ToList();
+                if (notAsked.Count > 0)
                 {
                     _log.Warning(
-                        "round {Round}: the Conventions reviewers are skipped — this repository has no "
-                        + "written rules for them to judge against ({Sources})",
-                        round, string.Join(", ", RuleFiles.SourceNames));
+                        "round {Round}: the Conventions reviewers are skipped — {Reason} ({Sources})",
+                        round, NoWrittenRules, string.Join(", ", RuleFiles.SourceNames));
                 }
                 _log.Information("round {Round} runs {Count} role(s): {Roles}", round, roles.Count, string.Join(", ", roles));
-                return BuildWork(roles, workingDir, context, round, isPlanStage: false,
-                    seed: StableSeed(session.State.SessionId, round),
-                    deal: _settings.DealCodeLenses);
+                return new RoundWork(
+                    BuildWork(roles, workingDir, context, round, isPlanStage: false,
+                        seed: StableSeed(session.State.SessionId, round),
+                        deal: _settings.DealCodeLenses),
+                    notAsked);
             }),
             ct);
     }
@@ -620,7 +631,8 @@ public sealed partial class PanelService
                 : null;
             using var scratch = stage.NeedsWorktree ? null : new ScratchDirectory();
             var workingDir = lease?.Path ?? scratch!.Path;
-            var work = await stage.MakeWork(session, workingDir, sha);
+            var built = await stage.MakeWork(session, workingDir, sha);
+            var work = built.Reviewers;
 
             // A stage nobody serves is a REFUSAL, not an empty round. With no reviewer the round
             // runs nothing, merges nothing, and passes the gate — reporting `proceed` having
@@ -672,7 +684,7 @@ public sealed partial class PanelService
             // the caller's own token did not. Inferring it from cancelled reviewers would have called
             // it a deadline the moment a PERSON cancelled a round, which is a different sentence and
             // a wrong one.
-            var summary = ReviewerSummaryFactory.From(results, excluded) with
+            var summary = ReviewerSummaryFactory.From(results, excluded, built.NotAsked) with
             {
                 // Read from the TIMER, and only when the caller did not also cancel. A person who
                 // cancels at the moment the deadline strikes is reported as a person: the round was
@@ -1172,6 +1184,15 @@ public sealed partial class PanelService
     /// session, a checkout and a git repository. A function is the answer to both.</para>
     /// <para>Derived rather than removed, so nothing observes a list changing under it.</para>
     /// </remarks>
+    /// <summary>Why the Conventions reviewers are dropped, in the one place both readers of it look.</summary>
+    /// <remarks>
+    /// The server's own log line and the sentence the calling AI receives are built from THIS string,
+    /// so the two cannot come to describe one decision in two ways — which the plan round asked for
+    /// after noticing they were about to be written twice.
+    /// </remarks>
+    internal const string NoWrittenRules =
+        "this repository has no written rules for them to judge against";
+
     internal static IReadOnlyList<ReviewRole> RolesWithRulesInMind(
         IReadOnlyList<ReviewRole> scheduled,
         bool hasRules) =>
@@ -1634,8 +1655,22 @@ public sealed partial class PanelService
 /// { Count: &gt; 0 }</c> is empty on an ordinary plan round, and reading the ROLES works only because
 /// no code round happens to carry <c>PlanCritique</c>.</para>
 /// </remarks>
+/// <summary>What a round will run, and any role it decided not to ask for.</summary>
+/// <remarks>
+/// The two travel together because the decision is made where the roles are chosen and the sentence
+/// is written where the round ends, and nothing carried the fact across the gap before — which is
+/// how a dropped role reached the server's log and never the caller.
+/// </remarks>
+internal sealed record RoundWork(
+    IReadOnlyList<ReviewerWork> Reviewers,
+    IReadOnlyList<SkippedRole> NotAsked)
+{
+    /// <summary>A round that skipped nothing, which is every plan round and most code rounds.</summary>
+    public static RoundWork Of(IReadOnlyList<ReviewerWork> reviewers) => new(reviewers, []);
+}
+
 internal sealed record StageRun(
     Func<SessionState, Transition> Begin,
     bool NeedsWorktree,
     bool IsPlanStage,
-    Func<PersistedSession, string, string, Task<IReadOnlyList<ReviewerWork>>> MakeWork);
+    Func<PersistedSession, string, string, Task<RoundWork>> MakeWork);

--- a/src_mcp/tests/ConventionsPassTests.cs
+++ b/src_mcp/tests/ConventionsPassTests.cs
@@ -172,4 +172,66 @@ public sealed class ConventionsPassTests
         PromptCatalog.ForRound(PromptCatalog.PlanRole, 1, NoChoice)
             .Id.Should().Be("plan-critique");
     }
+
+    /// <remarks>
+    /// The open tail of the conventions-is-its-own-role plan. A round in a repository with no written
+    /// rules drops its Conventions reviewers — correctly, because a conventions pass with nothing to
+    /// judge against would invent a standard — and the ONLY place that was said was the server's own
+    /// log. The AI that called the gate was handed a thinner round and no sentence saying why.
+    /// </remarks>
+    [Fact]
+    public void ARoundThatSkippedARole_SaysSoToTheCaller()
+    {
+        var summary = ReviewerSummary.AllAnswered(3) with
+        {
+            NotAsked = [new SkippedRole("Conventions", "this repository has no written rules for it to judge against")],
+        };
+
+        summary.Sentence.Should().Contain("Conventions")
+            .And.Contain("not asked")
+            .And.Contain("no written rules");
+    }
+
+    [Fact]
+    public void ASkippedRole_DoesNotReadAsAFailure()
+    {
+        // A reviewer that could not run is a problem; a role nobody asked for is a decision. Reported
+        // in the same words, a correct round reads as a degraded one.
+        var summary = ReviewerSummary.AllAnswered(3) with
+        {
+            NotAsked = [new SkippedRole("Conventions", "this repository has no written rules for it to judge against")],
+        };
+
+        summary.Sentence.Should().StartWith("all 3 reviewers answered");
+        summary.Sentence.Should().NotContain("could not run");
+        summary.Sentence.Should().NotContain("failed");
+    }
+
+    [Fact]
+    public void ARoundThatSkippedNothing_ReadsExactlyAsItAlwaysDid()
+    {
+        // This file's own rule, as an assertion: an addition for the rare round must not change the
+        // sentence of every ordinary one.
+        ReviewerSummary.AllAnswered(4).Sentence.Should().Be("all 4 reviewers answered");
+        new ReviewerSummary(4, 3, ["codex/Architecture: timeout"]).Sentence
+            .Should().Be("4 reviewers answered; failed: codex/Architecture: timeout".Replace("4 reviewers", "3 of 4 reviewers"));
+    }
+
+    [Fact]
+    public void EveryClauseAtOnce_KeepsItsOrder_WithTheSkipLast()
+    {
+        // A deadline explains the failures, the failures explain the count, and what was never asked
+        // for is last because it is the only one of the three that is not a problem.
+        var summary = new ReviewerSummary(4, 2, ["codex/Architecture: timeout"], ["gemini/Conventions: no key"])
+        {
+            EndedByDeadline = TimeSpan.FromMinutes(10),
+            NotAsked = [new SkippedRole("Conventions", "this repository has no written rules for it to judge against")],
+        };
+
+        summary.Sentence.Should().Be(
+            "2 of 4 reviewers answered; failed: codex/Architecture: timeout; "
+            + "the round reached its 10 minute limit and the reviewers still running were cancelled; "
+            + "1 enabled reviewer could not run: gemini/Conventions: no key; "
+            + "Conventions was not asked: this repository has no written rules for it to judge against");
+    }
 }

--- a/src_mcp/tests/ConventionsPassTests.cs
+++ b/src_mcp/tests/ConventionsPassTests.cs
@@ -184,7 +184,7 @@ public sealed class ConventionsPassTests
     {
         var summary = ReviewerSummary.AllAnswered(3) with
         {
-            NotAsked = [new SkippedRole("Conventions", "this repository has no written rules for it to judge against")],
+            NotAsked = [new SkippedRole("Conventions", "this repository has no written rules to judge against")],
         };
 
         summary.Sentence.Should().Contain("Conventions")
@@ -199,7 +199,7 @@ public sealed class ConventionsPassTests
         // in the same words, a correct round reads as a degraded one.
         var summary = ReviewerSummary.AllAnswered(3) with
         {
-            NotAsked = [new SkippedRole("Conventions", "this repository has no written rules for it to judge against")],
+            NotAsked = [new SkippedRole("Conventions", "this repository has no written rules to judge against")],
         };
 
         summary.Sentence.Should().StartWith("all 3 reviewers answered");
@@ -214,7 +214,7 @@ public sealed class ConventionsPassTests
         // sentence of every ordinary one.
         ReviewerSummary.AllAnswered(4).Sentence.Should().Be("all 4 reviewers answered");
         new ReviewerSummary(4, 3, ["codex/Architecture: timeout"]).Sentence
-            .Should().Be("4 reviewers answered; failed: codex/Architecture: timeout".Replace("4 reviewers", "3 of 4 reviewers"));
+            .Should().Be("3 of 4 reviewers answered; failed: codex/Architecture: timeout");
     }
 
     [Fact]
@@ -225,13 +225,34 @@ public sealed class ConventionsPassTests
         var summary = new ReviewerSummary(4, 2, ["codex/Architecture: timeout"], ["gemini/Conventions: no key"])
         {
             EndedByDeadline = TimeSpan.FromMinutes(10),
-            NotAsked = [new SkippedRole("Conventions", "this repository has no written rules for it to judge against")],
+            NotAsked = [new SkippedRole("Conventions", "this repository has no written rules to judge against")],
         };
 
         summary.Sentence.Should().Be(
             "2 of 4 reviewers answered; failed: codex/Architecture: timeout; "
             + "the round reached its 10 minute limit and the reviewers still running were cancelled; "
             + "1 enabled reviewer could not run: gemini/Conventions: no key; "
-            + "Conventions was not asked: this repository has no written rules for it to judge against");
+            + "Conventions was not asked: this repository has no written rules to judge against");
+    }
+
+    [Fact]
+    public void EveryOmittedRole_CarriesTheReasonItsOwnRuleGaveIt()
+    {
+        // The code round's finding, and the trap it names: mapping the DIFFERENCE onto one reason
+        // works while there is one rule, and tells the caller the wrong thing with complete
+        // confidence the day there are two. The pairing lives beside the rule that produces it.
+        IReadOnlyList<ReviewRole> scheduled =
+            [ReviewRole.Conventions, ReviewRole.Architecture, ReviewRole.SecurityReliability];
+
+        PanelService.RolesNotAsked(scheduled, hasRules: true).Should().BeEmpty();
+
+        var skipped = PanelService.RolesNotAsked(scheduled, hasRules: false);
+        skipped.Should().ContainSingle();
+        skipped[0].Role.Should().Be(nameof(ReviewRole.Conventions));
+        skipped[0].Reason.Should().Be(PanelService.NoWrittenRules);
+        // Derived from the filter, never written out beside it: what is not asked and what ran are
+        // the same decision read twice.
+        skipped.Select(s => s.Role).Should()
+            .NotIntersectWith(PanelService.RolesWithRulesInMind(scheduled, hasRules: false).Select(r => r.ToString()));
     }
 }

--- a/src_mcp/tests/EndToEndTests.cs
+++ b/src_mcp/tests/EndToEndTests.cs
@@ -237,6 +237,14 @@ public sealed class EndToEndTests : IAsyncLifetime
         var code = Parse(await service.ReviewCodeAsync(_repo, "feature", "main", Scope));
         code.GetProperty("verdict").GetString().Should().Be("proceed");
         code.GetProperty("reviewers").GetString().Should().Contain("all 6 reviewers answered", "3 roles x 2 providers");
+        // And WHY it is three roles and not four. This fixture repository has no written rules, so
+        // the Conventions reviewers are dropped — correctly, because a conventions pass with nothing
+        // to judge against would invent a standard — and until now that was said only in the server's
+        // own log. The AI that called the gate got a thinner round and no sentence at all.
+        code.GetProperty("reviewers").GetString().Should()
+            .Contain("Conventions was not asked")
+            .And.Contain("no written rules")
+            .And.NotContain("could not run", "a decision this gate made must not read as a failure");
         Parse(await service.ResolveAsync(_repo, "feature", "[]")).GetProperty("stage").GetString().Should().Be("Done");
 
         // The trail replays the whole story.
@@ -263,6 +271,11 @@ public sealed class EndToEndTests : IAsyncLifetime
 
         code.GetProperty("verdict").GetString().Should().Be("call_human");
         code.GetProperty("reviewers").GetString().Should().Contain("0 of 6").And.Contain("rate limited");
+        // A round can fail AND have skipped a role, and the failure must not swallow the skip: an
+        // implementation that built the sentence only for the happy path would still pass the check
+        // above while this reader — the one whose round went wrong — learned nothing about the
+        // fourth role. (codex, the plan round.)
+        code.GetProperty("reviewers").GetString().Should().Contain("Conventions was not asked");
         code.GetProperty("instruction").GetString().Should().Contain("do not proceed on your own");
     }
 


### PR DESCRIPTION
A code round in a repository with no written rules drops its **Conventions** reviewers — correctly,
because a conventions pass with nothing to judge against would invent a standard. The only place that
was ever said is the server's own log. The AI that called the gate got three roles instead of four and
no sentence explaining it, which reads as a failure or is not noticed at all.

This is the open tail of `PLAN_conventions_is_its_own_role.md`.

## Three ways a round can be smaller than its roster, and each says so in its own words

| | decided | reads as | cure |
|---|---|---|---|
| `Failures` | after the launch | a problem with the run | look at the vendor |
| `Excluded` | before the roster, from `CanRun` | a problem with the configuration | fix the credential or the runtime |
| `NotAsked` | before the roster, from the REPOSITORY | **not a problem at all** | write some rules, or nothing |

`ReviewerSummary.NotAsked` carries `SkippedRole(Role, Reason)` — **structured, not a finished
clause**, which the plan round asked for: a caller parsing the summary gets a role it can name, and
the punctuation is decided once beside the clauses it sits next to.

`Sentence` appends it **last** of the three additions, and the order carries meaning: a deadline
explains the failures, the failures explain the count, and what was never asked for is last because it
is the only one of the three that is not a problem. Its verb is its own — *was not asked*, never
*could not run*. A round that skipped nothing reads exactly as it always did, which is this file's own
stated rule and is now an assertion.

## What the code round changed

- **The reason was mapped over the difference**, so every omitted role got "no written rules" whatever
  dropped it. That works while there is one rule and tells the caller the wrong thing with complete
  confidence the day there are two. `RolesNotAsked` now sits beside `RolesWithRulesInMind`, so a
  second rule adds its reason next to the filter that produces it — still derived from the difference,
  so it cannot disagree with what actually ran.
- **A round whose whole roster is filtered out** returns before any summary exists, so it was refused
  with a sentence about vendors — sending somebody to check a configuration that is perfectly correct.
  The refusal carries the explanation now. Raised twice.
- **The new type captured its neighbour's documentation**: `<param name="Excluded">` was left
  describing `SkippedRole`, which has no such parameter. The build said nothing; the file was simply
  wrong for a reader.
- Smaller: a pronoun that disagreed with its own subject (*"Conventions was not asked: … for THEM to
  judge against"*); an overload instead of a `null` default, because C# cannot default a parameter to
  `[]` and an absent value here is an empty one; `RoundWork.Of` inlined at its only call site; and a
  test that stopped building its expected string with `.Replace`.

## Evidence

- RED first: `all 3 reviewers answered`, and nothing about Conventions.
- The end-to-end fixture turned out to be exactly this case — a repository with no rule files, which
  is why its own comment already read *"3 roles x 2 providers"* — so the journey is asserted where it
  happens, **and again on the round that also fails**, because a failure must not swallow the skip.
  Both watched failing with the argument removed.
- Release build: **0 warnings**. Whole C# suite: **1139 pass, 1 skipped, 0 fail**. `plan-lifecycle.mjs`
  clean; `pin-check.mjs` OK.

## The gate

Plan round `proceed` — 3 reviewers, 11 findings, **all 11 accepted**; two of them changed the design
(structured rather than pre-formatted, and derived rather than written down). Code round `proceed` —
12 reviewers, 26 findings, 9 accepted and built, 17 rejected with reasons.

The rejection worth naming: three reviewers asked for `ReviewRole` instead of a `string`, quoting the
rule against primitive obsession. `ReviewRole` lives in `CoaiMcp.Runners`; `ReviewerSummary` lives in
`CoaiMcp.Core`, whose project file references **nothing** — a purity held by
`ArchitectureTests`, not by habit. The neighbouring `Failures` field carries `provider/Role: reason`
as a string for exactly the same reason. Typing the field means moving an enum across the ring, which
is a change to the module boundary and belongs to a plan about that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)