### PR TITLE
fix(claude): a session gets the instructions again, through the one door left open

### DIFF
--- a/.agents/PROJECT.md
+++ b/.agents/PROJECT.md
@@ -60,5 +60,17 @@ node .agents/conventions/tools/pin-check.mjs
   entry, read once at startup via `creds config <key>`.
 - **Logging** per `.agents/conventions/common/logging-serilog.md`: coloured ANSI console (stderr in
   stdio mode) + one file per run under `logs/{yyyy-MM-dd}/`, everything UTC.
-- `.claude/settings.json` is a byte-identical copy of the family reference
-  (`.agents/conventions/settings/settings.json`) — never edit it independently.
+- `.claude/settings.json` was a byte-identical copy of the family reference
+  (`.agents/conventions/settings/settings.json`). It now carries ONE addition on top of it: a
+  `SessionStart` hook running `.claude/hooks/load-instructions.mjs`. Everything else stays
+  byte-identical, and the addition is temporary — it is being promoted into the family
+  reference, and when the pin carrying it lands here the copy goes back to being byte-identical.
+- **The Claude host adapter loads instructions through a hook, and that is not a preference.**
+  `validateInstructions` in `.agents/conventions/tools/lib/rule-cli.mjs` refuses a `CLAUDE.md`
+  that is anything but `@AGENTS.md` and refuses a non-empty `.claude/rules` — the two doors
+  Claude Code loads project instructions through on its own. Closing them is what makes one
+  source for two hosts true, and it also left a session holding 561 bytes telling it to go and
+  read the rules. The hook runs the same canonical resolver Codex is told to run, at the same
+  pin, and prints what applies to every task. Restoring instructions the obvious way instead —
+  imports in `CLAUDE.md`, or files under `.claude/rules` — makes `rules check` report
+  INCOMPLETE, which by ENTRY.md blocks edits. `claudeAdapter.test.mjs` guards both halves.

--- a/.agents/PROJECT.md
+++ b/.agents/PROJECT.md
@@ -60,11 +60,9 @@ node .agents/conventions/tools/pin-check.mjs
   entry, read once at startup via `creds config <key>`.
 - **Logging** per `.agents/conventions/common/logging-serilog.md`: coloured ANSI console (stderr in
   stdio mode) + one file per run under `logs/{yyyy-MM-dd}/`, everything UTC.
-- `.claude/settings.json` was a byte-identical copy of the family reference
-  (`.agents/conventions/settings/settings.json`). It now carries ONE addition on top of it: a
-  `SessionStart` hook running `.claude/hooks/load-instructions.mjs`. Everything else stays
-  byte-identical, and the addition is temporary — it is being promoted into the family
-  reference, and when the pin carrying it lands here the copy goes back to being byte-identical.
+- `.claude/settings.json` and `.claude/hooks/load-instructions.mjs` are byte-identical copies of
+  the family reference (`.agents/conventions/settings/`) — never edit either independently.
+  `adapter-check.mjs` fails CI when a copy drifts, is unwired or is missing.
 - **The Claude host adapter loads instructions through a hook, and that is not a preference.**
   `validateInstructions` in `.agents/conventions/tools/lib/rule-cli.mjs` refuses a `CLAUDE.md`
   that is anything but `@AGENTS.md` and refuses a non-empty `.claude/rules` — the two doors

--- a/.claude/hooks/load-instructions.mjs
+++ b/.claude/hooks/load-instructions.mjs
@@ -1,42 +1,60 @@
 #!/usr/bin/env node
 /**
- * Put this repository's instructions into a Claude Code session at its start.
+ * The Claude host adapter: put a repository's instructions into a session at its start.
  *
- * <p><b>Why this exists.</b> The shared layout is one source for two hosts, and it is enforced:
- * `CLAUDE.md` may contain only `@AGENTS.md`, and `.claude/rules` must be empty
- * (`tools/lib/rule-cli.mjs`, `validateInstructions`). Those are the two doors Claude Code loads
- * project instructions through on its own, so closing them left a session holding 561 bytes — an
- * instruction to go and read the rules — where it used to hold the rules themselves.</p>
+ * <p>Copied verbatim into each consumer as `.claude/hooks/load-instructions.mjs` and wired by
+ * `settings/settings.json`. `tools/adapter-check.mjs` fails when a copy has drifted from this file,
+ * for the same reason `pin-check.mjs` exists: a reference nothing compares is a reference that
+ * quietly stops being one.</p>
  *
- * <p>That difference is not stylistic. The old arrangement was enforced by the HOST: every session
- * had the rules whether or not the model thought to fetch them. The new one is enforced by the
- * model's own diligence, and the two rules that suffer most from being optional are exactly this
- * project's own — `vendor-routing`, whose violation is invisible in the output and has already cost
- * three cells of a measurement, and `review-gate`, the contract for calling this product's gate.</p>
+ * <p><b>Why a hook and not the obvious thing.</b> `ENTRY.md` is one loading procedure for two hosts,
+ * and `tools/lib/rule-cli.mjs` enforces the single source by refusing a `CLAUDE.md` that is anything
+ * but `@AGENTS.md` and refusing a non-empty `.claude/rules`. Those two are precisely the doors
+ * Claude Code loads project instructions through on its own, with no imports and no procedure. Shut
+ * them and a session starts holding an instruction to go and read the rules rather than the rules —
+ * measured in `dew_flow_connect_other_ais`, 561 bytes where ~10.5 KB used to arrive by itself.</p>
  *
- * <p>So this restores the guarantee WITHOUT touching either enforced door. It runs the canonical
- * resolver — the same one Codex is told to run, at the same pin — and prints what it emits.
- * `SessionStart` output becomes session context, so the always-core arrives before the first
- * decision rather than after somebody remembers to ask for it.</p>
+ * <p>That is a change of KIND, not of size: enforcement moved from the host to the model's own
+ * diligence, and `ENTRY.md` step 8 requires the procedure again after every compaction. Codex is
+ * unaffected — it was always going to follow AGENTS' imperative instructions. This restores for
+ * Claude what Claude used to get for free, without weakening the single-source rule by one byte.</p>
  *
- * <p><b>What it deliberately does NOT do.</b> It does not replace the procedure in
- * `.agents/conventions/ENTRY.md`. `--task inspect` yields the rules that apply to every task; the
- * ones that depend on WHICH files are being changed still need `explain`/`read` for the real task,
- * and the notice below says so. A hook cannot know at session start what the session will touch.</p>
+ * <p><b>What it deliberately does NOT do.</b> It does not replace the procedure. `--task inspect`
+ * selects what applies to EVERY task; anything chosen by which files are being changed still needs
+ * `explain`/`read` for the real task, and the notice below says so — a session start cannot know
+ * what the session will touch.</p>
  *
- * <p>It never fails the session. A missing submodule or resolver is reported as INCOMPLETE, in the
- * words ENTRY.md uses, with the two commands that fix it — because a hook that exits non-zero on a
- * fresh clone teaches people to delete the hook.</p>
+ * <p>It never fails a session. A missing submodule or resolver is reported as INCOMPLETE, in
+ * `ENTRY.md`'s own words, with the commands that fix it, and the exit code stays 0: a hook that
+ * fails on a fresh clone is a hook somebody deletes, and then nobody notices the rules are gone.</p>
  */
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
-/** The repository root, resolved the way ENTRY.md step 1 resolves it. */
+/** The repository root, resolved the way `ENTRY.md` step 1 resolves it. */
 function repoRoot() {
   return execFileSync('git', ['rev-parse', '--show-toplevel'], {
     encoding: 'utf8', timeout: 30_000, windowsHide: true, stdio: ['ignore', 'pipe', 'ignore'],
   }).trim();
+}
+
+/**
+ * The resolver, in a consumer or in the conventions repository itself.
+ *
+ * <p>`ENTRY.md` step 3 draws exactly this distinction, and the self-hosted case is not hypothetical:
+ * this repository runs the hook on itself, which is the only test of the mechanism that cannot pass
+ * while the mechanism is broken.</p>
+ */
+function resolverIn(root) {
+  const mounted = path.join(root, '.agents/conventions/tools/rules.mjs');
+  const selfHosted = path.join(root, 'tools/rules.mjs');
+
+  if (fs.existsSync(mounted)) {
+    return mounted;
+  }
+
+  return fs.existsSync(selfHosted) && fs.existsSync(path.join(root, 'ENTRY.md')) ? selfHosted : '';
 }
 
 function incomplete(reason) {
@@ -53,13 +71,13 @@ function incomplete(reason) {
 
 try {
   const root = repoRoot();
-  const resolver = path.join(root, '.agents/conventions/tools/rules.mjs');
-  if (!fs.existsSync(resolver)) {
-    incomplete(`No resolver at ${resolver} — the conventions submodule is not checked out.`);
+  const resolver = resolverIn(root);
+  if (resolver === '') {
+    incomplete(`No resolver under ${root} — the conventions submodule is not checked out.`);
     process.exit(0);
   }
 
-  // `inspect` is the neutral task: what comes back is what applies to EVERY task, which is the only
+  // `inspect` is the neutral task: what comes back is what applies to every task, which is the only
   // selection a session start can honestly make.
   const emitted = execFileSync(process.execPath, [resolver, 'read', '--repo', root, '--task', 'inspect'], {
     encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024, windowsHide: true,
@@ -69,9 +87,9 @@ try {
   process.stdout.write(
     'Project instructions for this repository, loaded at session start by '
     + '.claude/hooks/load-instructions.mjs from the pinned canonical source.\n\n'
-    + 'These are the rules that apply to EVERY task. Rules that depend on which files you change are\n'
-    + 'not here: before editing, follow .agents/conventions/ENTRY.md and run\n'
-    + '  node .agents/conventions/tools/rules.mjs explain --repo <root> --task <task> --file <path>\n'
+    + 'These are the rules that apply to EVERY task. Rules selected by which files you change are\n'
+    + 'not here: before editing, follow the entry procedure and run\n'
+    + '  node <resolver> explain --repo <root> --task <task> --file <path>\n'
     + 'then read what it selects. Re-run it after a compaction or when the scope changes.\n\n'
     + emitted,
   );

--- a/.claude/hooks/load-instructions.mjs
+++ b/.claude/hooks/load-instructions.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Put this repository's instructions into a Claude Code session at its start.
+ *
+ * <p><b>Why this exists.</b> The shared layout is one source for two hosts, and it is enforced:
+ * `CLAUDE.md` may contain only `@AGENTS.md`, and `.claude/rules` must be empty
+ * (`tools/lib/rule-cli.mjs`, `validateInstructions`). Those are the two doors Claude Code loads
+ * project instructions through on its own, so closing them left a session holding 561 bytes — an
+ * instruction to go and read the rules — where it used to hold the rules themselves.</p>
+ *
+ * <p>That difference is not stylistic. The old arrangement was enforced by the HOST: every session
+ * had the rules whether or not the model thought to fetch them. The new one is enforced by the
+ * model's own diligence, and the two rules that suffer most from being optional are exactly this
+ * project's own — `vendor-routing`, whose violation is invisible in the output and has already cost
+ * three cells of a measurement, and `review-gate`, the contract for calling this product's gate.</p>
+ *
+ * <p>So this restores the guarantee WITHOUT touching either enforced door. It runs the canonical
+ * resolver — the same one Codex is told to run, at the same pin — and prints what it emits.
+ * `SessionStart` output becomes session context, so the always-core arrives before the first
+ * decision rather than after somebody remembers to ask for it.</p>
+ *
+ * <p><b>What it deliberately does NOT do.</b> It does not replace the procedure in
+ * `.agents/conventions/ENTRY.md`. `--task inspect` yields the rules that apply to every task; the
+ * ones that depend on WHICH files are being changed still need `explain`/`read` for the real task,
+ * and the notice below says so. A hook cannot know at session start what the session will touch.</p>
+ *
+ * <p>It never fails the session. A missing submodule or resolver is reported as INCOMPLETE, in the
+ * words ENTRY.md uses, with the two commands that fix it — because a hook that exits non-zero on a
+ * fresh clone teaches people to delete the hook.</p>
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** The repository root, resolved the way ENTRY.md step 1 resolves it. */
+function repoRoot() {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8', timeout: 30_000, windowsHide: true, stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+
+function incomplete(reason) {
+  process.stdout.write(
+    'Instruction loading is INCOMPLETE — the shared resolver could not run.\n\n'
+    + `${reason}\n\n`
+    + 'Restore it inside the authorized task:\n'
+    + '  git submodule update --init .agents/conventions\n'
+    + '  npm ci --ignore-scripts --prefix .agents/conventions\n\n'
+    + 'Until then, read .agents/PROJECT.md and .agents/conventions/ENTRY.md directly, and treat\n'
+    + 'edits to affected files as blocked rather than defaulting to your own conventions.\n',
+  );
+}
+
+try {
+  const root = repoRoot();
+  const resolver = path.join(root, '.agents/conventions/tools/rules.mjs');
+  if (!fs.existsSync(resolver)) {
+    incomplete(`No resolver at ${resolver} — the conventions submodule is not checked out.`);
+    process.exit(0);
+  }
+
+  // `inspect` is the neutral task: what comes back is what applies to EVERY task, which is the only
+  // selection a session start can honestly make.
+  const emitted = execFileSync(process.execPath, [resolver, 'read', '--repo', root, '--task', 'inspect'], {
+    encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024, windowsHide: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  process.stdout.write(
+    'Project instructions for this repository, loaded at session start by '
+    + '.claude/hooks/load-instructions.mjs from the pinned canonical source.\n\n'
+    + 'These are the rules that apply to EVERY task. Rules that depend on which files you change are\n'
+    + 'not here: before editing, follow .agents/conventions/ENTRY.md and run\n'
+    + '  node .agents/conventions/tools/rules.mjs explain --repo <root> --task <task> --file <path>\n'
+    + 'then read what it selects. Re-run it after a compaction or when the scope changes.\n\n'
+    + emitted,
+  );
+} catch (error) {
+  incomplete(String(error?.stderr || error?.message || error).trim());
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,5 +8,17 @@
       "Bash",
       "PowerShell"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/load-instructions.mjs"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/load-instructions.mjs"
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/load-instructions.mjs"]
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,11 @@ jobs:
       - name: Pin check
         run: node .agents/conventions/tools/pin-check.mjs
 
+      # The Claude host adapter, which nothing else can notice going wrong: a session that never
+      # received the rules behaves exactly like one that received them and chose badly.
+      - name: Adapter check
+        run: node .agents/conventions/tools/adapter-check.mjs .
+
       # This product's own gate rule is the shared one now, and this repository is where the text
       # comes from — so a copy here would be the source disagreeing with itself.
       - name: Gate snippet

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -67,6 +67,14 @@ jobs:
       #     Test code and tooling, which is what `**/tests/**` already does for the .NET half.
       #     Without it a pull request that adds a test suite fails the 80 % new-code coverage gate
       #     for having added tests.
+      #
+      #   both lists            + .claude/hooks/**
+      #     The Claude host adapter, which exists to run `git rev-parse` and then the pinned
+      #     resolver — the developer's toolchain again, so S4036 fires for the same reason and can
+      #     never be satisfied for the same reason. Same caveat as above: real defects there are no
+      #     longer looked for either, and what guards it instead is
+      #     `src_vs_code/src/test/claudeAdapter.test.mjs`, which runs the hook and asserts what it
+      #     emits — including the case where the submodule is missing.
       - name: Begin
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -77,8 +85,8 @@ jobs:
             /d:sonar.token="$SONAR_TOKEN" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.cs.vscoveragexml.reportsPaths="coverage/*.xml"             /d:sonar.javascript.lcov.reportPaths="coverage/extension.lcov"             /d:sonar.typescript.lcov.reportPaths="coverage/extension.lcov" \
-            /d:sonar.exclusions="**/bin/**,**/obj/**,artifacts/**,**/node_modules/**,src_mcp/tests_fakecli/**,src_vs_code/scripts/**" \
-            /d:sonar.coverage.exclusions="**/tests/**,**/*.Tests/**,src_mcp/tests_fakecli/**,http/**,src_vs_code/src/test/**,src_vs_code/scripts/**"
+            /d:sonar.exclusions="**/bin/**,**/obj/**,artifacts/**,**/node_modules/**,src_mcp/tests_fakecli/**,src_vs_code/scripts/**,.claude/hooks/**" \
+            /d:sonar.coverage.exclusions="**/tests/**,**/*.Tests/**,src_mcp/tests_fakecli/**,http/**,src_vs_code/src/test/**,src_vs_code/scripts/**,.claude/hooks/**"
       - name: Build
         run: dotnet build dew_flow_connect_other_ais.slnx -c Release --no-incremental
       - name: Test with coverage

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -608,7 +608,7 @@
     "clean": "node -e \"require('node:fs').rmSync('out', { recursive: true, force: true })\"",
     "compile": "npm run clean && tsc -p ./",
     "typecheck": "tsc -p ./ --noEmit",
-    "test": "node --test src/test/prepareGate.test.mjs && npm run compile && node scripts/run-tests.mjs",
+    "test": "node --test src/test/prepareGate.test.mjs src/test/claudeAdapter.test.mjs && npm run compile && node scripts/run-tests.mjs",
     "test:contract": "npm run compile && node scripts/run-contract.mjs",
     "test:seam": "npm run compile && node scripts/run-seam.mjs",
     "bundle": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",

--- a/src_vs_code/src/test/claudeAdapter.test.mjs
+++ b/src_vs_code/src/test/claudeAdapter.test.mjs
@@ -76,9 +76,16 @@ test('the hook emits every always-rule, from the pinned canonical source', (t) =
     cwd: root, encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024, windowsHide: true,
   });
 
+  // Matched as a literal line rather than through a pattern built from the id. Escaping a string
+  // into a regex is a thing to get subtly wrong — CodeQL said so about the first version of this
+  // line, and it was right in general even though these ids are a constant list — and `startsWith`
+  // cannot be got wrong at all.
+  const opened = emitted.split('\n').map((line) => line.trimEnd());
   for (const id of ALWAYS) {
-    assert.match(emitted, new RegExp(`^BEGIN RULE ${id.replace(/\./g, '\\.')} sha256:`, 'm'),
-      `${id} did not reach the session`);
+    assert.ok(
+      opened.some((line) => line.startsWith(`BEGIN RULE ${id} sha256:`)),
+      `${id} did not reach the session`,
+    );
   }
   assert.match(emitted, /rules\.mjs explain/,
     'the hook must still send the reader to explain/read for the rules its neutral task cannot select');

--- a/src_vs_code/src/test/claudeAdapter.test.mjs
+++ b/src_vs_code/src/test/claudeAdapter.test.mjs
@@ -36,13 +36,18 @@ const ALWAYS = [
 
 test('the session-start hook is wired, and points at a file that exists', () => {
   const settings = JSON.parse(fs.readFileSync(path.join(root, '.claude/settings.json'), 'utf8'));
+  // Command AND args, because the wiring is in exec form: the command is `node` and the script is
+  // an argument, addressed through ${CLAUDE_PROJECT_DIR}. A relative path was the first version and
+  // CodeRabbit was right about it — a session started outside the project root would have failed to
+  // find the file, and the hook's own careful degradation cannot run when node cannot load it.
   const commands = (settings.hooks?.SessionStart ?? [])
     .flatMap((entry) => entry.hooks ?? [])
-    .map((hook) => hook.command ?? '');
+    .map((hook) => [hook.command ?? '', ...(hook.args ?? [])].join(' '));
 
   assert.ok(
-    commands.some((command) => command.includes(HOOK)),
-    `no SessionStart hook runs ${HOOK} — a Claude session would start with 561 bytes of instructions`,
+    commands.some((command) => command.includes(`\${CLAUDE_PROJECT_DIR}/${HOOK}`)),
+    `no SessionStart hook runs ${HOOK} by an absolute path — a session started outside the project `
+      + 'root would not find it, and one started inside would get 561 bytes of instructions',
   );
   assert.ok(fs.existsSync(path.join(root, HOOK)), `${HOOK} is wired but missing`);
 });

--- a/src_vs_code/src/test/claudeAdapter.test.mjs
+++ b/src_vs_code/src/test/claudeAdapter.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The Claude host adapter loads this repository's instructions, and does it the sanctioned way.
+ *
+ * <p>The shared layout is one source for two hosts, and it is enforced: `validateInstructions` in
+ * `.agents/conventions/tools/lib/rule-cli.mjs` refuses a `CLAUDE.md` that is anything but
+ * `@AGENTS.md`, and refuses a non-empty `.claude/rules`. Those are the two doors Claude Code loads
+ * project instructions through by itself, so closing them left a session holding an instruction to
+ * go and read the rules instead of the rules.</p>
+ *
+ * <p>The `SessionStart` hook is the third door, and the only one the resolver does not police. That
+ * is precisely why it needs a test: nothing outside this file would notice if the wiring were
+ * dropped, and the failure is silent — a session that simply does not have the rules behaves like a
+ * session that has them and ignores them.</p>
+ */
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const HOOK = '.claude/hooks/load-instructions.mjs';
+
+/** What must arrive before the first decision, whatever the session turns out to be about. */
+const ALWAYS = [
+  'common.coding-style',
+  'common.knowledge-base',
+  'common.security',
+  // This project's own, and the reason the guarantee matters rather than a nicety: breaking
+  // vendor-routing is invisible in the output and has already cost three cells of a measurement.
+  'local.common.review-gate',
+  'local.common.vendor-routing',
+];
+
+test('the session-start hook is wired, and points at a file that exists', () => {
+  const settings = JSON.parse(fs.readFileSync(path.join(root, '.claude/settings.json'), 'utf8'));
+  const commands = (settings.hooks?.SessionStart ?? [])
+    .flatMap((entry) => entry.hooks ?? [])
+    .map((hook) => hook.command ?? '');
+
+  assert.ok(
+    commands.some((command) => command.includes(HOOK)),
+    `no SessionStart hook runs ${HOOK} — a Claude session would start with 561 bytes of instructions`,
+  );
+  assert.ok(fs.existsSync(path.join(root, HOOK)), `${HOOK} is wired but missing`);
+});
+
+test('the enforced doors are left shut, so the shared resolver still calls this repository resolved', () => {
+  // Not a formality. Restoring instructions the OBVIOUS way — @-imports in CLAUDE.md, or files
+  // under .claude/rules — makes `rules check` report INCOMPLETE, which by ENTRY.md means edits are
+  // blocked. The hook exists because both of those are refused, and this asserts nobody undid that.
+  assert.equal(fs.readFileSync(path.join(root, 'CLAUDE.md'), 'utf8').trim(), '@AGENTS.md');
+
+  const legacy = path.join(root, '.claude/rules');
+  assert.ok(
+    !fs.existsSync(legacy) || fs.readdirSync(legacy).length === 0,
+    '.claude/rules is populated again; the resolver refuses that as a second source',
+  );
+});
+
+test('the hook emits every always-rule, from the pinned canonical source', (t) => {
+  const resolver = path.join(root, '.agents/conventions/tools/rules.mjs');
+  if (!fs.existsSync(resolver) || !fs.existsSync(path.join(root, '.agents/conventions/node_modules'))) {
+    const message = 'the conventions submodule is not prepared — run git submodule update --init '
+      + '.agents/conventions && npm ci --ignore-scripts --prefix .agents/conventions';
+    // Under CI both are present, and a skip there would hide exactly what this test is for.
+    assert.ok(process.env.CI === undefined, `${message} (CI must not skip this)`);
+    t.skip(message);
+
+    return;
+  }
+
+  const emitted = execFileSync(process.execPath, [path.join(root, HOOK)], {
+    cwd: root, encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024, windowsHide: true,
+  });
+
+  for (const id of ALWAYS) {
+    assert.match(emitted, new RegExp(`^BEGIN RULE ${id.replace(/\./g, '\\.')} sha256:`, 'm'),
+      `${id} did not reach the session`);
+  }
+  assert.match(emitted, /rules\.mjs explain/,
+    'the hook must still send the reader to explain/read for the rules its neutral task cannot select');
+});
+
+test('a session without the resolver is told loading is INCOMPLETE, and is not killed for it', (t) => {
+  const resolver = path.join(root, '.agents/conventions/tools/rules.mjs');
+  if (!fs.existsSync(resolver)) {
+    t.skip('nothing to move aside');
+
+    return;
+  }
+  const parked = `${resolver}.parked-by-test`;
+  fs.renameSync(resolver, parked);
+  t.after(() => fs.renameSync(parked, resolver));
+
+  // Exit 0 on purpose: a hook that fails a fresh clone is a hook somebody deletes.
+  const said = execFileSync(process.execPath, [path.join(root, HOOK)], {
+    cwd: root, encoding: 'utf8', timeout: 60_000, windowsHide: true,
+  });
+
+  assert.match(said, /INCOMPLETE/);
+  assert.match(said, /git submodule update --init \.agents\/conventions/);
+  assert.match(said, /npm ci --ignore-scripts --prefix \.agents\/conventions/);
+});

--- a/src_vs_code/src/test/claudeAdapter.test.mjs
+++ b/src_vs_code/src/test/claudeAdapter.test.mjs
@@ -40,14 +40,19 @@ test('the session-start hook is wired, and points at a file that exists', () => 
   // an argument, addressed through ${CLAUDE_PROJECT_DIR}. A relative path was the first version and
   // CodeRabbit was right about it — a session started outside the project root would have failed to
   // find the file, and the hook's own careful degradation cannot run when node cannot load it.
-  const commands = (settings.hooks?.SessionStart ?? [])
+  const declared = (settings.hooks?.SessionStart ?? [])
     .flatMap((entry) => entry.hooks ?? [])
-    .map((hook) => [hook.command ?? '', ...(hook.args ?? [])].join(' '));
+    .filter((hook) => hook.type === 'command');
+  const wired = declared.find((hook) => hook.command === 'node');
 
-  assert.ok(
-    commands.some((command) => command.includes(`\${CLAUDE_PROJECT_DIR}/${HOOK}`)),
-    `no SessionStart hook runs ${HOOK} by an absolute path — a session started outside the project `
-      + 'root would not find it, and one started inside would get 561 bytes of instructions',
+  // The exact contract, not a substring of it. A substring match would accept a different command,
+  // or the right one with extra arguments appended — and the whole point of exec form is that what
+  // runs is exactly this and nothing a shell got to reinterpret.
+  assert.deepEqual(
+    { command: wired?.command, args: wired?.args },
+    { command: 'node', args: [`\${CLAUDE_PROJECT_DIR}/${HOOK}`] },
+    `no SessionStart hook runs ${HOOK} by an absolute path in exec form — a session started outside `
+      + 'the project root would not find it, and one started inside would get 561 bytes of instructions',
   );
   assert.ok(fs.existsSync(path.join(root, HOOK)), `${HOOK} is wired but missing`);
 });

--- a/src_vs_code/src/test/claudeAdapter.test.mjs
+++ b/src_vs_code/src/test/claudeAdapter.test.mjs
@@ -92,7 +92,9 @@ test('the hook emits every always-rule, from the pinned canonical source', (t) =
       `${id} did not reach the session`,
     );
   }
-  assert.match(emitted, /rules\.mjs explain/,
+  // The reference hook words this generically — it runs in the conventions repository too, where the
+  // resolver is not under .agents/conventions — so the stable part is the verb and its arguments.
+  assert.match(emitted, /explain --repo <root> --task <task>/,
     'the hook must still send the reader to explain/read for the rules its neutral task cannot select');
 });
 


### PR DESCRIPTION
## What I found

The shared layout is one source for two hosts, and it is **enforced**. `validateInstructions` in `.agents/conventions/tools/lib/rule-cli.mjs`:

- `CLAUDE.md must contain only @AGENTS.md`
- `Legacy .claude/rules is nonempty; move policy to .agents/rules before claiming one source`

I hit both by trying them, not by reading them. And those two are exactly the doors Claude Code loads project instructions through **on its own** — no imports needed, the host does it.

Measured on this repository:

| | before | after #192 |
|---|---|---|
| `CLAUDE.md` | 3 971 B | **12 B** |
| `.claude/rules/common/` loaded by the host | 6 590 B | **0** |
| a session holds, having done nothing | ≥ 10.5 KB | **561 B** |

Those 561 bytes are an instruction to go and read the rules. So the guarantee moved from the **host** to the **model's diligence** — and ENTRY.md's step 8 says it must be re-done after every compaction. The two rules that suffer most from becoming optional are this project's own: `vendor-routing`, whose violation is *invisible in the output* and has already cost three cells of a measurement, and `review-gate`, the contract for calling this product's own gate.

Content itself is fine, and I checked: local rule bodies are byte-identical (only frontmatter added), the submodule pin is unchanged, and `.agents/PROJECT.md` preserves the old `CLAUDE.md` word for word except *(Claude Code)* → *(Claude Code or Codex)*. **Nothing was lost. What was lost is the loading.**

## What this does

Leaves both enforced doors shut and uses the third — `SessionStart` — which is the only mechanism the resolver does not police. The hook runs the **same canonical resolver Codex is told to run, at the same pin**, and prints what applies to every task: `common.coding-style`, `common.knowledge-base`, `common.security`, `local.common.review-gate`, `local.common.vendor-routing` — 24 KB with BEGIN/END boundaries and hashes intact.

It does **not** replace ENTRY.md's procedure and says so in its own output: a hook cannot know at session start which files the session will touch, so `explain`/`read` for the real task is still owed. Without the submodule it reports loading **INCOMPLETE** in ENTRY.md's own words, names the two commands that fix it, and **exits 0** — a hook that fails a fresh clone is a hook somebody deletes.

## RED first, all three

- hook unwired → *no SessionStart hook runs .claude/hooks/load-instructions.mjs*
- `.claude/rules` repopulated → the door test failed **and so did the emission test**, because the resolver refuses that repository outright. That is the cleanest demonstration available that the obvious fix is not on the table.
- Green after restoring. **Suite: 1398 tests, 0 failing.** `rules check` → `resolved`.

## Next, and why PROJECT.md says so

This is the reference implementation. It is being promoted into the family reference (`dew_flow_conventions/settings/`) next, after which `.claude/settings.json` goes back to byte-identical. Until then PROJECT.md records the one addition rather than leaving its *never edit it independently* line false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code now automatically loads project instructions when a session starts.
  * Instructions include universal guidance and directions for locating file-specific rules.

* **Bug Fixes**
  * Improved recovery messaging when instruction components are unavailable, including setup commands and an `INCOMPLETE` status.

* **Tests**
  * Added automated checks to verify instruction loading, configuration, rule compatibility, and graceful handling of missing components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->