### PR TITLE
docs(release): extension 0.31.22 · server 0.18.16

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
-## Unreleased
+## Extension 0.31.22 · Server 0.18.16 — 2026-09-10
+
+> This one carries **0.31.19, 0.31.20 and 0.31.21 as well**. Those three were written down and
+> versioned but never tagged, so nobody outside this repository ever received them — Ctrl+F in the
+> three webviews, the sidebar prompt that stays typed, and the chat tab's own icon are all in this
+> release, and their sections below are kept as they were written rather than folded in here.
+
+**A code round reviews what your branch changed, not what `main` did while you worked.** The diff
+went to the reviewers against the TIP of the base branch, so anything merged after you branched
+arrived as something YOUR branch had deleted. Measured on 2026-09-08: two vendors independently filed
+the same Blocking finding saying a release branch had deleted three source files and reverted the
+extension a version — none of it true, the branch had not touched them — and three of that round's 24
+gating findings were about work somebody else had merged, in a round that had cost 932k input tokens.
+It is a merge-base diff now, so a busy repository stops turning other people's commits into your
+phantom deletions.
+
+**A round that reviewed less than it was asked to says so, to the AI that asked.** A code round in a
+repository with no written rules drops its *Conventions* reviewers, which is right — a conventions
+pass with nothing to judge against invents a standard. It used to say that only in the server's own
+log: the caller got a shorter round and no sentence explaining it. The reason travels back now, and
+it is worded as a statement rather than a failure. Each omitted role carries its OWN reason, derived
+from the rule that dropped it, so a filter added later cannot make the gate say the wrong thing with
+complete confidence.
 
 **A conversation says what it has cost.** Beside the model picker, updated as answers arrive — which
 is where you decide whether to ask again or start fresh, and that decision is the one the number is

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.31.21",
+  "version": "0.31.22",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cuts the release the operator asked for, covering **everything since 0.31.18**.

## 0.31.19, 0.31.20 and 0.31.21 were never released

They have versions and changelog sections in this repository and **no tags and no GitHub releases** — the last one published was `extension-v0.31.18` on 2026-09-09. So Ctrl+F in the three webviews, the sidebar prompt that stays typed and the chat tab's own icon have been sitting here unshipped. This release carries them, and the changelog says so at the top of the section rather than folding them in silently.

## What is new on top of that

The whole chat lane, plus today's work:

- named prompts and named models as buttons above the composer, with a tab of their own that saves as you type
- a picker that asks for a **provider**, then one of its models
- the re-ask from an empty box with a different model chosen
- a pasted screenshot, with per-provider refusals **by name**
- a `Stop` that ends the turn it was drawn for
- a running cost beside the picker
- answers rendered with bounded links — a path inside the workspace opens in the editor, `http(s)` in the browser, anything else stays text
- a composer that stays put, a follow rule that does not drag you off what you are reading, and a conversation that survives a window reload
- `Ctrl+Alt+A` working in a **WSL window**, and a failed copy that says what actually happened
- the help describing all of it in **en, ru, uk, de, es**, and a README section for the chat

## The two gate entries the changelog never had

They shipped in `src_mcp` and the changelog had only ever tracked the extension's half of that day:

- **A code round diffs against the merge base**, not the tip of a base that moved. Measured 2026-09-08: two vendors independently filed the same Blocking finding saying a release branch had deleted three source files and reverted a version — none of it true — and three of that round's 24 gating findings were about somebody else's merge, in a round costing 932k input tokens.
- **A round that dropped its Conventions reviewers says so to the AI that called it**, with the reason, worded as a statement rather than a failure, and each omitted role carrying its own reason.

## Verified before the tag

- [x] `rm -rf out && npm test` — **1396 tests, 1394 pass, 2 skipped, 0 failing**
- [x] `npx vsce package` — **298.75 KB, 14 files**, builds clean
- [x] `pin-check.mjs` — at the remote tip (`895b24c`)
- [x] `plan-lifecycle.mjs` — only the four submodule-relative artifacts a worktree always shows
- [x] Manifest version `0.31.22` matches the tag the release workflow will refuse to disagree with

## After merge

`extension-v0.31.22` and `mcp-v0.18.16` get tagged on `main`. No `server-v` tag: `src_server` has **zero** commits since `server-v0.5.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)