### PR TITLE
docs(release): extension 0.32.3 · server 0.18.17

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,10 +1,29 @@
 # Changelog
 
-## Unreleased
+## Extension 0.32.3 · Server 0.18.17 — 2026-09-10
 
-**Shared instructions work with Claude Code and Codex.** The panel recognizes the neutral
-rules layout and still warns about an older local snippet. Distributed gate text is built
-from the pinned canonical source; an interrupted generation recovers on the next build.
+> **0.32.0, 0.32.1 and 0.32.2 do not exist.** The change below landed with the manifest already at
+> 0.32.3, and the number is left as it is rather than rewritten after the fact — a version that was
+> in `main` for a day is not a number to reuse. Nothing is missing between 0.31.22 and this.
+
+**Shared instructions work with Claude Code and Codex.** The panel recognizes the neutral rules
+layout and still warns about an older local snippet. Distributed gate text is built from the pinned
+canonical source; an interrupted generation recovers on the next build.
+
+**The gate reads the neutral layout too, which is the half of that change the notes above did not
+mention.** `coai-mcp` sampled a repository's rules from `.claude/rules` and `.cursor/rules` only, so
+a repository that had moved to the shared layout looked to a code round like a repository with no
+written rules — and a round with nothing to judge against correctly drops its *Conventions*
+reviewers. It now also reads `.agents/rules` and the canonical `common`, `csharp`, `rust` and
+`typescript` folders under `.agents/conventions`, and counts `.agents/PROJECT.md` alongside
+`CLAUDE.md`, `AGENTS.md`, `GEMINI.md` and the Copilot instructions. A mount that carries research and
+project text as well is not treated as a rules folder wholesale: only the canonical rule directories
+are sampled, and *this mount is empty* is now decided by whether any rule file was actually found
+under it rather than by whether the directory has bytes in it.
+
+**Every build regenerates the distributed gate text.** `prepare-gate` runs before compiling, before
+the typecheck, before the bundle and at the head of `npm test`, so the snippet the panel hands out
+cannot drift from the pinned canonical source between one build and the next.
 
 ## Extension 0.31.22 · Server 0.18.16 — 2026-09-10
 


### PR DESCRIPTION
Cuts both, as asked. The manifest was already at `0.32.3` when #192 merged — what was missing is the release heading, the note about the skipped numbers, and the half of the entry that describes the **server**.

## The server half was not in the notes

#192's changelog entry described the panel and the snippet. `coai-mcp` changed in the same commit and the entry said nothing about it, so a release cut from that text would have shipped a server change nobody had described.

`RuleFiles.cs` sampled a repository's rules from `.claude/rules` and `.cursor/rules` only. A repository that had already moved to the shared layout therefore looked, to a code round, like a repository with **no written rules** — and such a round correctly drops its *Conventions* reviewers. Which means the gate had quietly stopped reviewing conventions for exactly the repositories that adopted the new layout.

It now also reads `.agents/rules` and the canonical `common`, `csharp`, `rust`, `typescript` folders under `.agents/conventions`, counts `.agents/PROJECT.md` beside `CLAUDE.md`/`AGENTS.md`/`GEMINI.md`/Copilot instructions, samples only the canonical rule directories out of a mount that also carries research and project text, and decides *this mount is empty* by whether a rule file was actually found rather than by whether the directory has bytes.

## 0.32.0, 0.32.1 and 0.32.2 do not exist

The jump from 0.31.22 came in with the merge. The number is left alone rather than rewritten after the fact — a version that sat in `main` for a day is not one to reuse — and the changelog says so at the top of the section, so the gap does not read as three lost releases.

## Verified before the tag

- [x] `rm -rf out && npm test` — **1398 tests, 1397 pass, 1 skipped, 0 failing**
- [x] `npx vsce package` — **299.58 KB, 14 files**
- [x] `pin-check` — at the remote tip
- [x] Manifest `0.32.3` matches the tag the workflow refuses to disagree with

**A build note worth having in the history:** `prepare-gate` now runs before every compile, typecheck and bundle, and at the head of `npm test`. In a fresh worktree it fails twice before it works — once for the uninitialised submodule, once for its missing `node_modules`. Both are needed: `git submodule update --init` **and** `npm ci --ignore-scripts --prefix .agents/conventions`. The script's own error message names the second one, which is why this took two runs and not twenty.

## After merge

`extension-v0.32.3` and `mcp-v0.18.17`. No `server-v`: `src_server` still has zero commits since `server-v0.5.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release information for Extension 0.32.3 and Server 0.18.17.
  * Documented that the gate reads rules from the neutral `.agents` layout.
  * Documented that distributed gate text is regenerated during every build.
  * Clarified that versions 0.32.0–0.32.2 were not released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->