### PR TITLE
fix(chat): the money differencing goes, and the ledger keeps everything

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -2476,9 +2476,19 @@ without which turn one at 1000 and turn two at 1200 would have been recorded as 
 conversation on that vendor over-billed increasingly the longer it ran (the gate caught the plan doing
 exactly that). The key is the runtime and not the vendor row's id, because a row id is a person's own
 editable text: two Codex accounts as `codex-work` and `codex-home` would otherwise have been
-differenced by neither. `turnCost` applies the same rule to money — dead code today, since the one
-cumulative vendor prices nothing, and written so that the tokens and the bill cannot drift apart the
-day it does.
+differenced by neither.
+
+**Money is REFUSED for such a vendor rather than differenced (2026-09-10).** `turnCost` mirrored
+`turnTokens` and subtracted the bills too, which was unreachable code — the one cumulative vendor
+reports `costUsd: null` — and the operator ruled the arithmetic out. What stands in its place is not a
+clamp but a refusal: a cumulative vendor's per-turn money is `null`, because a running total is not
+what one turn cost and recording it as one would over-report every turn but the first, which is
+exactly the token defect the gate caught before this shipped. `null` means "nobody told us", and the
+log page then prices the row from the public list by the model that answered and marks it with the
+tilde. The deletion was checked against the two other things here that turn tokens into money — the
+public price lists, and the rate a person types on a vendor row — and neither goes through `turnCost`:
+both are dollars per million tokens applied when a row is DRAWN, while `turnCost` is only ever about a
+figure a vendor put on the wire itself.
 
 **Every turn is recorded, not every ANSWER.** The write sits before the branch in `oneTurn`, so a turn
 that was stopped or that fell over is written down with its outcome — those are the ones somebody

--- a/src_vs_code/src/chatAdapter.ts
+++ b/src_vs_code/src/chatAdapter.ts
@@ -93,9 +93,16 @@ export interface ChatAdapter {
    *
    * <p>`codex` counts up: turn one reports 1000, turn two reports 1200, and 1200 is not what turn two
    * cost. Recording what it says would over-bill every conversation on that vendor increasingly, the
-   * longer it ran. The session subtracts what the thread last reported — see `normalised` in
+   * longer it ran. The session subtracts what the thread last reported — see `perTurnUsage` in
    * `cliChatSession.ts` — so a `TurnResult` always carries the cost of ONE turn whatever the vendor
    * counts in.</p>
+   *
+   * <p><b>It governs the TOKENS. A cumulative vendor's money is refused, not differenced</b> —
+   * `turnCost` answers `null` for one, because no vendor has ever been seen billing a running total
+   * and inventing the arithmetic for it was dead code the operator ruled out on 2026-09-10. A `null`
+   * bill means "nobody told us what this turn cost", and the log page prices such a row from a public
+   * list instead and marks it as an estimate. Today the one cumulative vendor reports no money at
+   * all, so nothing observable turns on this.</p>
    *
    * <p><b>It lives on the adapter because it is a fact about the wire protocol</b>, and the adapter is
    * where this codebase keeps those. It was first a list of runtime NAMES in `chatUsage.ts`, and a

--- a/src_vs_code/src/chatUsage.ts
+++ b/src_vs_code/src/chatUsage.ts
@@ -113,38 +113,33 @@ function wentBackwards(
 }
 
 /**
- * What THIS turn was billed, by the same rule and for the same reason as {@link turnTokens}.
+ * What THIS turn was billed, as its vendor billed it — or nothing, when nobody can say.
  *
- * <p>Differenced separately from the tokens because the two can be missing independently — a vendor
- * can report tokens and no money, which two of the three do.</p>
+ * <p><b>The money used to be DIFFERENCED here, mirroring {@link turnTokens}, and the operator ruled
+ * that arithmetic out on 2026-09-10 as dead code.</b> It was: the only cumulative vendor reports
+ * `costUsd: null`, so the subtraction was unreachable, and no vendor anywhere has been observed
+ * billing a running total. Checked before deleting it, because two other things in this product turn
+ * tokens into money and neither goes through here — the public price lists and the rate a person
+ * types on a vendor row are both <i>dollars per million tokens</i>, applied when a row is DRAWN.
+ * This function is only ever about a figure a vendor put on the wire itself.</p>
  *
- * <p><b>This is dead code today and is written anyway.</b> The one cumulative vendor reports
- * `costUsd: null`, so nothing reaches the second branch. Leaving money un-differenced beside tokens
- * that are would be a trap set for whoever adds the next cumulative vendor, or for the day `codex`
- * starts pricing its own turns: the tokens would be right, the money would grow with the length of
- * the conversation, and nothing would say which of the two numbers to believe.</p>
+ * <p><b>What replaces it is a refusal, not a clamp, and the difference matters the day the case
+ * arrives.</b> A cumulative vendor's money is `null`: a running total is not what one turn cost, so
+ * recording it as one would over-report every turn but the first, increasingly, which is precisely
+ * the token defect the gate caught before this shipped. `null` says "nobody told us what this turn
+ * cost" — which is true — and the log page then prices the row from the public list by the model that
+ * answered and marks it with the tilde it already uses for an estimate. Today this changes nothing,
+ * because the one cumulative vendor reports no money at all.</p>
  */
-export function turnCost(
-  cumulative: boolean,
-  reported: ReportedUsage,
-  previous: { readonly costUsd: number | null } | undefined,
-): number | null {
-  if (reported.costUsd === null) {
+export function turnCost(cumulative: boolean, reported: ReportedUsage): number | null {
+  if (reported.costUsd === null || cumulative) {
     return null;
   }
-  if (!cumulative || previous === undefined || previous.costUsd === null
-    || reported.costUsd < previous.costUsd) {
-    // Passed through UNTOUCHED, deliberately. This is what a vendor said it charged — `claude` bills
-    // figures like 0.107958 — and rounding somebody else's invoice to make it prettier is not this
-    // module's business.
-    return Math.max(0, reported.costUsd);
-  }
 
-  // The subtraction is OURS, and so is the float noise it makes: $1.50 less $1.20 is $0.30 and
-  // arrives as 0.30000000000000004. Cleaned up here, at four decimals, which is the precision the
-  // rest of this product already counts money in — a round is fractions of a cent and two decimals
-  // would read as free.
-  return round4(reported.costUsd - previous.costUsd);
+  // Passed through UNTOUCHED otherwise. This is what a vendor said it charged — `claude` bills figures
+  // like 0.107958 — and rounding somebody else's invoice to make it prettier is not this module's
+  // business. The clamp is only against nonsense: a negative bill is not a credit.
+  return Math.max(0, reported.costUsd);
 }
 
 /** Four decimals, the precision this product counts money in. Cents would read a real cost as free. */

--- a/src_vs_code/src/chatUsageFile.ts
+++ b/src_vs_code/src/chatUsageFile.ts
@@ -46,12 +46,18 @@ import { ChatTurnRecord, chatUsageLine, parseChatUsage } from './chatUsage';
  *   <li>1000 a day, which nobody types, is 94 MB a year.</li>
  * </ul>
  *
- * <p><b>Nothing retires it, and that is the decision rather than the omission.</b> The file IS the
- * history: `conversationTotal` sums it, and deleting old lines would silently change what a past
- * conversation is recorded to have cost — a ledger that quietly forgets is worse than one that is
- * large. At the sizes above it is not large. What DID need fixing is the cost of holding it: the log
- * page used to re-read and re-parse the whole file every five seconds, so `PanelProvider` now caches
- * the parse and re-reads only when the file's size or mtime moves.</p>
+ * <p><b>Nothing retires it, and the operator ruled that on 2026-09-10 — asked with these numbers in
+ * front of them, the answer was "keep it for ever".</b> The file IS the history: `conversationTotal`
+ * sums it, and deleting old lines would silently change what a past conversation is recorded to have
+ * cost. A ledger that quietly forgets is worse than one that is large, and at the sizes above it is
+ * not large. The two alternatives were put and refused: trimming by age or count bounds the file but
+ * answers "what did I spend last year" WRONGLY rather than not at all, and rolling trimmed lines up
+ * into a summary per conversation keeps the truth at the price of a second record type. If a bound is
+ * ever wanted, the roll-up is the only version of it that does not lie.</p>
+ *
+ * <p>What DID need fixing is the cost of holding it: the log page used to re-read and re-parse the
+ * whole file every five seconds, so `PanelProvider` now caches the parse and re-reads only when the
+ * file's size or mtime moves.</p>
  *
  * <p>It is a plain file in the person's own data directory, named in the help; deleting it is theirs
  * to do, and costs them only the history.</p>

--- a/src_vs_code/src/cliChatSession.ts
+++ b/src_vs_code/src/cliChatSession.ts
@@ -575,7 +575,7 @@ export class CliChatSession implements ChatSession {
     }
     const cumulative = this.adapter.cumulative;
     const tokens = turnTokens(cumulative, raw, this.threadTotals);
-    const costUsd = turnCost(cumulative, raw, this.threadTotals);
+    const costUsd = turnCost(cumulative, raw);
     // The RAW figures, never the differenced ones: the next turn subtracts from what the vendor last
     // SAID, and subtracting from an already-differenced number would make every turn but the first
     // the difference of two differences.

--- a/src_vs_code/src/test/chatUsage.test.ts
+++ b/src_vs_code/src/test/chatUsage.test.ts
@@ -84,11 +84,9 @@ test('a cumulative total that goes BACKWARDS is a fresh baseline, not a free tur
     { tokensIn: 50, tokensOut: 10 },
     'a restarted thread’s turn was recorded as free',
   );
-  // And money follows the tokens, by the same rule.
-  assert.strictEqual(
-    turnCost(true, { tokensIn: 50, tokensOut: 10, costUsd: 0.2 }, { costUsd: 5 }),
-    0.2,
-  );
+  // Money does NOT follow the tokens any more: a cumulative vendor's bill is refused rather than
+  // differenced, so a restart is not a special case there — see the test that says so.
+  assert.strictEqual(turnCost(true, { tokensIn: 50, tokensOut: 10, costUsd: 0.2 }), null);
 });
 
 test('a negative number of tokens is still not a thing that can be true', () => {
@@ -213,22 +211,29 @@ test('the record takes usage that is ALREADY per-turn, and does not difference a
   assert.ok(!Object.keys(built).includes('runtime'), 'the runtime has no business in the file');
 });
 
-test('money is differenced by the same rule as tokens, so one cannot drift from the other', () => {
-  // Dead code today — the one cumulative vendor reports no money at all — and written anyway.
-  // Leaving money un-differenced beside tokens that are is a trap for whoever adds the next
-  // cumulative vendor: the tokens would be right and the bill would grow with the conversation.
-  assert.strictEqual(turnCost(true, { tokensIn: 0, tokensOut: 0, costUsd: 1.5 }, { costUsd: 1.2 }), 0.3);
-  assert.strictEqual(turnCost(false, { tokensIn: 0, tokensOut: 0, costUsd: 1.5 }, { costUsd: 1.2 }), 1.5);
+test('a CUMULATIVE vendor reports no per-turn bill, so none is recorded', () => {
+  // The operator ruled on 2026-09-10: the money-differencing arithmetic was dead code and goes. What
+  // replaces it is not a clamp but a REFUSAL, because the two are not the same when the case finally
+  // arrives. A running total is not what one turn cost, so recording it as one would over-report
+  // every turn but the first, increasingly, exactly as the token bug did before the gate caught it.
+  // `null` says "nobody told us what this turn cost", which is true, and the log page then prices the
+  // row from the public list by the model that answered and marks it with a tilde.
   assert.strictEqual(
-    turnCost(true, { tokensIn: 0, tokensOut: 0, costUsd: null }, { costUsd: 1.2 }),
+    turnCost(true, { tokensIn: 0, tokensOut: 0, costUsd: 1.5 }),
     null,
-    'a vendor that billed nothing must not be handed the previous turn’s bill',
+    'a running total was recorded as this turn’s bill',
   );
-  assert.strictEqual(
-    turnCost(true, { tokensIn: 0, tokensOut: 0, costUsd: 0.4 }, { costUsd: null }),
-    0.4,
-    'nothing to difference against is the first turn, not a free one',
-  );
+  // The vendor that DOES bill per turn is untouched, to the cent it actually charged.
+  assert.strictEqual(turnCost(false, { tokensIn: 0, tokensOut: 0, costUsd: 0.107958 }), 0.107958);
+  assert.strictEqual(turnCost(false, { tokensIn: 0, tokensOut: 0, costUsd: null }), null);
+  // And nonsense is not a debit.
+  assert.strictEqual(turnCost(false, { tokensIn: 0, tokensOut: 0, costUsd: -3 }), 0);
+});
+
+test('the OLD money-differencing rule is gone, and nothing calls it with a previous turn', () => {
+  // Guards the deletion itself: `turnCost` took a third argument and subtracted with it. A signature
+  // that still accepted one would let the arithmetic creep back in unnoticed.
+  assert.strictEqual(turnCost.length, 2, 'turnCost grew back a `previous` parameter');
 });
 
 test('a turn nobody reported numbers for is STILL a record, with zeroes and its outcome', () => {

--- a/todo/PLAN_who_said_it_and_what_it_cost.md
+++ b/todo/PLAN_who_said_it_and_what_it_cost.md
@@ -40,6 +40,13 @@
 >    a moment later. A turn nobody reported numbers for reads as unknown rather than as free.
 > 5. **The record carries the conversation's TITLE.** Not in the plan, and without it the log's *What*
 >    column reads as a UUID for every conversation row.
+> 6. **A cumulative vendor's MONEY is refused rather than differenced** (ruled 2026-09-10). The first
+>    version mirrored the token rule and subtracted the bills too; that was unreachable code, since the
+>    one cumulative vendor reports no money at all, and it went. A refusal — `null`, "nobody told us
+>    what this turn cost" — replaces it rather than a clamp, because recording a running total as one
+>    turn's bill is the same defect the token rule exists to prevent. Checked against the two other
+>    paths that turn tokens into money, the public price lists and the rate a person types on a vendor
+>    row: both are dollars per million applied when a row is DRAWN, and neither touches this.
 >
 > Companion: [PLAN_the_log_names_the_model.md](PLAN_the_log_names_the_model.md) — the same defect
 > on the review side (steps 2 and 3 open there). One decision, two surfaces; build them together
@@ -100,11 +107,23 @@ UUID conversation id and a plan filename in it, not estimated:
 | 200 | 18.8 MB |
 | 1000 (nobody types this) | 94 MB |
 
-**Nothing retires it, and that is a decision rather than an omission.** The file IS the history:
-`conversationTotal` sums it, so deleting old lines would silently change what a past conversation is
-recorded to have cost — a ledger that quietly forgets is worse than one that is large, and at the
-sizes above it is not large. It is a plain file in the person's own data directory, named in the help;
-deleting it is theirs to do and costs them only the history.
+**Nothing retires it. The operator was asked with these numbers in front of them and ruled "keep it
+for ever" on 2026-09-10** — so this is settled rather than merely unimplemented, which is the
+difference that stops it being raised a fourth time. The file IS the history: `conversationTotal` sums
+it, so deleting old lines would silently change what a past conversation is recorded to have cost, and
+a ledger that quietly forgets is worse than one that is large. At the sizes above it is not large. It
+is a plain file in the person's own data directory, named in the help; deleting it is theirs to do and
+costs them only the history.
+
+The two alternatives were put and refused, and are written down so a future reader does not have to
+re-derive them:
+
+| instead | what it costs |
+|---|---|
+| trim by age or by count | the file stops growing, and *"what did I spend last year"* is answered **wrongly** rather than not at all |
+| roll trimmed lines up into one summary per conversation | truth and a bound, at the price of a second record type in the format and the code around it |
+
+If a bound is ever wanted, the roll-up is the only version of it that does not lie.
 
 What did need fixing is the cost of HOLDING it. The log page ticks every five seconds while it is
 open and re-read and re-parsed the whole file on each one; `PanelProvider.chatLines` now caches the


### PR DESCRIPTION
The two questions `PLAN_who_said_it_and_what_it_cost.md` left open, both answered by the operator on 2026-09-10 — and both now written down as **rulings** rather than as one contributor's preference. That distinction earns its keep here: a reviewer raised the retention question twice across two gate rounds, and a question recorded as settled stops coming back.

## 1. The money differencing was dead code, and it is gone

`turnCost` mirrored `turnTokens` and subtracted the *bills* of a cumulative vendor as well as its tokens. That branch was unreachable:

```ts
if (reported.costUsd === null) return null;   // ← codex always leaves here
if (!cumulative || …) return …;               // ← claude always leaves here
return round4(reported.costUsd - previous.costUsd);   // ← nobody, ever
```

The only cumulative vendor is `codex`, and it reports `costUsd: null`. `claude` bills a real `total_cost_usd` but is `cumulative: false`. So the subtraction never ran, and no vendor anywhere has been observed billing a running total.

**Checked before deleting**, because the operator asked what it might collide with. Two other things in this product turn tokens into money, and neither goes through `turnCost`:

| path | what it is | where it applies |
|---|---|---|
| OpenRouter / LiteLLM lists | dollars per million tokens | when a row is **drawn** (`priceFor` → `modelPrice`) |
| the rate a person types on a vendor row | dollars per million tokens | when a row is **drawn** (`usage.ts:216`) — the only thing that can price a local engine at all |
| `turnCost` | a figure the vendor put **on the wire** | when a turn is **recorded** |

A local model cannot even hold a chat turn today: three runtimes have a chat adapter (`antigravity`, `claude`, `codex`) and `local` is not one of them, so it is refused by name. Its manual rate lives in review rounds and is applied at display time, entirely outside this function. No collision on either count.

**What replaces the arithmetic is a refusal, not a clamp** — the one place this is not simply a deletion, and the reason is worth a sentence. A cumulative vendor's per-turn money is now `null`, because a running total is not what one turn cost, and recording it as one would over-report every turn but the first, increasingly — which is *precisely* the token defect the gate caught before this feature shipped. `null` means "nobody told us what this turn cost", which is true, and the log page then prices the row from the public list by the model that answered and marks it with the tilde it already uses for an estimate. Today nothing observable changes, because the one cumulative vendor reports no money at all.

Red first: the new test went red with **1.5 recorded as a single turn's bill**.

## 2. The ledger keeps everything

Asked with the measured numbers in front of them — **270 bytes a record**, 4.7 MB a year at fifty turns a day, 18.8 MB at two hundred — the ruling was to keep it for ever. No behaviour changed; this was already what shipped. What changed is that the record now says who decided and when, and both refused alternatives sit beside it so nobody has to re-derive them:

| instead | what it costs |
|---|---|
| trim by age or by count | the file stops growing, and *"what did I spend last year"* is answered **wrongly** rather than not at all |
| roll trimmed lines up into one summary per conversation | truth *and* a bound, at the price of a second record type in the format and the code around it |

If a bound is ever wanted, the roll-up is the only version of it that does not lie.

## Tests

**1313 tests, 1312 pass, 1 skipped, 0 fail.**

Three tests changed hands. The new `a CUMULATIVE vendor reports no per-turn bill, so none is recorded` pins the refusal and the untouched per-turn path (`0.107958` to the cent, and a negative bill clamped rather than credited). `the OLD money-differencing rule is gone` asserts `turnCost.length === 2` — a signature that grew a `previous` parameter back would let the arithmetic creep in unnoticed. The old differencing test is deleted; the backwards-baseline test kept its token half and lost its money half.

`round4` stays: `conversationTotal` still needs it.

## Docs

`research/module_extension.md`, `src/chatAdapter.ts` (the `cumulative` field now says it governs the tokens and what happens to the money), `src/chatUsageFile.ts` (the growth budget carries the ruling and both refused alternatives), and the plan — a sixth deviation, and a retention paragraph that names the decision instead of implying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
