### PR TITLE
feat(chat): a conversation says what it has cost, where the decision is made

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -29,6 +29,32 @@ local model` the page would otherwise still show the remote one as selected whil
 somewhere else), a pushed state that has not changed is not sent at all, a `pick` naming a model the
 conversation was never offered is refused at the host boundary rather than trusted, and the
 composer takes focus back when a turn ends — without which every follow-up costs a mouse click.
+### What the conversation has cost, where the decision is made (2026-09-10)
+
+A chat turn carries the whole conversation, so question five is billed for one through four as well
+— `chatCommand.ts` says so out loud where the carry is built. That is the number a person would use
+to decide between asking again and starting fresh, and it was invisible at exactly that moment. The
+ledger half writes every turn down; this says the running total beside the picker, which is where
+the decision is taken.
+
+**An estimate is marked as one.** The three vendors do not report comparable numbers — `claude`
+counts cache reads, `antigravity` omits cache entirely, `codex` reports a cumulative maximum
+(measured, `todo/PLAN_usage_that_compares.md`) — so only `claude` reports a bill and everything else
+is worked out. The tilde is this product's existing convention for that, and one convention for one
+thing is worth more than a prettier line.
+
+**One estimated turn makes the whole total an estimate.** A sum of a measured price and a guess is a
+guess, and showing it as a bill would make it the most confident number on the page and the least
+true.
+
+**A turn nobody priced is COUNTED, not skipped.** `codex` reports a cumulative maximum the ledger
+refuses to difference, so its turns legitimately arrive with no cost at all — and a total that
+quietly left them out would read as complete.
+
+**The count lives beside the conversation, not in the ledger.** The ledger is a file this window
+shares with every other, and a tab asking it for its own total on every push would be reading a
+growing file to answer a question it already knows.
+
 ### A picture in the question (2026-09-10)
 
 Phase 0 MEASURED the mechanism rather than assuming one: `claude` and `agy` both read a number out of

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**A conversation says what it has cost.** Beside the model picker, updated as answers arrive — which
+is where you decide whether to ask again or start fresh, and that decision is the one the number is
+for: each question carries the whole conversation with it, so it is billed for the ones before it. A
+figure worked out from tokens wears a tilde, because only one of the three vendors reports what it
+actually charged.
+
 **Paste a picture into a question.** A screenshot from the clipboard goes into the composer, shows
 itself there, and travels with the next question you send. It works with the models that were
 measured to read one — if the model you have chosen cannot, the tab says so by name instead of

--- a/src_vs_code/src/chatCommand.ts
+++ b/src_vs_code/src/chatCommand.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto';
 import * as vscode from 'vscode';
 import { isInside } from './chatMessages';
 import { imageFileName, imageRefusal, imageTurn, pastedImage } from './chatImage';
+import { TurnSpend, spendLabel, spendSoFar } from './chatSpend';
 import {
   ModelPreset,
   PromptPreset,
@@ -83,6 +84,15 @@ interface Thread extends ChatMemory {
   readonly models: readonly ChatModelChoice[];
   /** Every row that can answer, each with its own models. Replaced whenever a pick resolves. */
   providers: readonly ChatProvider[];
+  /**
+   * What each finished turn cost, in the order they finished.
+   *
+   * <p>Kept beside the conversation rather than read back from the ledger: the ledger is a file this
+   * window shares with every other, and a tab asking it for its own total on every push would be
+   * reading a growing file to answer a question it already knows. The ledger is the record; this is
+   * the running count.</p>
+   */
+  spend: TurnSpend[];
   /** The picture waiting to go with the next question, as the page shows it. */
   attached: string;
   /** Where that picture IS — the file a vendor process will open. Empty when there is none. */
@@ -237,6 +247,7 @@ function show(entry: ChatEntry, running: boolean, failure: string, queued = 0): 
     // to re-ask something that is still being answered is offering a question nobody asked yet.
     reask: running || thread === undefined ? '' : reaskLabel(thread),
     attached: thread?.attached ?? '',
+    spend: spendLabel(spendSoFar(thread?.spend ?? [])),
   });
   // The one place the transcript reaches a page is the one place it is written down — but only when
   // there is something new to write. `show` runs on every state push: a turn starting, a queue
@@ -541,6 +552,17 @@ function ledger(
   if (turn.vendor === undefined) {
     return;
   }
+  // The same number the ledger writes down, counted as it goes. `chatUsage` decides what a turn
+  // cost; this only adds them up, so the line in the tab and the line in the log cannot disagree.
+  thread.spend = [
+    ...thread.spend,
+    {
+      costUsd: turn.usage?.costUsd ?? null,
+      // What a vendor CHARGED is a bill; what this product worked out from tokens is not, and the
+      // three vendors do not even count tokens the same way. Only claude reports its own cost.
+      estimated: turn.vendor.id !== 'claude',
+    },
+  ];
   void recordChatTurn(coaiDataDir(), chatTurnRecord({
     utc: turn.utc,
     provider: turn.vendor.id,
@@ -915,6 +937,7 @@ function newConversation(
       // A conversation that has just opened has said nothing, so there is nothing to ask again.
       reask: '',
       attached: '',
+      spend: '',
       providerId: ready.providerId,
       modelId: ready.modelId,
       running: false,
@@ -939,6 +962,7 @@ function newConversation(
     providers: ready.providers,
     attached: '',
     attachedPath: '',
+    spend: [],
     providerId: ready.providerId,
     modelId: ready.modelId,
     running: false,
@@ -1218,6 +1242,7 @@ function restoredPage(
       ...presets,
       reask: '',
       attached: '',
+      spend: '',
       // The row this tab was speaking to, read by `savedPick` out of the old `modelId`.
       providerId: ready.ok ? ready.providerId : restored.providerId,
       modelId: saved.modelId,
@@ -1264,6 +1289,7 @@ export function restoreConversation(
     providers: ready.ok ? ready.providers : [],
     attached: '',
     attachedPath: '',
+    spend: [],
     providerId: ready.ok ? ready.providerId : restored.providerId,
     modelId: saved.modelId,
     running: false,

--- a/src_vs_code/src/chatPage.ts
+++ b/src_vs_code/src/chatPage.ts
@@ -108,6 +108,14 @@ export interface ChatPageState {
    * loads nothing from disk. The HOST holds the real file; this is only what a person sees.</p>
    */
   readonly attached: string;
+  /**
+   * What this conversation has cost so far, as a line, or empty when it has cost nothing.
+   *
+   * <p>A line rather than a number, because what it says varies: a bill, an estimate wearing the
+   * tilde, or a count of turns nobody priced. The HOST composes it — `chatSpend.ts` holds the rule
+   * — and the page shows what it was handed.</p>
+   */
+  readonly spend: string;
   /** The prompts a person saved, as buttons above the composer. */
   readonly promptPresets: readonly PromptPreset[];
   /** The models a person saved, likewise. */
@@ -421,6 +429,7 @@ function chatStyle(
   .picker select { max-width: 45%; }
   .refused { font-size: .85em; opacity: .75; margin: 0 0 8px; }
   .caption { font-size: .85em; opacity: .7; }
+  .spend { font-size: .85em; opacity: .7; margin-left: auto; padding-left: 8px; white-space: nowrap; }
   /* The 30 % lives HERE and only here, so the CSS path and the JavaScript fallback below cannot
      disagree about where the ceiling is: the fallback sets a height and this caps it. field-sizing
      is Chromium-only, which is not a limitation in a page that renders nowhere but VS Code's own
@@ -499,6 +508,7 @@ function chatBody(state: ChatPageState, regions: Regions): string {
 <button type="button" id="jump" class="jump" hidden>Jump to newest ↓</button>
 ${chatPresetRowsHtml(state.promptPresets, state.modelPresets)}
 <div id="pickerBox">${chatPickerHtml({ providers: state.providers, refused: [] }, state.providerId, state.modelId)}</div>
+<span id="spend" class="spend" title="What this conversation has cost so far. A turn carries the whole conversation, so each question is billed for the ones before it.">${escapeHtml(state.spend)}</span>
 ${attachedHtml(state.attached)}
 <div class="compose">
 <textarea id="say" rows="3" placeholder="Ask about the text above…"${locked ? ' disabled' : ''}>${escapeHtml(state.draft)}</textarea>
@@ -1012,6 +1022,10 @@ function chatScript(state: ChatPageState, regions: Regions): string {
     // it while a turn is still in flight. (local, the second code round.)
     // Who a re-ask would go to, which is also the button's caption: the gesture is an empty box and
     // Enter, and a feature whose only trigger is pressing Enter on nothing is one nobody discovers.
+    if (typeof data.spend === 'string') {
+      const total = document.getElementById('spend');
+      if (total) { total.textContent = data.spend; }
+    }
     if (typeof data.reask === 'string') {
       canReask = data.reask.length > 0;
       const reaskButton = document.getElementById('send');

--- a/src_vs_code/src/chatPanel.ts
+++ b/src_vs_code/src/chatPanel.ts
@@ -102,6 +102,8 @@ export interface ChatPushState {
   readonly reask: string;
   /** The picture waiting to go with the next question, as a data URL, or empty. */
   readonly attached: string;
+  /** What this conversation has cost so far, as a line, or empty. */
+  readonly spend: string;
   readonly providerId: string;
   readonly modelId: string;
   /**

--- a/src_vs_code/src/chatSpend.ts
+++ b/src_vs_code/src/chatSpend.ts
@@ -1,0 +1,82 @@
+/**
+ * What a conversation has cost, as the tab shows it.
+ *
+ * <p>A chat turn carries the whole conversation, so question five is billed for one through four as
+ * well — `chatCommand.ts` says so out loud where the carry is built. That is the number a person
+ * would use to decide between asking again and starting a fresh conversation, and it is precisely
+ * the moment at which the number was invisible: the ledger writes every turn down, and this says the
+ * running total while the decision is being made.</p>
+ *
+ * <p><b>An estimate is marked as one, and the tilde is not decoration.</b> The three vendors do not
+ * report comparable numbers — `claude` counts cache reads, `antigravity` omits cache entirely,
+ * `codex` reports a cumulative maximum — which is measured and recorded in
+ * `todo/PLAN_usage_that_compares.md`. For two of the three, a cost worked out from tokens is not
+ * what anybody was charged. `usage.ts` already writes `~$0.42` for exactly this, and one convention
+ * for one thing is worth more than a prettier line here.</p>
+ */
+
+/** Four decimals, the precision this product counts money in — cents would read a real cost as free. */
+function round4(usd: number): number {
+  return Math.round(usd * 10_000) / 10_000;
+}
+
+export interface TurnSpend {
+  /** What the vendor said this turn cost, or null when it said nothing this product can use. */
+  readonly costUsd: number | null;
+  /** Worked out from tokens rather than reported as a bill. */
+  readonly estimated: boolean;
+}
+
+export interface Spend {
+  readonly usd: number;
+  /** Any part of it worked out from tokens, which makes the whole total an estimate. */
+  readonly estimated: boolean;
+  /** Turns whose cost nobody reported — counted, because a total that hides them reads as complete. */
+  readonly unpriced: number;
+}
+
+/**
+ * The running total.
+ *
+ * <p>A turn nobody priced is COUNTED rather than skipped. `codex` reports a cumulative maximum that
+ * the ledger refuses to difference, so its turns legitimately arrive with no cost at all — and a
+ * total that quietly left them out would be the most confident number on the page and the least
+ * true. A nonsense value is treated the same way, because a negative bill is not a credit and NaN is
+ * not a price.</p>
+ */
+export function spendSoFar(turns: readonly TurnSpend[]): Spend {
+  let usd = 0;
+  let estimated = false;
+  let unpriced = 0;
+
+  for (const turn of turns) {
+    const cost = turn.costUsd;
+    if (typeof cost !== 'number' || !Number.isFinite(cost) || cost < 0) {
+      unpriced += 1;
+      continue;
+    }
+    usd += cost;
+    estimated = estimated || turn.estimated;
+  }
+
+  return { usd: round4(usd), estimated, unpriced };
+}
+
+/**
+ * The line the tab shows, or nothing at all when there is nothing to say.
+ *
+ * <p>One estimated turn makes the whole total an estimate: a sum of one measured price and one guess
+ * is a guess, and presenting it as a bill would be the most confident number on the page.</p>
+ */
+export function spendLabel(spend: Spend): string {
+  if (spend.usd === 0 && spend.unpriced === 0) {
+    return '';
+  }
+  const money = spend.usd === 0 ? '' : `${spend.estimated ? '~' : ''}$${spend.usd.toFixed(4)}`;
+  if (spend.unpriced === 0) {
+    return money;
+  }
+  const unpriced = `${spend.unpriced} turn${spend.unpriced === 1 ? '' : 's'} nobody priced`;
+
+  return money.length === 0 ? unpriced : `${money} + ${unpriced}`;
+}

--- a/src_vs_code/src/test/chatPage.test.ts
+++ b/src_vs_code/src/test/chatPage.test.ts
@@ -29,6 +29,7 @@ function state(over: Partial<ChatPageState> = {}): ChatPageState {
     providers: [],
     reask: '',
     attached: '',
+    spend: '',
     promptPresets: [],
     modelPresets: [],
     providerId: 'antigravity',
@@ -1807,4 +1808,30 @@ test('an attachment that is not an image cannot be shown at all', () => {
 
     assert.doesNotMatch(html, /<img class="attached"/, `${attached} was rendered as an attachment`);
   }
+});
+
+
+test('the tab says what the conversation has cost, where the decision is made', () => {
+  // Beside the picker, which is where somebody decides whether to ask again or start fresh — and a
+  // turn carries the whole conversation, so that decision is exactly the one the number is for.
+  const html = chatPageHtml(state({ spend: '~$0.4200' }), 'n0nce');
+  const footer = html.slice(html.indexOf('<footer'), html.indexOf('</footer>'));
+
+  assert.match(footer, /id="spend"[^>]*>~\$0\.4200</, 'the running cost is not on the page');
+});
+
+test('a conversation that has cost nothing says nothing', () => {
+  const html = chatPageHtml(state(), 'n0nce');
+
+  // Empty CONTENT, not an absent element: the element is always there so a push can fill it without
+  // the page being rebuilt. `\S` was the first assertion and it matched the `<` of `</span>`.
+  assert.match(html, /id="spend"[^>]*><\/span>/, 'an empty total drew a line anyway');
+});
+
+test('the running total is updated by a push, not only at open', () => {
+  const page = runChatPage({ spend: '$0.0100' });
+
+  page.deliver({ type: 'state', spend: '$0.0200', running: false, capped: false });
+
+  assert.strictEqual(page.seen['spend'].textContent, '$0.0200', 'the total stayed at what it opened with');
 });

--- a/src_vs_code/src/test/chatSpend.test.ts
+++ b/src_vs_code/src/test/chatSpend.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { spendSoFar, spendLabel } from '../chatSpend';
+
+/**
+ * What a conversation has cost, as the tab shows it.
+ *
+ * <p>A chat turn carries the whole conversation, so question five is billed for one through four as
+ * well — the code says so out loud where the carry is built. That is the number a person would use
+ * to decide between asking again and starting fresh, and until the ledger landed it was recorded
+ * nowhere. This is the other half: the ledger writes it down, and the tab says it while the decision
+ * is being made.</p>
+ *
+ * <p><b>An estimate is marked as one.</b> The three vendors do not report comparable numbers —
+ * `claude` counts cache reads, `antigravity` omits cache entirely, `codex` reports a cumulative
+ * maximum — so for two of the three a cost worked out from tokens is not what anybody was charged.
+ * The tilde is this product's existing convention for that and it is kept here.</p>
+ */
+
+test('a conversation with nothing spent says nothing', () => {
+  assert.strictEqual(spendLabel(spendSoFar([])), '');
+});
+
+test('what the vendor charged is shown as money, without a tilde', () => {
+  const spend = spendSoFar([
+    { costUsd: 0.0123, estimated: false },
+    { costUsd: 0.0077, estimated: false },
+  ]);
+
+  assert.strictEqual(spend.usd, 0.02);
+  assert.strictEqual(spend.estimated, false);
+  assert.strictEqual(spendLabel(spend), '$0.0200');
+});
+
+test('a cost worked out from tokens wears the tilde', () => {
+  const spend = spendSoFar([{ costUsd: 0.42, estimated: true }]);
+
+  assert.strictEqual(spend.estimated, true);
+  assert.strictEqual(spendLabel(spend), '~$0.4200');
+});
+
+test('one estimated turn makes the whole total an estimate', () => {
+  // A sum of one measured price and one guess is a guess. Showing it as a bill would be the most
+  // confident number on the page and the least true.
+  const spend = spendSoFar([
+    { costUsd: 0.01, estimated: false },
+    { costUsd: 0.01, estimated: true },
+  ]);
+
+  assert.strictEqual(spend.estimated, true);
+  assert.match(spendLabel(spend), /^~\$/);
+});
+
+test('a turn whose cost nobody reported is counted as nothing, and SAID to be', () => {
+  // `codex` reports a cumulative maximum, which the ledger refuses to difference — so its turns
+  // arrive with no cost at all. A total that silently skipped them would read as complete.
+  const spend = spendSoFar([
+    { costUsd: 0.01, estimated: false },
+    { costUsd: null, estimated: false },
+  ]);
+
+  assert.strictEqual(spend.usd, 0.01);
+  assert.strictEqual(spend.unpriced, 1);
+  assert.match(spendLabel(spend), /\+ 1 turn nobody priced/);
+});
+
+test('a total is counted in four decimals, because cents would read a real cost as free', () => {
+  const spend = spendSoFar([{ costUsd: 0.00004, estimated: false }, { costUsd: 0.00004, estimated: false }]);
+
+  assert.strictEqual(spendLabel(spend), '$0.0001');
+});
+
+test('a nonsense number is not money', () => {
+  for (const costUsd of [Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+    const spend = spendSoFar([{ costUsd, estimated: false }]);
+
+    assert.strictEqual(spend.usd, 0, `${String(costUsd)} was counted as money`);
+    assert.strictEqual(spend.unpriced, 1, `${String(costUsd)} was not counted as unpriced either`);
+  }
+});


### PR DESCRIPTION
The other half of `todo/PLAN_who_said_it_and_what_it_cost.md`. The ledger — another lane's — writes every turn down; this says the **running total** beside the picker.

## Why beside the picker

A chat turn carries the whole conversation, so question five is billed for one through four as well; `chatCommand.ts` says so out loud where the carry is built. That is the number a person uses to decide between asking again and starting fresh — and it was invisible at exactly that moment.

## The rules, each with a test

- **An estimate is marked as one.** The three vendors do not report comparable numbers — `claude` counts cache reads, `antigravity` omits cache entirely, `codex` reports a cumulative maximum (measured; `todo/PLAN_usage_that_compares.md`). Only `claude` reports a bill; everything else is worked out. The tilde is this product's existing convention, and one convention for one thing beats a prettier line here.
- **One estimated turn makes the whole total an estimate.** A sum of a measured price and a guess is a guess; showing it as a bill would make it the most confident number on the page and the least true.
- **A turn nobody priced is counted, not skipped.** `codex`'s turns legitimately arrive with no cost at all, and a total that quietly left them out would read as complete.
- Four decimals, because cents would read a real cost as free. A negative bill is not a credit and `NaN` is not a price.

## Where the count lives

Beside the conversation, not read back from the ledger: the ledger is a file this window shares with every other, and a tab asking it for its own total on every push would be reading a growing file to answer a question it already knows. It adds up the same number `chatUsage` computes, so the line in the tab and the line in the log cannot disagree.

## Tests

**1340, 1338 passing, 0 failing.**

With this the chat-page lane is finished: every plan from the operator's list of 2026-09-09 that touches `chatPage.ts` is shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)