### PR TITLE
chore(release): extension 0.33.1 — both buttons in the presets tab work

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## Extension 0.33.1 — 2026-09-11
 
 **Add a model works.** It was not doing nothing — it was writing a preset with no reviewer named, and a preset that names no reviewer names nothing that can answer, so the list dropped it on the way back to the screen. Every press left a row in your settings that nothing could show, edit or remove. A new model preset now opens on the first reviewer that can chat, which you change on the row; with no such reviewer configured the button says so instead of writing something invisible, and the rows the old behaviour left behind are cleared when the tab opens.
 

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "connect-other-ais",
   "displayName": "ConnectOtherAIs",
   "description": "Your AI writes the code; other vendors' models review it — the plan before it is built, the diff after. A gate that holds until they agree, or until you decide.",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "publisher": "remsoftdev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Extension-only patch. The manifest goes to 0.33.1 and the CHANGELOG's Unreleased section is dated; `src_mcp` has not changed since 0.18.17.

Two defects in the tab 0.33.0 gave a way into: *Add a model* wrote a row its own reader refuses, and two prompts could read as **main**. No new surface, hence a patch.

The release workflow fires on the `extension-v0.33.1` tag and refuses one that disagrees with the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)