### PR TITLE
chore(release): extension 0.33.0 — the chat menu catches up with the tab

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## Extension 0.33.0 — 2026-09-10
 
 **The chat section in the sidebar catches up with the tab.** Two of the plans behind the chat named the panel as a surface and shipped only their tab half, so the section had stood unchanged since the morning it was written while the tab gained a picker, presets and a CRUD tab of its own.
 

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.32.3",
+  "version": "0.33.0",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Extension-only. The manifest goes to 0.33.0 and the CHANGELOG's Unreleased section is dated; `src_mcp` has not changed since 0.18.17.

A **minor** rather than a patch: the sidebar gains two controls and two settings (`coai.chatPromptChoice`, `coai.chatModelName`), which is a feature by any reading.

The release workflow fires on the `extension-v0.33.0` tag and refuses one that disagrees with the manifest, so the tag follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)