### PR TITLE
fix(presets): Add a model wrote a row its own reader refuses, and two prompts could read as main

### DIFF
--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -860,6 +860,23 @@ marked — refusing it would mean the silent substitution this whole change remo
 cannot be written says so once a session rather than once a render, because the consequence is one a
 person can act on: the section goes on offering models the command will not find.
 
+**Two defects in the CRUD tab, reported 2026-09-11 with screenshots.** *Add a model* appended
+`{ name: ‘New model’, provider: ‘’ }` and `chatModelPresetsFrom` refuses a row with no provider — so
+the page re-read the list, the reader dropped the row, and the screen was unchanged while
+`settings.json` grew a dead entry per press. The seed moved next to its reader as `freshPreset`,
+which is the whole point of where it lives now: a shape its own reader refuses cannot be written
+there without a test going red. `addModel` resolves the answering row FIRST — the first that can
+chat, the same default the chat itself takes — and refuses by name when none can, because a button
+that silently writes litter is worse than one that says why it cannot. `readableModelRow` clears the
+rows the old behaviour left, which are not drafts: no surface has ever been able to show one.
+
+And two prompts could both read as **main**. What was SAVED was right — `edited` unticks the others
+before the write — but an edit deliberately does not repaint, because a repaint under a caret is the
+defect the sidebar’s own prompt box had, and that rule had swallowed the one edit whose entire effect
+is on the rows it is NOT in. `repaintsAfter` carves the exception, beside `presetEdit` and tested with
+it: a checkbox has no caret. Unticking the siblings in the page’s own script was the alternative and
+was rejected — the same rule written twice, and the second copy is the one that drifts.
+
 **`coai.editChatPresets` reached a menu.** It shipped registered, in no `contributes.menus` entry and
 named in no view, so the tab it opens was reachable only from the command palette. The section has an
 **Edit presets…** button, routed like *Install the MCP server…* through `VSCODE_COMMAND_FOR`.

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -887,6 +887,17 @@ one, which is exactly what codex said. And unticking the ONLY main prompt is ref
 marks nothing when nothing is ticked and `mainPrompt` then falls back to the first, so the page would
 have shown no tick while the first prompt was quietly what a capture sends.
 
+**And what the code round then found in the fix itself.** The prune and the first render were
+started side by side, so the page painted the very rows the prune was removing — it is AWAITED
+before the panel is created now, and a cleanup that fails is logged rather than left as an unhandled
+rejection. A `main` edit naming a row that is not there rewrote every flag to `false` (a webview
+message can outlive the prompt it names), so an unknown id now changes nothing; and a refused untick
+returns the list ITSELF, which is how the host knows to skip a configuration write that would say
+the same thing. `freshPreset` became `freshPromptRow` and `freshModelRow`, the second with a
+REQUIRED provider — one factory with a defaulted one left the original defect available to the next
+caller who forgot the argument. And the sibling-unticking branch inside `edited` was left dead by
+the move and is gone: dead code beside a live rule is the second copy that drifts.
+
 **`coai.editChatPresets` reached a menu.** It shipped registered, in no `contributes.menus` entry and
 named in no view, so the tab it opens was reachable only from the command palette. The section has an
 **Edit presets…** button, routed like *Install the MCP server…* through `VSCODE_COMMAND_FOR`.

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -898,6 +898,20 @@ REQUIRED provider — one factory with a defaulted one left the original defect 
 caller who forgot the argument. And the sibling-unticking branch inside `edited` was left dead by
 the move and is gone: dead code beside a live rule is the second copy that drifts.
 
+**The second code round, which is where the cleanup rule got its own name.** Using the current
+reader’s ACCEPTANCE rule as migration authority was the mistake: an older build opening a newer
+settings file would permanently delete rows it merely does not understand yet. What may be deleted
+is what this product wrote by mistake, and that has a signature — `deadModelRow` is a `provider`
+written as an empty string, which no surface can produce any other way. A row with no `provider`
+field at all, or one carrying fields from a later build, is left where it is.
+
+Three more: a `main` edit is guarded by the LIST as well as the field, so a message naming the model
+list cannot be given a rule that belongs to the prompt list; `promptRowsAfterMain` returns the list
+ITSELF whenever every flag already says what was asked, so re-ticking the main one writes nothing;
+and `repaintsAfter` narrowed to `editRepaints`, taking only edit commands. A whole-command policy in
+the page parser that the host consulted for edits alone was a rule with a test and no effect —
+whether an `add` redraws depends on whether it was refused, which only the host knows.
+
 **`coai.editChatPresets` reached a menu.** It shipped registered, in no `contributes.menus` entry and
 named in no view, so the tab it opens was reachable only from the command palette. The section has an
 **Edit presets…** button, routed like *Install the MCP server…* through `VSCODE_COMMAND_FOR`.

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -877,6 +877,16 @@ is on the rows it is NOT in. `repaintsAfter` carves the exception, beside `prese
 it: a checkbox has no caret. Unticking the siblings in the page’s own script was the alternative and
 was rejected — the same rule written twice, and the second copy is the one that drifts.
 
+**What the plan round added to those two fixes.** All three vendors named the same gap: clearing the
+dead rows *on the next write* clears nothing for somebody who opens the tab, looks, and closes it —
+and nothing at all for somebody whose add is refused because no reviewer can chat. `pruneDeadModelRows`
+runs when the tab OPENS and writes only when something was dropped, so it runs once. The two decisions
+the host used to make inline moved beside the readers that judge them — `modelRowsAfterAdd` and
+`promptRowsAfterMain` — because a test of the seed passes while the command is still wired to the old
+one, which is exactly what codex said. And unticking the ONLY main prompt is refused: `onlyOneMain`
+marks nothing when nothing is ticked and `mainPrompt` then falls back to the first, so the page would
+have shown no tick while the first prompt was quietly what a capture sends.
+
 **`coai.editChatPresets` reached a menu.** It shipped registered, in no `contributes.menus` entry and
 named in no view, so the tab it opens was reachable only from the command palette. The section has an
 **Edit presets…** button, routed like *Install the MCP server…* through `VSCODE_COMMAND_FOR`.

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Add a model works.** It was not doing nothing — it was writing a preset with no reviewer named, and a preset that names no reviewer names nothing that can answer, so the list dropped it on the way back to the screen. Every press left a row in your settings that nothing could show, edit or remove. A new model preset now opens on the first reviewer that can chat, which you change on the row; with no such reviewer configured the button says so instead of writing something invisible, and the rows the old behaviour left behind are cleared the next time the list is written.
+
+**And only one prompt can look like the main one.** Ticking a second left both ticked on screen while the file held one — what was saved had been right all along, but the page is deliberately not redrawn while you type, and that rule had swallowed the one control whose whole effect is on the rows it is not in. A checkbox has no caret, so it is redrawn now.
+
 ## Extension 0.33.0 — 2026-09-10
 
 **The chat section in the sidebar catches up with the tab.** Two of the plans behind the chat named the panel as a surface and shipped only their tab half, so the section had stood unchanged since the morning it was written while the tab gained a picker, presets and a CRUD tab of its own.

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-**Add a model works.** It was not doing nothing — it was writing a preset with no reviewer named, and a preset that names no reviewer names nothing that can answer, so the list dropped it on the way back to the screen. Every press left a row in your settings that nothing could show, edit or remove. A new model preset now opens on the first reviewer that can chat, which you change on the row; with no such reviewer configured the button says so instead of writing something invisible, and the rows the old behaviour left behind are cleared the next time the list is written.
+**Add a model works.** It was not doing nothing — it was writing a preset with no reviewer named, and a preset that names no reviewer names nothing that can answer, so the list dropped it on the way back to the screen. Every press left a row in your settings that nothing could show, edit or remove. A new model preset now opens on the first reviewer that can chat, which you change on the row; with no such reviewer configured the button says so instead of writing something invisible, and the rows the old behaviour left behind are cleared when the tab opens.
 
 **And only one prompt can look like the main one.** Ticking a second left both ticked on screen while the file held one — what was saved had been right all along, but the page is deliberately not redrawn while you type, and that rule had swallowed the one control whose whole effect is on the rows it is not in. A checkbox has no caret, so it is redrawn now.
 

--- a/src_vs_code/src/chatPresets.ts
+++ b/src_vs_code/src/chatPresets.ts
@@ -244,3 +244,56 @@ export function freshPreset(
 export function readableModelRow(row: unknown): boolean {
   return chatModelPresetsFrom([row]).length === 1;
 }
+
+/** The rows a settings list holds, before any reader has had an opinion about them. */
+export type SavedRow = Record<string, unknown>;
+
+/**
+ * What the model list should hold after *Add a model* — or nothing, when it must refuse.
+ *
+ * <p>Here rather than in the panel host, because the plan round said the obvious thing: a test of
+ * the seed passes while the command is still wired to the old one. The rule this has to respect is
+ * two lines up, and both are now one file.</p>
+ *
+ * <p>It prunes as it writes. A row the reader discards cannot be shown, edited or removed on any
+ * surface, so it is not a draft — it is what the empty-provider seed left behind, and the write that
+ * adds a real row is the moment to be rid of it.</p>
+ *
+ * @param providerId the row the new preset answers through. EMPTY means nothing configured can chat,
+ *   and the answer is `undefined`: no write at all, so the caller says why instead of leaving
+ *   something invisible in the file.
+ */
+export function modelRowsAfterAdd(
+  rows: readonly SavedRow[],
+  providerId: string,
+): readonly SavedRow[] | undefined {
+  if (providerId.length === 0) {
+    return undefined;
+  }
+  const kept = rows.filter(readableModelRow);
+
+  return [...kept, freshPreset('model', kept as { id: string }[], providerId)];
+}
+
+/**
+ * What the prompt list should hold after the `main` box on one row was ticked or unticked.
+ *
+ * <p><b>Unticking the only main one is refused</b>, which makes the box a radio in everything but
+ * appearance. `onlyOneMain` marks nothing when nothing is ticked and `mainPrompt` then falls back to
+ * the FIRST prompt — so a list with no tick shows none while the first one is quietly what a capture
+ * sends. A control that cannot be turned off is honest; one that turns off and changes nothing is
+ * not. (gemini, the plan round.)</p>
+ */
+export function promptRowsAfterMain(
+  rows: readonly SavedRow[],
+  id: string,
+  ticked: boolean,
+): readonly SavedRow[] {
+  if (!ticked) {
+    const others = rows.some((row) => row['id'] !== id && row['main'] === true);
+
+    return others ? rows.map((row) => (row['id'] === id ? { ...row, main: false } : row)) : [...rows];
+  }
+
+  return rows.map((row) => ({ ...row, main: row['id'] === id }));
+}

--- a/src_vs_code/src/chatPresets.ts
+++ b/src_vs_code/src/chatPresets.ts
@@ -207,3 +207,40 @@ export function presetById<T extends { readonly id: string }>(
 ): T | undefined {
   return id.length === 0 ? undefined : presets.find((preset) => preset.id === id);
 }
+
+/**
+ * A new row for one of the two lists, in a shape that list's own reader will KEEP.
+ *
+ * <p><b>That is the whole point of it living here.</b> It used to sit in the panel host beside the
+ * write, and it seeded a model row with `provider: ''` — the one field `chatModelPresetsFrom`
+ * refuses, because a preset that names no row names nothing that can answer. So *Add a model* wrote
+ * a row, the page re-read the list, the reader dropped it, and the screen showed what it showed
+ * before. Every press left a dead row in `settings.json` that nothing could display, edit or remove.
+ * Next to its reader, that cannot happen without a test going red.</p>
+ *
+ * @param providerId the row a model preset will answer through — required for the preset to exist at
+ *   all, so the caller resolves one before offering to create it rather than writing an empty string
+ *   and hoping.
+ */
+export function freshPreset(
+  list: 'prompt' | 'model',
+  taken: readonly { readonly id: string }[],
+  providerId = '',
+): Record<string, unknown> {
+  const id = `preset-${Date.now().toString(36)}-${taken.length + 1}`;
+
+  return list === 'prompt'
+    ? { id, name: 'New prompt', text: 'Explain', main: false }
+    : { id, name: 'New model', provider: providerId, model: '' };
+}
+
+/**
+ * Whether a row is one its reader would keep — used to drop what an older build wrote by mistake.
+ *
+ * <p>A model row with no provider cannot be rendered, edited or removed on any surface, so it is not
+ * a draft somebody is composing: it is litter from the defect above. Cleared on the next write to
+ * the list rather than by a migration nobody would run.</p>
+ */
+export function readableModelRow(row: unknown): boolean {
+  return chatModelPresetsFrom([row]).length === 1;
+}

--- a/src_vs_code/src/chatPresets.ts
+++ b/src_vs_code/src/chatPresets.ts
@@ -222,16 +222,22 @@ export function presetById<T extends { readonly id: string }>(
  *   all, so the caller resolves one before offering to create it rather than writing an empty string
  *   and hoping.
  */
-export function freshPreset(
-  list: 'prompt' | 'model',
-  taken: readonly { readonly id: string }[],
-  providerId = '',
-): Record<string, unknown> {
-  const id = `preset-${Date.now().toString(36)}-${taken.length + 1}`;
+function freshId(taken: readonly { readonly id: string }[]): string {
+  return `preset-${Date.now().toString(36)}-${taken.length + 1}`;
+}
 
-  return list === 'prompt'
-    ? { id, name: 'New prompt', text: 'Explain', main: false }
-    : { id, name: 'New model', provider: providerId, model: '' };
+export function freshPromptRow(taken: readonly { readonly id: string }[]): SavedRow {
+  return { id: freshId(taken), name: 'New prompt', text: 'Explain', main: false };
+}
+
+/**
+ * @param providerId the row this preset answers through. REQUIRED, and that is the second half of
+ *   the fix: one factory with a DEFAULTED provider left the original defect available to the next
+ *   caller who forgot the argument. `model` is deliberately empty — the documented "whatever the row
+ *   is set to" — because seeding one would pick a model on somebody's behalf.
+ */
+export function freshModelRow(taken: readonly { readonly id: string }[], providerId: string): SavedRow {
+  return { id: freshId(taken), name: 'New model', provider: providerId, model: '' };
 }
 
 /**
@@ -272,7 +278,7 @@ export function modelRowsAfterAdd(
   }
   const kept = rows.filter(readableModelRow);
 
-  return [...kept, freshPreset('model', kept as { id: string }[], providerId)];
+  return [...kept, freshModelRow(kept as { id: string }[], providerId)];
 }
 
 /**
@@ -289,10 +295,18 @@ export function promptRowsAfterMain(
   id: string,
   ticked: boolean,
 ): readonly SavedRow[] {
+  // An id naming no row rewrites NOTHING. A webview message can arrive after the prompt it names was
+  // removed in another window, and mapping over the list would then set every flag to false: no tick
+  // on the page while `mainPrompt` falls back to the first prompt. The list ITSELF comes back, so the
+  // caller can tell a no-op from a change and skip a write that would say the same thing.
+  // (codex and gemini, the code round, from two directions.)
+  if (!rows.some((row) => row['id'] === id)) {
+    return rows;
+  }
   if (!ticked) {
     const others = rows.some((row) => row['id'] !== id && row['main'] === true);
 
-    return others ? rows.map((row) => (row['id'] === id ? { ...row, main: false } : row)) : [...rows];
+    return others ? rows.map((row) => (row['id'] === id ? { ...row, main: false } : row)) : rows;
   }
 
   return rows.map((row) => ({ ...row, main: row['id'] === id }));

--- a/src_vs_code/src/chatPresets.ts
+++ b/src_vs_code/src/chatPresets.ts
@@ -241,14 +241,20 @@ export function freshModelRow(taken: readonly { readonly id: string }[], provide
 }
 
 /**
- * Whether a row is one its reader would keep — used to drop what an older build wrote by mistake.
+ * Whether a row is the LITTER the empty-provider seed wrote — a rule of its own, deliberately.
  *
- * <p>A model row with no provider cannot be rendered, edited or removed on any surface, so it is not
- * a draft somebody is composing: it is litter from the defect above. Cleared on the next write to
- * the list rather than by a migration nobody would run.</p>
+ * <p>The obvious implementation was `chatModelPresetsFrom([row]).length === 0`: whatever the reader
+ * refuses. The code round showed why that is wrong as a cleanup rule (codex, Major): it makes the
+ * CURRENT reader's acceptance the authority on what may be deleted, so an older build opening a
+ * newer settings file would permanently remove rows it merely does not understand yet. What may be
+ * deleted is what this product wrote by mistake, and that has a signature — a `provider` written as
+ * an empty string, which no surface has ever been able to produce any other way. A row that is
+ * strange for any other reason, or has no provider FIELD at all, is left where it is.</p>
  */
-export function readableModelRow(row: unknown): boolean {
-  return chatModelPresetsFrom([row]).length === 1;
+export function deadModelRow(row: unknown): boolean {
+  const one = record(row);
+
+  return one !== undefined && one['provider'] === '';
 }
 
 /** The rows a settings list holds, before any reader has had an opinion about them. */
@@ -276,7 +282,7 @@ export function modelRowsAfterAdd(
   if (providerId.length === 0) {
     return undefined;
   }
-  const kept = rows.filter(readableModelRow);
+  const kept = rows.filter((row) => !deadModelRow(row));
 
   return [...kept, freshModelRow(kept as { id: string }[], providerId)];
 }
@@ -303,11 +309,17 @@ export function promptRowsAfterMain(
   if (!rows.some((row) => row['id'] === id)) {
     return rows;
   }
-  if (!ticked) {
-    const others = rows.some((row) => row['id'] !== id && row['main'] === true);
+  // What the list WOULD hold. Unticking the only main one is refused — `onlyOneMain` marks nothing
+  // when nothing is ticked and `mainPrompt` then falls back to the first prompt, so the page would
+  // show no tick while the first one is quietly what a capture sends.
+  const wanted = (row: SavedRow): boolean => (ticked
+    ? row['id'] === id
+    : (row['id'] === id ? !rows.some((other) => other['id'] !== id && other['main'] === true) : row['main'] === true));
 
-    return others ? rows.map((row) => (row['id'] === id ? { ...row, main: false } : row)) : rows;
-  }
-
-  return rows.map((row) => ({ ...row, main: row['id'] === id }));
+  // The list ITSELF when every flag already says that. The host writes only when the reference moved,
+  // so re-ticking the row that is already main, or unticking one that was never main, stops being a
+  // configuration event that says what the file said. (gemini and local, the code round.)
+  return rows.every((row) => (row['main'] === true) === wanted(row))
+    ? rows
+    : rows.map((row) => ({ ...row, main: wanted(row) }));
 }

--- a/src_vs_code/src/chatPresetsPage.ts
+++ b/src_vs_code/src/chatPresetsPage.ts
@@ -77,6 +77,8 @@ function idOf(value: unknown): string {
  * written twice, and the second copy is the one that drifts.</p>
  */
 export function repaintsAfter(command: PresetCommand): boolean {
+  // An `ignore` changed nothing, so there is nothing to draw again — and a repaint on every message
+  // this page does not understand would rebuild it from anything that reached the webview.
   if (command.kind === 'ignore') {
     return false;
   }

--- a/src_vs_code/src/chatPresetsPage.ts
+++ b/src_vs_code/src/chatPresetsPage.ts
@@ -76,6 +76,33 @@ function idOf(value: unknown): string {
  * rather than by unticking the siblings in the page's own script: that would be the same rule
  * written twice, and the second copy is the one that drifts.</p>
  */
+/**
+ * One edit, applied to the list it names.
+ *
+ * <p>The whole list is written back, because that is what a settings array IS — there is no way to
+ * update one element of one. Ticking `main` untick's the others here rather than in the reader, so
+ * what is SAVED is already true: a reader that had to correct the file every time it read it would
+ * be hiding a file nobody could trust.</p>
+ */
+export function editedRows(
+  rows: readonly Record<string, unknown>[],
+  command: Extract<PresetCommand, { kind: 'edit' }>,
+): readonly Record<string, unknown>[] {
+  // The `main` box does NOT come through here any more — `promptRowsAfterMain` owns that rule, next
+  // to the reader that enforces the same thing. The branch that used to untick the siblings was left
+  // dead by that move, and dead code beside a live rule is the second copy that drifts.
+  // The list ITSELF when the row already holds that value — choosing the option a select is already
+  // on is a click somebody makes, and writing the file back to say what it says is a configuration
+  // event every window then reacts to. The host writes only when the reference moved.
+  // The list ITSELF when nothing would change — the row already holds that value, or there is no row
+  // with that id at all. A stale message naming a removed row used to produce a new array with
+  // identical content, which the host read as a change and wrote back. (CodeRabbit, PR #198.)
+  return !rows.some((row) => row['id'] === command.id)
+    || rows.some((row) => row['id'] === command.id && row[command.field] === command.value)
+    ? rows
+    : rows.map((row) => (row['id'] === command.id ? { ...row, [command.field]: command.value } : row));
+}
+
 export function editRepaints(command: Extract<PresetCommand, { kind: 'edit' }>): boolean {
   return command.field === 'main';
 }

--- a/src_vs_code/src/chatPresetsPage.ts
+++ b/src_vs_code/src/chatPresetsPage.ts
@@ -76,14 +76,8 @@ function idOf(value: unknown): string {
  * rather than by unticking the siblings in the page's own script: that would be the same rule
  * written twice, and the second copy is the one that drifts.</p>
  */
-export function repaintsAfter(command: PresetCommand): boolean {
-  // An `ignore` changed nothing, so there is nothing to draw again — and a repaint on every message
-  // this page does not understand would rebuild it from anything that reached the webview.
-  if (command.kind === 'ignore') {
-    return false;
-  }
-
-  return command.kind !== 'edit' || command.field === 'main';
+export function editRepaints(command: Extract<PresetCommand, { kind: 'edit' }>): boolean {
+  return command.field === 'main';
 }
 
 export function presetEdit(message: unknown): PresetCommand {

--- a/src_vs_code/src/chatPresetsPage.ts
+++ b/src_vs_code/src/chatPresetsPage.ts
@@ -62,6 +62,28 @@ function idOf(value: unknown): string {
  * module that maps a webview message to an action is otherwise the one no unit test can reach, and a
  * wrong mapping would ship with every test green.</p>
  */
+/**
+ * Whether the page must be REDRAWN after this command was applied.
+ *
+ * <p>An edit deliberately does not repaint: the caret is in a box somebody is typing in, and moving
+ * it to the end of what they wrote is the defect the sidebar's own prompt box had. The `main` tick is
+ * the one edit that has to, and for a reason the rule did not anticipate — its whole effect is on the
+ * rows it is NOT in. Ticking one unticks the others in what is saved, so a page that is not redrawn
+ * shows two prompts marked main and a file that holds one. Reported with a screenshot of exactly
+ * that, 2026-09-11.</p>
+ *
+ * <p>A checkbox has no caret, so the rule it is carved out of does not apply to it. Decided here
+ * rather than by unticking the siblings in the page's own script: that would be the same rule
+ * written twice, and the second copy is the one that drifts.</p>
+ */
+export function repaintsAfter(command: PresetCommand): boolean {
+  if (command.kind === 'ignore') {
+    return false;
+  }
+
+  return command.kind !== 'edit' || command.field === 'main';
+}
+
 export function presetEdit(message: unknown): PresetCommand {
   if (typeof message !== 'object' || message === null) {
     return IGNORE;

--- a/src_vs_code/src/chatPresetsPanel.ts
+++ b/src_vs_code/src/chatPresetsPanel.ts
@@ -1,8 +1,15 @@
 import * as crypto from 'node:crypto';
 import * as vscode from 'vscode';
 import { ChatProvider, chatProvidersFrom } from './chatModels';
-import { ModelPreset, PromptPreset, chatModelPresetsFrom, chatPromptPresetsFrom } from './chatPresets';
-import { PresetCommand, chatPresetsHtml, presetEdit } from './chatPresetsPage';
+import {
+  ModelPreset,
+  PromptPreset,
+  chatModelPresetsFrom,
+  chatPromptPresetsFrom,
+  freshPreset,
+  readableModelRow,
+} from './chatPresets';
+import { PresetCommand, chatPresetsHtml, presetEdit, repaintsAfter } from './chatPresetsPage';
 import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
 import { teamServersFrom } from './teamServers';
 import { vendorsFrom } from './vendors';
@@ -58,15 +65,6 @@ async function write(key: string, value: unknown): Promise<void> {
   await config().update(key, value, vscode.ConfigurationTarget.Global);
 }
 
-/** A new row, with an id nothing else holds and a name a person will replace. */
-function fresh(list: 'prompt' | 'model', taken: readonly { readonly id: string }[]): Record<string, unknown> {
-  const id = `preset-${Date.now().toString(36)}-${taken.length + 1}`;
-
-  return list === 'prompt'
-    ? { id, name: 'New prompt', text: 'Explain', main: false }
-    : { id, name: 'New model', provider: '', model: '' };
-}
-
 /**
  * One edit, applied to the list it names.
  *
@@ -120,9 +118,13 @@ async function apply(command: PresetCommand): Promise<boolean> {
   const key = command.kind === 'ignore' ? '' : (command.list === 'prompt' ? PROMPTS_KEY : MODELS_KEY);
   if (command.kind === 'add') {
     const rows = key === PROMPTS_KEY ? promptRowsToWrite() : rowsOf(key);
-    await write(key, [...rows, fresh(command.list, rows as { id: string }[])]);
+    if (command.list === 'prompt') {
+      await write(key, [...rows, freshPreset('prompt', rows as { id: string }[])]);
 
-    return true;
+      return true;
+    }
+
+    return addModel(rows);
   }
   if (command.kind === 'remove') {
     const rows = key === PROMPTS_KEY ? promptRowsToWrite() : rowsOf(key);
@@ -134,9 +136,10 @@ async function apply(command: PresetCommand): Promise<boolean> {
     const rows = key === PROMPTS_KEY ? promptRowsToWrite() : rowsOf(key);
     await write(key, edited(rows, command));
 
-    // Not a re-render: the caret is in a box somebody is typing in, and moving it to the end of
-    // what they wrote is the defect the sidebar's own prompt box had.
-    return false;
+    // `repaintsAfter` decides, beside the message parser and tested with it. Typing must NOT
+    // repaint — the caret is in a box somebody is writing in — and the `main` tick MUST, because
+    // its whole effect is on the rows it is not in.
+    return repaintsAfter(command);
   }
 
   return false;
@@ -178,4 +181,33 @@ export function openChatPresets(): void {
     panel = undefined;
   });
   render();
+}
+
+/**
+ * A new model preset, which cannot exist without a row for it to answer through.
+ *
+ * <p>`chatModelPresetsFrom` refuses a row with no provider, so seeding one with an empty string
+ * wrote a preset nothing could ever render, edit or remove — which is exactly what *Add a model* did
+ * until 2026-09-11. The provider is resolved FIRST: the first row that can chat, which is the same
+ * default the chat itself takes, and the person changes it in the select on the row.</p>
+ *
+ * <p>With no such row there is nothing to seed, and a button that silently writes litter is worse
+ * than one that says why it cannot. The dead rows an earlier build left behind go at the same time —
+ * they are not drafts, because no surface has ever been able to show one.</p>
+ */
+async function addModel(rows: readonly Record<string, unknown>[]): Promise<boolean> {
+  const answering = providers()[0]?.id ?? '';
+  if (answering.length === 0) {
+    void vscode.window.showWarningMessage(
+      'A model preset names the reviewer that answers, and no configured reviewer can chat yet.'
+      + ' Enable one in the panel first — the chat speaks to antigravity, claude, codex and Team servers.',
+    );
+
+    return false;
+  }
+  const kept = rows.filter(readableModelRow);
+
+  await write(MODELS_KEY, [...kept, freshPreset('model', kept as { id: string }[], answering)]);
+
+  return true;
 }

--- a/src_vs_code/src/chatPresetsPanel.ts
+++ b/src_vs_code/src/chatPresetsPanel.ts
@@ -7,6 +7,8 @@ import {
   chatModelPresetsFrom,
   chatPromptPresetsFrom,
   freshPreset,
+  modelRowsAfterAdd,
+  promptRowsAfterMain,
   readableModelRow,
 } from './chatPresets';
 import { PresetCommand, chatPresetsHtml, presetEdit, repaintsAfter } from './chatPresetsPage';
@@ -134,7 +136,11 @@ async function apply(command: PresetCommand): Promise<boolean> {
   }
   if (command.kind === 'edit') {
     const rows = key === PROMPTS_KEY ? promptRowsToWrite() : rowsOf(key);
-    await write(key, edited(rows, command));
+    // The `main` box is a rule of its own — exactly one, and the last one cannot be turned off —
+    // so it is decided beside the reader that enforces the same thing, not in `edited`.
+    await write(key, command.field === 'main'
+      ? promptRowsAfterMain(rows, command.id, command.value === true)
+      : edited(rows, command));
 
     // `repaintsAfter` decides, beside the message parser and tested with it. Typing must NOT
     // repaint — the caret is in a box somebody is writing in — and the `main` tick MUST, because
@@ -157,6 +163,10 @@ function render(): void {
 
 /** Open the tab, or bring back the one that is already open. */
 export function openChatPresets(): void {
+  // Cleared on the way in, before anything is rendered: the rows an older build wrote are invisible
+  // on every surface, so the only moment anybody can be rid of them is one they do not have to ask
+  // for. It writes only when something was dropped, and the render below then finds a clean list.
+  void pruneDeadModelRows();
   if (panel !== undefined) {
     panel.reveal();
 
@@ -196,8 +206,8 @@ export function openChatPresets(): void {
  * they are not drafts, because no surface has ever been able to show one.</p>
  */
 async function addModel(rows: readonly Record<string, unknown>[]): Promise<boolean> {
-  const answering = providers()[0]?.id ?? '';
-  if (answering.length === 0) {
+  const written = modelRowsAfterAdd(rows, providers()[0]?.id ?? '');
+  if (written === undefined) {
     void vscode.window.showWarningMessage(
       'A model preset names the reviewer that answers, and no configured reviewer can chat yet.'
       + ' Enable one in the panel first — the chat speaks to antigravity, claude, codex and Team servers.',
@@ -205,9 +215,24 @@ async function addModel(rows: readonly Record<string, unknown>[]): Promise<boole
 
     return false;
   }
-  const kept = rows.filter(readableModelRow);
-
-  await write(MODELS_KEY, [...kept, freshPreset('model', kept as { id: string }[], answering)]);
+  await write(MODELS_KEY, written);
 
   return true;
+}
+
+/**
+ * The dead rows an older build wrote, cleared when the tab OPENS rather than on the next add.
+ *
+ * <p>Deferring it to the next write was the plan round's finding from all three vendors: somebody
+ * who opens the tab, sees their list and closes it again never triggers one, and somebody with no
+ * reviewer that can chat cannot trigger one at all — the add refuses before it writes. So the tab
+ * cleans up when it is shown. It writes ONLY when something was actually dropped, so it runs once
+ * and the render it triggers finds nothing left to do.</p>
+ */
+async function pruneDeadModelRows(): Promise<void> {
+  const rows = rowsOf(MODELS_KEY);
+  const kept = rows.filter(readableModelRow);
+  if (kept.length !== rows.length) {
+    await write(MODELS_KEY, kept);
+  }
 }

--- a/src_vs_code/src/chatPresetsPanel.ts
+++ b/src_vs_code/src/chatPresetsPanel.ts
@@ -6,7 +6,7 @@ import {
   PromptPreset,
   chatModelPresetsFrom,
   chatPromptPresetsFrom,
-  freshPreset,
+  freshPromptRow,
   modelRowsAfterAdd,
   promptRowsAfterMain,
   readableModelRow,
@@ -79,13 +79,10 @@ function edited(
   rows: readonly Record<string, unknown>[],
   command: Extract<PresetCommand, { kind: 'edit' }>,
 ): Record<string, unknown>[] {
-  return rows.map((row) => {
-    if (row['id'] !== command.id) {
-      return command.field === 'main' && command.value === true ? { ...row, main: false } : row;
-    }
-
-    return { ...row, [command.field]: command.value };
-  });
+  // The `main` box does NOT come through here any more — `promptRowsAfterMain` owns that rule, next
+  // to the reader that enforces the same thing. The branch that used to untick the siblings was left
+  // dead by that move, and dead code beside a live rule is the second copy that drifts.
+  return rows.map((row) => (row['id'] === command.id ? { ...row, [command.field]: command.value } : row));
 }
 
 function rowsOf(key: string): Record<string, unknown>[] {
@@ -121,7 +118,7 @@ async function apply(command: PresetCommand): Promise<boolean> {
   if (command.kind === 'add') {
     const rows = key === PROMPTS_KEY ? promptRowsToWrite() : rowsOf(key);
     if (command.list === 'prompt') {
-      await write(key, [...rows, freshPreset('prompt', rows as { id: string }[])]);
+      await write(key, [...rows, freshPromptRow(rows as { id: string }[])]);
 
       return true;
     }
@@ -138,9 +135,14 @@ async function apply(command: PresetCommand): Promise<boolean> {
     const rows = key === PROMPTS_KEY ? promptRowsToWrite() : rowsOf(key);
     // The `main` box is a rule of its own — exactly one, and the last one cannot be turned off —
     // so it is decided beside the reader that enforces the same thing, not in `edited`.
-    await write(key, command.field === 'main'
+    const next = command.field === 'main'
       ? promptRowsAfterMain(rows, command.id, command.value === true)
-      : edited(rows, command));
+      : edited(rows, command);
+    // The SAME array back means the rule refused — unticking the last main one, or an id naming no
+    // row. Writing it would be a configuration change event that says nothing, on every click.
+    if (next !== rows) {
+      await write(key, next);
+    }
 
     // `repaintsAfter` decides, beside the message parser and tested with it. Typing must NOT
     // repaint — the caret is in a box somebody is writing in — and the `main` tick MUST, because
@@ -163,10 +165,21 @@ function render(): void {
 
 /** Open the tab, or bring back the one that is already open. */
 export function openChatPresets(): void {
-  // Cleared on the way in, before anything is rendered: the rows an older build wrote are invisible
-  // on every surface, so the only moment anybody can be rid of them is one they do not have to ask
-  // for. It writes only when something was dropped, and the render below then finds a clean list.
-  void pruneDeadModelRows();
+  if (panel !== undefined) {
+    panel.reveal();
+
+    return;
+  }
+  // AWAITED before anything is drawn, which the code round was right about: the prune writes, the
+  // render reads, and started side by side the page paints the very rows the prune is removing. The
+  // tab opens after it either way — a cleanup that cannot run is not a reason to withhold the tab,
+  // and it is said out loud rather than swallowed.
+  void pruneDeadModelRows()
+    .catch((error: unknown) => { console.error('coai: the unusable model presets could not be cleared', error); })
+    .then(openPanel);
+}
+
+function openPanel(): void {
   if (panel !== undefined) {
     panel.reveal();
 

--- a/src_vs_code/src/chatPresetsPanel.ts
+++ b/src_vs_code/src/chatPresetsPanel.ts
@@ -11,7 +11,7 @@ import {
   promptRowsAfterMain,
   deadModelRow,
 } from './chatPresets';
-import { PresetCommand, chatPresetsHtml, editRepaints, presetEdit } from './chatPresetsPage';
+import { PresetCommand, chatPresetsHtml, editRepaints, editedRows, presetEdit } from './chatPresetsPage';
 import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
 import { teamServersFrom } from './teamServers';
 import { vendorsFrom } from './vendors';
@@ -65,29 +65,6 @@ function providers(): readonly ChatProvider[] {
 
 async function write(key: string, value: unknown): Promise<void> {
   await config().update(key, value, vscode.ConfigurationTarget.Global);
-}
-
-/**
- * One edit, applied to the list it names.
- *
- * <p>The whole list is written back, because that is what a settings array IS — there is no way to
- * update one element of one. Ticking `main` untick's the others here rather than in the reader, so
- * what is SAVED is already true: a reader that had to correct the file every time it read it would
- * be hiding a file nobody could trust.</p>
- */
-function edited(
-  rows: readonly Record<string, unknown>[],
-  command: Extract<PresetCommand, { kind: 'edit' }>,
-): readonly Record<string, unknown>[] {
-  // The `main` box does NOT come through here any more — `promptRowsAfterMain` owns that rule, next
-  // to the reader that enforces the same thing. The branch that used to untick the siblings was left
-  // dead by that move, and dead code beside a live rule is the second copy that drifts.
-  // The list ITSELF when the row already holds that value — choosing the option a select is already
-  // on is a click somebody makes, and writing the file back to say what it says is a configuration
-  // event every window then reacts to. The host writes only when the reference moved.
-  return rows.some((row) => row['id'] === command.id && row[command.field] === command.value)
-    ? rows
-    : rows.map((row) => (row['id'] === command.id ? { ...row, [command.field]: command.value } : row));
 }
 
 function rowsOf(key: string): Record<string, unknown>[] {
@@ -145,7 +122,7 @@ async function apply(command: PresetCommand): Promise<boolean> {
     // carries a `main` today, which is exactly why the guard belongs here rather than in a comment.
     const next = command.list === 'prompt' && command.field === 'main'
       ? promptRowsAfterMain(rows, command.id, command.value === true)
-      : edited(rows, command);
+      : editedRows(rows, command);
     // The SAME array back means the rule refused — unticking the last main one, or an id naming no
     // row. Writing it would be a configuration change event that says nothing, on every click.
     if (next === rows) {

--- a/src_vs_code/src/chatPresetsPanel.ts
+++ b/src_vs_code/src/chatPresetsPanel.ts
@@ -9,9 +9,9 @@ import {
   freshPromptRow,
   modelRowsAfterAdd,
   promptRowsAfterMain,
-  readableModelRow,
+  deadModelRow,
 } from './chatPresets';
-import { PresetCommand, chatPresetsHtml, presetEdit, repaintsAfter } from './chatPresetsPage';
+import { PresetCommand, chatPresetsHtml, editRepaints, presetEdit } from './chatPresetsPage';
 import { applyZoomDelta, currentUiScale, pushUiScaleTo } from './uiScaleHost';
 import { teamServersFrom } from './teamServers';
 import { vendorsFrom } from './vendors';
@@ -78,11 +78,16 @@ async function write(key: string, value: unknown): Promise<void> {
 function edited(
   rows: readonly Record<string, unknown>[],
   command: Extract<PresetCommand, { kind: 'edit' }>,
-): Record<string, unknown>[] {
+): readonly Record<string, unknown>[] {
   // The `main` box does NOT come through here any more — `promptRowsAfterMain` owns that rule, next
   // to the reader that enforces the same thing. The branch that used to untick the siblings was left
   // dead by that move, and dead code beside a live rule is the second copy that drifts.
-  return rows.map((row) => (row['id'] === command.id ? { ...row, [command.field]: command.value } : row));
+  // The list ITSELF when the row already holds that value — choosing the option a select is already
+  // on is a click somebody makes, and writing the file back to say what it says is a configuration
+  // event every window then reacts to. The host writes only when the reference moved.
+  return rows.some((row) => row['id'] === command.id && row[command.field] === command.value)
+    ? rows
+    : rows.map((row) => (row['id'] === command.id ? { ...row, [command.field]: command.value } : row));
 }
 
 function rowsOf(key: string): Record<string, unknown>[] {
@@ -135,19 +140,25 @@ async function apply(command: PresetCommand): Promise<boolean> {
     const rows = key === PROMPTS_KEY ? promptRowsToWrite() : rowsOf(key);
     // The `main` box is a rule of its own — exactly one, and the last one cannot be turned off —
     // so it is decided beside the reader that enforces the same thing, not in `edited`.
-    const next = command.field === 'main'
+    // The LIST as well as the field: `main` is a rule of the PROMPT list — exactly one, and the last
+    // cannot be turned off — and a message naming the model list must not be given it. No model row
+    // carries a `main` today, which is exactly why the guard belongs here rather than in a comment.
+    const next = command.list === 'prompt' && command.field === 'main'
       ? promptRowsAfterMain(rows, command.id, command.value === true)
       : edited(rows, command);
     // The SAME array back means the rule refused — unticking the last main one, or an id naming no
     // row. Writing it would be a configuration change event that says nothing, on every click.
-    if (next !== rows) {
-      await write(key, next);
+    if (next === rows) {
+      // Refused, or asked for what the file already said. Nothing was written, so there is nothing to
+      // draw again — and a repaint would move a caret in some other row for an edit that did nothing.
+      return false;
     }
+    await write(key, next);
 
-    // `repaintsAfter` decides, beside the message parser and tested with it. Typing must NOT
-    // repaint — the caret is in a box somebody is writing in — and the `main` tick MUST, because
-    // its whole effect is on the rows it is not in.
-    return repaintsAfter(command);
+    // `editRepaints` decides, beside the message parser and tested with it. Typing must NOT repaint —
+    // the caret is in a box somebody is writing in — and the `main` tick MUST, because its whole
+    // effect is on the rows it is not in.
+    return editRepaints(command);
   }
 
   return false;
@@ -244,7 +255,7 @@ async function addModel(rows: readonly Record<string, unknown>[]): Promise<boole
  */
 async function pruneDeadModelRows(): Promise<void> {
   const rows = rowsOf(MODELS_KEY);
-  const kept = rows.filter(readableModelRow);
+  const kept = rows.filter((row) => !deadModelRow(row));
   if (kept.length !== rows.length) {
     await write(MODELS_KEY, kept);
   }

--- a/src_vs_code/src/test/chatPresets.test.ts
+++ b/src_vs_code/src/test/chatPresets.test.ts
@@ -5,6 +5,7 @@ import {
   chatPromptPresetsFrom,
   freshModelRow,
   freshPromptRow,
+  deadModelRow,
   mainPrompt,
   modelRowsAfterAdd,
   promptRowsAfterMain,
@@ -284,11 +285,7 @@ test('unticking the only main one is refused, because something has to answer a 
   assert.deepStrictEqual(promptRowsAfterMain(rows, 'a', false).map((row: Record<string, unknown>) => row['main']), [true, false]);
 });
 
-test('unticking one that is not the main one changes nothing it should not', () => {
-  const rows = [{ id: 'a', name: 'A', text: 'a', main: true }, { id: 'b', name: 'B', text: 'b', main: false }];
 
-  assert.deepStrictEqual(promptRowsAfterMain(rows, 'b', false).map((row: Record<string, unknown>) => row['main']), [true, false]);
-});
 
 test('a main edit naming a prompt that is not there changes NOTHING', () => {
   // The code round, from codex and gemini independently: a webview message can name a row that was
@@ -315,4 +312,30 @@ test('a model row cannot be built without the reviewer that answers it', () => {
 
   assert.strictEqual(chatModelPresetsFrom([row]).length, 1);
   assert.strictEqual(chatPromptPresetsFrom([freshPromptRow([])]).length, 1);
+});
+
+test('the cleanup knows the litter it wrote, not merely what this reader refuses', () => {
+  // The code round (codex, Major): using the current reader's ACCEPTANCE rule as migration authority
+  // means an older build opening a newer file deletes rows it simply does not understand yet. The
+  // signature of the defect is its own rule — a provider written as an empty string — and a row that
+  // is strange for any other reason is left alone.
+  assert.strictEqual(deadModelRow({ id: 'x', name: 'New model', provider: '', model: '' }), true);
+  assert.strictEqual(deadModelRow({ id: 'x', name: 'Mine', provider: 'agy', model: '' }), false);
+  assert.strictEqual(deadModelRow({ id: 'x', name: 'Mine', provider: 'agy', someFutureField: 7 }), false,
+    'a row from a newer build was treated as litter');
+  assert.strictEqual(deadModelRow({ id: 'x', name: 'Mine' }), false, 'a row with no provider FIELD is not the litter');
+});
+
+test('re-ticking the prompt that is already main writes nothing', () => {
+  // Two vendors, from two directions: `rows.map(...)` allocates unconditionally, so the host's
+  // reference check saw a change that was not one and wrote the file back to say what it said.
+  const rows = [{ id: 'a', name: 'A', text: 'a', main: true }, { id: 'b', name: 'B', text: 'b', main: false }];
+
+  assert.strictEqual(promptRowsAfterMain(rows, 'a', true), rows);
+});
+
+test('unticking a prompt that was not main writes nothing either', () => {
+  const rows = [{ id: 'a', name: 'A', text: 'a', main: true }, { id: 'b', name: 'B', text: 'b', main: false }];
+
+  assert.strictEqual(promptRowsAfterMain(rows, 'b', false), rows);
 });

--- a/src_vs_code/src/test/chatPresets.test.ts
+++ b/src_vs_code/src/test/chatPresets.test.ts
@@ -254,6 +254,10 @@ test('adding a model prunes what the old defect wrote, and seeds a row the reade
   const written = modelRowsAfterAdd(rows, 'agy');
 
   assert.notStrictEqual(written, undefined);
+  // On the WHOLE list, not its first entry: CodeRabbit pointed out that a head-only assertion passes
+  // while `dead-2` is still in what gets written, because the reader filters it out again on the way
+  // back and hides exactly what this is meant to catch.
+  assert.deepStrictEqual(written!.filter(deadModelRow), [], 'a dead row survived the write');
   assert.deepStrictEqual(written!.map((row: Record<string, unknown>) => row['id']).slice(0, 1), ['real'], 'the dead rows survived the write');
   assert.strictEqual(chatModelPresetsFrom(written!).length, 2, 'the row that was added is not one the reader keeps');
 });

--- a/src_vs_code/src/test/chatPresets.test.ts
+++ b/src_vs_code/src/test/chatPresets.test.ts
@@ -5,6 +5,8 @@ import {
   chatPromptPresetsFrom,
   freshPreset,
   mainPrompt,
+  modelRowsAfterAdd,
+  promptRowsAfterMain,
   presetById,
   reaskFrom,
 } from '../chatPresets';
@@ -231,4 +233,58 @@ test('two new rows in a row do not share an id', () => {
   const second = freshPreset('model', [first as { id: string }], 'agy');
 
   assert.notStrictEqual(first['id'], second['id'], 'a second press produced a row that shadows the first');
+});
+
+/**
+ * The two decisions the HOST used to make inline, where no test could reach them.
+ *
+ * <p>The plan round said so in as many words (codex, Major): a helper test can pass while the
+ * command is still wired to the old seed. So the decisions moved here, beside the readers whose
+ * rules they have to respect.</p>
+ */
+test('adding a model prunes what the old defect wrote, and seeds a row the reader keeps', () => {
+  const rows = [
+    { id: 'dead-1', name: 'New model', provider: '', model: '' },
+    { id: 'real', name: 'Mine', provider: 'agy', model: 'gemini-3.8-flash-low' },
+    { id: 'dead-2', name: 'New model', provider: '', model: '' },
+  ];
+
+  const written = modelRowsAfterAdd(rows, 'agy');
+
+  assert.notStrictEqual(written, undefined);
+  assert.deepStrictEqual(written!.map((row: Record<string, unknown>) => row['id']).slice(0, 1), ['real'], 'the dead rows survived the write');
+  assert.strictEqual(chatModelPresetsFrom(written!).length, 2, 'the row that was added is not one the reader keeps');
+});
+
+test('adding a model with nothing that can chat writes NOTHING, so the list is not touched', () => {
+  // The alternative is the defect again: a write nobody can see. Refusing is the caller's cue to say
+  // why, and saying nothing while writing is what this whole fix is about.
+  assert.strictEqual(modelRowsAfterAdd([{ id: 'real', name: 'Mine', provider: 'agy', model: '' }], ''), undefined);
+});
+
+test('a list that is already clean is still written with its rows in order', () => {
+  const rows = [{ id: 'a', name: 'A', provider: 'agy', model: '' }, { id: 'b', name: 'B', provider: 'codex', model: '' }];
+
+  assert.deepStrictEqual(modelRowsAfterAdd(rows, 'agy')!.map((row: Record<string, unknown>) => row['id']).slice(0, 2), ['a', 'b']);
+});
+
+test('ticking one prompt as main unticks every other, in what is SAVED', () => {
+  const rows = [{ id: 'a', name: 'A', text: 'a', main: true }, { id: 'b', name: 'B', text: 'b', main: false }];
+
+  assert.deepStrictEqual(promptRowsAfterMain(rows, 'b', true).map((row: Record<string, unknown>) => row['main']), [false, true]);
+});
+
+test('unticking the only main one is refused, because something has to answer a capture', () => {
+  // The plan round (gemini, Major): `onlyOneMain` marks nothing when nothing is ticked, and
+  // `mainPrompt` then falls back to the FIRST prompt — so the page would show no tick while the first
+  // prompt is quietly the one being sent. A checkbox that cannot be unticked says the truth instead.
+  const rows = [{ id: 'a', name: 'A', text: 'a', main: true }, { id: 'b', name: 'B', text: 'b', main: false }];
+
+  assert.deepStrictEqual(promptRowsAfterMain(rows, 'a', false).map((row: Record<string, unknown>) => row['main']), [true, false]);
+});
+
+test('unticking one that is not the main one changes nothing it should not', () => {
+  const rows = [{ id: 'a', name: 'A', text: 'a', main: true }, { id: 'b', name: 'B', text: 'b', main: false }];
+
+  assert.deepStrictEqual(promptRowsAfterMain(rows, 'b', false).map((row: Record<string, unknown>) => row['main']), [true, false]);
 });

--- a/src_vs_code/src/test/chatPresets.test.ts
+++ b/src_vs_code/src/test/chatPresets.test.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import {
   chatModelPresetsFrom,
   chatPromptPresetsFrom,
+  freshPreset,
   mainPrompt,
   presetById,
   reaskFrom,
@@ -192,4 +193,42 @@ test('the answer before last is kept, because the conversation is not the last e
 
   assert.ok(again?.said.some((message) => message.text === 'first answer'),
     'an earlier answer was dropped along with the rejected one');
+});
+
+/**
+ * A new row must be one its own reader will KEEP.
+ *
+ * <p>Reported 2026-09-11: *Add a model* did nothing. It was not doing nothing — it appended
+ * `{ name: 'New model', provider: '', model: '' }` to `coai.chatModelPresets`, and
+ * `chatModelPresetsFrom` drops any row without a provider, so the page re-read the list and showed
+ * exactly what it showed before. Every press left a dead row in `settings.json` that nothing can
+ * display, edit or remove. The prompt side does not have the defect because its seed is two real
+ * values; the model side seeded the field its own reader refuses on.</p>
+ */
+test('a new model preset survives the reader that will render it', () => {
+  const kept = chatModelPresetsFrom([freshPreset('model', [], 'agy')]);
+
+  assert.strictEqual(kept.length, 1, 'the row a press of Add a model writes is dropped by the reader');
+  assert.strictEqual(kept[0]!.provider, 'agy');
+  assert.strictEqual(kept[0]!.name, 'New model');
+});
+
+test('a new prompt preset survives its reader too, which is why that button always worked', () => {
+  const kept = chatPromptPresetsFrom([freshPreset('prompt', [])]);
+
+  assert.strictEqual(kept.length, 1);
+  assert.strictEqual(kept[0]!.name, 'New prompt');
+});
+
+test('the reader still refuses a model row with no provider — the rule did not move', () => {
+  // The fix is the SEED, not a loosened reader: a preset that names no row names nothing that can
+  // answer, and the two button rows above the composer would render it as a button that does nothing.
+  assert.deepStrictEqual(chatModelPresetsFrom([freshPreset('model', [], '')]), []);
+});
+
+test('two new rows in a row do not share an id', () => {
+  const first = freshPreset('model', [], 'agy');
+  const second = freshPreset('model', [first as { id: string }], 'agy');
+
+  assert.notStrictEqual(first['id'], second['id'], 'a second press produced a row that shadows the first');
 });

--- a/src_vs_code/src/test/chatPresets.test.ts
+++ b/src_vs_code/src/test/chatPresets.test.ts
@@ -3,7 +3,8 @@ import { test } from 'node:test';
 import {
   chatModelPresetsFrom,
   chatPromptPresetsFrom,
-  freshPreset,
+  freshModelRow,
+  freshPromptRow,
   mainPrompt,
   modelRowsAfterAdd,
   promptRowsAfterMain,
@@ -208,7 +209,7 @@ test('the answer before last is kept, because the conversation is not the last e
  * values; the model side seeded the field its own reader refuses on.</p>
  */
 test('a new model preset survives the reader that will render it', () => {
-  const kept = chatModelPresetsFrom([freshPreset('model', [], 'agy')]);
+  const kept = chatModelPresetsFrom([freshModelRow([], 'agy')]);
 
   assert.strictEqual(kept.length, 1, 'the row a press of Add a model writes is dropped by the reader');
   assert.strictEqual(kept[0]!.provider, 'agy');
@@ -216,7 +217,7 @@ test('a new model preset survives the reader that will render it', () => {
 });
 
 test('a new prompt preset survives its reader too, which is why that button always worked', () => {
-  const kept = chatPromptPresetsFrom([freshPreset('prompt', [])]);
+  const kept = chatPromptPresetsFrom([freshPromptRow([])]);
 
   assert.strictEqual(kept.length, 1);
   assert.strictEqual(kept[0]!.name, 'New prompt');
@@ -225,12 +226,12 @@ test('a new prompt preset survives its reader too, which is why that button alwa
 test('the reader still refuses a model row with no provider — the rule did not move', () => {
   // The fix is the SEED, not a loosened reader: a preset that names no row names nothing that can
   // answer, and the two button rows above the composer would render it as a button that does nothing.
-  assert.deepStrictEqual(chatModelPresetsFrom([freshPreset('model', [], '')]), []);
+  assert.deepStrictEqual(chatModelPresetsFrom([freshModelRow([], '')]), []);
 });
 
 test('two new rows in a row do not share an id', () => {
-  const first = freshPreset('model', [], 'agy');
-  const second = freshPreset('model', [first as { id: string }], 'agy');
+  const first = freshModelRow([], 'agy');
+  const second = freshModelRow([first as { id: string }], 'agy');
 
   assert.notStrictEqual(first['id'], second['id'], 'a second press produced a row that shadows the first');
 });
@@ -287,4 +288,31 @@ test('unticking one that is not the main one changes nothing it should not', () 
   const rows = [{ id: 'a', name: 'A', text: 'a', main: true }, { id: 'b', name: 'B', text: 'b', main: false }];
 
   assert.deepStrictEqual(promptRowsAfterMain(rows, 'b', false).map((row: Record<string, unknown>) => row['main']), [true, false]);
+});
+
+test('a main edit naming a prompt that is not there changes NOTHING', () => {
+  // The code round, from codex and gemini independently: a webview message can name a row that was
+  // removed in another window, and `rows.map(row => ({...row, main: row.id === id}))` then sets every
+  // flag to false. The page shows no tick while `mainPrompt` falls back to the first prompt — the
+  // exact state the untick refusal above exists to prevent, reached through a different door.
+  const rows = [{ id: 'a', name: 'A', text: 'a', main: true }, { id: 'b', name: 'B', text: 'b', main: false }];
+
+  assert.strictEqual(promptRowsAfterMain(rows, 'gone', true), rows, 'an unknown id rewrote the list');
+  assert.strictEqual(promptRowsAfterMain(rows, 'gone', false), rows, 'an unknown id rewrote the list');
+});
+
+test('a refused untick returns the list ITSELF, so the caller can skip a write that changes nothing', () => {
+  const rows = [{ id: 'a', name: 'A', text: 'a', main: true }];
+
+  assert.strictEqual(promptRowsAfterMain(rows, 'a', false), rows, 'a no-op still produced a new list to write');
+});
+
+test('a model row cannot be built without the reviewer that answers it', () => {
+  // The code round (codex): `freshPreset('model', rows)` was callable and defaulted the provider to
+  // an empty string, which is the original defect available to the next caller. Two factories now,
+  // and the model one cannot be called without the row it answers through.
+  const row = freshModelRow([], 'agy');
+
+  assert.strictEqual(chatModelPresetsFrom([row]).length, 1);
+  assert.strictEqual(chatPromptPresetsFrom([freshPromptRow([])]).length, 1);
 });

--- a/src_vs_code/src/test/chatPresetsPage.test.ts
+++ b/src_vs_code/src/test/chatPresetsPage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { chatPresetsHtml, editRepaints, presetEdit } from '../chatPresetsPage';
+import { chatPresetsHtml, editRepaints, editedRows, presetEdit } from '../chatPresetsPage';
 
 /**
  * The tab where a person keeps their prompts and their models.
@@ -167,3 +167,13 @@ test('unticking is redrawn too, so the list cannot be left showing none', () => 
 // policy in the page parser, consulted by the host for edits only, is a rule with a test and no
 // effect: changing what it says about `add` would move a test and nothing else. Whether an add
 // redraws depends on whether it was refused, which only the host knows. (gemini, the code round.)
+
+test('an edit naming a row that is not in the list is a no-op the host can see', () => {
+  // CodeRabbit on PR #198: `edited` mapped over the rows and produced a NEW array with identical
+  // content, and the host's reference check read that as a change and wrote the file back. The same
+  // class as the `main` no-ops the code round found, through the field that is not `main`.
+  const rows = [{ id: 'a', name: 'A', text: 'a', main: true }];
+
+  assert.strictEqual(editedRows(rows, { kind: 'edit', list: 'prompt', id: 'gone', field: 'name', value: 'x' }), rows);
+  assert.notStrictEqual(editedRows(rows, { kind: 'edit', list: 'prompt', id: 'a', field: 'name', value: 'B' }), rows);
+});

--- a/src_vs_code/src/test/chatPresetsPage.test.ts
+++ b/src_vs_code/src/test/chatPresetsPage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { chatPresetsHtml, presetEdit } from '../chatPresetsPage';
+import { chatPresetsHtml, presetEdit, repaintsAfter } from '../chatPresetsPage';
 
 /**
  * The tab where a person keeps their prompts and their models.
@@ -130,4 +130,41 @@ test('a message this page does not understand is ignored, not guessed at', () =>
   for (const message of [undefined, null, {}, { type: 'edit' }, 'text', { type: 'nope' }]) {
     assert.deepStrictEqual(presetEdit(message), { kind: 'ignore' });
   }
+});
+
+/**
+ * Which edits the page must be REDRAWN after.
+ *
+ * <p>Reported 2026-09-11, with a screenshot of two prompts both ticked as main: *"логично, что мейн
+ * может быть один. а оно дает 2 галочки поставить"*. What is SAVED was already right —
+ * ticking one row unticks the others before the write — but an edit deliberately does not repaint,
+ * because a repaint under a caret is the defect the sidebar's own prompt box had. A checkbox has no
+ * caret, and its whole effect is on OTHER rows, so it was the one edit that had to be redrawn and
+ * was not. The page therefore showed a state the file never held.</p>
+ *
+ * <p>Decided here rather than in the page's script: unticking the siblings in the DOM as well would
+ * be the same rule written twice, and the second copy is the one that drifts.</p>
+ */
+test('ticking the main one is redrawn, because its effect is on the rows it is not in', () => {
+  assert.strictEqual(repaintsAfter({ kind: 'edit', list: 'prompt', id: 'p1', field: 'main', value: true }), true);
+});
+
+test('typing is NOT redrawn, which is the rule this exception is carved out of', () => {
+  for (const field of ['name', 'text', 'provider', 'model', 'startingPrompt'] as const) {
+    assert.strictEqual(
+      repaintsAfter({ kind: 'edit', list: 'prompt', id: 'p1', field, value: 'x' }),
+      false,
+      `${field} redraws the page under a caret`,
+    );
+  }
+});
+
+test('unticking is redrawn too, so the list cannot be left showing none', () => {
+  assert.strictEqual(repaintsAfter({ kind: 'edit', list: 'prompt', id: 'p1', field: 'main', value: false }), true);
+});
+
+test('adding and removing are redrawn, as they always were', () => {
+  assert.strictEqual(repaintsAfter({ kind: 'add', list: 'model' }), true);
+  assert.strictEqual(repaintsAfter({ kind: 'remove', list: 'model', id: 'm1' }), true);
+  assert.strictEqual(repaintsAfter({ kind: 'ignore' }), false);
 });

--- a/src_vs_code/src/test/chatPresetsPage.test.ts
+++ b/src_vs_code/src/test/chatPresetsPage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { chatPresetsHtml, presetEdit, repaintsAfter } from '../chatPresetsPage';
+import { chatPresetsHtml, editRepaints, presetEdit } from '../chatPresetsPage';
 
 /**
  * The tab where a person keeps their prompts and their models.
@@ -146,13 +146,13 @@ test('a message this page does not understand is ignored, not guessed at', () =>
  * be the same rule written twice, and the second copy is the one that drifts.</p>
  */
 test('ticking the main one is redrawn, because its effect is on the rows it is not in', () => {
-  assert.strictEqual(repaintsAfter({ kind: 'edit', list: 'prompt', id: 'p1', field: 'main', value: true }), true);
+  assert.strictEqual(editRepaints({ kind: 'edit', list: 'prompt', id: 'p1', field: 'main', value: true }), true);
 });
 
 test('typing is NOT redrawn, which is the rule this exception is carved out of', () => {
   for (const field of ['name', 'text', 'provider', 'model', 'startingPrompt'] as const) {
     assert.strictEqual(
-      repaintsAfter({ kind: 'edit', list: 'prompt', id: 'p1', field, value: 'x' }),
+      editRepaints({ kind: 'edit', list: 'prompt', id: 'p1', field, value: 'x' }),
       false,
       `${field} redraws the page under a caret`,
     );
@@ -160,11 +160,10 @@ test('typing is NOT redrawn, which is the rule this exception is carved out of',
 });
 
 test('unticking is redrawn too, so the list cannot be left showing none', () => {
-  assert.strictEqual(repaintsAfter({ kind: 'edit', list: 'prompt', id: 'p1', field: 'main', value: false }), true);
+  assert.strictEqual(editRepaints({ kind: 'edit', list: 'prompt', id: 'p1', field: 'main', value: false }), true);
 });
 
-test('adding and removing are redrawn, as they always were', () => {
-  assert.strictEqual(repaintsAfter({ kind: 'add', list: 'model' }), true);
-  assert.strictEqual(repaintsAfter({ kind: 'remove', list: 'model', id: 'm1' }), true);
-  assert.strictEqual(repaintsAfter({ kind: 'ignore' }), false);
-});
+// Adding and removing are NOT decided here any more. The code round was right that a whole-command
+// policy in the page parser, consulted by the host for edits only, is a rule with a test and no
+// effect: changing what it says about `add` would move a test and nothing else. Whether an add
+// redraws depends on whether it was refused, which only the host knows. (gemini, the code round.)


### PR DESCRIPTION
Two defects in the tab **Edit chat presets** opens, both reported 2026-09-11 with screenshots.

## 1. *Add a model* appeared to do nothing

It was not doing nothing. It appended `{ name: 'New model', provider: '', model: '' }` to `coai.chatModelPresets`, and `chatModelPresetsFrom` refuses a row with no provider — *"a row without a PROVIDER is not one: the provider is what answers"*. So the page re-read the list, the reader discarded the row, and the screen was unchanged. `rowsOf` reads the **raw** setting, so every press left a dead entry that no surface could display, edit or remove.

The prompt button never had the defect: its seed is two real values. The model branch seeded the one field its own reader refuses on.

**The fix is the seed, not a loosened reader.** `freshPromptRow` / `freshModelRow(taken, providerId)` live beside the readers now — the provider is a **required** argument, so a caller who forgets it does not compile. `addModel` resolves the answering row first, and with nothing that can chat it says so instead of writing something invisible. The litter is cleared when the tab opens.

## 2. Two prompts could both read as *main*

What was **saved** was right all along — ticking one unticks the others before the write. But an edit deliberately does not repaint, because a repaint under a caret is the defect the sidebar's own prompt box had, and that rule had swallowed the one edit whose entire effect is on the rows it is **not** in. A checkbox has no caret, so it is redrawn now.

## What the gate found in the fix

Plan round: 11 findings, 4 taken — chiefly that clearing the litter *"on the next write"* clears nothing for somebody who opens the tab and closes it, and nothing at all when the add refuses before writing. Code round, two passes, 23 findings, 18 taken:

- The prune **raced the first render** — awaited before the panel is created now, and its failure logged rather than left floating.
- A `main` edit **naming a row that is not there** rewrote every flag to `false`, leaving no tick while `mainPrompt` quietly fell back to the first prompt.
- The cleanup was using the **reader's acceptance rule as migration authority** — an older build opening a newer file would have deleted rows it merely does not understand. `deadModelRow` is the defect's own signature instead.
- A `main` edit is guarded by the **list** as well as the field.
- Re-ticking the prompt that is already main wrote the file back to say what it said.
- `repaintsAfter` narrowed to `editRepaints`: a whole-command policy the host consulted for edits only was a rule with a test and no effect.

## Tests

RED first on every behaviour, with the real symptom — `the row a press of Add a model writes is dropped by the reader`, and the `main` tick reported as not redrawn. Both original fixes were then proved with teeth by removing them again: the seed back to `''`, the repaint exception back out — both red, both green on restore.

`npm test` **1445 pass, 0 fail** (1427 before this branch). `typecheck`, `plan-lifecycle`, `pin-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - New model presets now open with a compatible provider selected, or clearly indicate when none is available.
  - Unusable model rows left by earlier behavior are automatically cleaned up.
  - Only one prompt can be marked as the main prompt at a time.
  - Main-prompt changes update immediately, while unrelated edits avoid unnecessary refreshing.

- **Documentation**
  - Added documentation describing the preset fixes and resulting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->