### PR TITLE
feat(chat): a picture in the question

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -29,6 +29,32 @@ local model` the page would otherwise still show the remote one as selected whil
 somewhere else), a pushed state that has not changed is not sent at all, a `pick` naming a model the
 conversation was never offered is refused at the host boundary rather than trusted, and the
 composer takes focus back when a turn ends — without which every follow-up costs a mouse click.
+### An empty box asks the other model the same thing (2026-09-10)
+
+Entry 24, in the operator's words: *"maybe I don't like gemini's answer and want to switch to Fable.
+If I switch the model and press Enter with an empty box — take the previous context (except the last
+answer) and feed it to the new model."*
+
+**Except the last answer**, and the reason is sound: an answer somebody rejected, handed to the next
+model, is a model being asked to agree with it. The QUESTION is kept and re-sent verbatim — it is
+what they want answered again — and everything before it stays, because that is the conversation the
+answer was given in. Both the answer and its question leave the transcript: the question comes back
+as this turn's own, and keeping the answer would show it twice in a conversation that has moved past
+it.
+
+**On offer only when the model has CHANGED since that answer.** Pressing Enter on an empty box with
+the same model chosen does what it has always done, which is nothing.
+
+**The gesture is invisible, so the button says it.** `send()` has always refused an empty box, which
+is what made the gesture free to take — and a feature whose only trigger is pressing Enter on nothing
+is a feature nobody discovers. The Send button reads *Re-ask · <model>* whenever there is something
+to re-ask, which is both the second way in and the only way to know the first exists. Text in the box
+is a question and is never swallowed by it.
+
+**It goes through `oneTurn`, and that is the point.** A re-ask is a turn: the lock, the turn number a
+stop can name, the transcript, the model recorded on the answer and the cap on a forgetful
+conversation all happen because this is not a second path.
+
 ### The presets tab (2026-09-10)
 
 `chatPresetsPage.ts` and `chatPresetsPanel.ts` — a page module and a thin panel host, which is the

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -29,6 +29,39 @@ local model` the page would otherwise still show the remote one as selected whil
 somewhere else), a pushed state that has not changed is not sent at all, a `pick` naming a model the
 conversation was never offered is refused at the host boundary rather than trusted, and the
 composer takes focus back when a turn ends — without which every follow-up costs a mouse click.
+### A picture in the question (2026-09-10)
+
+Phase 0 MEASURED the mechanism rather than assuming one: `claude` and `agy` both read a number out of
+a real PNG when the file's PATH was named in the prompt. **The vendor process opens the file itself**,
+which makes the file's name, its location and its lifetime part of the contract with the model rather
+than an implementation detail.
+
+**The page reads the bytes and writes nothing.** Only the page has a clipboard event; only the host
+has a disk. The page posts a data URL and the host writes the file the vendor will open.
+
+**`img-src data:` and nothing wider.** The CSP is `default-src 'none'`, which blocks images too, so a
+thumbnail of what was just pasted needs that one addition: no remote host, no `file:`, and
+`localResourceRoots` stays empty. `attachedHtml` also refuses to render a `src` that is not one of the
+four image types — the value comes from the host, so it is not arbitrary, but a page that renders a
+`src` it has not looked at is a page that would render `javascript:` the day something else fills
+that field.
+
+**SVG is refused although it is an image.** It is markup with script in it, and the one thing this
+feature does is hand a file to a process that will open it.
+
+**Refused BY NAME where the provider cannot take one**, which is the rule the picker already keeps.
+`codex` is refused as UNTESTED rather than as incapable — its account hit a usage limit during phase
+0, and that is a different sentence from a measured no. A Team server is refused because an image is
+a wire-format change on a server deployed by hand.
+
+**The file is named here, from what the image IS**, never from anything the page said: a name from
+the page would be a path fragment chosen by whatever wrote into the clipboard. One directory per
+conversation, which is what makes forgetting them possible.
+
+**A picture goes with the question it was pasted for and no other.** The turn names the file, the
+vendor opens it, and the attachment is spent — keeping it would send the same screenshot with every
+question after it.
+
 ### An empty box asks the other model the same thing (2026-09-10)
 
 Entry 24, in the operator's words: *"maybe I don't like gemini's answer and want to switch to Fable.

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**Paste a picture into a question.** A screenshot from the clipboard goes into the composer, shows
+itself there, and travels with the next question you send. It works with the models that were
+measured to read one — if the model you have chosen cannot, the tab says so by name instead of
+quietly sending the words alone.
+
 **Ask the other model the same thing.** Switch the model after an answer you did not like, and the
 Send button becomes *Re-ask · <that model>* — press it, or press Enter on an empty box, and the
 question goes to the new model with the conversation behind it and without the answer you rejected.

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Ask the other model the same thing.** Switch the model after an answer you did not like, and the
+Send button becomes *Re-ask · <that model>* — press it, or press Enter on an empty box, and the
+question goes to the new model with the conversation behind it and without the answer you rejected.
+
 **Your prompts and your models, saved by name.** The single prompt in the sidebar has become a list
 you build: give each one a name, tick the one to use when a capture sends by itself, and they appear
 as buttons above the composer — models in their vendor's colour, prompts in another. **ConnectOtherAIs:

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import * as vscode from 'vscode';
 import { isInside } from './chatMessages';
+import { imageFileName, imageRefusal, imageTurn, pastedImage } from './chatImage';
 import {
   ModelPreset,
   PromptPreset,
@@ -82,6 +83,10 @@ interface Thread extends ChatMemory {
   readonly models: readonly ChatModelChoice[];
   /** Every row that can answer, each with its own models. Replaced whenever a pick resolves. */
   providers: readonly ChatProvider[];
+  /** The picture waiting to go with the next question, as the page shows it. */
+  attached: string;
+  /** Where that picture IS — the file a vendor process will open. Empty when there is none. */
+  attachedPath: string;
   /** The row that answers, and which of its models — empty for whatever the row is set to. */
   providerId: string;
   modelId: string;
@@ -231,6 +236,7 @@ function show(entry: ChatEntry, running: boolean, failure: string, queued = 0): 
     // Who would answer a re-ask. Empty while a turn runs: the button is locked anyway, and offering
     // to re-ask something that is still being answered is offering a question nobody asked yet.
     reask: running || thread === undefined ? '' : reaskLabel(thread),
+    attached: thread?.attached ?? '',
   });
   // The one place the transcript reaches a page is the one place it is written down — but only when
   // there is something new to write. `show` runs on every state push: a turn starting, a queue
@@ -407,7 +413,11 @@ async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
   // Named, because a budget is the kind of thing that must be readable at a glance: a server takes
   // less than a pipe, and which one this conversation is is the whole difference.
   const budget = thread.forgetful ? REMOTE_CARRY_BUDGET : CARRY_BUDGET;
-  const sent = carrying.length > 0 ? carriedTurn(carrying, text, chatLanguage(), budget) : text;
+  // A picture goes with the question it was pasted for, and with that one only: the file is named
+  // in the turn, the vendor process opens it, and the attachment is spent. Keeping it would send the
+  // same screenshot with every question after it.
+  const asked = thread.attachedPath.length > 0 ? imageTurn(text, thread.attachedPath) : text;
+  const sent = carrying.length > 0 ? carriedTurn(carrying, asked, chatLanguage(), budget) : asked;
 
   // When the person asked, which ROW heard it, and which of that row's models — all taken BEFORE the
   // turn, because the ledger must name what actually answered rather than what is configured by the
@@ -904,6 +914,7 @@ function newConversation(
       modelPresets: savedModels(config),
       // A conversation that has just opened has said nothing, so there is nothing to ask again.
       reask: '',
+      attached: '',
       providerId: ready.providerId,
       modelId: ready.modelId,
       running: false,
@@ -926,6 +937,8 @@ function newConversation(
     passage: state.passage,
     models: ready.models,
     providers: ready.providers,
+    attached: '',
+    attachedPath: '',
     providerId: ready.providerId,
     modelId: ready.modelId,
     running: false,
@@ -999,6 +1012,21 @@ function conversationHooks(panels: ChatPanels): Parameters<typeof createChatPane
         thread?.session.dispose();
         thread?.home.release();
       },
+      onAttach: (id, dataUrl) => {
+        const thread = threads.get(id);
+        const entry = panels.entryOf(id);
+        if (thread !== undefined && entry !== undefined) {
+          void attachPicture(entry, thread, dataUrl);
+        }
+      },
+      onUnattach: (id) => {
+        const thread = threads.get(id);
+        const entry = panels.entryOf(id);
+        if (thread !== undefined && entry !== undefined) {
+          forgetPicture(thread);
+          show(entry, false, '');
+        }
+      },
       onReask: (id) => {
         const thread = threads.get(id);
         const entry = panels.entryOf(id);
@@ -1070,6 +1098,68 @@ async function openWorkspaceFile(
 }
 
 /**
+ * Where a conversation's pictures live: one directory per conversation, under the extension's own.
+ *
+ * <p>The vendor process OPENS these files — that is the mechanism phase 0 measured — so they are
+ * real files with a real path, and their lifetime is a contract rather than a detail. One directory
+ * per conversation is what makes forgetting them possible: the tab closing removes it whole, the
+ * way `chatOrphans.ts` ends the processes.</p>
+ */
+function pictureDir(id: string): string {
+  return path.join(coaiDataDir(), 'pictures', id.replace(/[^\w-]/g, ''));
+}
+
+/** Take the picture off, and take the FILE with it — a file nobody will open is a file left behind. */
+function forgetPicture(thread: Thread): void {
+  if (thread.attachedPath.length > 0) {
+    try {
+      fs.rmSync(thread.attachedPath, { force: true });
+    } catch {
+      // A file that cannot be removed is not worth a sentence to the person: it is in a temp
+      // directory the tab's own close sweeps, and saying so would explain nothing they can act on.
+    }
+  }
+  thread.attached = '';
+  thread.attachedPath = '';
+}
+
+/**
+ * Keep a pasted picture, or say why it cannot be kept.
+ *
+ * <p>Refused BY NAME where the chosen provider cannot take one. The worst outcome this feature has
+ * is a picture that silently does not arrive: somebody pastes a screenshot, asks about it, and is
+ * answered about the text alone with nothing anywhere saying the image was dropped.</p>
+ */
+async function attachPicture(entry: ChatEntry, thread: Thread, dataUrl: string): Promise<void> {
+  const refusal = imageRefusal(thread.providerId);
+  if (refusal.length > 0) {
+    show(entry, thread.running, refusal);
+
+    return;
+  }
+  const picture = pastedImage(dataUrl);
+  if (picture === undefined) {
+    show(entry, thread.running, 'That is not a picture this can send — PNG, JPEG, WebP and GIF only.');
+
+    return;
+  }
+  forgetPicture(thread);
+  const dir = pictureDir(entry.id.toString());
+  try {
+    await fs.promises.mkdir(dir, { recursive: true });
+    const file = path.join(dir, imageFileName(picture.type, thread.turn + 1));
+    await fs.promises.writeFile(file, Buffer.from(picture.base64, 'base64'));
+    thread.attached = dataUrl;
+    thread.attachedPath = file;
+  } catch {
+    show(entry, thread.running, 'The picture could not be written to disk, so nothing was attached.');
+
+    return;
+  }
+  show(entry, thread.running, '');
+}
+
+/**
  * The name of the model that a re-ask would go to, or empty when there is nothing to re-ask.
  *
  * <p>The LABEL rather than the id, because it goes on a button a person reads. `reaskFrom` decides
@@ -1127,6 +1217,7 @@ function restoredPage(
       providers: ready.ok ? ready.providers : [],
       ...presets,
       reask: '',
+      attached: '',
       // The row this tab was speaking to, read by `savedPick` out of the old `modelId`.
       providerId: ready.ok ? ready.providerId : restored.providerId,
       modelId: saved.modelId,
@@ -1171,6 +1262,8 @@ export function restoreConversation(
     passage: saved.passage,
     models: ready.ok ? ready.models : [],
     providers: ready.ok ? ready.providers : [],
+    attached: '',
+    attachedPath: '',
     providerId: ready.ok ? ready.providerId : restored.providerId,
     modelId: saved.modelId,
     running: false,

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -4,7 +4,13 @@ import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import * as vscode from 'vscode';
 import { isInside } from './chatMessages';
-import { ModelPreset, PromptPreset, chatModelPresetsFrom, chatPromptPresetsFrom } from './chatPresets';
+import {
+  ModelPreset,
+  PromptPreset,
+  chatModelPresetsFrom,
+  chatPromptPresetsFrom,
+  reaskFrom,
+} from './chatPresets';
 import { ChatTabMemory, SavedTab, reloadedNote } from './chatTabs';
 import { ChatEntry, ChatPanels } from './chatPanels';
 import { ChatSession, TurnResult } from './chatSession';
@@ -222,6 +228,9 @@ function show(entry: ChatEntry, running: boolean, failure: string, queued = 0): 
     // The turn a stop would name. Zero while nothing runs, which is also what the page renders no
     // control for — a stop that names no turn is refused by the seam rather than obeyed loosely.
     turn: running ? (thread?.turn ?? 0) : 0,
+    // Who would answer a re-ask. Empty while a turn runs: the button is locked anyway, and offering
+    // to re-ask something that is still being answered is offering a question nobody asked yet.
+    reask: running || thread === undefined ? '' : reaskLabel(thread),
   });
   // The one place the transcript reaches a page is the one place it is written down — but only when
   // there is something new to write. `show` runs on every state push: a turn starting, a queue
@@ -333,6 +342,31 @@ async function reopened(thread: Thread): Promise<string> {
  */
 /** What a stopped turn leaves in the transcript, so it never ends on a dangling question. */
 const STOPPED_ANSWER = '(you stopped this answer)';
+
+/**
+ * Ask the model chosen NOW the question the last answer was given to.
+ *
+ * <p>Entry 24. The conversation goes across MINUS that answer — an answer somebody rejected, handed
+ * to the next model, is a model being asked to agree with it — and the question is re-sent verbatim,
+ * because it is what they want answered again rather than re-typed.</p>
+ *
+ * <p>It goes through `oneTurn`, which is the point: a re-ask is a turn. Everything a turn already
+ * does — the lock, the turn number a stop can name, the transcript, the model recorded on the
+ * answer, the cap on a forgetful conversation — happens because this is not a second path.</p>
+ */
+async function oneReask(entry: ChatEntry, thread: Thread): Promise<void> {
+  const again = reaskFrom(thread.messages, thread.providerId);
+  if (again === undefined) {
+    return;
+  }
+  // The rejected answer and its question leave the transcript: the question comes back as this
+  // turn's own, and keeping the answer would show it twice in a conversation that has moved past it.
+  thread.messages = thread.messages.slice(0, -2);
+  // What the NEXT model is handed. `carry` is what `oneTurn` sends ahead of the question, and it is
+  // exactly the conversation before the answer nobody wanted.
+  thread.carry = [...again.said];
+  await oneTurn(entry, again.question);
+}
 
 async function oneTurn(entry: ChatEntry, text: string): Promise<void> {
   const thread = threads.get(entry.id);
@@ -868,6 +902,8 @@ function newConversation(
       providers: ready.providers,
       promptPresets: savedPrompts(config),
       modelPresets: savedModels(config),
+      // A conversation that has just opened has said nothing, so there is nothing to ask again.
+      reask: '',
       providerId: ready.providerId,
       modelId: ready.modelId,
       running: false,
@@ -963,6 +999,13 @@ function conversationHooks(panels: ChatPanels): Parameters<typeof createChatPane
         thread?.session.dispose();
         thread?.home.release();
       },
+      onReask: (id) => {
+        const thread = threads.get(id);
+        const entry = panels.entryOf(id);
+        if (thread !== undefined && entry !== undefined) {
+          void oneReask(entry, thread);
+        }
+      },
       onRestart: () => undefined,
       onUseLocal: () => undefined,
       onPageError: (_id, message) => {
@@ -1027,6 +1070,16 @@ async function openWorkspaceFile(
 }
 
 /**
+ * The name of the model that a re-ask would go to, or empty when there is nothing to re-ask.
+ *
+ * <p>The LABEL rather than the id, because it goes on a button a person reads. `reaskFrom` decides
+ * whether there is anything to re-ask at all; this only names who would take it.</p>
+ */
+function reaskLabel(thread: Thread): string {
+  return reaskFrom(thread.messages, thread.providerId) === undefined ? '' : answeredBy(thread).label;
+}
+
+/**
  * Which model a turn was answered by, as the page will caption it.
  *
  * <p>The label is the one the picker offered, so the caption reads as the name a person chose from
@@ -1073,6 +1126,7 @@ function restoredPage(
       models: ready.ok ? ready.models : [],
       providers: ready.ok ? ready.providers : [],
       ...presets,
+      reask: '',
       // The row this tab was speaking to, read by `savedPick` out of the old `modelId`.
       providerId: ready.ok ? ready.providerId : restored.providerId,
       modelId: saved.modelId,

--- a/src_vs_code/src/chatImage.ts
+++ b/src_vs_code/src/chatImage.ts
@@ -1,0 +1,109 @@
+/**
+ * A picture in the question.
+ *
+ * <p>Phase 0 of this plan MEASURED the mechanism rather than assuming one: `claude` and `agy` both
+ * read a number out of a real PNG when the file's PATH was named in the prompt, and that is the one
+ * vector both answered to. It means the vendor process opens the file itself — so the file's name,
+ * its location and its lifetime are part of the contract with the model, not an implementation
+ * detail somebody may change later.</p>
+ *
+ * <p>Pure, so every rule below is a test rather than a claim, and because the two that matter most
+ * are refusals: what is not an image, and which providers cannot be handed one.</p>
+ */
+
+/** The four a screenshot actually is. */
+export const IMAGE_TYPES: readonly string[] = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
+
+/**
+ * SVG is deliberately absent.
+ *
+ * <p>It is an image the way an HTML file is an image: markup, with script in it. The one thing this
+ * feature does is hand a file to a process that will open it, and handing it a document that can
+ * carry code is the one shape of this feature that would be a mistake.</p>
+ */
+const EXTENSIONS: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+};
+
+/** A screenshot is measured in hundreds of kilobytes; twenty megabytes of base64 is not one. */
+const MAX_BASE64 = 20_000_000;
+
+export interface PastedImage {
+  readonly type: string;
+  readonly base64: string;
+}
+
+/**
+ * What a paste actually was.
+ *
+ * <p>A `data:` URL and nothing else, of a type on the list, with a body that is really base64. The
+ * page reads a clipboard — which anything on the machine can write into — so this is a boundary and
+ * behaves like one: it answers nothing for whatever it does not recognise, rather than passing a
+ * string along for somebody further in to make sense of.</p>
+ */
+export function pastedImage(dataUrl: string): PastedImage | undefined {
+  const match = /^data:([a-z]+\/[a-z+-]+);base64,([A-Za-z0-9+/=]+)$/.exec(dataUrl);
+  if (match === null) {
+    return undefined;
+  }
+  const [, type = '', base64 = ''] = match;
+  if (!IMAGE_TYPES.includes(type) || base64.length === 0 || base64.length > MAX_BASE64) {
+    return undefined;
+  }
+
+  return { type, base64 };
+}
+
+/**
+ * What the file is called.
+ *
+ * <p>Made HERE, from what the image is, and never from anything the page said: a name that came
+ * from the page would be a path fragment chosen by whatever wrote into the clipboard. The number is
+ * the turn it belongs to, which makes a directory of them readable when something goes wrong.</p>
+ */
+export function imageFileName(type: string, turn: number): string {
+  return `coai-${turn}.${EXTENSIONS[type] ?? 'png'}`;
+}
+
+/**
+ * Why this provider cannot be handed a picture, or empty when it can.
+ *
+ * <p>Named, because the worst outcome of this whole feature is a picture that silently does not
+ * arrive: somebody pastes a screenshot, asks about it, and is answered about the text alone with
+ * nothing anywhere saying the image was dropped. The picker already follows this rule for models
+ * that cannot answer at all.</p>
+ *
+ * <p>`codex` is refused as UNTESTED rather than as incapable — its account hit a usage limit during
+ * phase 0, and that is a different sentence from a measured no.</p>
+ */
+export function imageRefusal(providerId: string): string {
+  if (providerId.includes('-')) {
+    return `A Team server cannot take a picture yet — ${providerId} answers over a wire that has no`
+      + ' place for one. Send it to a model that runs on this machine.';
+  }
+  if (providerId === 'codex') {
+    return 'Whether codex can read a picture has not been measured — its account hit a usage limit'
+      + ' during the measurement, which is not the same as a no. Until it is re-run, send pictures'
+      + ' to claude or antigravity.';
+  }
+
+  return '';
+}
+
+/**
+ * The turn a picture travels in.
+ *
+ * <p>The PATH goes last, for the same reason the captured passage does in `chatPrompt.ts`: whatever
+ * must survive a long turn goes at the end, and here that is the instruction to look at the file.
+ * A question with no words is still a question — pasting a screenshot and pressing Enter asks
+ * something perfectly clear — so the turn says what to do with it either way.</p>
+ */
+export function imageTurn(question: string, absolutePath: string): string {
+  const asked = question.trim();
+  const said = asked.length > 0 ? asked : 'What is in this image?';
+
+  return `${said}\n\nThe image is a file on this machine. Read it at:\n${absolutePath}`;
+}

--- a/src_vs_code/src/chatMessages.ts
+++ b/src_vs_code/src/chatMessages.ts
@@ -31,6 +31,7 @@ export interface PageMessage {
   readonly file?: unknown;
   readonly line?: unknown;
   readonly index?: unknown;
+  readonly data?: unknown;
 }
 
 export type ChatCommand =
@@ -60,6 +61,9 @@ export type ChatCommand =
    * rendering of.
    */
   | { readonly kind: 'reask' }
+  /** A picture pasted into the composer, as the data URL the page read out of the clipboard. */
+  | { readonly kind: 'attach'; readonly dataUrl: string }
+  | { readonly kind: 'unattach' }
   | { readonly kind: 'restart' }
   | { readonly kind: 'useLocal' }
   | { readonly kind: 'pageError'; readonly message: string }
@@ -235,6 +239,13 @@ export function chatCommandOf(message: PageMessage | undefined): ChatCommand {
     }
     case 'reask':
       return { kind: 'reask' };
+    case 'attach': {
+      const data = text(message.data);
+
+      return data.length === 0 ? IGNORE : { kind: 'attach', dataUrl: data };
+    }
+    case 'unattach':
+      return { kind: 'unattach' };
     case 'restart':
       return { kind: 'restart' };
     case 'useLocal':

--- a/src_vs_code/src/chatMessages.ts
+++ b/src_vs_code/src/chatMessages.ts
@@ -53,6 +53,13 @@ export type ChatCommand =
    */
   | { readonly kind: 'stop'; readonly turn: number }
   | { readonly kind: 'zoom'; readonly delta: number }
+  /**
+   * Ask the OTHER model the same thing: the conversation minus the last answer, and the question
+   * that answer was given to. It carries nothing else — the host holds the transcript and decides
+   * what "the last answer" is, because a page that named it would be naming a message it has only a
+   * rendering of.
+   */
+  | { readonly kind: 'reask' }
   | { readonly kind: 'restart' }
   | { readonly kind: 'useLocal' }
   | { readonly kind: 'pageError'; readonly message: string }
@@ -226,6 +233,8 @@ export function chatCommandOf(message: PageMessage | undefined): ChatCommand {
         ? { kind: 'copyAnswer', index }
         : IGNORE;
     }
+    case 'reask':
+      return { kind: 'reask' };
     case 'restart':
       return { kind: 'restart' };
     case 'useLocal':

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -4,6 +4,7 @@ import { ZOOM_CSS, zoomControlHtml, zoomScript, zoomStyle } from './zoomControl'
 import { vendorPalette } from './vendorColour';
 import { ChatProvider, ChatProviderList } from './chatModels';
 import { ModelPreset, PromptPreset } from './chatPresets';
+import { pastedImage } from './chatImage';
 
 /**
  * The conversation tab: the passage that started it, what has been said, and a box to say more.
@@ -100,6 +101,13 @@ export interface ChatPageState {
    * <p>The HOST decides: it knows which model gave the last answer and which one is chosen now.</p>
    */
   readonly reask: string;
+  /**
+   * The picture waiting to go with the next question, as a data URL — or empty when there is none.
+   *
+   * <p>A data URL because the page cannot read a file: `localResourceRoots` is empty and the CSP
+   * loads nothing from disk. The HOST holds the real file; this is only what a person sees.</p>
+   */
+  readonly attached: string;
   /** The prompts a person saved, as buttons above the composer. */
   readonly promptPresets: readonly PromptPreset[];
   /** The models a person saved, likewise. */
@@ -267,6 +275,23 @@ export function chatPresetRowsHtml(
   return `<div id="presets">${modelRow}${promptRow}</div>`;
 }
 
+/**
+ * The picture waiting to go with the next question.
+ *
+ * <p>Rendered only when it really is an image this page may show. The host built this value from
+ * what the page sent it, so it is not arbitrary — but a page that renders a `src` it has not looked
+ * at is a page that would render `javascript:` the day something else fills that field, and the
+ * check costs one call.</p>
+ */
+function attachedHtml(attached: string): string {
+  if (pastedImage(attached) === undefined) {
+    return '';
+  }
+
+  return `<div class="attachment"><img class="attached" src="${escapeHtml(attached)}" alt="the picture that will go with the next question">`
+    + '<button type="button" id="unattach" title="Take the picture off">Remove</button></div>';
+}
+
 /** What a capped conversation offers instead of a composer nobody can use. */
 export function chatCappedHtml(capped: boolean): string {
   if (!capped) {
@@ -335,6 +360,9 @@ function chatStyle(
   .jump { position: absolute; bottom: calc(100% + 6px); left: 50%; transform: translateX(-50%); font: inherit; color: var(--vscode-button-foreground); background: var(--vscode-button-background); border: none; border-radius: 12px; padding: 4px 12px; cursor: pointer; box-shadow: 0 2px 6px rgba(0, 0, 0, .35); }
   .jump:hover { background: var(--vscode-button-hoverBackground); }
   .compose { display: flex; gap: 8px; align-items: flex-end; }
+  .attachment { display: flex; gap: 8px; align-items: center; margin: 0 0 6px; }
+  .attached { max-height: 84px; max-width: 40%; border: 1px solid var(--vscode-panel-border); border-radius: 4px; }
+  #unattach { font: inherit; font-size: .9em; color: var(--vscode-foreground); background: none; border: 1px solid var(--vscode-panel-border); border-radius: 3px; padding: 2px 8px; cursor: pointer; }
   header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; }
   h1 { font-size: 1.2em; margin: 0; }
   .passage { border-left: 3px solid var(--vscode-panel-border); padding: 6px 0 6px 12px; margin: 0 0 16px; white-space: pre-wrap; opacity: .85; }
@@ -471,6 +499,7 @@ function chatBody(state: ChatPageState, regions: Regions): string {
 <button type="button" id="jump" class="jump" hidden>Jump to newest ↓</button>
 ${chatPresetRowsHtml(state.promptPresets, state.modelPresets)}
 <div id="pickerBox">${chatPickerHtml({ providers: state.providers, refused: [] }, state.providerId, state.modelId)}</div>
+${attachedHtml(state.attached)}
 <div class="compose">
 <textarea id="say" rows="3" placeholder="Ask about the text above…"${locked ? ' disabled' : ''}>${escapeHtml(state.draft)}</textarea>
 <button type="button" id="send"${locked ? ' disabled' : ''}>${state.reask.length > 0 ? `Re-ask · ${escapeHtml(state.reask)}` : 'Send'}</button>
@@ -694,6 +723,33 @@ function chatScript(state: ChatPageState, regions: Regions): string {
       if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); send(); }
     });
     say.addEventListener('input', fitComposer);
+    // A picture from the clipboard. The page reads the bytes because only the page has a clipboard
+    // event; it writes nothing to disk, because it cannot - the HOST holds the file, which is what
+    // the vendor process will open. Anything that is not an image pastes as the text it is.
+    say.addEventListener('paste', function (event) {
+      const items = event.clipboardData && event.clipboardData.items;
+      if (!items) { return; }
+      for (let index = 0; index < items.length; index += 1) {
+        const item = items[index];
+        if (!item || item.kind !== 'file' || typeof item.type !== 'string' || item.type.indexOf('image/') !== 0) {
+          continue;
+        }
+        const file = typeof item.getAsFile === 'function' ? item.getAsFile() : null;
+        if (!file) { continue; }
+        event.preventDefault();
+        if (typeof FileReader !== 'function') {
+          vscode.postMessage({ type: 'command', command: 'pageError', message: 'this editor cannot read a pasted picture' });
+          return;
+        }
+        const reader = new FileReader();
+        reader.onload = function () {
+          vscode.postMessage({ type: 'command', command: 'attach', data: String(reader.result || '') });
+        };
+        reader.readAsDataURL(file);
+
+        return;
+      }
+    });
   }
   // The second caller of the ONE send. Attached here rather than as an onclick attribute: the page's
   // CSP is script-src 'nonce-...', so an inline handler is not merely untidy, it is a dead button.
@@ -851,6 +907,12 @@ function chatScript(state: ChatPageState, regions: Regions): string {
       }
     });
   }
+  const unattach = document.getElementById('unattach');
+  if (unattach) {
+    unattach.addEventListener('click', function () {
+      vscode.postMessage({ type: 'command', command: 'unattach' });
+    });
+  }
   const jump = document.getElementById('jump');
   if (jump) {
     jump.addEventListener('click', function () {
@@ -991,7 +1053,7 @@ export function chatPageHtml(state: ChatPageState, nonce: string): string {
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${escapeHtml(state.title)}</title>
 <style>

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -89,6 +89,17 @@ export interface ChatPageState {
   readonly models: readonly ChatModelChoice[];
   /** Every provider this conversation may put a question to, each with its own models. */
   readonly providers: readonly ChatProvider[];
+  /**
+   * Who would answer a re-ask, or empty when there is nothing to re-ask.
+   *
+   * <p>The gesture is an EMPTY box and Enter — free to take, because an empty box has always been
+   * refused — and a feature whose only trigger is pressing Enter on nothing is a feature nobody
+   * discovers. So the Send button reads *Re-ask · <model>* whenever this is set, which is both the
+   * second way in and the only way to know the first exists.</p>
+   *
+   * <p>The HOST decides: it knows which model gave the last answer and which one is chosen now.</p>
+   */
+  readonly reask: string;
   /** The prompts a person saved, as buttons above the composer. */
   readonly promptPresets: readonly PromptPreset[];
   /** The models a person saved, likewise. */
@@ -462,7 +473,7 @@ ${chatPresetRowsHtml(state.promptPresets, state.modelPresets)}
 <div id="pickerBox">${chatPickerHtml({ providers: state.providers, refused: [] }, state.providerId, state.modelId)}</div>
 <div class="compose">
 <textarea id="say" rows="3" placeholder="Ask about the text above…"${locked ? ' disabled' : ''}>${escapeHtml(state.draft)}</textarea>
-<button type="button" id="send"${locked ? ' disabled' : ''}>Send</button>
+<button type="button" id="send"${locked ? ' disabled' : ''}>${state.reask.length > 0 ? `Re-ask · ${escapeHtml(state.reask)}` : 'Send'}</button>
 </div>
 <div class="hint">Enter sends · Shift+Enter for a new line</div>
 </footer>`;
@@ -639,11 +650,24 @@ function chatScript(state: ChatPageState, regions: Regions): string {
       }
     });
   }
+  // Set by the host with every state, and read by send() below: an empty box means "ask the other
+  // model the same thing" only while there IS another model to ask.
+  var canReask = ${jsonForScript(state.reask.length > 0)};
   function send() {
     const box = document.getElementById('say');
     if (!box || box.disabled) { return; }
     const text = box.value.trim();
-    if (text.length === 0) { return; }
+    if (text.length === 0) {
+      // The whole of entry 24. Text in the box is a question and must never be swallowed by this;
+      // an empty box was refused before this existed and is refused still when there is nothing to
+      // re-ask, so nothing that used to work has changed meaning.
+      if (canReask) {
+        vscode.postMessage({ type: 'command', command: 'reask' });
+        lock(true);
+      }
+
+      return;
+    }
     box.value = '';
     vscode.postMessage({ type: 'command', command: 'send', text: text });
     fitComposer();
@@ -924,6 +948,13 @@ function chatScript(state: ChatPageState, regions: Regions): string {
     // Only a real boolean moves the lock. A state that says nothing about running - a partial push,
     // or a null across the bridge - must leave the composer as it is rather than quietly unlocking
     // it while a turn is still in flight. (local, the second code round.)
+    // Who a re-ask would go to, which is also the button's caption: the gesture is an empty box and
+    // Enter, and a feature whose only trigger is pressing Enter on nothing is one nobody discovers.
+    if (typeof data.reask === 'string') {
+      canReask = data.reask.length > 0;
+      const reaskButton = document.getElementById('send');
+      if (reaskButton) { reaskButton.textContent = canReask ? 'Re-ask · ' + data.reask : 'Send'; }
+    }
     // A stop is about the turn in flight. When nothing is in flight it is about nothing — and
     // holding on to the number would disable the same-numbered turn of the NEXT conversation, since
     // restarting keeps this page and begins counting again. (gemini and local, the code round, from

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -62,6 +62,9 @@ export interface ChatPanelHooks {
   readonly onRestart: (id: object) => void;
   /** Ask the model that is chosen NOW the question the last answer was given to. */
   readonly onReask: (id: object) => void;
+  /** A picture was pasted into the composer, or taken off it again. */
+  readonly onAttach: (id: object, dataUrl: string) => void;
+  readonly onUnattach: (id: object) => void;
   /** Move the thread to a model that keeps a conversation. */
   readonly onUseLocal: (id: object) => void;
   /** The page trapped an error, or the host failed to handle one of its messages. */
@@ -97,6 +100,8 @@ export interface ChatPushState {
   readonly providers: readonly ChatProvider[];
   /** Who would answer a re-ask, or empty when there is nothing to re-ask. */
   readonly reask: string;
+  /** The picture waiting to go with the next question, as a data URL, or empty. */
+  readonly attached: string;
   readonly providerId: string;
   readonly modelId: string;
   /**
@@ -260,6 +265,14 @@ async function handle(id: object, message: PageMessage, hooks: ChatPanelHooks): 
       return;
     case 'reask':
       hooks.onReask(id);
+
+      return;
+    case 'attach':
+      hooks.onAttach(id, command.dataUrl);
+
+      return;
+    case 'unattach':
+      hooks.onUnattach(id);
 
       return;
     case 'restart':

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -60,6 +60,8 @@ export interface ChatPanelHooks {
   readonly onClosed: (id: object) => void;
   /** Start again with the same passage. */
   readonly onRestart: (id: object) => void;
+  /** Ask the model that is chosen NOW the question the last answer was given to. */
+  readonly onReask: (id: object) => void;
   /** Move the thread to a model that keeps a conversation. */
   readonly onUseLocal: (id: object) => void;
   /** The page trapped an error, or the host failed to handle one of its messages. */
@@ -93,6 +95,8 @@ export interface ChatPushState {
   readonly models: readonly ChatModelChoice[];
   /** Every row that can answer, each with its own models — what the picker offers. */
   readonly providers: readonly ChatProvider[];
+  /** Who would answer a re-ask, or empty when there is nothing to re-ask. */
+  readonly reask: string;
   readonly providerId: string;
   readonly modelId: string;
   /**
@@ -252,6 +256,10 @@ async function handle(id: object, message: PageMessage, hooks: ChatPanelHooks): 
       return;
     case 'copyAnswer':
       hooks.onCopyAnswer(id, command.index);
+
+      return;
+    case 'reask':
+      hooks.onReask(id);
 
       return;
     case 'restart':

--- a/src_vs_code/src/chatPresets.ts
+++ b/src_vs_code/src/chatPresets.ts
@@ -162,6 +162,44 @@ export function chatModelPresetsFrom(saved: unknown): readonly ModelPreset[] {
   });
 }
 
+/**
+ * What a re-ask would consist of, or nothing when there is nothing to re-ask.
+ *
+ * <p>Entry 24 of the operator's list: *"maybe I don't like gemini's answer and want to switch to
+ * Fable. If I switch the model and press Enter with an empty box — take the previous context (except
+ * the last answer) and feed it to the new model."*</p>
+ *
+ * <p><b>Except the last answer</b>, and the reason is sound: an answer somebody rejected, handed to
+ * the next model, is a model being asked to agree with it. The QUESTION is kept — it is what they
+ * want answered again — and everything before it stays, because that is the conversation the answer
+ * was given in.</p>
+ *
+ * <p>On offer only when the model has CHANGED since that answer. Pressing Enter on an empty box with
+ * the same model chosen is the gesture doing nothing, which is what it has always done.</p>
+ */
+export function reaskFrom(
+  messages: readonly { readonly role: 'you' | 'model'; readonly text: string; readonly model?: { readonly id: string } | undefined }[],
+  chosen: string,
+): { readonly said: readonly { readonly role: 'you' | 'model'; readonly text: string }[]; readonly question: string } | undefined {
+  const last = messages.length - 1;
+  if (last < 1 || messages[last]?.role !== 'model' || chosen.length === 0) {
+    return undefined;
+  }
+  const answered = messages[last]?.model?.id ?? '';
+  if (answered.length === 0 || answered === chosen) {
+    return undefined;
+  }
+  const question = messages[last - 1];
+  if (question?.role !== 'you' || question.text.trim().length === 0) {
+    return undefined;
+  }
+
+  return {
+    said: messages.slice(0, last - 1).map((message) => ({ role: message.role, text: message.text })),
+    question: question.text,
+  };
+}
+
 /** The preset a button named, or nothing — a click naming an id that is gone chooses nothing. */
 export function presetById<T extends { readonly id: string }>(
   presets: readonly T[],

--- a/src_vs_code/src/test/bundledPage.test.ts
+++ b/src_vs_code/src/test/bundledPage.test.ts
@@ -289,6 +289,7 @@ function bundledChatPage(): { bundle: string; html: string } {
         { id: 'antigravity', label: 'Gemini', caption: 'local', models: [{ id: 'g', label: 'G' }] },
       ],
       providerId: 'antigravity',
+      reask: '',
       promptPresets: [],
       modelPresets: [],
       modelId: 'g',

--- a/src_vs_code/src/test/chatImage.test.ts
+++ b/src_vs_code/src/test/chatImage.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { IMAGE_TYPES, imageFileName, imageRefusal, imageTurn, pastedImage } from '../chatImage';
+
+/**
+ * A picture in the question.
+ *
+ * <p>Phase 0 measured the mechanism rather than assuming it: `claude` and `agy` both read a number
+ * out of a real PNG when the file's PATH was named in the prompt, which means the vendor process
+ * opens the file itself — so the temp file's name, location and lifetime are part of the contract
+ * and not an implementation detail. Everything here is that contract, decided without a host.</p>
+ */
+
+test('an image arrives as a data URL, and anything else is not an image', () => {
+  const png = pastedImage('data:image/png;base64,iVBORw0KGgo=');
+  assert.strictEqual(png?.type, 'image/png');
+  assert.strictEqual(png?.base64, 'iVBORw0KGgo=');
+
+  for (const bad of [
+    '',
+    'data:text/html;base64,PHNjcmlwdD4=',
+    'data:image/svg+xml;base64,PHN2Zz4=',
+    'https://example.com/a.png',
+    'data:image/png,notbase64',
+    'data:image/png;base64,',
+    `data:image/png;base64,${'A'.repeat(20_000_001)}`,
+  ]) {
+    assert.strictEqual(pastedImage(bad), undefined, `${bad.slice(0, 40)} was accepted as an image`);
+  }
+});
+
+test('svg is refused although it is an image, because it is a document', () => {
+  // An SVG is markup with script in it, and the one thing this feature does is hand a file to a
+  // process that will open it. The four types accepted are the ones a screenshot actually is.
+  assert.ok(!IMAGE_TYPES.includes('image/svg+xml'));
+  assert.deepStrictEqual([...IMAGE_TYPES].sort(), ['image/gif', 'image/jpeg', 'image/png', 'image/webp']);
+});
+
+test('the file is named by what it is, never by anything a page said', () => {
+  // The page sends bytes and a type; the NAME is made here. A name that came from the page would be
+  // a path fragment chosen by whatever wrote into the clipboard.
+  assert.match(imageFileName('image/png', 1), /^coai-1\.png$/);
+  assert.match(imageFileName('image/jpeg', 2), /^coai-2\.jpg$/);
+  assert.match(imageFileName('image/webp', 3), /^coai-3\.webp$/);
+  assert.match(imageFileName('image/gif', 4), /^coai-4\.gif$/);
+});
+
+test('a provider that cannot take a picture is refused BY NAME', () => {
+  // The worst outcome is a picture that silently does not arrive: a person pastes a screenshot, asks
+  // about it, and is answered about the text alone with nothing saying the image was dropped.
+  assert.strictEqual(imageRefusal('claude'), '');
+  assert.strictEqual(imageRefusal('antigravity'), '');
+  assert.match(imageRefusal('codex'), /codex/, 'the refusal does not name what refused');
+  assert.match(imageRefusal('remsoftdev-codex'), /team server|remsoftdev-codex/i);
+});
+
+test('the turn names the file where the model will look for it', () => {
+  const turn = imageTurn('What is this?', 'C:\\Users\\x\\AppData\\Local\\Temp\\coai-1.png');
+
+  assert.match(turn, /What is this\?/, 'the question was lost');
+  assert.match(turn, /coai-1\.png/, 'the model is not told where the image is');
+  // The path is LAST, for the same reason the passage is: whatever must survive a long turn goes at
+  // the end, and here that is the instruction to look at the file.
+  assert.ok(turn.indexOf('coai-1.png') > turn.indexOf('What is this?'));
+});
+
+test('a turn with no question still says what to do with the picture', () => {
+  // Pasting an image and pressing Enter is a whole question in itself.
+  const turn = imageTurn('', '/tmp/coai-1.png');
+
+  assert.ok(turn.trim().length > 0, 'an image with no words became an empty turn');
+  assert.match(turn, /coai-1\.png/);
+});

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -27,6 +27,7 @@ function state(over: Partial<ChatPageState> = {}): ChatPageState {
     messages: [],
     models: MODELS,
     providers: [],
+    reask: '',
     promptPresets: [],
     modelPresets: [],
     providerId: 'antigravity',
@@ -1658,4 +1659,73 @@ test('a click on the row itself does nothing', () => {
   page.fire('presets', 'click', { target: { closest: () => null } });
 
   assert.deepStrictEqual(page.posted.filter((message) => String(message['command']).startsWith('use')), []);
+});
+
+
+/* ------------------------------------------------------------------------------------------------
+ * Entry 24: "maybe I don't like gemini's answer and want to switch to Fable. If I switch the model
+ * and press Enter with an empty box — take the previous context (except the last answer) and feed it
+ * to the new model." An empty box has always been refused, so the gesture was free to take; what it
+ * needed was a way to be discovered.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('when a re-ask is on offer the button says so, and names who would answer', () => {
+  const html = chatPageHtml(state({ reask: 'Claude Opus' }), 'n0nce');
+  const button = html.slice(html.indexOf('id="send"'), html.indexOf('</button>', html.indexOf('id="send"')));
+
+  assert.match(button, /Re-ask · Claude Opus/, 'the only way in is a gesture nobody can see');
+});
+
+test('with nothing to re-ask the button is a Send button', () => {
+  const html = chatPageHtml(state(), 'n0nce');
+  const button = html.slice(html.indexOf('id="send"'), html.indexOf('</button>', html.indexOf('id="send"')));
+
+  assert.match(button, />Send$/, 'the button is not a plain Send button');
+  assert.doesNotMatch(button, /Re-ask/);
+});
+
+test('an empty box re-asks when there is something to re-ask, and does nothing when there is not', () => {
+  const offered = runChatPage({ reask: 'Claude Opus' });
+  offered.seen['say'].value = '';
+  offered.fire('send', 'click');
+
+  assert.deepStrictEqual(offered.posted.filter((message) => message['command'] === 'reask'),
+    [{ type: 'command', command: 'reask' }]);
+  assert.deepStrictEqual(offered.posted.filter((message) => message['command'] === 'send'), [],
+    'an empty box sent an empty question');
+
+  const plain = runChatPage();
+  plain.seen['say'].value = '';
+  plain.fire('send', 'click');
+  assert.deepStrictEqual(plain.posted.filter((message) => message['command'] === 'reask'), [],
+    'a page with nothing to re-ask re-asked anyway');
+});
+
+test('a box with something in it sends it, re-ask or no re-ask', () => {
+  // The re-ask is what an EMPTY box means. Text in the box is a question, and it must not be
+  // swallowed by a gesture that happens to be available.
+  const page = runChatPage({ reask: 'Claude Opus' });
+  page.seen['say'].value = 'a different question';
+  page.fire('send', 'click');
+
+  assert.deepStrictEqual(page.posted.filter((message) => message['command'] === 'send'),
+    [{ type: 'command', command: 'send', text: 'a different question' }]);
+  assert.deepStrictEqual(page.posted.filter((message) => message['command'] === 'reask'), []);
+});
+
+test('a re-ask locks the composer like any other turn', () => {
+  const page = runChatPage({ reask: 'Claude Opus' });
+  page.seen['say'].value = '';
+  page.fire('send', 'click');
+  page.fire('send', 'click');
+
+  assert.strictEqual(page.seen['say'].disabled, true, 'the composer stayed open during a re-ask');
+  assert.strictEqual(page.posted.filter((message) => message['command'] === 'reask').length, 1,
+    'a second press re-asked a second time');
+});
+
+test('a model label in the button is escaped like everything else', () => {
+  const html = chatPageHtml(state({ reask: '<img src=x onerror=alert(1)>' }), 'n0nce');
+
+  assert.doesNotMatch(html, /<img/i, 'a model label reached the page as markup');
 });

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -28,6 +28,7 @@ function state(over: Partial<ChatPageState> = {}): ChatPageState {
     models: MODELS,
     providers: [],
     reask: '',
+    attached: '',
     promptPresets: [],
     modelPresets: [],
     providerId: 'antigravity',
@@ -450,6 +451,16 @@ function runChatPage(over: RunOptions = {}): RunningPage {
   };
   // Captured so a test can say "the composer changed height", which is the event story 4 reacts to.
   let observed: (() => void) | undefined;
+  // What a browser gives the page for reading a pasted file. Node has none, and the page correctly
+  // refuses without one — so a harness without it tests the refusal rather than the paste.
+  class FakeFileReader {
+    public result = '';
+    public onload: (() => void) | undefined;
+    readAsDataURL(): void {
+      this.result = 'data:image/png;base64,iVBORw0KGgo=';
+      this.onload?.();
+    }
+  }
   class FakeResizeObserver {
     constructor(callback: () => void) { observed = callback; }
     observe() { /* the page observes one element */ }
@@ -457,7 +468,7 @@ function runChatPage(over: RunOptions = {}): RunningPage {
   }
 
 
-  new Function('document', 'window', 'acquireVsCodeApi', 'requestAnimationFrame', 'ResizeObserver', body)(
+  new Function('document', 'window', 'acquireVsCodeApi', 'requestAnimationFrame', 'ResizeObserver', 'FileReader', body)(
     document_,
     window_,
     // `setState` as well as `postMessage`: the page tells VS Code which conversation it is the
@@ -465,6 +476,7 @@ function runChatPage(over: RunOptions = {}): RunningPage {
     () => ({ postMessage: (message: Record<string, unknown>) => posted.push(message), setState: () => undefined }),
     (fn: () => void) => { pending.push(fn); },
     withoutResizeObserver === true ? undefined : FakeResizeObserver,
+    FakeFileReader,
   );
 
   const region = () => {
@@ -1728,4 +1740,71 @@ test('a model label in the button is escaped like everything else', () => {
   const html = chatPageHtml(state({ reask: '<img src=x onerror=alert(1)>' }), 'n0nce');
 
   assert.doesNotMatch(html, /<img/i, 'a model label reached the page as markup');
+});
+
+
+/* ------------------------------------------------------------------------------------------------
+ * Entry 13: paste a picture into the composer. Phase 0 measured that the mechanism is a file PATH
+ * named in the prompt, which the vendor process opens itself.
+ * ---------------------------------------------------------------------------------------------- */
+
+test('the page may show an image and may load nothing else', () => {
+  // The CSP is `default-src 'none'`, which blocks images too. A thumbnail of what was just pasted
+  // needs `img-src data:` and NOTHING wider: no remote host, no file:, and the page still loads
+  // nothing from disk because `localResourceRoots` is empty.
+  const html = chatPageHtml(state(), 'n0nce');
+  const csp = html.slice(html.indexOf('Content-Security-Policy'), html.indexOf('>', html.indexOf('Content-Security-Policy')));
+
+  assert.match(csp, /img-src data:/, 'a pasted image cannot be shown at all');
+  assert.doesNotMatch(csp, /img-src[^;]*https?:/, 'the page may load an image from the network');
+  assert.doesNotMatch(csp, /img-src[^;]*file:/, 'the page may load an image from the filesystem');
+});
+
+test('a pasted image is offered to the host, and anything else pastes as text', () => {
+  const page = runChatPage();
+
+  page.fire('say', 'paste', {
+    clipboardData: {
+      items: [{ kind: 'file', type: 'image/png', getAsFile: () => ({ name: 'x.png' }) }],
+    },
+  });
+
+  assert.deepStrictEqual(page.posted.filter((message) => message['command'] === 'attach'),
+    [{ type: 'command', command: 'attach', data: 'data:image/png;base64,iVBORw0KGgo=' }],
+    'a pasted picture was not offered to the host');
+
+  const text = runChatPage();
+  text.fire('say', 'paste', { clipboardData: { items: [{ kind: 'string', type: 'text/plain' }] } });
+  assert.deepStrictEqual(text.posted.filter((message) => message['command'] === 'attach'), [],
+    'pasted text was treated as a picture');
+});
+
+test('an attached picture is shown, and can be taken off again', () => {
+  const html = chatPageHtml(state({ attached: 'data:image/png;base64,iVBORw0KGgo=' }), 'n0nce');
+
+  assert.match(html, /<img class="attached" src="data:image\/png;base64,/, 'the attachment is not shown');
+  assert.match(html, /id="unattach"/, 'an attachment cannot be taken off');
+
+  const none = chatPageHtml(state(), 'n0nce');
+  assert.doesNotMatch(none, /class="attached"/, 'an empty attachment drew a box anyway');
+});
+
+test('taking the picture off names it to the host', () => {
+  const page = runChatPage({ attached: 'data:image/png;base64,iVBORw0KGgo=' });
+
+  page.fire('unattach', 'click');
+
+  assert.deepStrictEqual(page.posted.filter((message) => message['command'] === 'unattach'),
+    [{ type: 'command', command: 'unattach' }]);
+});
+
+test('an attachment that is not an image cannot be shown at all', () => {
+  // The state comes from the host, which built it from what the page sent — but a page rendering a
+  // src it has not looked at is a page that would render `javascript:` if the host ever handed it
+  // one. The check is here as well because this is where it becomes an attribute.
+  for (const attached of ['javascript:alert(1)', 'https://example.com/a.png', 'data:text/html;base64,PHA+']) {
+    const html = chatPageHtml(state({ attached }), 'n0nce');
+
+    assert.doesNotMatch(html, /<img class="attached"/, `${attached} was rendered as an attachment`);
+  }
 });


### PR DESCRIPTION
Phase 1 of `todo/PLAN_a_picture_in_the_question.md`, built on the mechanism phase 0 **measured** rather than assumed: `claude` and `agy` both read a number out of a real PNG when the file's **path** was named in the prompt.

That is what shapes the whole thing. The vendor process opens the file itself, so its name, its location and its lifetime are a contract with the model — not an implementation detail somebody may change later.

## What it does

Paste a screenshot into the composer: it shows itself there, travels with the next question, and is spent by it. Take it off with Remove.

## The parts that are careful

- **The page reads the bytes and writes nothing.** Only the page has a clipboard event; only the host has a disk.
- **`img-src data:` and nothing wider** — the CSP is `default-src 'none'`, which blocks images too. No remote host, no `file:`, and `localResourceRoots` stays empty. The page also refuses to render a `src` that is not one of the four image types: the value comes from the host so it is not arbitrary, but a page that renders a `src` it has not looked at is a page that would render `javascript:` the day something else fills that field.
- **SVG is refused although it is an image** — it is markup with script in it, and the one thing this feature does is hand a file to a process that will open it.
- **Refused by name where the provider cannot take one**, the rule the picker already keeps. `codex` is refused as **untested** rather than as incapable, which is what phase 0 actually established — its account hit a usage limit mid-probe, and that is a different sentence from a measured no. A Team server is refused because an image is a wire-format change on a server deployed by hand.
- **The file is named here, from what the image IS**, never from anything the page said — a name from the page would be a path fragment chosen by whatever wrote into the clipboard. One directory per conversation, which is what makes forgetting it possible.
- **A picture goes with the question it was pasted for and no other.** Keeping it would send the same screenshot with every question after it.

## Tests

**1271, 1269 passing, 0 failing.** The harness gained a `FileReader`: Node has none, so the page correctly refused to read a paste — and a harness without one tests the refusal rather than the paste.

## The tail

The Team server's wire format is the next item for that half, and `codex` needs its probe re-run before it can be refused as anything but untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)